### PR TITLE
chore: group vitest dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      test-tooling:
+        patterns:
+          - vitest
+          - "@vitest/coverage-v8"
 
   - package-ecosystem: github-actions
     directory: /

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -11,6 +11,10 @@ function loadPackageManifest(): PackageManifest {
   return JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as PackageManifest
 }
 
+function loadDependabotConfig(): string {
+  return readFileSync(join(process.cwd(), '.github', 'dependabot.yml'), 'utf8')
+}
+
 function normalizeVersionRange(range: string | undefined): string {
   return (range ?? '').replace(/^[\^~]/, '')
 }
@@ -22,5 +26,15 @@ describe('package metadata', () => {
     expect(normalizeVersionRange(devDependencies['@vitest/coverage-v8'])).toBe(
       normalizeVersionRange(devDependencies.vitest),
     )
+  })
+
+  it('groups vitest tooling updates together in dependabot', () => {
+    const dependabotConfig = loadDependabotConfig()
+
+    expect(dependabotConfig).toContain('groups:')
+    expect(dependabotConfig).toContain('test-tooling:')
+    expect(dependabotConfig).toContain('patterns:')
+    expect(dependabotConfig).toContain('- vitest')
+    expect(dependabotConfig).toContain('- "@vitest/coverage-v8"')
   })
 })


### PR DESCRIPTION
## Summary
- group `vitest` and `@vitest/coverage-v8` into the same Dependabot npm update batch
- extend `package-metadata` tests to enforce the grouping rule alongside version alignment

## Test Plan
- [x] `npm run test:run -- tests/unit/package-metadata.test.ts`
- [x] `npx -y node@20.20.2 ./node_modules/typescript/bin/tsc --noEmit`
- [x] `npx -y node@20.20.2 ./node_modules/vitest/vitest.mjs run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to group test-related dependency updates into a single batch.

* **Tests**
  * Added validation for Dependabot grouping configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->