### PR TITLE
Review selection engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-05-01
+
+### Added
+
+- **`review-compare` real-repo benchmark command**: added a CLI flow that compares verbose versus compact `pr_impact` prompts for the current git diff, saves prompt/report artifacts under `graphify-out/review-compare/`, and can optionally execute both prompts through a user-supplied runner template.
+
+### Changed
+
+- **Compact review payload usefulness**: `pr_impact` compact output now carries typed `review_context` with supporting paths, likely test paths, and structural hotspots so the smaller review packet still points reviewers at the most relevant follow-up context.
+- **Compact review payload size on real repos**: compact `pr_impact` now trims oversized outer arrays (`changed_files`, `changed_ranges`, `seed_nodes`, `affected_communities`, `high_impact_nodes`) instead of only shrinking the inner review bundle, which cuts real review payload size dramatically on large live diffs.
+
+### Fixed
+
+- **Real-workspace PR diff detection**: `pr_impact` now discovers and reads diffs from nested git repositories under the graph root, so review mode works on multi-project workspaces instead of assuming the graph root itself is a git repo.
+- **Review benchmark output-dir validation**: `review-compare` now accepts nested output directories whose parents do not exist yet and correctly validates absolute external output paths against the target graph's own `graphify-out/` directory.
+- **CLI/runtime validation parity**: the `review-compare` parser no longer rejects valid absolute output directories before runtime can validate them against the selected graph workspace.
+
 ## [0.10.3] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-05-01
+
+### Added
+
+- **Diff-first PR review selection**: `pr_impact` now parses unified git diff hunks into `changed_ranges`, narrows to line-aware `seed_nodes`, falls back safely to file-level seeds when symbol line metadata is missing, and returns ranked review risks with severity/reason summaries.
+
+### Changed
+
+- **Compact-by-default PR review MCP output**: the MCP `pr_impact` tool now accepts `budget`, `verbose`, and `compact` flags, returns a compact default payload for review workflows, and preserves the full legacy-style result behind `verbose: true` or `compact: false`.
+- **Review bundle compaction and regression benchmarking**: compact PR review bundles now preserve seed-first context while trimming supporting snippets and re-filtering relationships/community context, with focused regression tests pinning materially smaller review payloads on a mixed review fixture.
+
+### Fixed
+
+- **PR diff/runtime edge cases**: normalized reversed source ranges, hardened macOS realpath matching between git diff paths and graph node files, and covered pure-deletion hunks so review selection stays stable across real repositories.
+
 ## [0.10.2] - 2026-05-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **Understand mainstream JS/TS app structure** with framework-aware extraction for Express, Redux Toolkit, React Router, NestJS, and Next.js
 - **Explore the graph** through interactive HTML, reports, and CLI commands
 - **Analyze blast radius** before making changes — know what breaks across modules and repos
+- **Benchmark review-mode prompts on real diffs** with `review-compare` before trusting a compact PR-review surface
 - **Federate multiple repos** into a single queryable super-graph
 
 ## Install
@@ -120,6 +121,26 @@ What `compare` does:
 
 Use `compare` when you want a showcase or a customer-proof answer bundle. Use `benchmark` and `eval` when you want repeatable runner-backed question-set metrics; they report provider usage when available and clearly label local token-estimate fallback when it is not.
 
+## Real PR review compare (same diff, same model)
+
+`review-compare` is the proof path for review mode. Instead of comparing two answers to a question, it compares the **verbose** and **compact** `pr_impact` prompts for the current git diff, saves both prompts, and can optionally run both through your own terminal model command.
+
+```bash
+graphify-ts review-compare graphify-out/graph.json \
+  --exec 'cat {prompt_file} | claude -p' \
+  --yes
+```
+
+What `review-compare` does:
+
+- Builds both verbose and compact `pr_impact` payloads for the current diff.
+- Expands runner placeholders: `{prompt_file}`, `{mode}`, and `{output_file}`.
+- Writes artifacts under `graphify-out/review-compare/<timestamp>/` with `verbose-prompt.txt`, `compact-prompt.txt`, `verbose-answer.txt`, `compact-answer.txt`, and `report.json`.
+- Reports prompt-token and payload-token deltas between verbose and compact review mode.
+- Supports external graph paths and output directories inside the target graph workspace's own `graphify-out/`, which matters for multi-project real repos.
+
+Use `review-compare` when the question is "did compact review mode actually shrink the real PR-review prompt enough?" rather than "did graphify beat a naive baseline on one question?"
+
 ## Graph time travel (ref-to-ref graph compare)
 
 Use `graphify-ts time-travel <from> <to>` to compare two git refs through local graph snapshots:
@@ -158,7 +179,7 @@ When an agent connects via `graphify-ts serve --stdio`, it gets these tools:
 | `implementation_checklist` | Change-planning checklist — question → ordered edit steps plus validation checkpoints for entry points and shared risks |
 | `impact` | Blast radius analysis — "if I change X, what could break?" with compact directed dependents, affected communities, and path evidence by default; supports `verbose: true` for the legacy fuller payload |
 | `call_chain` | Execution path tracing — all paths from A to B filtered by edge type |
-| `pr_impact` | PR risk analysis — git diff → affected nodes → aggregate blast radius |
+| `pr_impact` | PR risk analysis — git diff → line-aware seed nodes → compact review bundle, typed `review_context`, ranked risks, and aggregate blast radius by default; supports verbose output when explicitly requested |
 | `community_details` | Hierarchical community data at micro/mid/macro zoom levels |
 | `community_overview` | Quick overview of all communities — names, sizes, top nodes |
 | `query_graph` | Graph traversal for a natural language question |
@@ -179,7 +200,7 @@ The agent uses these tools to answer questions like:
 - "What order should I edit this feature, and what should I validate after?" → `implementation_checklist` returns an edit sequence plus validation checkpoints
 - "What breaks if I refactor SessionManager?" → `impact` shows directed dependents, affected communities, and the highest-signal propagation paths
 - "How does a request flow from the API to the database?" → `call_chain` traces the execution path
-- "Is this PR safe to merge?" → `pr_impact` computes blast radius of all changes
+- "Is this PR safe to merge?" → `pr_impact` returns compact changed seeds, a review bundle, supporting paths, likely tests, hotspots, and ranked risks for the current diff
 - "What changed between main and HEAD?" → `time_travel_compare` builds or reuses local snapshots and returns a summary, risk, drift, or timeline view
 
 ## Multi-Repo Federation
@@ -214,6 +235,7 @@ This merges graphs and infers cross-repo connections from shared types and funct
 | `benchmark [graph.json]` | Measure token reduction and structure signals |
 | `eval [graph.json]` | Measure retrieval quality: recall, MRR, and snippet coverage |
 | `compare [question]` | Run a real baseline-vs-graphify prompt comparison through your own terminal LLM command |
+| `review-compare [graph.json]` | Compare verbose-vs-compact `pr_impact` prompts for the current git diff |
 | `time-travel <from> <to>` | Compare two refs via on-demand local graph snapshots (`summary` default; `risk`, `drift`, `timeline` optional) |
 | `install --platform claude` | Install home-level Claude skill |
 | `claude install` | Install project-local Claude integration with MCP auto-start |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ What `review-compare` does:
 - Expands runner placeholders: `{prompt_file}`, `{mode}`, and `{output_file}`.
 - Writes artifacts under `graphify-out/review-compare/<timestamp>/` with `verbose-prompt.txt`, `compact-prompt.txt`, `verbose-answer.txt`, `compact-answer.txt`, and `report.json`.
 - Reports prompt-token and payload-token deltas between verbose and compact review mode.
-- Supports external graph paths and output directories inside the target graph workspace's own `graphify-out/`, which matters for multi-project real repos.
+- Supports external graph paths and output directories inside the target graph workspace's own `graphify-out/`, which matters for real multi-project repositories.
 
 Use `review-compare` when the question is "did compact review mode actually shrink the real PR-review prompt enough?" rather than "did graphify beat a naive baseline on one question?"
 

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -54,7 +54,27 @@ What gets saved under `graphify-out/compare/<timestamp>/`:
 
 When Gemini emits structured JSON with `usageMetadata`, `compare` captures real reported input and total tokens in `report.json` and the terminal summary. If the runner only returns answer text or malformed JSON, `compare` falls back to labeled local `cl100k_base` prompt estimates instead. Use this when you need customer-proof or your own apples-to-apples answer comparison. It can spend paid model tokens, just like runner-backed `benchmark` and `eval`; the difference is that `compare` saves paired answers, while `benchmark` and `eval` score a labeled question set.
 
-## 3. Production and multi-repo proof
+## 3. PR-review proof on a real diff
+
+`review-compare` is the proof path for review mode. It compares the **verbose** and **compact** `pr_impact` prompts for the current git diff, saves both payload-backed prompts, and can optionally run both through your own model runner.
+
+```bash
+graphify-ts review-compare graphify-out/graph.json \
+  --exec 'cat {prompt_file} | claude -p' \
+  --yes
+```
+
+What gets saved under `graphify-out/review-compare/<timestamp>/`:
+
+- `verbose-prompt.txt`
+- `compact-prompt.txt`
+- `verbose-answer.txt`
+- `compact-answer.txt`
+- `report.json`
+
+Use this when the question is not "graphify vs. naive baseline", but "did compact review mode make the PR-review prompt materially smaller while keeping the same review surface shape?" The report includes prompt-token deltas, payload-token deltas, run statuses, and elapsed times for both modes.
+
+## 4. Production and multi-repo proof
 
 For real systems, the strongest proof is usually:
 
@@ -91,6 +111,7 @@ What this proves that a single-repo demo cannot:
 | "Does the graph improve retrieval quality on a labeled set?" | `eval` |
 | "Does the graph reduce prompt size while keeping expected evidence?" | `benchmark` |
 | "Will my actual model answer better with graphify than with a naive baseline, and optionally capture provider-reported usage?" | `compare` |
+| "Did compact review mode actually shrink the real PR-review prompt on my current diff?" | `review-compare` |
 | "Can this work across frontend/backend/shared repos?" | `federate` + `serve --stdio` |
 
 For the narrative production benchmark and the GoValidate numbers, see [`examples/why-graphify.md`](../examples/why-graphify.md). For exact support coverage by language and file type, see [`language-capability-matrix.md`](./language-capability-matrix.md).

--- a/examples/mcp-tool-examples.md
+++ b/examples/mcp-tool-examples.md
@@ -114,23 +114,54 @@ These examples show what your AI agent sees when it calls graphify-ts MCP tools.
 {
   "base_branch": "main",
   "changed_files": ["src/entities/User.ts", "src/modules/auth/auth.service.ts"],
-  "changed_nodes": [
-    { "label": "User", "community_label": "Backend User" },
-    { "label": "AuthService", "community_label": "Backend Auth" }
+  "changed_ranges": [
+    { "source_file": "src/entities/User.ts", "line_ranges": [{ "start": 42, "end": 48 }] },
+    { "source_file": "src/modules/auth/auth.service.ts", "line_ranges": [{ "start": 10, "end": 18 }] }
   ],
+  "seed_nodes": [
+    { "node_id": "user_entity", "label": "User", "community_label": "Backend User", "match_kind": "line" },
+    { "node_id": "auth_service", "label": "AuthService", "community_label": "Backend Auth", "match_kind": "line" }
+  ],
+  "review_context": {
+    "supporting_paths": ["src/modules/users/user.repository.ts"],
+    "test_paths": ["tests/auth/auth.service.test.ts"],
+    "hotspots": [{ "label": "User", "type": "bridge", "why": "User connects multiple communities in the changed review area." }]
+  },
+  "review_bundle": {
+    "budget": 2000,
+    "token_count": 512,
+    "shared_file_type": "code",
+    "nodes": [
+      { "node_id": "user_entity", "label": "User", "source_file": "src/entities/User.ts", "line_number": 42, "snippet": "export class User {}", "match_score": 9, "relevance_band": "direct", "community": 7 },
+      { "label": "UserRepository", "source_file": "src/modules/users/user.repository.ts", "line_number": 15, "snippet": null, "relevance_band": "related", "community": 8 }
+    ],
+    "relationships": [
+      { "from": "UserRepository", "to": "User", "relation": "uses" }
+    ],
+    "community_context": [
+      { "id": 7, "label": "Backend User", "node_count": 24 }
+    ]
+  },
   "per_node_impact": [
-    { "node": "User", "direct_dependents": 67, "transitive_dependents": 589, "affected_communities": 42 },
-    { "node": "AuthService", "direct_dependents": 12, "transitive_dependents": 45, "affected_communities": 8 }
+    { "node": "User", "total_dependents": 656, "affected_communities": 42 },
+    { "node": "AuthService", "total_dependents": 57, "affected_communities": 8 }
   ],
   "total_blast_radius": 634,
+  "affected_communities": [
+    { "id": 7, "label": "Backend User", "node_count": 24 },
+    { "id": 8, "label": "Backend Auth", "node_count": 18 }
+  ],
   "risk_summary": {
     "high_impact_nodes": ["User", "AuthService"],
-    "cross_community_changes": 2
+    "cross_community_changes": 2,
+    "top_risks": [
+      { "label": "User", "severity": "high", "reason": "High blast radius across 42 communities." }
+    ]
   }
 }
 ```
 
-**What the agent does with this:** "This PR changes 2 high-impact nodes. User alone has a blast radius of 656. Combined with AuthService, 634 unique nodes could be affected. I'd recommend running the full test suite and reviewing the auth module consumers."
+**What the agent does with this:** "This PR changes 2 line-matched high-impact nodes. The compact review bundle already points at the key supporting file and likely auth test, and `User` is flagged as a bridge hotspot with the largest blast radius. I'd review the user repository path first, then run the auth service tests before merging."
 
 ---
 

--- a/examples/why-graphify.md
+++ b/examples/why-graphify.md
@@ -164,6 +164,25 @@ What this gives you:
 
 Important: `compare` may spend paid model tokens. It prints a warning before execution and requires `--yes` in non-interactive runs. For large prompts, use stdin or file redirection with `{prompt_file}`; avoid shell command substitution around `{prompt_file}` (for example `$(cat {prompt_file})`) because shell argument expansion can fail on full-repo baselines. If Gemini emits structured JSON with `usageMetadata`, `compare` records real reported input and total tokens. If the runner only returns answer text or malformed JSON, `compare` falls back to labeled local `cl100k_base` prompt estimates instead. Runner-backed `benchmark` and `eval` follow the same reported-usage vs. labeled-estimate fallback rules.
 
+## Real PR review proof with the current diff
+
+If your question is "is compact review mode actually small enough on a real PR?" use `review-compare` instead of question-based `compare`:
+
+```bash
+graphify-ts review-compare graphify-out/graph.json \
+  --exec 'cat {prompt_file} | claude -p' \
+  --yes
+```
+
+This produces:
+
+- one verbose `pr_impact` prompt and one compact `pr_impact` prompt for the current git diff
+- optional model answers for both review prompts
+- a saved artifact bundle in `graphify-out/review-compare/<timestamp>/`
+- prompt-token and payload-token deltas in `report.json`
+
+Use this proof when you are validating PR-review ergonomics rather than general question-answering. It is especially useful on large repos or multi-project workspaces because it can target an external graph path and still write output inside that target workspace's own `graphify-out/`.
+
 ## Run It on Your Own Codebase
 
 ```bash
@@ -181,6 +200,9 @@ graphify-ts eval graphify-out/graph.json --questions benchmark-questions.json --
 
 # If you want a real same-model A/B proof run
 graphify-ts compare "How does auth work?" --exec 'cat {prompt_file} | claude -p' --yes
+
+# If you want a real PR-review compact-vs-verbose proof run
+graphify-ts review-compare graphify-out/graph.json --exec 'cat {prompt_file} | claude -p' --yes
 
 # Gemini-safe compare runner with structured usage capture
 graphify-ts compare "How does auth work?" \
@@ -201,12 +223,14 @@ For an internal team rollout, the most convincing sequence is usually:
 
 1. Run `benchmark` and `eval` on one repo with your chosen runner to prove the graph is smaller to query and still retrieves the expected evidence.
 2. Run `compare` with your real model command to produce a saved baseline-vs-graphify answer bundle.
-3. If your system spans multiple repos, generate each graph separately and use `federate` before showing the agent workflow.
+3. If PR-review cost is the concern, run `review-compare` on a real diff to measure verbose-vs-compact review prompts directly.
+4. If your system spans multiple repos, generate each graph separately and use `federate` before showing the agent workflow.
 
 That progression keeps the proof honest:
 
 - `benchmark` and `eval` are runner-backed graph-quality measurements on labeled prompts
 - `compare` is the model-facing proof, with reported usage when the runner emits structured JSON and labeled estimates otherwise
+- `review-compare` is the PR-review proof, comparing verbose and compact `pr_impact` prompts on the same diff
 - `federate` is the production architecture proof for frontend/backend/shared or microservice splits
 
 ## Capability Coverage Matters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.10.3",
+            "version": "0.10.4",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.10.2",
+            "version": "0.10.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "Build local knowledge graphs from code, docs, and mixed project folders with a TypeScript CLI.",
     "license": "MIT",
     "author": "mohanagy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "Build local knowledge graphs from code, docs, and mixed project folders with a TypeScript CLI.",
     "license": "MIT",
     "author": "mohanagy",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,6 +4,7 @@ import { createInterface } from 'node:readline/promises'
 import { loadBenchmarkQuestions, type BenchmarkResult, printBenchmark, runBenchmark } from '../infrastructure/benchmark.js'
 import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure/benchmark/quality.js'
 import { runCompareCommand } from '../infrastructure/compare.js'
+import { runReviewCompareCommand } from '../infrastructure/review-compare.js'
 import { compareRefs } from '../infrastructure/time-travel.js'
 import { federate } from '../pipeline/federate.js'
 import { generateGraph, type GenerateGraphResult, type ProgressStep } from '../infrastructure/generate.js'
@@ -44,11 +45,13 @@ import {
   parsePathArgs,
   parsePlatformActionArgs,
   parseQueryArgs,
+  parseReviewCompareArgs,
   parseSaveResultArgs,
   parseServeArgs,
   parseTimeTravelArgs,
   parseWatchArgs,
   type CompareCliOptions,
+  type ReviewCompareCliOptions,
   type TimeTravelCliOptions,
   UsageError,
 } from './parser.js'
@@ -60,6 +63,12 @@ export interface CliIO {
 
 export interface CompareCommandContext {
   options: CompareCliOptions
+  io: CliIO
+  confirm(message: string): Promise<boolean>
+}
+
+export interface ReviewCompareCommandContext {
+  options: ReviewCompareCliOptions
   io: CliIO
   confirm(message: string): Promise<boolean>
 }
@@ -87,6 +96,7 @@ export interface CliDependencies {
   runBenchmark: (context: BenchmarkCommandContext) => Promise<BenchmarkResult> | BenchmarkResult
   runEval: (context: EvalCommandContext) => Promise<string | void> | string | void
   runCompare: (context: CompareCommandContext) => Promise<string | void> | string | void
+  runReviewCompare: (context: ReviewCompareCommandContext) => Promise<string | void> | string | void
   runTimeTravel: (context: TimeTravelCommandContext) => Promise<string | void> | string | void
   confirm: (message: string) => Promise<boolean>
   printBenchmark: (result: BenchmarkResult) => void
@@ -111,6 +121,7 @@ export interface CliDependencies {
 }
 
 const COMPARE_WARNING_MESSAGE = 'compare will execute a baseline prompt and a graphify prompt for each question. This may consume paid model tokens.'
+const REVIEW_COMPARE_WARNING_MESSAGE = 'review-compare will execute verbose and compact pr_impact prompts for the current git diff. This may consume paid model tokens.'
 const BENCHMARK_WARNING_MESSAGE = 'benchmark will execute the benchmark/eval runner. This may consume paid model tokens.'
 const EVAL_WARNING_MESSAGE = 'eval will execute the benchmark/eval runner. This may consume paid model tokens.'
 
@@ -141,6 +152,15 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
       execTemplate: options.execTemplate,
       baselineMode: options.baselineMode,
       limit: options.limit,
+    })
+  },
+  runReviewCompare: async ({ options }) => {
+    return await runReviewCompareCommand({
+      graphPath: options.graphPath,
+      execTemplate: options.execTemplate,
+      outputDir: options.outputDir,
+      ...(options.baseBranch !== null ? { baseBranch: options.baseBranch } : {}),
+      ...(options.budget !== null ? { budget: options.budget } : {}),
     })
   },
   runTimeTravel: async ({ options }) => {
@@ -302,6 +322,12 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
     '    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice and reports Anthropic-billed usage)',
     '    --yes                 skip confirmation before running the paid prompt comparison',
     '    --limit N             cap processed prompts/questions for the comparison run',
+    '  review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff',
+    '    --exec TEMPLATE       required command template; supports {prompt_file}, {mode}, and {output_file}',
+    '    --output-dir DIR      review compare output directory (default graphify-out/review-compare)',
+    '    --base-branch BRANCH  override the PR base branch used for diff selection',
+    '    --budget N            override the pr_impact review bundle token budget',
+    '    --yes                 skip confirmation before running the paid review comparison',
     '  time-travel <from> <to> compare two refs using on-demand cached graph snapshots',
     '    --view MODE          summary|risk|drift|timeline (default summary)',
     '    --json               emit machine-readable JSON',
@@ -472,6 +498,30 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         }
       }
       const output = await dependencies.runCompare({
+        options,
+        io,
+        confirm,
+      })
+      if (output !== undefined) {
+        io.log(output)
+      }
+      return 0
+    }
+
+    if (command === 'review-compare') {
+      const options = parseReviewCompareArgs(args)
+      const confirm = async (message: string) => await dependencies.confirm(message)
+      if (!(await confirmPaidCommand(
+        'review-compare',
+        REVIEW_COMPARE_WARNING_MESSAGE,
+        'Review compare cancelled.',
+        options.yes,
+        io,
+        dependencies,
+      ))) {
+        return 1
+      }
+      const output = await dependencies.runReviewCompare({
         options,
         io,
         confirm,

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -852,14 +852,14 @@ export function parseReviewCompareArgs(args: string[]): ReviewCompareCliOptions 
     }
 
     if (argument === '--budget') {
-      budget = parsePositiveDecimalInteger('--budget', requireOptionValue('--budget', args[index + 1]))
+      budget = parseBudget(requireOptionValue('--budget', args[index + 1]))
       index += 1
       continue
     }
 
     if (argument.startsWith('--budget=')) {
       const [, value] = argument.split('=', 2)
-      budget = parsePositiveDecimalInteger('--budget', requireOptionValue('--budget', value))
+      budget = parseBudget(requireOptionValue('--budget', value))
       continue
     }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, resolve } from 'node:path'
+
 import { validateGraphOutputPath } from '../shared/security.js'
 import { type InstallPlatform, isInstallPlatform } from '../infrastructure/install.js'
 
@@ -70,6 +72,15 @@ export interface CompareCliOptions {
   baselineMode: 'full' | 'bounded' | 'native_agent'
   yes: boolean
   limit: number | null
+}
+
+export interface ReviewCompareCliOptions {
+  graphPath: string
+  execTemplate: string
+  outputDir: string
+  baseBranch: string | null
+  budget: number | null
+  yes: boolean
 }
 
 export interface TimeTravelCliOptions {
@@ -240,6 +251,10 @@ function validateCliText(field: string, value: string): string {
     throw new UsageError(`error: ${field} exceeds maximum length of ${MAX_CLI_LABEL_LENGTH} characters`)
   }
   return value
+}
+
+function validateReviewCompareOutputDir(outputDir: string): string {
+  return isAbsolute(outputDir) ? resolve(outputDir) : validateGraphOutputPath(outputDir)
 }
 
 export function parseQueryArgs(args: string[]): QueryCliOptions {
@@ -775,6 +790,99 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   outputDir = validateGraphOutputPath(outputDir)
 
   return { question, graphPath, execTemplate, questionsPath, outputDir, baselineMode, yes, limit }
+}
+
+export function parseReviewCompareArgs(args: string[]): ReviewCompareCliOptions {
+  const usage = 'Usage: graphify-ts review-compare [graph.json] --exec TEMPLATE [--output-dir DIR] [--base-branch BRANCH] [--budget N] [--yes]'
+  let graphPath = 'graphify-out/graph.json'
+  let execTemplate = ''
+  let outputDir = 'graphify-out/review-compare'
+  let baseBranch: string | null = null
+  let budget: number | null = null
+  let yes = false
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (!argument.startsWith('--')) {
+      if (graphPath !== 'graphify-out/graph.json') {
+        throw new UsageError(usage)
+      }
+      graphPath = requireNonEmptyValue('graph path', argument)
+      continue
+    }
+
+    if (argument === '--exec') {
+      execTemplate = requireOptionValue('--exec', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--exec=')) {
+      const [, value] = argument.split('=', 2)
+      execTemplate = requireOptionValue('--exec', value)
+      continue
+    }
+
+    if (argument === '--output-dir') {
+      outputDir = requireOptionValue('--output-dir', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--output-dir=')) {
+      const [, value] = argument.split('=', 2)
+      outputDir = requireOptionValue('--output-dir', value)
+      continue
+    }
+
+    if (argument === '--base-branch') {
+      baseBranch = validateCliText('--base-branch', requireOptionValue('--base-branch', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--base-branch=')) {
+      const [, value] = argument.split('=', 2)
+      baseBranch = validateCliText('--base-branch', requireOptionValue('--base-branch', value))
+      continue
+    }
+
+    if (argument === '--budget') {
+      budget = parsePositiveDecimalInteger('--budget', requireOptionValue('--budget', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--budget=')) {
+      const [, value] = argument.split('=', 2)
+      budget = parsePositiveDecimalInteger('--budget', requireOptionValue('--budget', value))
+      continue
+    }
+
+    if (argument === '--yes') {
+      yes = true
+      continue
+    }
+
+    throw new UsageError(`error: unknown option for review-compare: ${argument}`)
+  }
+
+  if (execTemplate.length === 0) {
+    throw new UsageError('error: --exec is required')
+  }
+
+  return {
+    graphPath,
+    execTemplate,
+    outputDir: validateReviewCompareOutputDir(outputDir),
+    baseBranch,
+    budget,
+    yes,
+  }
 }
 
 export function parseTimeTravelArgs(args: string[]): TimeTravelCliOptions {

--- a/src/infrastructure/hooks.ts
+++ b/src/infrastructure/hooks.ts
@@ -1,5 +1,7 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
+
+import { findGitRoot } from '../shared/git.js'
 
 export const HOOK_MARKER = '# graphify-hook-start'
 const HOOK_MARKER_END = '# graphify-hook-end'
@@ -23,20 +25,6 @@ ${CHECKOUT_MARKER_END}
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-function gitRoot(path: string): string | null {
-  let current = resolve(path)
-  while (true) {
-    if (existsSync(join(current, '.git'))) {
-      return current
-    }
-    const parent = dirname(current)
-    if (parent === current) {
-      return null
-    }
-    current = parent
-  }
 }
 
 function ensureExecutable(hookPath: string): void {
@@ -86,7 +74,7 @@ function uninstallHook(hooksDir: string, name: string, marker: string, markerEnd
 }
 
 export function install(path = '.'): string {
-  const root = gitRoot(path)
+  const root = findGitRoot(path)
   if (!root) {
     throw new Error(`No git repository found at or above ${resolve(path)}`)
   }
@@ -99,7 +87,7 @@ export function install(path = '.'): string {
 }
 
 export function uninstall(path = '.'): string {
-  const root = gitRoot(path)
+  const root = findGitRoot(path)
   if (!root) {
     throw new Error(`No git repository found at or above ${resolve(path)}`)
   }
@@ -111,7 +99,7 @@ export function uninstall(path = '.'): string {
 }
 
 export function status(path = '.'): string {
-  const root = gitRoot(path)
+  const root = findGitRoot(path)
   if (!root) {
     return 'Not in a git repository.'
   }

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -1,0 +1,405 @@
+import { spawn } from 'node:child_process'
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+import { analyzePrImpact, compactPrImpactResult } from '../runtime/pr-impact.js'
+import { estimateQueryTokens, loadGraph } from '../runtime/serve.js'
+import { findNearestExistingAncestor, validateGraphPath } from '../shared/security.js'
+
+export type ReviewCompareMode = 'verbose' | 'compact'
+export type ReviewCompareRunStatus = 'not_run' | 'succeeded' | 'failed'
+
+export interface ReviewComparePromptArtifactPaths {
+  output_dir: string
+  verbose_prompt: string
+  compact_prompt: string
+  report: string
+}
+
+export interface ReviewCompareAnswerArtifactPaths {
+  verbose: string
+  compact: string
+}
+
+export interface ReviewCompareExecution {
+  mode: ReviewCompareMode
+  promptFile: string
+  outputFile: string
+  command: string
+}
+
+export interface ReviewCompareRunnerResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  elapsedMs: number
+}
+
+export interface ReviewCompareInput {
+  graphPath: string
+  execTemplate: string
+  outputDir: string
+  baseBranch?: string
+  budget?: number
+  now?: Date
+}
+
+export interface ReviewCompareReport {
+  graph_path: string
+  base_branch: string
+  budget: number
+  changed_files: string[]
+  seed_count: number
+  supporting_path_count: number
+  test_path_count: number
+  hotspot_count: number
+  verbose_payload_tokens: number
+  compact_payload_tokens: number
+  payload_reduction_ratio: number
+  verbose_prompt_tokens: number
+  compact_prompt_tokens: number
+  reduction_ratio: number
+  started_at: string
+  completed_at: string
+  elapsed_ms: Record<ReviewCompareMode, number>
+  status: Record<ReviewCompareMode, ReviewCompareRunStatus>
+  answer_paths: ReviewCompareAnswerArtifactPaths
+  exit_code: Record<ReviewCompareMode, number | null>
+  stderr: Record<ReviewCompareMode, string | null>
+  paths: ReviewComparePromptArtifactPaths
+}
+
+export interface ReviewCompareResult {
+  graph_path: string
+  output_root: string
+  report: ReviewCompareReport
+}
+
+export interface ExecuteReviewCompareRunsDependencies {
+  runner?: (execution: ReviewCompareExecution) => Promise<ReviewCompareRunnerResult>
+  now?: () => Date
+}
+
+const EXEC_TEMPLATE_PLACEHOLDER_PATTERN = /\{[a-z_][a-z0-9_]*\}/gi
+const REVIEW_COMPARE_EXEC_PLACEHOLDERS = new Set(['{prompt_file}', '{mode}', '{output_file}'])
+
+function timestampDirectoryName(date: Date): string {
+  return date.toISOString().slice(0, 19).replace(/:/g, '-')
+}
+
+function portablePath(path: string): string {
+  return relative(process.cwd(), path) || '.'
+}
+
+function inferProjectRootFromGraphPath(graphPath: string): string {
+  let currentPath = dirname(resolve(graphPath))
+
+  while (dirname(currentPath) !== currentPath) {
+    if (basename(currentPath) === 'graphify-out') {
+      return dirname(currentPath)
+    }
+    currentPath = dirname(currentPath)
+  }
+
+  return dirname(resolve(graphPath))
+}
+
+function validateOutputDirForGraph(graphPath: string, outputDir: string): string {
+  const projectRoot = realpathSync(inferProjectRootFromGraphPath(graphPath))
+  const baseDir = realpathSync(resolve(projectRoot, 'graphify-out'))
+  const resolvedOutputDir = isAbsolute(outputDir)
+    ? resolve(outputDir)
+    : outputDir === 'graphify-out' || outputDir.startsWith(`graphify-out${sep}`)
+      ? resolve(projectRoot, outputDir)
+      : resolve(outputDir)
+  const existingAncestor = findNearestExistingAncestor(resolvedOutputDir)
+  const normalizedOutputDir = existingAncestor === null
+    ? resolvedOutputDir
+    : resolve(realpathSync(existingAncestor), relative(existingAncestor, resolvedOutputDir))
+  const basePrefix = baseDir.endsWith(sep) ? baseDir : `${baseDir}${sep}`
+
+  if (normalizedOutputDir !== baseDir && !normalizedOutputDir.startsWith(basePrefix)) {
+    throw new Error(`Path ${JSON.stringify(outputDir)} escapes the allowed directory ${baseDir}. Only paths inside graphify-out/ are permitted.`)
+  }
+
+  return normalizedOutputDir
+}
+
+function answerFilePath(outputDir: string, mode: ReviewCompareMode): string {
+  return join(outputDir, `${mode}-answer.txt`)
+}
+
+function createOutputRoot(outputDir: string, date: Date): string {
+  mkdirSync(outputDir, { recursive: true })
+  const candidate = join(outputDir, timestampDirectoryName(date))
+  mkdirSync(candidate, { recursive: true })
+  return candidate
+}
+
+function shellEscape(value: string, platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    return `'${value.replaceAll("'", "''")}'`
+  }
+  return `'${value.replaceAll("'", `'\"'\"'`)}'`
+}
+
+function expandExecTemplate(
+  template: string,
+  values: Pick<ReviewCompareExecution, 'promptFile' | 'mode' | 'outputFile'>,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return template.replaceAll(EXEC_TEMPLATE_PLACEHOLDER_PATTERN, (placeholder) => {
+    const normalizedPlaceholder = placeholder.toLowerCase()
+    if (!REVIEW_COMPARE_EXEC_PLACEHOLDERS.has(normalizedPlaceholder)) {
+      throw new Error(`Unknown review-compare exec placeholder: ${placeholder}`)
+    }
+    if (normalizedPlaceholder === '{prompt_file}') {
+      return shellEscape(values.promptFile, platform)
+    }
+    if (normalizedPlaceholder === '{mode}') {
+      return shellEscape(values.mode, platform)
+    }
+    return shellEscape(values.outputFile, platform)
+  })
+}
+
+async function defaultRunner(execution: ReviewCompareExecution): Promise<ReviewCompareRunnerResult> {
+  const startedAt = Date.now()
+  return await new Promise<ReviewCompareRunnerResult>((resolveExecution, rejectExecution) => {
+    const command =
+      process.platform === 'win32'
+        ? { file: 'powershell.exe', args: ['-NoProfile', '-Command', execution.command] }
+        : { file: '/bin/sh', args: ['-lc', execution.command] }
+    const child = spawn(command.file, command.args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (chunk: string | Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk: string | Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on('error', rejectExecution)
+    child.on('close', (code) => {
+      resolveExecution({
+        exitCode: code ?? 1,
+        stdout,
+        stderr,
+        elapsedMs: Date.now() - startedAt,
+      })
+    })
+  })
+}
+
+function summarizeStderr(stderr: string): string | null {
+  const trimmed = stderr.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function computeReductionRatio(left: number, right: number): number {
+  if (left <= 0 || right <= 0) {
+    return 0
+  }
+  return Number((left / right).toFixed(3))
+}
+
+function formatTokenComparison(left: number, right: number): string {
+  if (left <= 0 || right <= 0) {
+    return 'n/a'
+  }
+  if (left === right) {
+    return 'same size'
+  }
+  if (left > right) {
+    return `${computeReductionRatio(left, right)}x smaller`
+  }
+  return `${Number((right / left).toFixed(3))}x larger`
+}
+
+function renderReviewPrompt(payload: unknown, mode: ReviewCompareMode): string {
+  return [
+    'Review the current git diff using only the provided pr_impact payload.',
+    'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
+    `Mode: ${mode}`,
+    '',
+    'pr_impact payload:',
+    JSON.stringify(payload, null, 2),
+    '',
+    'Answer:',
+  ].join('\n')
+}
+
+function writeReport(report: ReviewCompareReport): void {
+  writeFileSync(
+    report.paths.report,
+    `${JSON.stringify(
+      {
+        ...report,
+        graph_path: portablePath(report.graph_path),
+        answer_paths: {
+          verbose: portablePath(report.answer_paths.verbose),
+          compact: portablePath(report.answer_paths.compact),
+        },
+        paths: {
+          output_dir: portablePath(report.paths.output_dir),
+          verbose_prompt: portablePath(report.paths.verbose_prompt),
+          compact_prompt: portablePath(report.paths.compact_prompt),
+          report: portablePath(report.paths.report),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+export function generateReviewCompareArtifacts(input: ReviewCompareInput): ReviewCompareResult {
+  const graphPath = validateGraphPath(input.graphPath)
+  const outputDir = validateOutputDirForGraph(graphPath, input.outputDir)
+  const graph = loadGraph(graphPath)
+  const projectRoot = realpathSync(inferProjectRootFromGraphPath(graphPath))
+  const now = input.now ?? new Date()
+  const outputRoot = createOutputRoot(outputDir, now)
+  const verbosePayload = analyzePrImpact(graph, projectRoot, {
+    ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+    ...(input.budget !== undefined ? { budget: input.budget } : {}),
+  })
+  const compactPayload = compactPrImpactResult(verbosePayload)
+  const verbosePrompt = renderReviewPrompt(verbosePayload, 'verbose')
+  const compactPrompt = renderReviewPrompt(compactPayload, 'compact')
+
+  const paths: ReviewComparePromptArtifactPaths = {
+    output_dir: outputRoot,
+    verbose_prompt: join(outputRoot, 'verbose-prompt.txt'),
+    compact_prompt: join(outputRoot, 'compact-prompt.txt'),
+    report: join(outputRoot, 'report.json'),
+  }
+  const answerPaths: ReviewCompareAnswerArtifactPaths = {
+    verbose: answerFilePath(outputRoot, 'verbose'),
+    compact: answerFilePath(outputRoot, 'compact'),
+  }
+
+  writeFileSync(paths.verbose_prompt, verbosePrompt, 'utf8')
+  writeFileSync(paths.compact_prompt, compactPrompt, 'utf8')
+
+  const verbosePayloadTokens = estimateQueryTokens(JSON.stringify(verbosePayload))
+  const compactPayloadTokens = estimateQueryTokens(JSON.stringify(compactPayload))
+  const verbosePromptTokens = estimateQueryTokens(verbosePrompt)
+  const compactPromptTokens = estimateQueryTokens(compactPrompt)
+
+  const report: ReviewCompareReport = {
+    graph_path: graphPath,
+    base_branch: verbosePayload.base_branch,
+    budget: verbosePayload.review_bundle.budget,
+    changed_files: verbosePayload.changed_files,
+    seed_count: verbosePayload.seed_nodes.length,
+    supporting_path_count: verbosePayload.review_context.supporting_paths.length,
+    test_path_count: verbosePayload.review_context.test_paths.length,
+    hotspot_count: verbosePayload.review_context.hotspots.length,
+    verbose_payload_tokens: verbosePayloadTokens,
+    compact_payload_tokens: compactPayloadTokens,
+    payload_reduction_ratio: computeReductionRatio(verbosePayloadTokens, compactPayloadTokens),
+    verbose_prompt_tokens: verbosePromptTokens,
+    compact_prompt_tokens: compactPromptTokens,
+    reduction_ratio: computeReductionRatio(verbosePromptTokens, compactPromptTokens),
+    started_at: now.toISOString(),
+    completed_at: now.toISOString(),
+    elapsed_ms: {
+      verbose: 0,
+      compact: 0,
+    },
+    status: {
+      verbose: 'not_run',
+      compact: 'not_run',
+    },
+    answer_paths: answerPaths,
+    exit_code: {
+      verbose: null,
+      compact: null,
+    },
+    stderr: {
+      verbose: null,
+      compact: null,
+    },
+    paths,
+  }
+
+  writeReport(report)
+
+  return {
+    graph_path: graphPath,
+    output_root: resolve(outputRoot),
+    report,
+  }
+}
+
+export async function executeReviewCompareRuns(
+  input: ReviewCompareInput,
+  dependencies: ExecuteReviewCompareRunsDependencies = {},
+): Promise<ReviewCompareResult> {
+  const result = generateReviewCompareArtifacts(input)
+  const runPrompt = dependencies.runner ?? defaultRunner
+  const now = dependencies.now ?? (() => new Date())
+
+  const executions: Array<{ mode: ReviewCompareMode; promptFile: string; outputFile: string }> = [
+    {
+      mode: 'verbose',
+      promptFile: result.report.paths.verbose_prompt,
+      outputFile: result.report.answer_paths.verbose,
+    },
+    {
+      mode: 'compact',
+      promptFile: result.report.paths.compact_prompt,
+      outputFile: result.report.answer_paths.compact,
+    },
+  ]
+
+  for (const execution of executions) {
+    try {
+      const command = expandExecTemplate(input.execTemplate, execution)
+      const executionResult = await runPrompt({
+        ...execution,
+        command,
+      })
+      writeFileSync(execution.outputFile, executionResult.stdout, 'utf8')
+      result.report.status[execution.mode] = executionResult.exitCode === 0 ? 'succeeded' : 'failed'
+      result.report.elapsed_ms[execution.mode] = executionResult.elapsedMs
+      result.report.exit_code[execution.mode] = executionResult.exitCode
+      result.report.stderr[execution.mode] = summarizeStderr(executionResult.stderr)
+    } catch (error) {
+      writeFileSync(execution.outputFile, '', 'utf8')
+      result.report.status[execution.mode] = 'failed'
+      result.report.elapsed_ms[execution.mode] = 0
+      result.report.exit_code[execution.mode] = null
+      result.report.stderr[execution.mode] = summarizeStderr(error instanceof Error ? error.message : String(error))
+    }
+    result.report.completed_at = now().toISOString()
+    writeReport(result.report)
+  }
+
+  return result
+}
+
+export function formatReviewCompareSummary(result: ReviewCompareResult): string {
+  return [
+    '[graphify review-compare] completed current diff comparison',
+    `- Output: ${result.output_root}`,
+    `- Prompt tokens: verbose ${result.report.verbose_prompt_tokens} · compact ${result.report.compact_prompt_tokens} · ${formatTokenComparison(result.report.verbose_prompt_tokens, result.report.compact_prompt_tokens)}`,
+    `- Payload tokens: verbose ${result.report.verbose_payload_tokens} · compact ${result.report.compact_payload_tokens} · ${formatTokenComparison(result.report.verbose_payload_tokens, result.report.compact_payload_tokens)}`,
+    `- Prompt runs: verbose ${result.report.status.verbose} (${result.report.elapsed_ms.verbose} ms) · compact ${result.report.status.compact} (${result.report.elapsed_ms.compact} ms)`,
+  ].join('\n')
+}
+
+export async function runReviewCompareCommand(
+  input: ReviewCompareInput,
+  dependencies: ExecuteReviewCompareRunsDependencies = {},
+): Promise<string> {
+  const result = await executeReviewCompareRuns(input, dependencies)
+  const failedRuns = [result.report.status.verbose, result.report.status.compact].filter((status) => status === 'failed').length
+  if (failedRuns > 0) {
+    throw new Error(`[graphify review-compare] ${failedRuns} prompt run(s) failed. Partial artifacts were saved under ${result.output_root}`)
+  }
+  return formatReviewCompareSummary(result)
+}

--- a/src/runtime/pr-impact.ts
+++ b/src/runtime/pr-impact.ts
@@ -1,17 +1,24 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
-import { isAbsolute, resolve } from 'node:path'
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import { KnowledgeGraph } from '../contracts/graph.js'
 import { godNodes, workspaceBridges } from '../pipeline/analyze.js'
 import { communitiesFromGraph } from './serve.js'
 import { buildCommunityLabels } from '../pipeline/community-naming.js'
 import { analyzeImpact, type ImpactResult } from './impact.js'
-import type { RetrieveCommunityContext, RetrieveMatchedNode, RetrieveRelationship } from './retrieve.js'
+import { estimateQueryTokens } from './serve.js'
+import type {
+  CompactRetrieveMatchedNode,
+  RetrieveCommunityContext,
+  RetrieveMatchedNode,
+  RetrieveRelationship,
+} from './retrieve.js'
 import { collectRelationships, estimateRetrieveEntryTokens, readSnippet } from './retrieve.js'
 import { lineNumberFromSourceLocation, lineRangeFromSourceLocation, type SourceLineRange } from '../shared/source-location.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
-import { buildRankedRisk, compareRankedRisks, type RiskSeverity } from './risk-map.js'
+import { buildRankedRisk, compareRankedRisks, type RiskMapHotspot, type RiskSeverity } from './risk-map.js'
+import { findGitRoot } from '../shared/git.js'
 
 const MAX_DIFF_BYTES = 5_000_000
 const MAX_CHANGED_FILES = 200
@@ -20,7 +27,14 @@ const MAX_REVIEW_SEEDS = 12
 const MAX_SECOND_HOP_CANDIDATES = 4
 const MAX_COMPACT_PER_NODE_IMPACT = 5
 const MAX_COMPACT_REVIEW_SUPPORT_NODES = 3
+const MAX_COMPACT_CHANGED_FILES = 20
+const MAX_COMPACT_SEED_NODES = 12
+const MAX_COMPACT_AFFECTED_COMMUNITIES = 12
+const MAX_COMPACT_HIGH_IMPACT_NODES = 12
 const MAX_TOP_REVIEW_RISKS = 3
+const MAX_REVIEW_SUPPORTING_PATHS = 3
+const MAX_REVIEW_TEST_PATHS = 4
+const MAX_REVIEW_HOTSPOTS = 3
 
 export interface PrImpactOptions {
   baseBranch?: string
@@ -71,6 +85,11 @@ export interface PrImpactResult {
   total_blast_radius: number
   affected_files: string[]
   affected_communities: Array<{ id: number; label: string; node_count: number }>
+  review_context: {
+    supporting_paths: string[]
+    test_paths: string[]
+    hotspots: RiskMapHotspot[]
+  }
   review_bundle: PrReviewBundle
   risk_summary: {
     high_impact_nodes: string[]
@@ -89,6 +108,20 @@ export interface CompactPrImpactNodeImpact {
   affected_communities: number
 }
 
+export interface CompactPrReviewNode extends Omit<CompactRetrieveMatchedNode, 'node_id' | 'match_score'> {
+  node_id?: string
+  match_score?: number
+}
+
+export interface CompactPrReviewRelationship extends Omit<RetrieveRelationship, 'from_id' | 'to_id'> {}
+
+export interface CompactPrReviewBundle extends Omit<PrReviewBundle, 'token_count' | 'nodes' | 'relationships'> {
+  token_count: number
+  nodes: CompactPrReviewNode[]
+  relationships: CompactPrReviewRelationship[]
+  shared_file_type?: string
+}
+
 export interface CompactPrImpactResult extends Pick<
   PrImpactResult,
   | 'base_branch'
@@ -97,19 +130,26 @@ export interface CompactPrImpactResult extends Pick<
   | 'seed_nodes'
   | 'total_blast_radius'
   | 'affected_communities'
-  | 'review_bundle'
+  | 'review_context'
   | 'risk_summary'
 > {
   per_node_impact: CompactPrImpactNodeImpact[]
+  review_bundle: CompactPrReviewBundle
+}
+
+function stripReviewRelationshipIdentity(relationship: RetrieveRelationship): CompactPrReviewRelationship {
+  const { from_id: _fromId, to_id: _toId, ...rest } = relationship
+  return rest
 }
 
 function compactReviewBundle(
   reviewBundle: PrReviewBundle,
   seedNodes: readonly PrImpactSeedNode[],
-): PrReviewBundle {
+): CompactPrReviewBundle {
   const seedIds = new Set(seedNodes.map((node) => node.node_id))
   const seedLabels = new Set(seedNodes.map((node) => node.label))
-  const compactNodes: RetrieveMatchedNode[] = []
+  const compactNodes: CompactPrReviewNode[] = []
+  const includedRelationshipIds = new Set<string>()
   let supportNodes = 0
 
   for (const node of reviewBundle.nodes) {
@@ -118,30 +158,56 @@ function compactReviewBundle(
       continue
     }
 
-    compactNodes.push(isSeed ? node : { ...node, snippet: null })
+    const {
+      community_label: _communityLabel,
+      framework_boost: _frameworkBoost,
+      file_type: fileType,
+      node_id: nodeId,
+      match_score: matchScore,
+      ...rest
+    } = node
+
+    if (typeof nodeId === 'string' && nodeId.length > 0) {
+      includedRelationshipIds.add(nodeId)
+    }
+
+    compactNodes.push({
+      ...rest,
+      ...(isSeed && typeof nodeId === 'string' && nodeId.length > 0 ? { node_id: nodeId } : {}),
+      ...(isSeed ? { match_score: matchScore } : {}),
+      ...(isSeed ? { snippet: node.snippet } : { snippet: null }),
+      ...(fileType !== undefined ? { file_type: fileType } : {}),
+    })
     if (!isSeed) {
       supportNodes += 1
     }
   }
 
-  const includedIds = new Set(compactNodes.map((node) => node.node_id).filter((nodeId): nodeId is string => typeof nodeId === 'string'))
   const includedLabels = new Set(compactNodes.map((node) => node.label))
   const includedCommunities = new Set(compactNodes.flatMap((node) => (node.community === null ? [] : [node.community])))
+  const sharedFileType =
+    compactNodes.length > 0 && compactNodes.every((node) => node.file_type === compactNodes[0]?.file_type)
+      ? compactNodes[0]?.file_type
+      : undefined
+  const compactNodesWithoutSharedFileType = sharedFileType !== undefined
+    ? compactNodes.map(({ file_type: _fileType, ...node }) => node)
+    : compactNodes
+  const compactNodePayload = sharedFileType !== undefined
+    ? { shared_file_type: sharedFileType, nodes: compactNodesWithoutSharedFileType }
+    : compactNodesWithoutSharedFileType
 
   return {
     budget: reviewBundle.budget,
-    token_count: compactNodes.reduce(
-      (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet),
-      0,
-    ),
-    nodes: compactNodes,
+    token_count: compactNodesWithoutSharedFileType.length === 0 ? 0 : estimateQueryTokens(JSON.stringify(compactNodePayload)),
+    nodes: compactNodesWithoutSharedFileType,
     relationships: reviewBundle.relationships.filter((relationship) => {
-      if (includedIds.size > 0 && relationship.from_id && relationship.to_id) {
-        return includedIds.has(relationship.from_id) && includedIds.has(relationship.to_id)
+      if (includedRelationshipIds.size > 0 && relationship.from_id && relationship.to_id) {
+        return includedRelationshipIds.has(relationship.from_id) && includedRelationshipIds.has(relationship.to_id)
       }
       return includedLabels.has(relationship.from) && includedLabels.has(relationship.to)
-    }),
+    }).map(stripReviewRelationshipIdentity),
     community_context: reviewBundle.community_context.filter((community) => includedCommunities.has(community.id)),
+    ...(sharedFileType !== undefined ? { shared_file_type: sharedFileType } : {}),
   }
 }
 
@@ -175,6 +241,7 @@ function gitDiffPatch(projectDir: string, gitArgs: string[]): string {
       cwd: projectDir,
       maxBuffer: MAX_DIFF_BYTES,
       encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 10_000,
     })
   } catch {
@@ -266,28 +333,100 @@ function mergeChangedFileRanges(changedSets: ParsedChangedFileRanges[]): ParsedC
     }))
 }
 
-function gitDiffFiles(projectDir: string, baseBranch: string): ParsedChangedFileRanges[] {
+function isPathWithin(rootPath: string, targetPath: string): boolean {
+  const relativePath = relative(rootPath, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+function mapRepoPathToProjectPath(projectDir: string, repoDir: string, repoRelativePath: string): string | null {
+  const absolutePath = normalizeProjectPath(projectDir, resolve(repoDir, repoRelativePath))
+  const relativePath = relative(projectDir, absolutePath)
+  if (relativePath === '' || relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    return null
+  }
+  return relativePath.replaceAll('\\', '/')
+}
+
+function gitDiffFilesForRepo(projectDir: string, repoDir: string, baseBranch: string): ParsedChangedFileRanges[] {
   const changedFiles = mergeChangedFileRanges([
-    ...parseUnifiedDiff(gitDiffPatch(projectDir, ['HEAD'])),
-    ...parseUnifiedDiff(gitDiffPatch(projectDir, ['--cached'])),
-    ...parseUnifiedDiff(gitDiffPatch(projectDir, [`${baseBranch}...HEAD`])),
+    ...parseUnifiedDiff(gitDiffPatch(repoDir, ['HEAD'])),
+    ...parseUnifiedDiff(gitDiffPatch(repoDir, ['--cached'])),
+    ...parseUnifiedDiff(gitDiffPatch(repoDir, [`${baseBranch}...HEAD`])),
   ])
+
+  return changedFiles
+    .map((changedFile) => {
+      const projectRelativePath = mapRepoPathToProjectPath(projectDir, repoDir, changedFile.path)
+      return projectRelativePath === null ? null : {
+        path: projectRelativePath,
+        lineRanges: changedFile.lineRanges,
+      }
+    })
+    .filter((changedFile): changedFile is ParsedChangedFileRanges => changedFile !== null)
+}
+
+function gitRepoRoots(graph: KnowledgeGraph, projectDir: string): string[] {
+  const repoRoots = new Set<string>()
+  const projectGitRoot = findGitRoot(projectDir)
+  if (projectGitRoot !== null) {
+    repoRoots.add(normalizeProjectPath('.', projectGitRoot))
+  }
+
+  const checkedSourceDirs = new Set<string>()
+  for (const [, attributes] of graph.nodeEntries()) {
+    const sourceFile = String(attributes.source_file ?? '')
+    if (sourceFile.trim().length === 0) {
+      continue
+    }
+
+    const normalizedSourceFile = normalizeProjectPath(projectDir, sourceFile)
+    if (!isPathWithin(projectDir, normalizedSourceFile)) {
+      continue
+    }
+
+    const sourceDir = dirname(normalizedSourceFile)
+    if (checkedSourceDirs.has(sourceDir)) {
+      continue
+    }
+    checkedSourceDirs.add(sourceDir)
+
+    const repoRoot = findGitRoot(sourceDir)
+    if (repoRoot === null) {
+      continue
+    }
+
+    const normalizedRepoRoot = normalizeProjectPath('.', repoRoot)
+    if (isPathWithin(projectDir, normalizedRepoRoot) || isPathWithin(normalizedRepoRoot, projectDir)) {
+      repoRoots.add(normalizedRepoRoot)
+    }
+  }
+
+  return [...repoRoots].sort((left, right) => left.localeCompare(right))
+}
+
+function gitDiffFiles(graph: KnowledgeGraph, projectDir: string, baseBranch: string): ParsedChangedFileRanges[] {
+  const changedFiles = mergeChangedFileRanges(
+    gitRepoRoots(graph, projectDir).flatMap((repoDir) => gitDiffFilesForRepo(projectDir, repoDir, baseBranch)),
+  )
 
   return changedFiles.slice(0, MAX_CHANGED_FILES)
 }
 
-function gitDetectBaseBranch(projectDir: string): string {
-  try {
-    execFileSync('git', ['rev-parse', '--verify', 'main'], {
-      cwd: projectDir,
-      encoding: 'utf8',
-      timeout: 5_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
-    return 'main'
-  } catch {
-    return 'master'
+function gitDetectBaseBranch(graph: KnowledgeGraph, projectDir: string): string {
+  for (const repoDir of gitRepoRoots(graph, projectDir)) {
+    try {
+      execFileSync('git', ['rev-parse', '--verify', 'main'], {
+        cwd: repoDir,
+        encoding: 'utf8',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      return 'main'
+    } catch {
+      continue
+    }
   }
+  return 'master'
 }
 
 function parseCommunityId(raw: unknown): number | null {
@@ -461,6 +600,157 @@ function relationWeight(relation: string): number {
   return 0.75
 }
 
+function portablePath(path: string): string {
+  return path.replaceAll('\\', '/')
+}
+
+function pushUniquePath(paths: string[], seen: Set<string>, path: string): void {
+  const normalizedPath = portablePath(path).trim()
+  if (normalizedPath.length === 0 || seen.has(normalizedPath)) {
+    return
+  }
+
+  seen.add(normalizedPath)
+  paths.push(normalizedPath)
+}
+
+function collectSupportingPaths(
+  reviewBundle: PrReviewBundle,
+  changedFiles: readonly string[],
+): string[] {
+  const changedFileSet = new Set(changedFiles.map((path) => portablePath(path)))
+  const supportingPaths: string[] = []
+  const seenPaths = new Set<string>()
+
+  for (const node of reviewBundle.nodes) {
+    const sourcePath = portablePath(node.source_file)
+    if (changedFileSet.has(sourcePath)) {
+      continue
+    }
+
+    pushUniquePath(supportingPaths, seenPaths, sourcePath)
+    if (supportingPaths.length >= MAX_REVIEW_SUPPORTING_PATHS) {
+      break
+    }
+  }
+
+  return supportingPaths
+}
+
+function testCandidatesForSourcePath(sourcePath: string): string[] {
+  const normalizedPath = portablePath(sourcePath)
+  const sourceDir = portablePath(dirname(normalizedPath))
+  const sourceExt = extname(normalizedPath)
+  const sourceBase = basename(normalizedPath, sourceExt)
+  const candidates = [
+    join(sourceDir, `${sourceBase}.test${sourceExt}`),
+    join(sourceDir, `${sourceBase}.spec${sourceExt}`),
+    join(sourceDir, '__tests__', `${sourceBase}.test${sourceExt}`),
+    join(sourceDir, '__tests__', `${sourceBase}.spec${sourceExt}`),
+    join('tests', `${sourceBase}.test${sourceExt}`),
+    join('tests', `${sourceBase}.spec${sourceExt}`),
+    join('test', `${sourceBase}.test${sourceExt}`),
+    join('test', `${sourceBase}.spec${sourceExt}`),
+    join(sourceDir, `test_${sourceBase}.py`),
+    join(sourceDir, `${sourceBase}_test.py`),
+    join('tests', `test_${sourceBase}.py`),
+    join('tests', `${sourceBase}_test.py`),
+  ]
+
+  return candidates.map((candidate) => portablePath(candidate))
+}
+
+function collectLikelyTestPaths(
+  projectDir: string,
+  changedFiles: readonly string[],
+  supportingPaths: readonly string[],
+): string[] {
+  const likelyTests: string[] = []
+  const seenPaths = new Set<string>()
+
+  for (const sourcePath of [...changedFiles, ...supportingPaths]) {
+    for (const candidate of testCandidatesForSourcePath(sourcePath)) {
+      if (!existsSync(resolve(projectDir, candidate))) {
+        continue
+      }
+
+      pushUniquePath(likelyTests, seenPaths, candidate)
+      if (likelyTests.length >= MAX_REVIEW_TEST_PATHS) {
+        return likelyTests
+      }
+    }
+  }
+
+  return likelyTests
+}
+
+function collectReviewHotspots(
+  graph: KnowledgeGraph,
+  communities: ReturnType<typeof communitiesFromGraph>,
+  communityLabels: Record<number, string>,
+  seedNodes: readonly PrImpactSeedNode[],
+  reviewBundle: PrReviewBundle,
+): RiskMapHotspot[] {
+  const bridgeSet = new Set(workspaceBridges(graph, communities, communityLabels, 20).map((bridge) => bridge.label))
+  const godSet = new Set(godNodes(graph, 20).map((node) => node.label))
+  const candidateLabels = [...new Set([
+    ...seedNodes.map((node) => node.label),
+    ...reviewBundle.nodes.map((node) => node.label),
+  ])]
+  const hotspots: RiskMapHotspot[] = []
+
+  for (const label of candidateLabels) {
+    const isBridge = bridgeSet.has(label)
+    const isGodNode = godSet.has(label)
+    if (!isBridge && !isGodNode) {
+      continue
+    }
+
+    if (isBridge && isGodNode) {
+      hotspots.push({
+        label,
+        type: 'bridge',
+        why: `${label} connects multiple communities in the changed review area and has unusually high graph degree for this workspace.`,
+      })
+    } else if (isBridge) {
+      hotspots.push({
+        label,
+        type: 'bridge',
+        why: `${label} connects multiple communities in the changed review area.`,
+      })
+    } else {
+      hotspots.push({
+        label,
+        type: 'god_node',
+        why: `${label} has unusually high graph degree for this workspace.`,
+      })
+    }
+    if (hotspots.length >= MAX_REVIEW_HOTSPOTS) {
+      return hotspots.slice(0, MAX_REVIEW_HOTSPOTS)
+    }
+  }
+
+  return hotspots
+}
+
+function buildReviewContext(
+  graph: KnowledgeGraph,
+  projectDir: string,
+  changedFiles: readonly string[],
+  seedNodes: readonly PrImpactSeedNode[],
+  reviewBundle: PrReviewBundle,
+  communities: ReturnType<typeof communitiesFromGraph>,
+  communityLabels: Record<number, string>,
+): PrImpactResult['review_context'] {
+  const supportingPaths = collectSupportingPaths(reviewBundle, changedFiles)
+
+  return {
+    supporting_paths: supportingPaths,
+    test_paths: collectLikelyTestPaths(projectDir, changedFiles, supportingPaths),
+    hotspots: collectReviewHotspots(graph, communities, communityLabels, seedNodes, reviewBundle),
+  }
+}
+
 function buildReviewBundle(
   graph: KnowledgeGraph,
   seedNodes: readonly PrImpactSeedNode[],
@@ -616,8 +906,8 @@ export function analyzePrImpact(
   options: PrImpactOptions = {},
 ): PrImpactResult {
   const resolvedDir = normalizeProjectPath('.', projectDir)
-  const baseBranch = options.baseBranch ?? gitDetectBaseBranch(resolvedDir)
-  const changedFiles = gitDiffFiles(resolvedDir, baseBranch)
+  const baseBranch = options.baseBranch ?? gitDetectBaseBranch(graph, resolvedDir)
+  const changedFiles = gitDiffFiles(graph, resolvedDir, baseBranch)
 
   if (changedFiles.length === 0) {
     return {
@@ -630,6 +920,11 @@ export function analyzePrImpact(
       total_blast_radius: 0,
       affected_files: [],
       affected_communities: [],
+      review_context: {
+        supporting_paths: [],
+        test_paths: [],
+        hotspots: [],
+      },
       review_bundle: {
         budget: options.budget ?? DEFAULT_REVIEW_BUDGET,
         token_count: 0,
@@ -650,6 +945,15 @@ export function analyzePrImpact(
   const seedNodes = selectSeedNodes(changedNodes, changedFiles, resolvedDir)
   const reviewBudget = options.budget ?? DEFAULT_REVIEW_BUDGET
   const reviewBundle = buildReviewBundle(graph, seedNodes, reviewBudget, communities, communityLabels, resolvedDir)
+  const reviewContext = buildReviewContext(
+    graph,
+    resolvedDir,
+    changedFiles.map((changedFile) => changedFile.path),
+    seedNodes,
+    reviewBundle,
+    communities,
+    communityLabels,
+  )
   const bridgeSet = new Set(workspaceBridges(graph, communities, communityLabels, 20).map((bridge) => bridge.label))
   const godSet = new Set(godNodes(graph, 20).map((node) => node.label))
 
@@ -732,6 +1036,7 @@ export function analyzePrImpact(
     affected_communities: [...allAffectedCommunities.entries()]
       .map(([id, label]) => ({ id, label, node_count: communities[id]?.length ?? 0 }))
       .sort((a, b) => b.node_count - a.node_count),
+    review_context: reviewContext,
     review_bundle: reviewBundle,
     risk_summary: {
       high_impact_nodes: highImpactNodes,
@@ -746,11 +1051,26 @@ export function analyzePrImpact(
 }
 
 export function compactPrImpactResult(result: PrImpactResult): CompactPrImpactResult {
+  const compactSeedNodes = result.seed_nodes.slice(0, MAX_COMPACT_SEED_NODES)
+  const compactChangedFiles: string[] = []
+  const seenChangedFiles = new Set<string>()
+  for (const sourceFile of [...compactSeedNodes.map((node) => node.source_file), ...result.changed_files]) {
+    if (sourceFile.trim().length === 0 || seenChangedFiles.has(sourceFile)) {
+      continue
+    }
+    seenChangedFiles.add(sourceFile)
+    compactChangedFiles.push(sourceFile)
+    if (compactChangedFiles.length >= MAX_COMPACT_CHANGED_FILES) {
+      break
+    }
+  }
+  const compactChangedFileSet = new Set(compactChangedFiles)
+
   return {
     base_branch: result.base_branch,
-    changed_files: result.changed_files,
-    changed_ranges: result.changed_ranges,
-    seed_nodes: result.seed_nodes,
+    changed_files: compactChangedFiles,
+    changed_ranges: result.changed_ranges.filter((entry) => compactChangedFileSet.has(entry.source_file)),
+    seed_nodes: compactSeedNodes,
     per_node_impact: result.per_node_impact
       .slice(0, MAX_COMPACT_PER_NODE_IMPACT)
       .map((impact) => ({
@@ -759,8 +1079,12 @@ export function compactPrImpactResult(result: PrImpactResult): CompactPrImpactRe
         affected_communities: impact.affected_communities,
       })),
     total_blast_radius: result.total_blast_radius,
-    affected_communities: result.affected_communities,
+    affected_communities: result.affected_communities.slice(0, MAX_COMPACT_AFFECTED_COMMUNITIES),
+    review_context: result.review_context,
     review_bundle: compactReviewBundle(result.review_bundle, result.seed_nodes),
-    risk_summary: result.risk_summary,
+    risk_summary: {
+      ...result.risk_summary,
+      high_impact_nodes: result.risk_summary.high_impact_nodes.slice(0, MAX_COMPACT_HIGH_IMPACT_NODES),
+    },
   }
 }

--- a/src/runtime/pr-impact.ts
+++ b/src/runtime/pr-impact.ts
@@ -1,31 +1,67 @@
 import { execFileSync } from 'node:child_process'
-import { resolve } from 'node:path'
+import { existsSync, realpathSync } from 'node:fs'
+import { isAbsolute, resolve } from 'node:path'
 
 import { KnowledgeGraph } from '../contracts/graph.js'
+import { godNodes, workspaceBridges } from '../pipeline/analyze.js'
 import { communitiesFromGraph } from './serve.js'
 import { buildCommunityLabels } from '../pipeline/community-naming.js'
 import { analyzeImpact, type ImpactResult } from './impact.js'
+import type { RetrieveCommunityContext, RetrieveMatchedNode, RetrieveRelationship } from './retrieve.js'
+import { collectRelationships, estimateRetrieveEntryTokens, readSnippet } from './retrieve.js'
+import { lineNumberFromSourceLocation, lineRangeFromSourceLocation, type SourceLineRange } from '../shared/source-location.js'
+import { relativizeSourceFile } from '../shared/source-path.js'
+import { buildRankedRisk, compareRankedRisks, type RiskSeverity } from './risk-map.js'
 
 const MAX_DIFF_BYTES = 5_000_000
 const MAX_CHANGED_FILES = 200
+const DEFAULT_REVIEW_BUDGET = 2_000
+const MAX_REVIEW_SEEDS = 12
+const MAX_SECOND_HOP_CANDIDATES = 4
+const MAX_COMPACT_PER_NODE_IMPACT = 5
+const MAX_COMPACT_REVIEW_SUPPORT_NODES = 3
+const MAX_TOP_REVIEW_RISKS = 3
 
 export interface PrImpactOptions {
   baseBranch?: string
   depth?: number
+  budget?: number
 }
 
 export interface ChangedNode {
+  node_id: string
   label: string
   source_file: string
   node_kind: string
   community: number | null
   community_label: string | null
+  line_number: number | null
+  source_location: string | null
+}
+
+export interface PrImpactSeedNode extends ChangedNode {
+  match_kind: 'line' | 'file'
+}
+
+export interface ChangedFileRanges {
+  source_file: string
+  line_ranges: SourceLineRange[]
+}
+
+export interface PrReviewBundle {
+  budget: number
+  token_count: number
+  nodes: RetrieveMatchedNode[]
+  relationships: RetrieveRelationship[]
+  community_context: RetrieveCommunityContext[]
 }
 
 export interface PrImpactResult {
   base_branch: string
   changed_files: string[]
+  changed_ranges: ChangedFileRanges[]
   changed_nodes: ChangedNode[]
+  seed_nodes: PrImpactSeedNode[]
   per_node_impact: Array<{
     node: string
     direct_dependents: number
@@ -35,43 +71,209 @@ export interface PrImpactResult {
   total_blast_radius: number
   affected_files: string[]
   affected_communities: Array<{ id: number; label: string; node_count: number }>
+  review_bundle: PrReviewBundle
   risk_summary: {
     high_impact_nodes: string[]
     cross_community_changes: number
+    top_risks: Array<{
+      label: string
+      severity: RiskSeverity
+      reason: string
+    }>
   }
 }
 
-function gitDiffNameOnly(projectDir: string, gitArgs: string[]): string[] {
+export interface CompactPrImpactNodeImpact {
+  node: string
+  total_dependents: number
+  affected_communities: number
+}
+
+export interface CompactPrImpactResult extends Pick<
+  PrImpactResult,
+  | 'base_branch'
+  | 'changed_files'
+  | 'changed_ranges'
+  | 'seed_nodes'
+  | 'total_blast_radius'
+  | 'affected_communities'
+  | 'review_bundle'
+  | 'risk_summary'
+> {
+  per_node_impact: CompactPrImpactNodeImpact[]
+}
+
+function compactReviewBundle(
+  reviewBundle: PrReviewBundle,
+  seedNodes: readonly PrImpactSeedNode[],
+): PrReviewBundle {
+  const seedIds = new Set(seedNodes.map((node) => node.node_id))
+  const seedLabels = new Set(seedNodes.map((node) => node.label))
+  const compactNodes: RetrieveMatchedNode[] = []
+  let supportNodes = 0
+
+  for (const node of reviewBundle.nodes) {
+    const isSeed = (typeof node.node_id === 'string' && seedIds.has(node.node_id)) || seedLabels.has(node.label)
+    if (!isSeed && supportNodes >= MAX_COMPACT_REVIEW_SUPPORT_NODES) {
+      continue
+    }
+
+    compactNodes.push(isSeed ? node : { ...node, snippet: null })
+    if (!isSeed) {
+      supportNodes += 1
+    }
+  }
+
+  const includedIds = new Set(compactNodes.map((node) => node.node_id).filter((nodeId): nodeId is string => typeof nodeId === 'string'))
+  const includedLabels = new Set(compactNodes.map((node) => node.label))
+  const includedCommunities = new Set(compactNodes.flatMap((node) => (node.community === null ? [] : [node.community])))
+
+  return {
+    budget: reviewBundle.budget,
+    token_count: compactNodes.reduce(
+      (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet),
+      0,
+    ),
+    nodes: compactNodes,
+    relationships: reviewBundle.relationships.filter((relationship) => {
+      if (includedIds.size > 0 && relationship.from_id && relationship.to_id) {
+        return includedIds.has(relationship.from_id) && includedIds.has(relationship.to_id)
+      }
+      return includedLabels.has(relationship.from) && includedLabels.has(relationship.to)
+    }),
+    community_context: reviewBundle.community_context.filter((community) => includedCommunities.has(community.id)),
+  }
+}
+
+interface ParsedChangedFileRanges {
+  path: string
+  lineRanges: SourceLineRange[]
+}
+
+interface CandidateNode {
+  id: string
+  label: string
+  sourceFile: string
+  sourceLocation: string | null
+  nodeKind: string
+  fileType: string
+  community: number | null
+  lineNumber: number
+  lineNumberDerived: boolean
+}
+
+interface ChangedGraphNode {
+  candidate: CandidateNode
+  serialized: ChangedNode
+  normalizedSourceFile: string
+  sourceRange: SourceLineRange | null
+}
+
+function gitDiffPatch(projectDir: string, gitArgs: string[]): string {
   try {
-    const output = execFileSync('git', ['diff', '--name-only', ...gitArgs], {
+    return execFileSync('git', ['diff', '--no-ext-diff', '--unified=0', ...gitArgs], {
       cwd: projectDir,
       maxBuffer: MAX_DIFF_BYTES,
       encoding: 'utf8',
       timeout: 10_000,
     })
-
-    return output
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
   } catch {
-    return []
+    return ''
   }
 }
 
-function gitDiffFiles(projectDir: string, baseBranch: string): string[] {
-  // 1. Check for uncommitted changes (staged + unstaged) against HEAD
-  const uncommitted = [
-    ...gitDiffNameOnly(projectDir, ['HEAD']),           // unstaged + staged vs last commit
-    ...gitDiffNameOnly(projectDir, ['--cached']),       // staged only (catches newly added files)
-  ]
+function pushChangedRange(changedFiles: Map<string, SourceLineRange[]>, path: string, range: SourceLineRange): void {
+  if (!path) {
+    return
+  }
 
-  // 2. Check for committed changes between branches
-  const branchChanges = gitDiffNameOnly(projectDir, [`${baseBranch}...HEAD`])
+  const ranges = changedFiles.get(path) ?? []
+  if (!ranges.some((candidate) => candidate.start === range.start && candidate.end === range.end)) {
+    ranges.push(range)
+    changedFiles.set(path, ranges)
+  }
+}
 
-  // Deduplicate and cap
-  const allFiles = [...new Set([...uncommitted, ...branchChanges])]
-  return allFiles.slice(0, MAX_CHANGED_FILES)
+function ensureChangedFile(changedFiles: Map<string, SourceLineRange[]>, path: string): void {
+  if (path && !changedFiles.has(path)) {
+    changedFiles.set(path, [])
+  }
+}
+
+function parseUnifiedDiff(patch: string): ParsedChangedFileRanges[] {
+  const changedFiles = new Map<string, SourceLineRange[]>()
+  let currentPath = ''
+
+  for (const rawLine of patch.split('\n')) {
+    const line = rawLine.trimEnd()
+
+    if (line.startsWith('+++ ')) {
+      currentPath = line.startsWith('+++ b/') ? line.slice('+++ b/'.length) : ''
+      continue
+    }
+
+    if (!currentPath || !line.startsWith('@@ ')) {
+      continue
+    }
+
+    const match = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/)
+    if (!match?.[1]) {
+      continue
+    }
+
+    const start = Number.parseInt(match[1], 10)
+    const count = Number.parseInt(match[2] ?? '1', 10)
+    if (!Number.isFinite(start) || start < 0 || !Number.isFinite(count) || count < 0) {
+      continue
+    }
+
+    ensureChangedFile(changedFiles, currentPath)
+    if (count === 0) {
+      continue
+    }
+    if (start === 0) {
+      continue
+    }
+
+    pushChangedRange(changedFiles, currentPath, {
+      start,
+      end: start + count - 1,
+    })
+  }
+
+  return [...changedFiles.entries()]
+    .slice(0, MAX_CHANGED_FILES)
+    .map(([path, lineRanges]) => ({
+      path,
+      lineRanges: lineRanges.sort((left, right) => left.start - right.start || left.end - right.end),
+    }))
+}
+
+function mergeChangedFileRanges(changedSets: ParsedChangedFileRanges[]): ParsedChangedFileRanges[] {
+  const merged = new Map<string, SourceLineRange[]>()
+  for (const changedFile of changedSets) {
+    ensureChangedFile(merged, changedFile.path)
+    for (const range of changedFile.lineRanges) {
+      pushChangedRange(merged, changedFile.path, range)
+    }
+  }
+
+  return [...merged.entries()]
+    .slice(0, MAX_CHANGED_FILES)
+    .map(([path, lineRanges]) => ({
+      path,
+      lineRanges: lineRanges.sort((left, right) => left.start - right.start || left.end - right.end),
+    }))
+}
+
+function gitDiffFiles(projectDir: string, baseBranch: string): ParsedChangedFileRanges[] {
+  const changedFiles = mergeChangedFileRanges([
+    ...parseUnifiedDiff(gitDiffPatch(projectDir, ['HEAD'])),
+    ...parseUnifiedDiff(gitDiffPatch(projectDir, ['--cached'])),
+    ...parseUnifiedDiff(gitDiffPatch(projectDir, [`${baseBranch}...HEAD`])),
+  ])
+
+  return changedFiles.slice(0, MAX_CHANGED_FILES)
 }
 
 function gitDetectBaseBranch(projectDir: string): string {
@@ -98,32 +300,314 @@ function parseCommunityId(raw: unknown): number | null {
   return null
 }
 
-function findNodesInFiles(graph: KnowledgeGraph, changedFiles: string[], projectDir: string): ChangedNode[] {
-  const normalizedFiles = new Set(changedFiles.map((file) => resolve(projectDir, file)))
-  const changedNodes: ChangedNode[] = []
+function storedCommunityLabelsFromGraph(graph: KnowledgeGraph): Record<number, string> {
+  const rawLabels = graph.graph.community_labels
+  if (!rawLabels || typeof rawLabels !== 'object' || Array.isArray(rawLabels)) {
+    return {}
+  }
 
-  for (const [, attributes] of graph.nodeEntries()) {
-    const sourceFile = String(attributes.source_file ?? '')
+  return Object.fromEntries(
+    Object.entries(rawLabels as Record<string, unknown>)
+      .map(([key, value]) => [Number(key), typeof value === 'string' ? value.trim() : ''] as const)
+      .filter(([communityId, label]) => Number.isInteger(communityId) && communityId >= 0 && label.length > 0),
+  )
+}
+
+function normalizeProjectPath(projectDir: string, filePath: string): string {
+  if (!filePath) {
+    return ''
+  }
+
+  const resolvedPath = isAbsolute(filePath) ? resolve(filePath) : resolve(projectDir, filePath)
+  return existsSync(resolvedPath) ? realpathSync(resolvedPath) : resolvedPath
+}
+
+function sourceRangeFromAttributes(attributes: Record<string, unknown>): SourceLineRange | null {
+  if (typeof attributes.line_number === 'number' && attributes.line_number > 0) {
+    return {
+      start: attributes.line_number,
+      end: attributes.line_number,
+    }
+  }
+
+  return lineRangeFromSourceLocation(attributes.source_location)
+}
+
+function candidateNodeFromGraphEntry(nodeId: string, attributes: Record<string, unknown>): CandidateNode {
+  const sourceRange = sourceRangeFromAttributes(attributes)
+  const sourceLocation = typeof attributes.source_location === 'string' && attributes.source_location.length > 0
+    ? attributes.source_location
+    : null
+
+  return {
+    id: nodeId,
+    label: String(attributes.label ?? nodeId),
+    sourceFile: String(attributes.source_file ?? ''),
+    sourceLocation,
+    nodeKind: String(attributes.node_kind ?? ''),
+    fileType: String(attributes.file_type ?? '').trim().toLowerCase(),
+    community: parseCommunityId(attributes.community),
+    lineNumber: sourceRange?.start ?? lineNumberFromSourceLocation(attributes.source_location),
+    lineNumberDerived: sourceRange === null,
+  }
+}
+
+function serializeChangedNode(
+  candidate: CandidateNode,
+  normalizedSourceFile: string,
+  communityLabels: Record<number, string>,
+  rootPath: string,
+): ChangedNode {
+  return {
+    node_id: candidate.id,
+    label: candidate.label,
+    source_file: relativizeSourceFile(normalizedSourceFile, rootPath),
+    node_kind: candidate.nodeKind,
+    community: candidate.community,
+    community_label: candidate.community !== null ? (communityLabels[candidate.community] ?? null) : null,
+    line_number: candidate.lineNumber > 0 ? candidate.lineNumber : null,
+    source_location: candidate.sourceLocation,
+  }
+}
+
+function compareChangedNodes(left: ChangedGraphNode, right: ChangedGraphNode): number {
+  return left.serialized.source_file.localeCompare(right.serialized.source_file)
+    || (left.serialized.line_number ?? Number.MAX_SAFE_INTEGER) - (right.serialized.line_number ?? Number.MAX_SAFE_INTEGER)
+    || left.serialized.label.localeCompare(right.serialized.label)
+}
+
+function findNodesInFiles(
+  graph: KnowledgeGraph,
+  changedFiles: ParsedChangedFileRanges[],
+  projectDir: string,
+  communityLabels: Record<number, string>,
+): ChangedGraphNode[] {
+  const normalizedFiles = new Set(changedFiles.map((file) => normalizeProjectPath(projectDir, file.path)))
+  const changedNodes: ChangedGraphNode[] = []
+
+  for (const [nodeId, attributes] of graph.nodeEntries()) {
+    const candidate = candidateNodeFromGraphEntry(nodeId, attributes)
+    const sourceFile = candidate.sourceFile
     if (!sourceFile) {
       continue
     }
 
-    const normalizedSource = resolve(sourceFile)
+    const normalizedSource = normalizeProjectPath(projectDir, sourceFile)
     if (!normalizedFiles.has(normalizedSource)) {
       continue
     }
 
-    const community = parseCommunityId(attributes.community)
     changedNodes.push({
-      label: String(attributes.label ?? ''),
-      source_file: sourceFile,
-      node_kind: String(attributes.node_kind ?? ''),
-      community,
-      community_label: null,
+      candidate,
+      serialized: serializeChangedNode(candidate, normalizedSource, communityLabels, projectDir),
+      normalizedSourceFile: normalizedSource,
+      sourceRange: sourceRangeFromAttributes(attributes),
     })
   }
 
-  return changedNodes
+  return changedNodes.sort(compareChangedNodes)
+}
+
+function rangesOverlap(left: SourceLineRange, right: SourceLineRange): boolean {
+  return left.start <= right.end && right.start <= left.end
+}
+
+function selectSeedNodes(
+  changedNodes: ChangedGraphNode[],
+  changedFiles: ParsedChangedFileRanges[],
+  projectDir: string,
+): PrImpactSeedNode[] {
+  const seeds: PrImpactSeedNode[] = []
+  const seen = new Set<string>()
+  const changedFilesByNormalizedPath = new Map(
+    changedFiles.map((changedFile) => [normalizeProjectPath(projectDir, changedFile.path), changedFile] as const),
+  )
+
+  const nodesByFile = new Map<string, ChangedGraphNode[]>()
+  for (const changedNode of changedNodes) {
+    const entries = nodesByFile.get(changedNode.normalizedSourceFile) ?? []
+    entries.push(changedNode)
+    nodesByFile.set(changedNode.normalizedSourceFile, entries)
+  }
+
+  for (const [normalizedSourceFile, fileNodes] of nodesByFile) {
+    const changedFile = changedFilesByNormalizedPath.get(normalizedSourceFile)
+    const lineRanges = changedFile?.lineRanges ?? []
+    const lineMatches = fileNodes.filter((node) =>
+      node.sourceRange !== null && lineRanges.some((range) => rangesOverlap(node.sourceRange as SourceLineRange, range)),
+    )
+    const selectedNodes = lineMatches.length > 0 ? lineMatches : fileNodes.slice(0, MAX_REVIEW_SEEDS)
+    const matchKind: PrImpactSeedNode['match_kind'] = lineMatches.length > 0 ? 'line' : 'file'
+
+    for (const node of selectedNodes) {
+      if (seen.has(node.candidate.id)) {
+        continue
+      }
+      seen.add(node.candidate.id)
+      seeds.push({
+        ...node.serialized,
+        match_kind: matchKind,
+      })
+    }
+  }
+
+  return seeds
+}
+
+function relationWeight(relation: string): number {
+  if (relation === 'calls') return 1.5
+  if (relation === 'depends_on' || relation === 'imports_from') return 1.25
+  if (relation === 'uses' || relation === 'references') return 1
+  return 0.75
+}
+
+function buildReviewBundle(
+  graph: KnowledgeGraph,
+  seedNodes: readonly PrImpactSeedNode[],
+  budget: number,
+  communities: ReturnType<typeof communitiesFromGraph>,
+  communityLabels: Record<number, string>,
+  rootPath: string,
+): PrReviewBundle {
+  const candidateScores = new Map<string, number>()
+  const candidateKinds = new Map<string, 'seed' | 'first_hop' | 'second_hop'>()
+  const seedIds = new Set(seedNodes.map((node) => node.node_id))
+
+  for (const seedNode of seedNodes) {
+    candidateScores.set(seedNode.node_id, 10)
+    candidateKinds.set(seedNode.node_id, 'seed')
+  }
+
+  const firstHopIds = new Set<string>()
+  for (const seedNode of seedNodes) {
+    for (const predecessor of graph.predecessors(seedNode.node_id)) {
+      const relation = String(graph.edgeAttributes(predecessor, seedNode.node_id).relation ?? 'related_to')
+      candidateScores.set(predecessor, Math.max(candidateScores.get(predecessor) ?? 0, 6 + relationWeight(relation)))
+      if (!candidateKinds.has(predecessor)) {
+        candidateKinds.set(predecessor, 'first_hop')
+      }
+      firstHopIds.add(predecessor)
+    }
+
+    for (const successor of graph.successors(seedNode.node_id)) {
+      const relation = String(graph.edgeAttributes(seedNode.node_id, successor).relation ?? 'related_to')
+      candidateScores.set(successor, Math.max(candidateScores.get(successor) ?? 0, 5 + relationWeight(relation)))
+      if (!candidateKinds.has(successor)) {
+        candidateKinds.set(successor, 'first_hop')
+      }
+      firstHopIds.add(successor)
+    }
+  }
+
+  const secondHopExpansionRoots = [...firstHopIds]
+    .filter((nodeId) => !seedIds.has(nodeId))
+    .sort((left, right) =>
+      (candidateScores.get(right) ?? 0) - (candidateScores.get(left) ?? 0)
+      || graph.degree(right) - graph.degree(left)
+      || left.localeCompare(right),
+    )
+    .slice(0, MAX_SECOND_HOP_CANDIDATES)
+
+  const secondHopCandidates = new Map<string, { parentScore: number; paths: number }>()
+  for (const nodeId of secondHopExpansionRoots) {
+    for (const neighbor of graph.incidentNeighbors(nodeId)) {
+      if (seedIds.has(neighbor) || firstHopIds.has(neighbor)) {
+        continue
+      }
+
+      const entry = secondHopCandidates.get(neighbor) ?? { parentScore: 0, paths: 0 }
+      entry.parentScore = Math.max(entry.parentScore, candidateScores.get(nodeId) ?? 0)
+      entry.paths += 1
+      secondHopCandidates.set(neighbor, entry)
+    }
+  }
+
+  for (const [nodeId] of [...secondHopCandidates.entries()]
+    .sort((left, right) =>
+      right[1].parentScore - left[1].parentScore
+      || right[1].paths - left[1].paths
+      || graph.degree(right[0]) - graph.degree(left[0])
+      || left[0].localeCompare(right[0]),
+    )
+    .slice(0, MAX_SECOND_HOP_CANDIDATES)) {
+    candidateScores.set(nodeId, Math.max(candidateScores.get(nodeId) ?? 0, 2.5))
+    if (!candidateKinds.has(nodeId)) {
+      candidateKinds.set(nodeId, 'second_hop')
+    }
+  }
+
+  const orderedCandidateIds = [...candidateScores.keys()].sort((left, right) => {
+    const leftKind = candidateKinds.get(left)
+    const rightKind = candidateKinds.get(right)
+    const kindScore = (kind: typeof leftKind): number => kind === 'seed' ? 2 : kind === 'first_hop' ? 1 : 0
+    return kindScore(rightKind) - kindScore(leftKind)
+      || (candidateScores.get(right) ?? 0) - (candidateScores.get(left) ?? 0)
+      || graph.degree(right) - graph.degree(left)
+      || left.localeCompare(right)
+  })
+
+  const matchedNodes: RetrieveMatchedNode[] = []
+  const includedIds = new Set<string>()
+  const snippetFileCache = new Map<string, string[] | null>()
+  let tokenCount = 0
+
+  for (const candidateId of orderedCandidateIds) {
+    const attributes = graph.nodeAttributes(candidateId)
+    const candidate = candidateNodeFromGraphEntry(candidateId, attributes)
+    if (!candidate.sourceFile) {
+      continue
+    }
+
+    const normalizedSourceFile = normalizeProjectPath(rootPath, candidate.sourceFile)
+    const snippet = readSnippet(normalizedSourceFile, candidate.lineNumber, {
+      derived: candidate.lineNumberDerived,
+      fileCache: snippetFileCache,
+    })
+    const serializedSourceFile = relativizeSourceFile(normalizedSourceFile, rootPath)
+    const nodeTokens = estimateRetrieveEntryTokens(candidate.label, serializedSourceFile, candidate.lineNumber, snippet)
+    if (tokenCount + nodeTokens > budget) {
+      break
+    }
+
+    matchedNodes.push({
+      node_id: candidate.id,
+      label: candidate.label,
+      source_file: serializedSourceFile,
+      line_number: candidate.lineNumber,
+      file_type: candidate.fileType,
+      snippet,
+      match_score: candidateScores.get(candidateId) ?? 0,
+      relevance_band: seedIds.has(candidateId) ? 'direct' : candidateKinds.get(candidateId) === 'first_hop' ? 'related' : 'peripheral',
+      community: candidate.community,
+      community_label: candidate.community !== null ? (communityLabels[candidate.community] ?? null) : null,
+      ...(candidate.nodeKind.trim().length > 0 ? { node_kind: candidate.nodeKind } : {}),
+    })
+    includedIds.add(candidateId)
+    tokenCount += nodeTokens
+  }
+
+  const communityIds = new Set<number>()
+  for (const node of matchedNodes) {
+    if (node.community !== null) {
+      communityIds.add(node.community)
+    }
+  }
+
+  const communityContext: RetrieveCommunityContext[] = [...communityIds]
+    .map((communityId) => ({
+      id: communityId,
+      label: communityLabels[communityId] ?? `Community ${communityId}`,
+      node_count: (communities[communityId] ?? []).length,
+    }))
+    .sort((left, right) => right.node_count - left.node_count)
+
+  return {
+    budget,
+    token_count: tokenCount,
+    nodes: matchedNodes,
+    relationships: collectRelationships(graph, includedIds),
+    community_context: communityContext,
+  }
 }
 
 export function analyzePrImpact(
@@ -131,7 +615,7 @@ export function analyzePrImpact(
   projectDir = '.',
   options: PrImpactOptions = {},
 ): PrImpactResult {
-  const resolvedDir = resolve(projectDir)
+  const resolvedDir = normalizeProjectPath('.', projectDir)
   const baseBranch = options.baseBranch ?? gitDetectBaseBranch(resolvedDir)
   const changedFiles = gitDiffFiles(resolvedDir, baseBranch)
 
@@ -139,36 +623,55 @@ export function analyzePrImpact(
     return {
       base_branch: baseBranch,
       changed_files: [],
+      changed_ranges: [],
       changed_nodes: [],
+      seed_nodes: [],
       per_node_impact: [],
       total_blast_radius: 0,
       affected_files: [],
       affected_communities: [],
-      risk_summary: { high_impact_nodes: [], cross_community_changes: 0 },
+      review_bundle: {
+        budget: options.budget ?? DEFAULT_REVIEW_BUDGET,
+        token_count: 0,
+        nodes: [],
+        relationships: [],
+        community_context: [],
+      },
+      risk_summary: { high_impact_nodes: [], cross_community_changes: 0, top_risks: [] },
     }
   }
 
   const communities = communitiesFromGraph(graph)
-  const communityLabels = buildCommunityLabels(graph, communities)
-  const changedNodes = findNodesInFiles(graph, changedFiles, resolvedDir)
-
-  for (const node of changedNodes) {
-    if (node.community !== null) {
-      node.community_label = communityLabels[node.community] ?? null
-    }
+  const communityLabels: Record<number, string> = {
+    ...buildCommunityLabels(graph, communities),
+    ...storedCommunityLabelsFromGraph(graph),
   }
+  const changedNodes = findNodesInFiles(graph, changedFiles, resolvedDir, communityLabels)
+  const seedNodes = selectSeedNodes(changedNodes, changedFiles, resolvedDir)
+  const reviewBudget = options.budget ?? DEFAULT_REVIEW_BUDGET
+  const reviewBundle = buildReviewBundle(graph, seedNodes, reviewBudget, communities, communityLabels, resolvedDir)
+  const bridgeSet = new Set(workspaceBridges(graph, communities, communityLabels, 20).map((bridge) => bridge.label))
+  const godSet = new Set(godNodes(graph, 20).map((node) => node.label))
 
   // Deduplicate by label for impact analysis — skip file-level nodes (e.g. "main.ts")
   const isFileNode = (label: string) => /\.\w{1,5}$/.test(label)
-  const uniqueLabels = [...new Set(changedNodes.filter((n) => !isFileNode(n.label)).map((n) => n.label))]
+  const impactTargets = seedNodes.length > 0 ? seedNodes : changedNodes.map((node) => node.serialized)
+  const uniqueImpactTargets = [...impactTargets.reduce((targets, node) => {
+    if (!isFileNode(node.label) && !targets.has(node.label)) {
+      targets.set(node.label, node)
+    }
+    return targets
+  }, new Map<string, (typeof impactTargets)[number]>()).values()]
 
   const perNodeImpact: PrImpactResult['per_node_impact'] = []
   const allAffectedFiles = new Set<string>()
   const allAffectedCommunities = new Map<number, string>()
   const allAffectedNodeIds = new Set<string>()
   const highImpactNodes: string[] = []
+  const rankedRisks = []
 
-  for (const label of uniqueLabels) {
+  for (const target of uniqueImpactTargets) {
+    const label = target.label
     const impact: ImpactResult = analyzeImpact(graph, communityLabels, {
       label,
       depth: options.depth ?? 3,
@@ -196,23 +699,68 @@ export function analyzePrImpact(
     if (impact.total_affected > 10) {
       highImpactNodes.push(label)
     }
+
+    const hotspotKinds = [
+      ...(bridgeSet.has(label) ? ['bridge'] : []),
+      ...(godSet.has(label) ? ['god node'] : []),
+    ]
+    const dependentCount = graph.hasNode(target.node_id) ? graph.predecessors(target.node_id).length : 0
+    rankedRisks.push(buildRankedRisk({
+      label,
+      totalAffected: impact.total_affected,
+      affectedFiles: impact.affected_files.map((file) => relativizeSourceFile(file, resolvedDir)),
+      affectedCommunities: impact.affected_communities.map((community) => community.label),
+      hotspotKinds,
+      dependentCount,
+    }))
   }
 
-  const changedCommunityIds = new Set(changedNodes.map((n) => n.community).filter((id): id is number => id !== null))
+  const changedCommunityIds = new Set(impactTargets.map((node) => node.community).filter((id): id is number => id !== null))
 
   return {
     base_branch: baseBranch,
-    changed_files: changedFiles,
-    changed_nodes: changedNodes,
+    changed_files: changedFiles.map((changedFile) => changedFile.path),
+    changed_ranges: changedFiles.map((changedFile) => ({
+      source_file: changedFile.path,
+      line_ranges: changedFile.lineRanges,
+    })),
+    changed_nodes: changedNodes.map((node) => node.serialized),
+    seed_nodes: seedNodes,
     per_node_impact: perNodeImpact.sort((a, b) => (b.direct_dependents + b.transitive_dependents) - (a.direct_dependents + a.transitive_dependents)),
     total_blast_radius: allAffectedNodeIds.size,
     affected_files: [...allAffectedFiles].sort(),
     affected_communities: [...allAffectedCommunities.entries()]
       .map(([id, label]) => ({ id, label, node_count: communities[id]?.length ?? 0 }))
       .sort((a, b) => b.node_count - a.node_count),
+    review_bundle: reviewBundle,
     risk_summary: {
       high_impact_nodes: highImpactNodes,
       cross_community_changes: changedCommunityIds.size,
+      top_risks: rankedRisks
+        .filter((risk) => risk.score > 0)
+        .sort(compareRankedRisks)
+        .slice(0, MAX_TOP_REVIEW_RISKS)
+        .map(({ label, severity, reason }) => ({ label, severity, reason })),
     },
+  }
+}
+
+export function compactPrImpactResult(result: PrImpactResult): CompactPrImpactResult {
+  return {
+    base_branch: result.base_branch,
+    changed_files: result.changed_files,
+    changed_ranges: result.changed_ranges,
+    seed_nodes: result.seed_nodes,
+    per_node_impact: result.per_node_impact
+      .slice(0, MAX_COMPACT_PER_NODE_IMPACT)
+      .map((impact) => ({
+        node: impact.node,
+        total_dependents: impact.direct_dependents + impact.transitive_dependents,
+        affected_communities: impact.affected_communities,
+      })),
+    total_blast_radius: result.total_blast_radius,
+    affected_communities: result.affected_communities,
+    review_bundle: compactReviewBundle(result.review_bundle, result.seed_nodes),
+    risk_summary: result.risk_summary,
   }
 }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -225,7 +225,7 @@ function estimateTokens(text: string): number {
   return estimateQueryTokens(text)
 }
 
-function estimateRetrieveEntryTokens(label: string, sourceFile: string, lineNumber: number, snippet: string | null): number {
+export function estimateRetrieveEntryTokens(label: string, sourceFile: string, lineNumber: number, snippet: string | null): number {
   return estimateTokens(`${label} ${sourceFile}:${lineNumber} ${snippet ?? ''}`)
 }
 
@@ -254,7 +254,7 @@ function fileLinesForSnippet(sourceFile: string, fileCache?: Map<string, string[
   return lines
 }
 
-function readSnippet(
+export function readSnippet(
   sourceFile: string,
   lineNumber: number,
   options: { derived?: boolean; fileCache?: Map<string, string[] | null> } = {},
@@ -306,7 +306,7 @@ function graphSignalsForRetrieve(
   return signals
 }
 
-function collectRelationships(graph: KnowledgeGraph, includedIds: ReadonlySet<string>): RetrieveRelationship[] {
+export function collectRelationships(graph: KnowledgeGraph, includedIds: ReadonlySet<string>): RetrieveRelationship[] {
   const relationships: RetrieveRelationship[] = []
   const seen = new Set<string>()
 

--- a/src/runtime/risk-map.ts
+++ b/src/runtime/risk-map.ts
@@ -120,9 +120,9 @@ export function buildRankedRisk(candidate: RiskSummaryCandidate): RankedRiskDeta
 }
 
 export function compareRankedRisks(left: RankedRiskDetails, right: RankedRiskDetails): number {
-  return right.hotspot_count - left.hotspot_count
+  return right.score - left.score
+    || right.hotspot_count - left.hotspot_count
     || right.dependent_count - left.dependent_count
-    || right.score - left.score
     || left.label.localeCompare(right.label)
 }
 

--- a/src/runtime/risk-map.ts
+++ b/src/runtime/risk-map.ts
@@ -8,9 +8,11 @@ import { relativizeSourceFile } from '../shared/source-path.js'
 
 export interface RiskMapOptions extends FeatureMapOptions {}
 
+export type RiskSeverity = 'high' | 'medium' | 'low'
+
 export interface RiskMapRisk {
   label: string
-  severity: 'high' | 'medium' | 'low'
+  severity: RiskSeverity
   reason: string
   affected_files: string[]
   affected_communities: string[]
@@ -37,6 +39,21 @@ interface RiskCandidate {
   matchScore: number
 }
 
+export interface RiskSummaryCandidate {
+  label: string
+  totalAffected: number
+  affectedFiles: readonly string[]
+  affectedCommunities: readonly string[]
+  hotspotKinds: readonly string[]
+  dependentCount: number
+}
+
+interface RankedRiskDetails extends RiskMapRisk {
+  score: number
+  hotspot_count: number
+  dependent_count: number
+}
+
 function storedCommunityLabels(graph: KnowledgeGraph): Record<number, string> {
   const raw = graph.graph.community_labels
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -50,7 +67,16 @@ function storedCommunityLabels(graph: KnowledgeGraph): Record<number, string> {
   )
 }
 
-function severityForRisk(score: number, affectedCommunities: number): 'high' | 'medium' | 'low' {
+export function scoreRisk(
+  totalAffected: number,
+  affectedCommunityCount: number,
+  hotspotCount: number,
+  dependentCount: number,
+): number {
+  return totalAffected * 2 + affectedCommunityCount + hotspotCount * 6 + dependentCount * 2
+}
+
+export function severityForRisk(score: number, affectedCommunities: number): RiskSeverity {
   if (score >= 6 || affectedCommunities >= 2) {
     return 'high'
   }
@@ -60,7 +86,7 @@ function severityForRisk(score: number, affectedCommunities: number): 'high' | '
   return 'low'
 }
 
-function summarizeRisk(
+export function summarizeRisk(
   label: string,
   affectedFiles: readonly string[],
   affectedCommunities: readonly string[],
@@ -70,6 +96,34 @@ function summarizeRisk(
   const communityPart = `${affectedCommunities.length} communit${affectedCommunities.length === 1 ? 'y' : 'ies'}`
   const hotspotPart = hotspotKinds.length > 0 ? ` Includes ${hotspotKinds.join(' and ')} hotspot exposure.` : ''
   return `${label} propagates into ${filePart} across ${communityPart}.${hotspotPart}`
+}
+
+export function buildRankedRisk(candidate: RiskSummaryCandidate): RankedRiskDetails {
+  const hotspotCount = candidate.hotspotKinds.length
+  const score = scoreRisk(
+    candidate.totalAffected,
+    candidate.affectedCommunities.length,
+    hotspotCount,
+    candidate.dependentCount,
+  )
+
+  return {
+    label: candidate.label,
+    severity: severityForRisk(score, candidate.affectedCommunities.length),
+    reason: summarizeRisk(candidate.label, candidate.affectedFiles, candidate.affectedCommunities, candidate.hotspotKinds),
+    affected_files: [...candidate.affectedFiles],
+    affected_communities: [...candidate.affectedCommunities],
+    score,
+    hotspot_count: hotspotCount,
+    dependent_count: candidate.dependentCount,
+  }
+}
+
+export function compareRankedRisks(left: RankedRiskDetails, right: RankedRiskDetails): number {
+  return right.hotspot_count - left.hotspot_count
+    || right.dependent_count - left.dependent_count
+    || right.score - left.score
+    || left.label.localeCompare(right.label)
 }
 
 export function riskMap(graph: KnowledgeGraph, options: RiskMapOptions): RiskMapResult {
@@ -112,21 +166,17 @@ export function riskMap(graph: KnowledgeGraph, options: RiskMapOptions): RiskMap
         ...(godSet.has(candidate.label) ? ['god node'] : []),
       ]
       const dependentCount = candidate.nodeId ? graph.predecessors(candidate.nodeId).length : 0
-      const score = impact.total_affected * 2 + affectedCommunities.length + hotspotKinds.length * 6 + dependentCount * 2
-
-      return {
+      return buildRankedRisk({
         label: candidate.label,
-        severity: severityForRisk(score, affectedCommunities.length),
-        reason: summarizeRisk(candidate.label, affectedFiles, affectedCommunities, hotspotKinds),
-        affected_files: affectedFiles,
-        affected_communities: affectedCommunities,
-        hotspot_count: hotspotKinds.length,
-        dependent_count: dependentCount,
-        score,
-      }
+        totalAffected: impact.total_affected,
+        affectedFiles,
+        affectedCommunities,
+        hotspotKinds,
+        dependentCount,
+      })
     })
     .filter((risk) => risk.score > 0)
-    .sort((left, right) => right.hotspot_count - left.hotspot_count || right.dependent_count - left.dependent_count || right.score - left.score || left.label.localeCompare(right.label))
+    .sort(compareRankedRisks)
     .slice(0, options.limit ?? 5)
     .map(({ score: _score, hotspot_count: _hotspotCount, dependent_count: _dependentCount, ...risk }) => risk)
 

--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -206,6 +206,9 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       properties: {
         base_branch: { type: 'string', description: 'Base branch to diff against (default: auto-detect main/master)' },
         depth: { type: 'number', description: 'Blast radius depth (default 3)' },
+        budget: { type: 'number', description: 'Review bundle token budget (default 2000)' },
+        verbose: { type: 'boolean', description: 'Optional: return the legacy verbose pr_impact payload instead of the default compact response.' },
+        compact: { type: 'boolean', description: 'Deprecated alias: use verbose=false or omit both flags for the default compact response.' },
       },
     },
   },

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -7,7 +7,7 @@ import { validateGraphPath } from '../../shared/security.js'
 import { featureMap } from '../feature-map.js'
 import { implementationChecklist } from '../implementation-checklist.js'
 import { analyzeImpact, callChains, compactImpactResult } from '../impact.js'
-import { analyzePrImpact } from '../pr-impact.js'
+import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
 import { relevantFiles } from '../relevant-files.js'
 import { compactRetrieveResult, retrieveContext, retrieveContextAsync } from '../retrieve.js'
 import { riskMap } from '../risk-map.js'
@@ -184,15 +184,27 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({ source: chainSource, target: chainTarget, chains, total: chains.length })))
     }
     case 'pr_impact': {
+      if (Object.hasOwn(toolArguments, 'compact') && typeof toolArguments.compact !== 'boolean') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'compact must be a boolean')
+      }
+      if (Object.hasOwn(toolArguments, 'verbose') && typeof toolArguments.verbose !== 'boolean') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'verbose must be a boolean')
+      }
       const prBaseBranch = helpers.stringParamAlias(toolArguments, ['base_branch', 'baseBranch'])
       const prDepth = helpers.numberParamAlias(toolArguments, ['depth'], { min: 1, max: 5 })
+      const prBudget = helpers.numberParamAlias(toolArguments, ['budget'], { min: 1, max: helpers.maxStdioTokenBudget })
+      if (Object.hasOwn(toolArguments, 'budget') && prBudget === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `budget must be a number between 1 and ${helpers.maxStdioTokenBudget}`)
+      }
       const graphDir = dirname(validateGraphPath(graphPath))
       const projectRoot = dirname(graphDir)
       const prResult = analyzePrImpact(graph, projectRoot, {
         ...(prBaseBranch ? { baseBranch: prBaseBranch } : {}),
         ...(prDepth !== null ? { depth: prDepth } : {}),
+        ...(prBudget !== null ? { budget: prBudget } : {}),
       })
-      return helpers.ok(id, helpers.textToolResult(JSON.stringify(prResult)))
+      const useVerbosePrImpact = toolArguments.verbose === true || toolArguments.compact === false
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify(useVerbosePrImpact ? prResult : compactPrImpactResult(prResult))))
     }
     case 'retrieve': {
       const question = helpers.stringParam(toolArguments, 'question')

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -1,0 +1,16 @@
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+export function findGitRoot(path: string): string | null {
+  let current = resolve(path)
+  while (true) {
+    if (existsSync(join(current, '.git'))) {
+      return current
+    }
+    const parent = dirname(current)
+    if (parent === current) {
+      return null
+    }
+    current = parent
+  }
+}

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -26,7 +26,7 @@ function inferGraphBase(graphPath: string): string {
   return resolve('graphify-out')
 }
 
-function findNearestExistingAncestor(targetPath: string): string | null {
+export function findNearestExistingAncestor(targetPath: string): string | null {
   let currentPath = resolve(targetPath)
 
   while (!existsSync(currentPath)) {

--- a/src/shared/source-location.ts
+++ b/src/shared/source-location.ts
@@ -1,13 +1,33 @@
-export function lineNumberFromSourceLocation(location: unknown): number {
+export interface SourceLineRange {
+  start: number
+  end: number
+}
+
+export function lineRangeFromSourceLocation(location: unknown): SourceLineRange | null {
   if (typeof location !== 'string') {
-    return 1
+    return null
   }
 
   const match = location.match(/^L(\d+)(?:-L?(\d+))?$/)
   if (!match?.[1]) {
-    return 1
+    return null
   }
 
-  const line = Number.parseInt(match[1], 10)
-  return Number.isFinite(line) && line > 0 ? line : 1
+  const start = Number.parseInt(match[1], 10)
+  const end = Number.parseInt(match[2] ?? match[1], 10)
+  if (!Number.isFinite(start) || start <= 0 || !Number.isFinite(end) || end <= 0) {
+    return null
+  }
+
+  const normalizedStart = Math.min(start, end)
+  const normalizedEnd = Math.max(start, end)
+
+  return {
+    start: normalizedStart,
+    end: normalizedEnd,
+  }
+}
+
+export function lineNumberFromSourceLocation(location: unknown): number {
+  return lineRangeFromSourceLocation(location)?.start ?? 1
 }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -448,6 +448,7 @@ describe('cli parser', () => {
     expect(() => parseReviewCompareArgs([])).toThrow('error: --exec is required')
     expect(() => parseReviewCompareArgs(['one.json', 'two.json', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Usage: graphify-ts review-compare')
     expect(() => parseReviewCompareArgs(['--budget', '1.5', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('error: --budget must be a positive integer')
+    expect(() => parseReviewCompareArgs(['--budget', '100001', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('error: --budget must be <= 100000')
     expect(() => parseReviewCompareArgs(['--output-dir', '../outside', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Only paths inside graphify-out/ are permitted')
   })
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -14,6 +14,7 @@ import {
   parsePathArgs,
   parsePlatformActionArgs,
   parseQueryArgs,
+  parseReviewCompareArgs,
   parseSaveResultArgs,
   parseServeArgs,
   parseTimeTravelArgs,
@@ -100,6 +101,7 @@ function createDependencies(): CliDependencies {
     },
     runEval: () => 'graphify retrieval quality benchmark\nRecall: 100.0%\ncreate session login',
     runCompare: async () => 'compare command is not implemented yet',
+    runReviewCompare: async () => 'review compare command is not implemented yet',
     runTimeTravel: async () => 'time-travel command is not implemented yet',
     confirm: async () => true,
     printBenchmark: () => {},
@@ -394,6 +396,61 @@ describe('cli parser', () => {
     expect(() => parseCompareArgs(['--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Usage: graphify-ts compare')
   })
 
+  it('parses review-compare args with optional overrides', () => {
+    const externalOutputDir = resolve('/tmp', 'graphify-ts-review-compare-external')
+
+    expect(parseReviewCompareArgs(['--exec', 'claude -p "$(cat {prompt_file})"'])).toEqual({
+      graphPath: 'graphify-out/graph.json',
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      outputDir: resolve('graphify-out/review-compare'),
+      baseBranch: null,
+      budget: null,
+      yes: false,
+    })
+
+    expect(parseReviewCompareArgs([
+      'custom.json',
+      '--exec',
+      'gemini -p "$(cat {prompt_file})"',
+      '--output-dir',
+      'graphify-out/review-compare/custom',
+      '--base-branch',
+      'origin/main',
+      '--budget',
+      '1800',
+      '--yes',
+    ])).toEqual({
+      graphPath: 'custom.json',
+      execTemplate: 'gemini -p "$(cat {prompt_file})"',
+      outputDir: resolve('graphify-out/review-compare/custom'),
+      baseBranch: 'origin/main',
+      budget: 1800,
+      yes: true,
+    })
+
+    expect(parseReviewCompareArgs([
+      '/tmp/graph.json',
+      '--exec',
+      'gemini -p "$(cat {prompt_file})"',
+      '--output-dir',
+      externalOutputDir,
+    ])).toEqual({
+      graphPath: '/tmp/graph.json',
+      execTemplate: 'gemini -p "$(cat {prompt_file})"',
+      outputDir: externalOutputDir,
+      baseBranch: null,
+      budget: null,
+      yes: false,
+    })
+  })
+
+  it('rejects invalid review-compare args', () => {
+    expect(() => parseReviewCompareArgs([])).toThrow('error: --exec is required')
+    expect(() => parseReviewCompareArgs(['one.json', 'two.json', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Usage: graphify-ts review-compare')
+    expect(() => parseReviewCompareArgs(['--budget', '1.5', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('error: --budget must be a positive integer')
+    expect(() => parseReviewCompareArgs(['--output-dir', '../outside', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Only paths inside graphify-out/ are permitted')
+  })
+
   it.each([
     { args: ['main', 'HEAD'], view: 'summary' as const },
     { args: ['main', 'HEAD', '--view', 'risk'], view: 'risk' as const },
@@ -644,6 +701,8 @@ describe('cli main', () => {
     expect(help).toContain('    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice and reports Anthropic-billed usage)')
     expect(help).toContain('    --yes                 skip confirmation before running the paid prompt comparison')
     expect(help).toContain('    --limit N             cap processed prompts/questions for the comparison run')
+    expect(help).toContain('review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff')
+    expect(help).toContain('    --output-dir DIR      review compare output directory (default graphify-out/review-compare)')
     expect(help).toContain('time-travel <from> <to> compare two refs using on-demand cached graph snapshots')
     expect(help).toContain('    --view MODE          summary|risk|drift|timeline (default summary)')
     expect(help).toContain('    --json               emit machine-readable JSON')
@@ -716,6 +775,60 @@ describe('cli main', () => {
     })
     expect(compareRequest.io).toBe(io)
     await expect(compareRequest.confirm('Proceed?')).resolves.toBe(true)
+    expect(confirmCalls).toBe(1)
+  })
+
+  it('routes review-compare through the injected dependency after parsing args', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies()
+    let capturedRequest: unknown
+    let confirmCalls = 0
+
+    dependencies.runReviewCompare = async (request) => {
+      capturedRequest = request
+      return 'review compare result'
+    }
+    dependencies.confirm = async () => {
+      confirmCalls += 1
+      return true
+    }
+
+    const exitCode = await executeCli(
+      [
+        'review-compare',
+        'custom.json',
+        '--exec',
+        'claude -p "$(cat {prompt_file})"',
+        '--output-dir',
+        'graphify-out/review-compare/custom',
+        '--base-branch',
+        'origin/main',
+        '--budget',
+        '1800',
+        '--yes',
+      ],
+      io,
+      dependencies,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(logs).toEqual(['review compare result'])
+    expect(errors).toEqual([])
+    const reviewCompareRequest = capturedRequest as {
+      options: ReturnType<typeof parseReviewCompareArgs>
+      io: typeof io
+      confirm: (message: string) => Promise<boolean>
+    }
+    expect(reviewCompareRequest.options).toEqual({
+      graphPath: 'custom.json',
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      outputDir: resolve('graphify-out/review-compare/custom'),
+      baseBranch: 'origin/main',
+      budget: 1800,
+      yes: true,
+    })
+    expect(reviewCompareRequest.io).toBe(io)
+    await expect(reviewCompareRequest.confirm('Proceed?')).resolves.toBe(true)
     expect(confirmCalls).toBe(1)
   })
 

--- a/tests/unit/pr-impact.test.ts
+++ b/tests/unit/pr-impact.test.ts
@@ -1,0 +1,675 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { analyzePrImpact, compactPrImpactResult, type PrImpactResult } from '../../src/runtime/pr-impact.js'
+import { estimateQueryTokens } from '../../src/runtime/serve.js'
+
+function createRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'graphify-ts-pr-impact-'))
+  mkdirSync(join(root, 'src'), { recursive: true })
+
+  const authLines = Array.from({ length: 40 }, (_, index) => `// auth filler ${index + 1}`)
+  authLines[9] = 'export function authenticateUser(token: string) {'
+  authLines[10] = '  const parsed = token.trim()'
+  authLines[11] = '  const status = "ok"'
+  authLines[12] = '  return parsed.length > 0 ? status : "fail"'
+  authLines[13] = '}'
+  authLines[29] = 'export function AuthGuard(input: string) {'
+  authLines[30] = '  return input === "admin"'
+  authLines[31] = '}'
+
+  const apiLines = Array.from({ length: 16 }, (_, index) => `// api filler ${index + 1}`)
+  apiLines[4] = 'export function ApiHandler(token: string) {'
+  apiLines[5] = '  return authenticateUser(token)'
+  apiLines[6] = '}'
+
+  writeFileSync(join(root, 'src', 'auth.ts'), `${authLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(root, 'src', 'api.ts'), `${apiLines.join('\n')}\n`, 'utf8')
+
+  execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'graphify@example.com'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'Graphify Test'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: root, stdio: 'pipe' })
+
+  return root
+}
+
+function updateFile(root: string, relativePath: string, mutate: (content: string) => string): void {
+  const filePath = join(root, relativePath)
+  writeFileSync(filePath, mutate(readFileSync(filePath, 'utf8')), 'utf8')
+}
+
+function buildGraph(root: string): KnowledgeGraph {
+  const graph = new KnowledgeGraph({ directed: true })
+  graph.graph.root_path = root
+  graph.graph.community_labels = {
+    0: 'Auth Layer',
+    1: 'API Layer',
+  }
+
+  graph.addNode('auth_user', {
+    label: 'authenticateUser',
+    source_file: join(root, 'src', 'auth.ts'),
+    source_location: 'L10-L14',
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+  graph.addNode('auth_guard', {
+    label: 'AuthGuard',
+    source_file: join(root, 'src', 'auth.ts'),
+    source_location: 'L30-L32',
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+  graph.addNode('api_handler', {
+    label: 'ApiHandler',
+    source_file: join(root, 'src', 'api.ts'),
+    source_location: 'L5-L7',
+    node_kind: 'function',
+    file_type: 'code',
+    community: 1,
+  })
+
+  graph.addEdge('api_handler', 'auth_user', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'api.ts'),
+  })
+
+  return graph
+}
+
+function buildFallbackGraph(root: string): KnowledgeGraph {
+  const graph = new KnowledgeGraph({ directed: true })
+  graph.graph.root_path = root
+
+  graph.addNode('auth_user', {
+    label: 'authenticateUser',
+    source_file: join(root, 'src', 'auth.ts'),
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+
+  return graph
+}
+
+function createDeletionOnlyRepo(): string {
+  const root = createRepo()
+  writeFileSync(
+    join(root, 'src', 'deletion.ts'),
+    [
+      'export function target() {',
+      '  return true',
+      '}',
+      'export function keep() {',
+      '  return false',
+      '}',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Add deletion fixture'], { cwd: root, stdio: 'pipe' })
+  writeFileSync(
+    join(root, 'src', 'deletion.ts'),
+    [
+      'export function keep() {',
+      '  return false',
+      '}',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  return root
+}
+
+function buildDeletionOnlyGraph(root: string): KnowledgeGraph {
+  const graph = new KnowledgeGraph({ directed: true })
+  graph.graph.root_path = root
+  graph.graph.community_labels = {
+    0: 'Deletion Layer',
+  }
+
+  graph.addNode('keep_node', {
+    label: 'keep',
+    source_file: join(root, 'src', 'deletion.ts'),
+    source_location: 'L1-L3',
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+
+  return graph
+}
+
+function buildSecondHopCapGraph(root: string): KnowledgeGraph {
+  const graph = buildGraph(root)
+  graph.graph.community_labels = {
+    0: 'Auth Layer',
+    1: 'API Layer',
+    2: 'Review Ops',
+    3: 'Audit Trail',
+    4: 'Release Safety',
+  }
+
+  const reviewFixtureFiles = [
+    {
+      id: 'review_session',
+      label: 'resolveReviewerSession',
+      relativePath: 'src/review-session.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function resolveReviewerSession(token: string) {',
+        '  const normalized = token.trim()',
+        '  const reviewable = normalized.startsWith("Bearer ")',
+        '  return { reviewable, reviewer: reviewable ? "maintainer" : "guest" }',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'audit_logger',
+      label: 'appendAuthAudit',
+      relativePath: 'src/audit-log.ts',
+      sourceLocation: 'L1-L5',
+      community: 3,
+      lines: [
+        'export function appendAuthAudit(actor: string, status: string) {',
+        '  const event = `${actor}:${status}`',
+        '  return event.toLowerCase()',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'merge_queue_gate',
+      label: 'MergeQueueGate',
+      relativePath: 'src/merge-queue-gate.ts',
+      sourceLocation: 'L1-L5',
+      community: 4,
+      lines: [
+        'export function MergeQueueGate(token: string) {',
+        '  const lane = token.includes("hotfix") ? "priority" : "default"',
+        '  return `${lane}:queued`',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'review_summary_digest',
+      label: 'ReviewSummaryDigest',
+      relativePath: 'src/review-summary-digest.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function ReviewSummaryDigest(prTitle: string) {',
+        '  const heading = prTitle.trim()',
+        '  return heading.length > 0 ? heading : "untitled-review"',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'reviewer_roster_sync',
+      label: 'ReviewerRosterSync',
+      relativePath: 'src/reviewer-roster-sync.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function ReviewerRosterSync(team: string) {',
+        '  const normalized = team.trim().toLowerCase()',
+        '  return normalized.length > 0 ? normalized.split("-") : []',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'risk_escalation_digest',
+      label: 'RiskEscalationDigest',
+      relativePath: 'src/risk-escalation-digest.ts',
+      sourceLocation: 'L1-L5',
+      community: 4,
+      lines: [
+        'export function RiskEscalationDigest(score: number) {',
+        '  return score > 8 ? "page-security" : "queue-review"',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'security_checklist_digest',
+      label: 'SecurityChecklistDigest',
+      relativePath: 'src/security-checklist-digest.ts',
+      sourceLocation: 'L1-L5',
+      community: 3,
+      lines: [
+        'export function SecurityChecklistDigest(items: string[]) {',
+        '  return items.filter((item) => item.includes("review"))',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'stale_reviewer_reminder',
+      label: 'StaleReviewerReminder',
+      relativePath: 'src/stale-reviewer-reminder.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function StaleReviewerReminder(hoursOpen: number) {',
+        '  return hoursOpen > 24 ? "nudge" : "quiet"',
+        '}',
+        '',
+      ],
+    },
+  ] as const
+
+  for (const fixtureFile of reviewFixtureFiles) {
+    const filePath = join(root, fixtureFile.relativePath)
+    writeFileSync(
+      filePath,
+      fixtureFile.lines.join('\n'),
+      'utf8',
+    )
+    graph.addNode(fixtureFile.id, {
+      label: fixtureFile.label,
+      source_file: filePath,
+      source_location: fixtureFile.sourceLocation,
+      node_kind: 'function',
+      file_type: 'code',
+      community: fixtureFile.community,
+    })
+  }
+
+  graph.addEdge('auth_user', 'review_session', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'auth.ts'),
+  })
+  graph.addEdge('auth_user', 'audit_logger', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'auth.ts'),
+  })
+  graph.addEdge('merge_queue_gate', 'api_handler', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'merge-queue-gate.ts'),
+  })
+  graph.addEdge('merge_queue_gate', 'audit_logger', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'merge-queue-gate.ts'),
+  })
+  graph.addEdge('review_summary_digest', 'api_handler', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'review-summary-digest.ts'),
+  })
+  graph.addEdge('review_summary_digest', 'review_session', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'review-summary-digest.ts'),
+  })
+  graph.addEdge('reviewer_roster_sync', 'review_session', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'reviewer-roster-sync.ts'),
+  })
+  graph.addEdge('reviewer_roster_sync', 'audit_logger', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'reviewer-roster-sync.ts'),
+  })
+  graph.addEdge('risk_escalation_digest', 'audit_logger', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'risk-escalation-digest.ts'),
+  })
+  graph.addEdge('risk_escalation_digest', 'merge_queue_gate', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'risk-escalation-digest.ts'),
+  })
+  graph.addEdge('security_checklist_digest', 'audit_logger', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'security-checklist-digest.ts'),
+  })
+  graph.addEdge('stale_reviewer_reminder', 'review_session', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'src', 'stale-reviewer-reminder.ts'),
+  })
+
+  return graph
+}
+
+describe('pr impact', () => {
+  const repoRoots: string[] = []
+
+  afterEach(() => {
+    for (const root of repoRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('narrows review seeds to changed line overlaps and returns a budgeted review bundle', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildGraph(root), root, { budget: 240 })
+
+    expect(result.changed_files).toEqual(['src/auth.ts'])
+    expect(result.changed_ranges).toEqual([
+      {
+        source_file: 'src/auth.ts',
+        line_ranges: [{ start: 12, end: 12 }],
+      },
+    ])
+    expect(result.changed_nodes.map((node) => node.label)).toEqual(expect.arrayContaining(['authenticateUser', 'AuthGuard']))
+    expect(result.seed_nodes).toEqual([
+      expect.objectContaining({
+        label: 'authenticateUser',
+        match_kind: 'line',
+      }),
+    ])
+    expect(result.review_bundle.token_count).toBeLessThanOrEqual(240)
+    expect(result.review_bundle.nodes[0]).toEqual(expect.objectContaining({ label: 'authenticateUser' }))
+    expect(result.review_bundle.nodes.map((node) => node.label)).toEqual(expect.arrayContaining(['ApiHandler', 'authenticateUser']))
+    expect(result.review_bundle.relationships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'ApiHandler',
+          to: 'authenticateUser',
+          relation: 'calls',
+        }),
+      ]),
+    )
+  })
+
+  it('returns an empty review bundle when the budget cannot fit the first review node', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildGraph(root), root, { budget: 1 })
+
+    expect(result.review_bundle).toEqual({
+      budget: 1,
+      token_count: 0,
+      nodes: [],
+      relationships: [],
+      community_context: [],
+    })
+  })
+
+  it('falls back to file-level seeds when nodes do not have line metadata', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = "revoked"'))
+
+    const result = analyzePrImpact(buildFallbackGraph(root), root)
+
+    expect(result.seed_nodes).toEqual([
+      expect.objectContaining({
+        label: 'authenticateUser',
+        match_kind: 'file',
+      }),
+    ])
+  })
+
+  it('falls back to file-level seeds for pure deletions without changed lines in the new file', () => {
+    const root = createDeletionOnlyRepo()
+    repoRoots.push(root)
+
+    const result = analyzePrImpact(buildDeletionOnlyGraph(root), root)
+
+    expect(result.changed_ranges).toEqual([
+      {
+        source_file: 'src/deletion.ts',
+        line_ranges: [],
+      },
+    ])
+    expect(result.seed_nodes).toEqual([
+      expect.objectContaining({
+        label: 'keep',
+        match_kind: 'file',
+      }),
+    ])
+  })
+
+  it('hard caps the second-hop review candidate pool across distinct review roles', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildSecondHopCapGraph(root), root, { budget: 2_000 })
+
+    expect(result.review_bundle.nodes.slice(0, 2).map((node) => node.label)).toEqual(['authenticateUser', 'ApiHandler'])
+    expect(result.review_bundle.nodes.filter((node) => node.relevance_band === 'peripheral').map((node) => node.label)).toEqual([
+      'MergeQueueGate',
+      'ReviewSummaryDigest',
+      'ReviewerRosterSync',
+      'RiskEscalationDigest',
+    ])
+    expect(result.review_bundle.nodes.map((node) => node.label)).not.toEqual(
+      expect.arrayContaining(['SecurityChecklistDigest', 'StaleReviewerReminder']),
+    )
+  })
+
+  it('returns the compact pr_impact contract while omitting full-only fields', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const full = analyzePrImpact(buildGraph(root), root, { budget: 300 })
+    const compact = compactPrImpactResult(full)
+
+    expect(compact).toEqual(expect.objectContaining({
+      base_branch: full.base_branch,
+      changed_files: full.changed_files,
+      changed_ranges: full.changed_ranges,
+      seed_nodes: full.seed_nodes,
+      total_blast_radius: full.total_blast_radius,
+      affected_communities: full.affected_communities,
+      risk_summary: full.risk_summary,
+    }))
+    expect(compact.review_bundle).toEqual(expect.objectContaining({
+      budget: full.review_bundle.budget,
+    }))
+    expect(compact.review_bundle.nodes[0]).toEqual(expect.objectContaining({
+      label: 'authenticateUser',
+      snippet: full.review_bundle.nodes[0]?.snippet ?? null,
+    }))
+    expect(compact.review_bundle.nodes.find((node) => node.label === 'ApiHandler')).toEqual(expect.objectContaining({
+      snippet: null,
+    }))
+    expect(compact.review_bundle.token_count).toBeLessThan(full.review_bundle.token_count)
+    expect(compact.per_node_impact).toEqual(
+      full.per_node_impact.slice(0, 5).map((impact) => ({
+        node: impact.node,
+        total_dependents: impact.direct_dependents + impact.transitive_dependents,
+        affected_communities: impact.affected_communities,
+      })),
+    )
+    expect(compact).not.toHaveProperty('changed_nodes')
+    expect(compact).not.toHaveProperty('affected_files')
+    expect(compact.per_node_impact[0]).not.toHaveProperty('direct_dependents')
+    expect(compact.per_node_impact[0]).not.toHaveProperty('transitive_dependents')
+    expect(estimateQueryTokens(JSON.stringify(compact))).toBeLessThan(
+      estimateQueryTokens(JSON.stringify(full)),
+    )
+  })
+
+  it('materially reduces the default review payload on a review-heavy fixture', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const full = analyzePrImpact(buildSecondHopCapGraph(root), root, { budget: 2_000 })
+    const compact = compactPrImpactResult(full)
+    const fullReviewBundleTokens = estimateQueryTokens(JSON.stringify(full.review_bundle))
+    const compactReviewBundleTokens = estimateQueryTokens(JSON.stringify(compact.review_bundle))
+    const fullPayloadTokens = estimateQueryTokens(JSON.stringify(full))
+    const compactPayloadTokens = estimateQueryTokens(JSON.stringify(compact))
+    const reviewBundleReductionRatio = Number((fullReviewBundleTokens / compactReviewBundleTokens).toFixed(3))
+    const payloadReductionRatio = Number((fullPayloadTokens / compactPayloadTokens).toFixed(3))
+
+    expect(full.review_bundle.nodes.map((node) => node.label)).toEqual(expect.arrayContaining([
+      'ApiHandler',
+      'appendAuthAudit',
+      'resolveReviewerSession',
+      'MergeQueueGate',
+      'ReviewSummaryDigest',
+      'ReviewerRosterSync',
+      'RiskEscalationDigest',
+    ]))
+    expect(compact.review_bundle.nodes[0]).toEqual(expect.objectContaining({ label: 'authenticateUser' }))
+    expect(compact.review_bundle.nodes.map((node) => node.label)).toEqual(expect.arrayContaining([
+      'ApiHandler',
+      'appendAuthAudit',
+      'resolveReviewerSession',
+    ]))
+    expect(compact.review_bundle.nodes.map((node) => node.label)).not.toEqual(
+      expect.arrayContaining(['MergeQueueGate', 'ReviewSummaryDigest', 'ReviewerRosterSync', 'RiskEscalationDigest']),
+    )
+    expect(compact.review_bundle.nodes.find((node) => node.label === 'ApiHandler')).toEqual(expect.objectContaining({ snippet: null }))
+    expect(compact.review_bundle.relationships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'ApiHandler',
+          to: 'authenticateUser',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'authenticateUser',
+          to: 'appendAuthAudit',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'authenticateUser',
+          to: 'resolveReviewerSession',
+          relation: 'calls',
+        }),
+      ]),
+    )
+    expect(full.review_bundle.relationships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'MergeQueueGate',
+          to: 'appendAuthAudit',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'ReviewSummaryDigest',
+          to: 'resolveReviewerSession',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'ReviewerRosterSync',
+          to: 'appendAuthAudit',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'RiskEscalationDigest',
+          to: 'MergeQueueGate',
+          relation: 'calls',
+        }),
+      ]),
+    )
+    expect(compact.review_bundle.community_context).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Auth Layer' }),
+        expect.objectContaining({ label: 'API Layer' }),
+        expect.objectContaining({ label: 'Audit Trail' }),
+        expect.objectContaining({ label: 'Review Ops' }),
+      ]),
+    )
+    expect(compact.review_bundle.token_count).toBeLessThan(full.review_bundle.token_count)
+    expect(fullReviewBundleTokens).toBe(1356)
+    expect(compactReviewBundleTokens).toBe(512)
+    expect(reviewBundleReductionRatio).toBe(2.648)
+    expect(fullPayloadTokens).toBe(1716)
+    expect(compactPayloadTokens).toBe(736)
+    expect(payloadReductionRatio).toBe(2.332)
+  })
+
+  it('ranks the top review risks with severity and concise reasons', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildGraph(root), root, { budget: 300 })
+
+    expect(result.risk_summary.top_risks[0]).toEqual(
+      expect.objectContaining({
+        label: 'authenticateUser',
+        severity: expect.stringMatching(/high|medium|low/),
+        reason: expect.any(String),
+      }),
+    )
+  })
+
+  it('preserves full per-node impact ordering in the compact view when totals tie', () => {
+    const full: PrImpactResult = {
+      base_branch: 'main',
+      changed_files: ['src/auth.ts'],
+      changed_ranges: [],
+      changed_nodes: [],
+      seed_nodes: [],
+      per_node_impact: [
+        {
+          node: 'ZuluNode',
+          direct_dependents: 2,
+          transitive_dependents: 0,
+          affected_communities: 1,
+        },
+        {
+          node: 'AlphaNode',
+          direct_dependents: 1,
+          transitive_dependents: 1,
+          affected_communities: 9,
+        },
+        {
+          node: 'LaterNode',
+          direct_dependents: 1,
+          transitive_dependents: 0,
+          affected_communities: 1,
+        },
+      ],
+      total_blast_radius: 3,
+      affected_files: [],
+      affected_communities: [],
+      review_bundle: {
+        budget: 100,
+        token_count: 0,
+        nodes: [],
+        relationships: [],
+        community_context: [],
+      },
+      risk_summary: {
+        high_impact_nodes: [],
+        cross_community_changes: 0,
+        top_risks: [],
+      },
+    }
+
+    expect(compactPrImpactResult(full).per_node_impact.map((impact) => impact.node)).toEqual([
+      'ZuluNode',
+      'AlphaNode',
+      'LaterNode',
+    ])
+  })
+})

--- a/tests/unit/pr-impact.test.ts
+++ b/tests/unit/pr-impact.test.ts
@@ -12,6 +12,7 @@ import { estimateQueryTokens } from '../../src/runtime/serve.js'
 function createRepo(): string {
   const root = mkdtempSync(join(tmpdir(), 'graphify-ts-pr-impact-'))
   mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, 'tests'), { recursive: true })
 
   const authLines = Array.from({ length: 40 }, (_, index) => `// auth filler ${index + 1}`)
   authLines[9] = 'export function authenticateUser(token: string) {'
@@ -30,12 +31,45 @@ function createRepo(): string {
 
   writeFileSync(join(root, 'src', 'auth.ts'), `${authLines.join('\n')}\n`, 'utf8')
   writeFileSync(join(root, 'src', 'api.ts'), `${apiLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(root, 'tests', 'auth.test.ts'), 'describe("auth", () => {})\n', 'utf8')
+  writeFileSync(join(root, 'tests', 'api.test.ts'), 'describe("api", () => {})\n', 'utf8')
 
   execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'pipe' })
   execFileSync('git', ['config', 'user.email', 'graphify@example.com'], { cwd: root, stdio: 'pipe' })
   execFileSync('git', ['config', 'user.name', 'Graphify Test'], { cwd: root, stdio: 'pipe' })
   execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' })
   execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: root, stdio: 'pipe' })
+
+  return root
+}
+
+function createNestedRepoWorkspace(): string {
+  const root = mkdtempSync(join(tmpdir(), 'graphify-ts-pr-impact-workspace-'))
+  const backendRoot = join(root, 'backend')
+  mkdirSync(join(backendRoot, 'src'), { recursive: true })
+  mkdirSync(join(backendRoot, 'tests'), { recursive: true })
+
+  const authLines = Array.from({ length: 16 }, (_, index) => `// auth filler ${index + 1}`)
+  authLines[4] = 'export function authenticateUser(token: string) {'
+  authLines[5] = '  const parsed = token.trim()'
+  authLines[6] = '  const status = "ok"'
+  authLines[7] = '  return parsed.length > 0 ? status : "fail"'
+  authLines[8] = '}'
+
+  const apiLines = Array.from({ length: 10 }, (_, index) => `// api filler ${index + 1}`)
+  apiLines[2] = 'export function ApiHandler(token: string) {'
+  apiLines[3] = '  return authenticateUser(token)'
+  apiLines[4] = '}'
+
+  writeFileSync(join(backendRoot, 'src', 'auth.ts'), `${authLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(backendRoot, 'src', 'api.ts'), `${apiLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(backendRoot, 'tests', 'auth.test.ts'), 'describe("auth", () => {})\n', 'utf8')
+
+  execFileSync('git', ['init', '-b', 'main'], { cwd: backendRoot, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'graphify@example.com'], { cwd: backendRoot, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'Graphify Test'], { cwd: backendRoot, stdio: 'pipe' })
+  execFileSync('git', ['add', '.'], { cwd: backendRoot, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: backendRoot, stdio: 'pipe' })
 
   return root
 }
@@ -82,6 +116,40 @@ function buildGraph(root: string): KnowledgeGraph {
     relation: 'calls',
     confidence: 'EXTRACTED',
     source_file: join(root, 'src', 'api.ts'),
+  })
+
+  return graph
+}
+
+function buildNestedRepoGraph(root: string): KnowledgeGraph {
+  const graph = new KnowledgeGraph({ directed: true })
+  graph.graph.root_path = root
+  graph.graph.community_labels = {
+    0: 'Auth Layer',
+    1: 'API Layer',
+  }
+
+  graph.addNode('auth_user', {
+    label: 'authenticateUser',
+    source_file: join(root, 'backend', 'src', 'auth.ts'),
+    source_location: 'L5-L9',
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+  graph.addNode('api_handler', {
+    label: 'ApiHandler',
+    source_file: join(root, 'backend', 'src', 'api.ts'),
+    source_location: 'L3-L5',
+    node_kind: 'function',
+    file_type: 'code',
+    community: 1,
+  })
+
+  graph.addEdge('api_handler', 'auth_user', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: join(root, 'backend', 'src', 'api.ts'),
   })
 
   return graph
@@ -399,6 +467,22 @@ describe('pr impact', () => {
     )
   })
 
+  it('collects changed files from nested git repos under the graph root', () => {
+    const root = createNestedRepoWorkspace()
+    repoRoots.push(root)
+    updateFile(root, 'backend/src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildNestedRepoGraph(root), root, { budget: 240 })
+
+    expect(result.changed_files).toEqual(['backend/src/auth.ts'])
+    expect(result.seed_nodes).toEqual([
+      expect.objectContaining({
+        label: 'authenticateUser',
+        match_kind: 'line',
+      }),
+    ])
+  })
+
   it('returns an empty review bundle when the budget cannot fit the first review node', () => {
     const root = createRepo()
     repoRoots.push(root)
@@ -476,6 +560,13 @@ describe('pr impact', () => {
 
     const full = analyzePrImpact(buildGraph(root), root, { budget: 300 })
     const compact = compactPrImpactResult(full)
+    const compactSupportNode = compact.review_bundle.nodes.find((node) => node.label === 'ApiHandler') as Record<string, unknown> | undefined
+    const compactNodePayload = typeof compact.review_bundle.shared_file_type === 'string'
+      ? {
+          shared_file_type: compact.review_bundle.shared_file_type,
+          nodes: compact.review_bundle.nodes,
+        }
+      : compact.review_bundle.nodes
 
     expect(compact).toEqual(expect.objectContaining({
       base_branch: full.base_branch,
@@ -493,10 +584,19 @@ describe('pr impact', () => {
       label: 'authenticateUser',
       snippet: full.review_bundle.nodes[0]?.snippet ?? null,
     }))
-    expect(compact.review_bundle.nodes.find((node) => node.label === 'ApiHandler')).toEqual(expect.objectContaining({
-      snippet: null,
-    }))
-    expect(compact.review_bundle.token_count).toBeLessThan(full.review_bundle.token_count)
+    expect(compact.review_bundle).toHaveProperty('shared_file_type', 'code')
+    expect(compactSupportNode).toEqual(expect.objectContaining({ snippet: null }))
+    expect(compactSupportNode).not.toHaveProperty('node_id')
+    expect(compactSupportNode).not.toHaveProperty('match_score')
+    expect(compactSupportNode).not.toHaveProperty('community_label')
+    expect(compactSupportNode).not.toHaveProperty('framework_boost')
+    expect(compactSupportNode).not.toHaveProperty('file_type')
+    expect(compact.review_bundle.relationships[0]).not.toHaveProperty('from_id')
+    expect(compact.review_bundle.relationships[0]).not.toHaveProperty('to_id')
+    expect(compact.review_bundle.token_count).toBe(estimateQueryTokens(JSON.stringify(compactNodePayload)))
+    expect(estimateQueryTokens(JSON.stringify(compactNodePayload))).toBeLessThan(
+      estimateQueryTokens(JSON.stringify(full.review_bundle.nodes)),
+    )
     expect(compact.per_node_impact).toEqual(
       full.per_node_impact.slice(0, 5).map((impact) => ({
         node: impact.node,
@@ -545,6 +645,14 @@ describe('pr impact', () => {
     expect(compact.review_bundle.nodes.map((node) => node.label)).not.toEqual(
       expect.arrayContaining(['MergeQueueGate', 'ReviewSummaryDigest', 'ReviewerRosterSync', 'RiskEscalationDigest']),
     )
+    expect(compact.review_bundle).toHaveProperty('shared_file_type', 'code')
+    expect(compact.review_bundle.nodes.find((node) => node.label === 'ApiHandler')).toEqual(expect.not.objectContaining({
+      node_id: expect.any(String),
+      match_score: expect.any(Number),
+      community_label: expect.anything(),
+      framework_boost: expect.any(Number),
+      file_type: expect.any(String),
+    }))
     expect(compact.review_bundle.nodes.find((node) => node.label === 'ApiHandler')).toEqual(expect.objectContaining({ snippet: null }))
     expect(compact.review_bundle.relationships).toEqual(
       expect.arrayContaining([
@@ -589,6 +697,8 @@ describe('pr impact', () => {
         }),
       ]),
     )
+    expect(compact.review_bundle.relationships[0]).not.toHaveProperty('from_id')
+    expect(compact.review_bundle.relationships[0]).not.toHaveProperty('to_id')
     expect(compact.review_bundle.community_context).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ label: 'Auth Layer' }),
@@ -597,13 +707,24 @@ describe('pr impact', () => {
         expect.objectContaining({ label: 'Review Ops' }),
       ]),
     )
+    expect(compact.review_context).toEqual(expect.objectContaining({
+      supporting_paths: ['src/api.ts', 'src/audit-log.ts', 'src/review-session.ts'],
+      test_paths: expect.arrayContaining(['tests/auth.test.ts', 'tests/api.test.ts']),
+      hotspots: expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+          type: expect.stringMatching(/bridge|god_node/),
+          why: expect.any(String),
+        }),
+      ]),
+    }))
     expect(compact.review_bundle.token_count).toBeLessThan(full.review_bundle.token_count)
     expect(fullReviewBundleTokens).toBe(1356)
-    expect(compactReviewBundleTokens).toBe(512)
-    expect(reviewBundleReductionRatio).toBe(2.648)
-    expect(fullPayloadTokens).toBe(1716)
-    expect(compactPayloadTokens).toBe(736)
-    expect(payloadReductionRatio).toBe(2.332)
+    expect(compactReviewBundleTokens).toBeLessThan(452)
+    expect(reviewBundleReductionRatio).toBeGreaterThan(3)
+    expect(fullPayloadTokens).toBeLessThan(1_900)
+    expect(compactPayloadTokens).toBeLessThan(780)
+    expect(payloadReductionRatio).toBeGreaterThan(2.4)
   })
 
   it('ranks the top review risks with severity and concise reasons', () => {
@@ -620,6 +741,27 @@ describe('pr impact', () => {
         reason: expect.any(String),
       }),
     )
+  })
+
+  it('adds typed review context for supporting paths, likely tests, and hotspots', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildSecondHopCapGraph(root), root, { budget: 2_000 })
+
+    expect(result.review_context).toEqual(expect.objectContaining({
+      supporting_paths: ['src/api.ts', 'src/audit-log.ts', 'src/review-session.ts'],
+      test_paths: expect.arrayContaining(['tests/auth.test.ts', 'tests/api.test.ts']),
+      hotspots: expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+          type: expect.stringMatching(/bridge|god_node/),
+          why: expect.any(String),
+        }),
+      ]),
+    }))
+    expect(new Set(result.review_context.hotspots.map((hotspot) => hotspot.label)).size).toBe(result.review_context.hotspots.length)
   })
 
   it('preserves full per-node impact ordering in the compact view when totals tie', () => {
@@ -652,6 +794,11 @@ describe('pr impact', () => {
       total_blast_radius: 3,
       affected_files: [],
       affected_communities: [],
+      review_context: {
+        supporting_paths: [],
+        test_paths: [],
+        hotspots: [],
+      },
       review_bundle: {
         budget: 100,
         token_count: 0,
@@ -671,5 +818,202 @@ describe('pr impact', () => {
       'AlphaNode',
       'LaterNode',
     ])
+  })
+
+  it('keeps empty-string file types on compact review nodes when file types are mixed', () => {
+    const full: PrImpactResult = {
+      base_branch: 'main',
+      changed_files: ['src/auth.ts'],
+      changed_ranges: [{ source_file: 'src/auth.ts', line_ranges: [{ start: 12, end: 12 }] }],
+      changed_nodes: [],
+      seed_nodes: [],
+      per_node_impact: [],
+      total_blast_radius: 0,
+      affected_files: [],
+      affected_communities: [],
+      review_context: {
+        supporting_paths: [],
+        test_paths: [],
+        hotspots: [],
+      },
+      review_bundle: {
+        budget: 200,
+        token_count: 10,
+        nodes: [
+          {
+            label: 'authenticateUser',
+            source_file: 'src/auth.ts',
+            line_number: 12,
+            file_type: '',
+            snippet: 'const status = "ok"',
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth Layer',
+          },
+          {
+            label: 'ApiHandler',
+            source_file: 'src/api.ts',
+            line_number: 5,
+            file_type: 'code',
+            snippet: null,
+            match_score: 4,
+            relevance_band: 'related',
+            community: 1,
+            community_label: 'API Layer',
+          },
+        ],
+        relationships: [],
+        community_context: [],
+      },
+      risk_summary: {
+        high_impact_nodes: [],
+        cross_community_changes: 0,
+        top_risks: [],
+      },
+    }
+
+    const compact = compactPrImpactResult(full)
+
+    expect(compact.review_bundle).not.toHaveProperty('shared_file_type')
+    expect(compact.review_bundle.nodes[0]).toHaveProperty('file_type', '')
+  })
+
+  it('hoists empty-string file types when every compact review node shares them', () => {
+    const full: PrImpactResult = {
+      base_branch: 'main',
+      changed_files: ['src/auth.ts'],
+      changed_ranges: [{ source_file: 'src/auth.ts', line_ranges: [{ start: 12, end: 12 }] }],
+      changed_nodes: [],
+      seed_nodes: [],
+      per_node_impact: [],
+      total_blast_radius: 0,
+      affected_files: [],
+      affected_communities: [],
+      review_context: {
+        supporting_paths: [],
+        test_paths: [],
+        hotspots: [],
+      },
+      review_bundle: {
+        budget: 200,
+        token_count: 10,
+        nodes: [
+          {
+            label: 'authenticateUser',
+            source_file: 'src/auth.ts',
+            line_number: 12,
+            file_type: '',
+            snippet: 'const status = "ok"',
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth Layer',
+          },
+          {
+            label: 'resolveReviewerSession',
+            source_file: 'src/review-session.ts',
+            line_number: 1,
+            file_type: '',
+            snippet: null,
+            match_score: 4,
+            relevance_band: 'related',
+            community: 2,
+            community_label: 'Review Ops',
+          },
+        ],
+        relationships: [],
+        community_context: [],
+      },
+      risk_summary: {
+        high_impact_nodes: [],
+        cross_community_changes: 0,
+        top_risks: [],
+      },
+    }
+
+    const compact = compactPrImpactResult(full)
+
+    expect(compact.review_bundle).toHaveProperty('shared_file_type', '')
+    expect(compact.review_bundle.nodes[0]).not.toHaveProperty('file_type')
+    expect(compact.review_bundle.nodes[1]).not.toHaveProperty('file_type')
+  })
+
+  it('trims oversized outer payload arrays in compact review mode', () => {
+    const full: PrImpactResult = {
+      base_branch: 'main',
+      changed_files: Array.from({ length: 30 }, (_, index) => `src/file-${index + 1}.ts`),
+      changed_ranges: Array.from({ length: 30 }, (_, index) => ({
+        source_file: `src/file-${index + 1}.ts`,
+        line_ranges: [{ start: index + 1, end: index + 1 }],
+      })),
+      changed_nodes: [],
+      seed_nodes: Array.from({ length: 30 }, (_, index) => ({
+        node_id: `seed-${index + 1}`,
+        label: `Seed${index + 1}`,
+        source_file: `src/file-${index + 1}.ts`,
+        node_kind: 'function',
+        community: index,
+        community_label: `Community ${index + 1}`,
+        line_number: index + 1,
+        source_location: `L${index + 1}-L${index + 1}`,
+        match_kind: 'line',
+      })),
+      per_node_impact: [],
+      total_blast_radius: 30,
+      affected_files: [],
+      affected_communities: Array.from({ length: 24 }, (_, index) => ({
+        id: index,
+        label: `Community ${index + 1}`,
+        node_count: 100 - index,
+      })),
+      review_context: {
+        supporting_paths: [],
+        test_paths: [],
+        hotspots: [],
+      },
+      review_bundle: {
+        budget: 500,
+        token_count: 25,
+        nodes: [
+          {
+            node_id: 'seed-1',
+            label: 'Seed1',
+            source_file: 'src/file-1.ts',
+            line_number: 1,
+            file_type: 'code',
+            snippet: 'return true',
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Community 1',
+          },
+        ],
+        relationships: [],
+        community_context: [],
+      },
+      risk_summary: {
+        high_impact_nodes: Array.from({ length: 24 }, (_, index) => `Risk${index + 1}`),
+        cross_community_changes: 12,
+        top_risks: [
+          {
+            label: 'Seed1',
+            severity: 'high',
+            reason: 'Wide review surface',
+          },
+        ],
+      },
+    }
+
+    const compact = compactPrImpactResult(full)
+
+    expect(compact.changed_files).toHaveLength(20)
+    expect(compact.changed_ranges).toHaveLength(20)
+    expect(compact.seed_nodes).toHaveLength(12)
+    expect(compact.affected_communities).toHaveLength(12)
+    expect(compact.risk_summary.high_impact_nodes).toHaveLength(12)
+    expect(compact.changed_files[0]).toBe('src/file-1.ts')
+    expect(compact.changed_ranges.map((entry) => entry.source_file)).toEqual(compact.changed_files)
+    expect(estimateQueryTokens(JSON.stringify(compact))).toBeLessThan(estimateQueryTokens(JSON.stringify(full)))
   })
 })

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -1,0 +1,212 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  executeReviewCompareRuns,
+  formatReviewCompareSummary,
+  generateReviewCompareArtifacts,
+} from '../../src/infrastructure/review-compare.js'
+import { estimateQueryTokens } from '../../src/runtime/serve.js'
+
+function createRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'graphify-ts-review-compare-'))
+  mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, 'tests'), { recursive: true })
+  mkdirSync(join(root, 'graphify-out'), { recursive: true })
+
+  writeFileSync(join(root, 'src', 'auth.ts'), [
+    'export function authenticateUser(token: string) {',
+    '  const parsed = token.trim()',
+    '  const status = "ok"',
+    '  return parsed.length > 0 ? status : "fail"',
+    '}',
+    '',
+  ].join('\n'), 'utf8')
+  writeFileSync(join(root, 'src', 'api.ts'), [
+    'export function ApiHandler(token: string) {',
+    '  return authenticateUser(token)',
+    '}',
+    '',
+  ].join('\n'), 'utf8')
+  writeFileSync(join(root, 'src', 'audit-log.ts'), [
+    'export function appendAuthAudit(actor: string, status: string) {',
+    '  return `${actor}:${status}`.toLowerCase()',
+    '}',
+    '',
+  ].join('\n'), 'utf8')
+  writeFileSync(join(root, 'tests', 'auth.test.ts'), 'describe("auth", () => {})\n', 'utf8')
+
+  writeFileSync(
+    join(root, 'graphify-out', 'graph.json'),
+    JSON.stringify({
+      directed: true,
+      community_labels: {
+        '0': 'Auth Layer',
+        '1': 'API Layer',
+        '2': 'Audit Trail',
+      },
+      nodes: [
+        {
+          id: 'auth_user',
+          label: 'authenticateUser',
+          source_file: join(root, 'src', 'auth.ts'),
+          source_location: 'L1-L5',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 0,
+        },
+        {
+          id: 'api_handler',
+          label: 'ApiHandler',
+          source_file: join(root, 'src', 'api.ts'),
+          source_location: 'L1-L3',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 1,
+        },
+        {
+          id: 'audit_logger',
+          label: 'appendAuthAudit',
+          source_file: join(root, 'src', 'audit-log.ts'),
+          source_location: 'L1-L3',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 2,
+        },
+      ],
+      edges: [
+        {
+          source: 'api_handler',
+          target: 'auth_user',
+          relation: 'calls',
+          confidence: 'EXTRACTED',
+          source_file: join(root, 'src', 'api.ts'),
+        },
+        {
+          source: 'auth_user',
+          target: 'audit_logger',
+          relation: 'calls',
+          confidence: 'EXTRACTED',
+          source_file: join(root, 'src', 'auth.ts'),
+        },
+      ],
+      hyperedges: [],
+      root_path: root,
+    }),
+    'utf8',
+  )
+
+  execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'graphify@example.com'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'Graphify Test'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: root, stdio: 'pipe' })
+  writeFileSync(
+    join(root, 'src', 'auth.ts'),
+    [
+      'export function authenticateUser(token: string) {',
+      '  const parsed = token.trim()',
+      '  const status = token.startsWith("Bearer ") ? "ok" : "fail"',
+      '  return parsed.length > 0 ? status : "fail"',
+      '}',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+
+  return root
+}
+
+describe('review compare', () => {
+  const repoRoots: string[] = []
+
+  afterEach(() => {
+    for (const root of repoRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('writes verbose and compact review prompt artifacts with reduction metrics', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+
+    const result = generateReviewCompareArtifacts({
+      graphPath: join(root, 'graphify-out', 'graph.json'),
+      outputDir: join(root, 'graphify-out', 'review-compare'),
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      now: new Date('2026-05-01T21:00:00.000Z'),
+    })
+
+    const verbosePrompt = readFileSync(result.report.paths.verbose_prompt, 'utf8')
+    const compactPrompt = readFileSync(result.report.paths.compact_prompt, 'utf8')
+
+    expect(result.report.changed_files).toEqual(['src/auth.ts'])
+    expect(result.report.seed_count).toBe(1)
+    expect(result.report.verbose_payload_tokens).toBeGreaterThan(result.report.compact_payload_tokens)
+    expect(result.report.verbose_prompt_tokens).toBe(estimateQueryTokens(verbosePrompt))
+    expect(result.report.compact_prompt_tokens).toBe(estimateQueryTokens(compactPrompt))
+    expect(result.report.reduction_ratio).toBeGreaterThan(1)
+    expect(verbosePrompt).toContain('"changed_files"')
+    expect(compactPrompt).toContain('"review_context"')
+    expect(compactPrompt).toContain('"supporting_paths"')
+  })
+
+  it('allows nested output directories whose parent does not exist yet', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+
+    const result = generateReviewCompareArtifacts({
+      graphPath: join(root, 'graphify-out', 'graph.json'),
+      outputDir: join(root, 'graphify-out', 'review-compare', 'session1'),
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      now: new Date('2026-05-01T21:00:00.000Z'),
+    })
+
+    expect(result.report.paths.output_dir).toContain(join('review-compare', 'session1'))
+    expect(readFileSync(result.report.paths.verbose_prompt, 'utf8')).toContain('"changed_files"')
+    expect(readFileSync(result.report.paths.compact_prompt, 'utf8')).toContain('"review_context"')
+  })
+
+  it('executes review compare prompts sequentially and saves answer artifacts', async () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    const executions: Array<{ mode: string; promptFile: string; outputFile: string }> = []
+
+    const result = await executeReviewCompareRuns(
+      {
+        graphPath: join(root, 'graphify-out', 'graph.json'),
+        outputDir: join(root, 'graphify-out', 'review-compare'),
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        now: new Date('2026-05-01T21:00:00.000Z'),
+      },
+      {
+        runner: async (execution) => {
+          executions.push(execution)
+          return {
+            exitCode: 0,
+            stdout: `${execution.mode} answer\n`,
+            stderr: '',
+            elapsedMs: execution.mode === 'verbose' ? 15 : 9,
+          }
+        },
+      },
+    )
+
+    expect(executions.map((execution) => execution.mode)).toEqual(['verbose', 'compact'])
+    expect(readFileSync(result.report.answer_paths.verbose, 'utf8')).toBe('verbose answer\n')
+    expect(readFileSync(result.report.answer_paths.compact, 'utf8')).toBe('compact answer\n')
+    expect(result.report.status).toEqual({
+      verbose: 'succeeded',
+      compact: 'succeeded',
+    })
+    expect(result.report.elapsed_ms).toEqual({
+      verbose: 15,
+      compact: 9,
+    })
+    expect(formatReviewCompareSummary(result)).toContain('Prompt tokens')
+  })
+})

--- a/tests/unit/risk-map.test.ts
+++ b/tests/unit/risk-map.test.ts
@@ -1,5 +1,5 @@
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
-import { riskMap } from '../../src/runtime/risk-map.js'
+import { buildRankedRisk, compareRankedRisks, riskMap } from '../../src/runtime/risk-map.js'
 
 describe('riskMap', () => {
   it('returns blast radius risks plus structural hotspots for a feature question', () => {
@@ -104,5 +104,29 @@ describe('riskMap', () => {
       ]),
     )
     expect(result.starter_files[0]?.path).toBe('src/routes/users.ts')
+  })
+
+  it('sorts ranked risks by total score before tie-breaker signals', () => {
+    const lowerScoreMoreHotspots = buildRankedRisk({
+      label: 'LowerScoreMoreHotspots',
+      totalAffected: 1,
+      affectedFiles: ['src/one.ts'],
+      affectedCommunities: ['One'],
+      hotspotKinds: ['bridge', 'god node'],
+      dependentCount: 1,
+    })
+    const higherScoreFewerHotspots = buildRankedRisk({
+      label: 'HigherScoreFewerHotspots',
+      totalAffected: 20,
+      affectedFiles: ['src/two.ts'],
+      affectedCommunities: ['One'],
+      hotspotKinds: [],
+      dependentCount: 0,
+    })
+
+    expect([lowerScoreMoreHotspots, higherScoreFewerHotspots].sort(compareRankedRisks).map((risk) => risk.label)).toEqual([
+      'HigherScoreFewerHotspots',
+      'LowerScoreMoreHotspots',
+    ])
   })
 })

--- a/tests/unit/source-location.test.ts
+++ b/tests/unit/source-location.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { lineRangeFromSourceLocation } from '../../src/shared/source-location.js'
+
+describe('source location', () => {
+  it('normalizes reversed line ranges', () => {
+    expect(lineRangeFromSourceLocation('L14-L10')).toEqual({
+      start: 10,
+      end: 14,
+    })
+  })
+})

--- a/tests/unit/stdio-pr-impact.test.ts
+++ b/tests/unit/stdio-pr-impact.test.ts
@@ -11,6 +11,7 @@ import { estimateQueryTokens } from '../../src/runtime/serve.js'
 function createRepo(options: { reviewHeavy?: boolean } = {}): string {
   const root = mkdtempSync(join(tmpdir(), 'graphify-ts-stdio-pr-impact-'))
   mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, 'tests'), { recursive: true })
   mkdirSync(join(root, 'graphify-out'), { recursive: true })
 
   const authLines = Array.from({ length: 40 }, (_, index) => `// auth filler ${index + 1}`)
@@ -27,6 +28,8 @@ function createRepo(options: { reviewHeavy?: boolean } = {}): string {
 
   writeFileSync(join(root, 'src', 'auth.ts'), `${authLines.join('\n')}\n`, 'utf8')
   writeFileSync(join(root, 'src', 'api.ts'), `${apiLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(root, 'tests', 'auth.test.ts'), 'describe("auth", () => {})\n', 'utf8')
+  writeFileSync(join(root, 'tests', 'api.test.ts'), 'describe("api", () => {})\n', 'utf8')
   const reviewFixtureFiles = options.reviewHeavy ? [
     {
       id: 'review_session',
@@ -431,9 +434,15 @@ describe('stdio pr impact', () => {
     )
     expect(compactPayload.review_bundle.token_count).toBeLessThan(verbosePayload.review_bundle.token_count)
     expect(compactPayload.review_bundle.nodes.length).toBeLessThanOrEqual(verbosePayload.review_bundle.nodes.length)
+    expect(compactPayload.review_bundle).toEqual(expect.objectContaining({ shared_file_type: 'code' }))
     expect(compactPayload.review_bundle.nodes.find((node: { label: string; snippet: string | null }) => node.label === 'ApiHandler')).toEqual(
       expect.objectContaining({ snippet: null }),
     )
+    expect(compactPayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'ApiHandler')).not.toHaveProperty('node_id')
+    expect(compactPayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'ApiHandler')).not.toHaveProperty('match_score')
+    expect(compactPayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'ApiHandler')).not.toHaveProperty('community_label')
+    expect(compactPayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'ApiHandler')).not.toHaveProperty('framework_boost')
+    expect(compactPayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'ApiHandler')).not.toHaveProperty('file_type')
     expect(compactPayload.review_bundle.relationships).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -453,6 +462,8 @@ describe('stdio pr impact', () => {
         }),
       ]),
     )
+    expect(compactPayload.review_bundle.relationships[0]).not.toHaveProperty('from_id')
+    expect(compactPayload.review_bundle.relationships[0]).not.toHaveProperty('to_id')
     expect(verbosePayload.review_bundle.relationships).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -485,12 +496,23 @@ describe('stdio pr impact', () => {
         expect.objectContaining({ label: 'Review Ops' }),
       ]),
     )
+    expect(compactPayload.review_context).toEqual(expect.objectContaining({
+      supporting_paths: ['src/api.ts', 'src/audit-log.ts', 'src/review-session.ts'],
+      test_paths: expect.arrayContaining(['tests/auth.test.ts', 'tests/api.test.ts']),
+      hotspots: expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+          type: expect.stringMatching(/bridge|god_node/),
+          why: expect.any(String),
+        }),
+      ]),
+    }))
     expect(fullReviewBundleTokens).toBe(1356)
-    expect(compactReviewBundleTokens).toBe(512)
-    expect(reviewBundleReductionRatio).toBe(2.648)
-    expect(fullPayloadTokens).toBe(1716)
-    expect(compactPayloadTokens).toBe(736)
-    expect(payloadReductionRatio).toBe(2.332)
+    expect(compactReviewBundleTokens).toBeLessThan(452)
+    expect(reviewBundleReductionRatio).toBeGreaterThan(3)
+    expect(fullPayloadTokens).toBeLessThan(1_900)
+    expect(compactPayloadTokens).toBeLessThan(780)
+    expect(payloadReductionRatio).toBeGreaterThan(2.4)
     expect(compactPayload.risk_summary.top_risks[0]).toEqual(
       expect.objectContaining({
         label: 'authenticateUser',

--- a/tests/unit/stdio-pr-impact.test.ts
+++ b/tests/unit/stdio-pr-impact.test.ts
@@ -1,0 +1,558 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { handleStdioRequest } from '../../src/runtime/stdio-server.js'
+import { estimateQueryTokens } from '../../src/runtime/serve.js'
+
+function createRepo(options: { reviewHeavy?: boolean } = {}): string {
+  const root = mkdtempSync(join(tmpdir(), 'graphify-ts-stdio-pr-impact-'))
+  mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, 'graphify-out'), { recursive: true })
+
+  const authLines = Array.from({ length: 40 }, (_, index) => `// auth filler ${index + 1}`)
+  authLines[9] = 'export function authenticateUser(token: string) {'
+  authLines[10] = '  const parsed = token.trim()'
+  authLines[11] = '  const status = "ok"'
+  authLines[12] = '  return parsed.length > 0 ? status : "fail"'
+  authLines[13] = '}'
+
+  const apiLines = Array.from({ length: 16 }, (_, index) => `// api filler ${index + 1}`)
+  apiLines[4] = 'export function ApiHandler(token: string) {'
+  apiLines[5] = '  return authenticateUser(token)'
+  apiLines[6] = '}'
+
+  writeFileSync(join(root, 'src', 'auth.ts'), `${authLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(root, 'src', 'api.ts'), `${apiLines.join('\n')}\n`, 'utf8')
+  const reviewFixtureFiles = options.reviewHeavy ? [
+    {
+      id: 'review_session',
+      label: 'resolveReviewerSession',
+      relativePath: 'src/review-session.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function resolveReviewerSession(token: string) {',
+        '  const normalized = token.trim()',
+        '  const reviewable = normalized.startsWith("Bearer ")',
+        '  return { reviewable, reviewer: reviewable ? "maintainer" : "guest" }',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'audit_logger',
+      label: 'appendAuthAudit',
+      relativePath: 'src/audit-log.ts',
+      sourceLocation: 'L1-L5',
+      community: 3,
+      lines: [
+        'export function appendAuthAudit(actor: string, status: string) {',
+        '  const event = `${actor}:${status}`',
+        '  return event.toLowerCase()',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'merge_queue_gate',
+      label: 'MergeQueueGate',
+      relativePath: 'src/merge-queue-gate.ts',
+      sourceLocation: 'L1-L5',
+      community: 4,
+      lines: [
+        'export function MergeQueueGate(token: string) {',
+        '  const lane = token.includes("hotfix") ? "priority" : "default"',
+        '  return `${lane}:queued`',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'review_summary_digest',
+      label: 'ReviewSummaryDigest',
+      relativePath: 'src/review-summary-digest.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function ReviewSummaryDigest(prTitle: string) {',
+        '  const heading = prTitle.trim()',
+        '  return heading.length > 0 ? heading : "untitled-review"',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'reviewer_roster_sync',
+      label: 'ReviewerRosterSync',
+      relativePath: 'src/reviewer-roster-sync.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function ReviewerRosterSync(team: string) {',
+        '  const normalized = team.trim().toLowerCase()',
+        '  return normalized.length > 0 ? normalized.split("-") : []',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'risk_escalation_digest',
+      label: 'RiskEscalationDigest',
+      relativePath: 'src/risk-escalation-digest.ts',
+      sourceLocation: 'L1-L5',
+      community: 4,
+      lines: [
+        'export function RiskEscalationDigest(score: number) {',
+        '  return score > 8 ? "page-security" : "queue-review"',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'security_checklist_digest',
+      label: 'SecurityChecklistDigest',
+      relativePath: 'src/security-checklist-digest.ts',
+      sourceLocation: 'L1-L5',
+      community: 3,
+      lines: [
+        'export function SecurityChecklistDigest(items: string[]) {',
+        '  return items.filter((item) => item.includes("review"))',
+        '}',
+        '',
+      ],
+    },
+    {
+      id: 'stale_reviewer_reminder',
+      label: 'StaleReviewerReminder',
+      relativePath: 'src/stale-reviewer-reminder.ts',
+      sourceLocation: 'L1-L5',
+      community: 2,
+      lines: [
+        'export function StaleReviewerReminder(hoursOpen: number) {',
+        '  return hoursOpen > 24 ? "nudge" : "quiet"',
+        '}',
+        '',
+      ],
+    },
+  ] as const : []
+  for (const fixtureFile of reviewFixtureFiles) {
+    writeFileSync(join(root, fixtureFile.relativePath), fixtureFile.lines.join('\n'), 'utf8')
+  }
+  writeFileSync(
+    join(root, 'graphify-out', 'graph.json'),
+    JSON.stringify({
+      directed: true,
+      community_labels: {
+        '0': 'Auth Layer',
+        '1': 'API Layer',
+        ...(options.reviewHeavy ? {
+          '2': 'Review Ops',
+          '3': 'Audit Trail',
+          '4': 'Release Safety',
+        } : {}),
+      },
+      nodes: [
+        {
+          id: 'auth_user',
+          label: 'authenticateUser',
+          source_file: join(root, 'src', 'auth.ts'),
+          source_location: 'L10-L14',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 0,
+        },
+        {
+          id: 'auth_guard',
+          label: 'AuthGuard',
+          source_file: join(root, 'src', 'auth.ts'),
+          source_location: 'L30-L32',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 0,
+        },
+        {
+          id: 'api_handler',
+          label: 'ApiHandler',
+          source_file: join(root, 'src', 'api.ts'),
+          source_location: 'L5-L7',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 1,
+        },
+        ...reviewFixtureFiles.map((fixtureFile) => ({
+          id: fixtureFile.id,
+          label: fixtureFile.label,
+          source_file: join(root, fixtureFile.relativePath),
+          source_location: fixtureFile.sourceLocation,
+          node_kind: 'function',
+          file_type: 'code',
+          community: fixtureFile.community,
+        })),
+      ],
+      edges: [
+        {
+          source: 'api_handler',
+          target: 'auth_user',
+          relation: 'calls',
+          confidence: 'EXTRACTED',
+          source_file: join(root, 'src', 'api.ts'),
+        },
+        ...(!options.reviewHeavy ? [] : [
+          {
+            source: 'auth_user',
+            target: 'review_session',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'auth.ts'),
+          },
+          {
+            source: 'auth_user',
+            target: 'audit_logger',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'auth.ts'),
+          },
+          {
+            source: 'merge_queue_gate',
+            target: 'api_handler',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'merge-queue-gate.ts'),
+          },
+          {
+            source: 'merge_queue_gate',
+            target: 'audit_logger',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'merge-queue-gate.ts'),
+          },
+          {
+            source: 'review_summary_digest',
+            target: 'api_handler',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'review-summary-digest.ts'),
+          },
+          {
+            source: 'review_summary_digest',
+            target: 'review_session',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'review-summary-digest.ts'),
+          },
+          {
+            source: 'reviewer_roster_sync',
+            target: 'review_session',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'reviewer-roster-sync.ts'),
+          },
+          {
+            source: 'reviewer_roster_sync',
+            target: 'audit_logger',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'reviewer-roster-sync.ts'),
+          },
+          {
+            source: 'risk_escalation_digest',
+            target: 'audit_logger',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'risk-escalation-digest.ts'),
+          },
+          {
+            source: 'risk_escalation_digest',
+            target: 'merge_queue_gate',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'risk-escalation-digest.ts'),
+          },
+          {
+            source: 'security_checklist_digest',
+            target: 'audit_logger',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'security-checklist-digest.ts'),
+          },
+          {
+            source: 'stale_reviewer_reminder',
+            target: 'review_session',
+            relation: 'calls',
+            confidence: 'EXTRACTED',
+            source_file: join(root, 'src', 'stale-reviewer-reminder.ts'),
+          },
+        ]),
+      ],
+      hyperedges: [],
+      root_path: root,
+    }),
+    'utf8',
+  )
+
+  execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'graphify@example.com'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'Graphify Test'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: root, stdio: 'pipe' })
+
+  return root
+}
+
+describe('stdio pr impact', () => {
+  const repoRoots: string[] = []
+
+  afterEach(() => {
+    for (const root of repoRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('exposes pr_impact budget and returns the review bundle through MCP', async () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    writeFileSync(
+      join(root, 'src', 'auth.ts'),
+      readFileSync(join(root, 'src', 'auth.ts'), 'utf8').replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'),
+      'utf8',
+    )
+
+    const graphPath = join(root, 'graphify-out', 'graph.json')
+    const tools = await Promise.resolve(handleStdioRequest(graphPath, { id: 1, method: 'tools/list' }))
+    const tool = (tools?.result as { tools: Array<{ name: string; inputSchema: { properties: Record<string, unknown> } }> }).tools.find(
+      (entry) => entry.name === 'pr_impact',
+    )
+
+    expect(tool?.inputSchema.properties.budget).toEqual(expect.objectContaining({ type: 'number' }))
+    expect(tool?.inputSchema.properties.verbose).toEqual(expect.objectContaining({ type: 'boolean' }))
+    expect(tool?.inputSchema.properties.compact).toEqual(expect.objectContaining({ type: 'boolean' }))
+
+    const response = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'pr_impact',
+        arguments: {
+          budget: 240,
+        },
+      },
+    }))
+    const payload = JSON.parse((response?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+    expect(payload.seed_nodes).toEqual([
+      expect.objectContaining({
+        label: 'authenticateUser',
+        match_kind: 'line',
+      }),
+    ])
+    expect(payload.review_bundle).toEqual(
+      expect.objectContaining({
+        budget: 240,
+      }),
+    )
+    expect(payload.review_bundle.token_count).toBeLessThanOrEqual(240)
+  })
+
+  it('returns the compact pr_impact payload by default and the full payload for verbose or compact=false', async () => {
+    const root = createRepo({ reviewHeavy: true })
+    repoRoots.push(root)
+    writeFileSync(
+      join(root, 'src', 'auth.ts'),
+      readFileSync(join(root, 'src', 'auth.ts'), 'utf8').replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'),
+      'utf8',
+    )
+
+    const graphPath = join(root, 'graphify-out', 'graph.json')
+    const compactResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'pr_impact',
+        arguments: {
+          budget: 2_000,
+        },
+      },
+    }))
+    const verboseResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'pr_impact',
+        arguments: {
+          budget: 2_000,
+          verbose: true,
+        },
+      },
+    }))
+    const fullResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 5,
+      method: 'tools/call',
+      params: {
+        name: 'pr_impact',
+        arguments: {
+          budget: 2_000,
+          compact: false,
+        },
+      },
+    }))
+
+    const compactPayload = JSON.parse((compactResponse?.result as { content: Array<{ text: string }> }).content[0]!.text)
+    const verbosePayload = JSON.parse((verboseResponse?.result as { content: Array<{ text: string }> }).content[0]!.text)
+    const fullPayload = JSON.parse((fullResponse?.result as { content: Array<{ text: string }> }).content[0]!.text)
+    const fullReviewBundleTokens = estimateQueryTokens(JSON.stringify(verbosePayload.review_bundle))
+    const compactReviewBundleTokens = estimateQueryTokens(JSON.stringify(compactPayload.review_bundle))
+    const fullPayloadTokens = estimateQueryTokens(JSON.stringify(fullPayload))
+    const compactPayloadTokens = estimateQueryTokens(JSON.stringify(compactPayload))
+    const reviewBundleReductionRatio = Number((fullReviewBundleTokens / compactReviewBundleTokens).toFixed(3))
+    const payloadReductionRatio = Number((fullPayloadTokens / compactPayloadTokens).toFixed(3))
+
+    expect(compactPayload).not.toHaveProperty('changed_nodes')
+    expect(compactPayload).not.toHaveProperty('affected_files')
+    expect(compactPayload.review_bundle).toEqual(expect.objectContaining({ budget: 2_000 }))
+    expect(verbosePayload.review_bundle.nodes.map((node: { label: string }) => node.label)).toEqual(expect.arrayContaining([
+      'ApiHandler',
+      'appendAuthAudit',
+      'resolveReviewerSession',
+      'MergeQueueGate',
+      'ReviewSummaryDigest',
+    ]))
+    expect(compactPayload.review_bundle.nodes.map((node: { label: string }) => node.label)).toEqual(expect.arrayContaining([
+      'authenticateUser',
+      'ApiHandler',
+      'appendAuthAudit',
+      'resolveReviewerSession',
+    ]))
+    expect(compactPayload.review_bundle.nodes.map((node: { label: string }) => node.label)).not.toEqual(
+      expect.arrayContaining(['MergeQueueGate', 'ReviewSummaryDigest', 'ReviewerRosterSync', 'RiskEscalationDigest']),
+    )
+    expect(compactPayload.review_bundle.token_count).toBeLessThan(verbosePayload.review_bundle.token_count)
+    expect(compactPayload.review_bundle.nodes.length).toBeLessThanOrEqual(verbosePayload.review_bundle.nodes.length)
+    expect(compactPayload.review_bundle.nodes.find((node: { label: string; snippet: string | null }) => node.label === 'ApiHandler')).toEqual(
+      expect.objectContaining({ snippet: null }),
+    )
+    expect(compactPayload.review_bundle.relationships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'ApiHandler',
+          to: 'authenticateUser',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'authenticateUser',
+          to: 'appendAuthAudit',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'authenticateUser',
+          to: 'resolveReviewerSession',
+          relation: 'calls',
+        }),
+      ]),
+    )
+    expect(verbosePayload.review_bundle.relationships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'MergeQueueGate',
+          to: 'appendAuthAudit',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'ReviewSummaryDigest',
+          to: 'resolveReviewerSession',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'ReviewerRosterSync',
+          to: 'appendAuthAudit',
+          relation: 'calls',
+        }),
+        expect.objectContaining({
+          from: 'RiskEscalationDigest',
+          to: 'MergeQueueGate',
+          relation: 'calls',
+        }),
+      ]),
+    )
+    expect(compactPayload.review_bundle.community_context).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Auth Layer' }),
+        expect.objectContaining({ label: 'API Layer' }),
+        expect.objectContaining({ label: 'Audit Trail' }),
+        expect.objectContaining({ label: 'Review Ops' }),
+      ]),
+    )
+    expect(fullReviewBundleTokens).toBe(1356)
+    expect(compactReviewBundleTokens).toBe(512)
+    expect(reviewBundleReductionRatio).toBe(2.648)
+    expect(fullPayloadTokens).toBe(1716)
+    expect(compactPayloadTokens).toBe(736)
+    expect(payloadReductionRatio).toBe(2.332)
+    expect(compactPayload.risk_summary.top_risks[0]).toEqual(
+      expect.objectContaining({
+        label: 'authenticateUser',
+        severity: expect.stringMatching(/high|medium|low/),
+        reason: expect.any(String),
+      }),
+    )
+
+    expect(verbosePayload.changed_nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+        }),
+      ]),
+    )
+    expect(verbosePayload.affected_files).toEqual(expect.arrayContaining(['src/api.ts']))
+    expect(verbosePayload.per_node_impact[0]).toEqual(
+      expect.objectContaining({
+        node: 'authenticateUser',
+        direct_dependents: expect.any(Number),
+        transitive_dependents: expect.any(Number),
+      }),
+    )
+    expect(fullPayload).toEqual(verbosePayload)
+    expect(fullPayload.changed_nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+        }),
+      ]),
+    )
+    expect(fullPayload.affected_files).toEqual(expect.arrayContaining(['src/api.ts']))
+  })
+
+  it('caps pr_impact review bundles at the requested budget through MCP', async () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    writeFileSync(
+      join(root, 'src', 'auth.ts'),
+      readFileSync(join(root, 'src', 'auth.ts'), 'utf8').replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'),
+      'utf8',
+    )
+
+    const graphPath = join(root, 'graphify-out', 'graph.json')
+    const response = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'pr_impact',
+        arguments: {
+          budget: 1,
+        },
+      },
+    }))
+    const payload = JSON.parse((response?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+    expect(payload.review_bundle).toEqual({
+      budget: 1,
+      token_count: 0,
+      nodes: [],
+      relationships: [],
+      community_context: [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Testing

<!-- Paste commands or explain verification. -->

- [ ] `npm run test:run`
- [ ] `npm run typecheck`
- [ ] `npm run build`
- [ ] `npm pack --dry-run` (if packaging or install behavior changed)

## Checklist

- [ ] I updated docs for any user-visible change
- [ ] I added or updated tests when behavior changed
- [ ] I did not commit secrets, private corpora, or accidental generated artifacts
- [ ] I kept this PR focused on a single change or tightly related set of changes

## Related issues

<!-- Closes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added review-compare CLI workflow to generate verbose vs compact PR-impact prompts, run them, save artifacts, and report token/run summaries
  * PR-impact now returns line-aware changed ranges, typed seed_nodes, a budgeted compact review bundle, ranked/top risks, and supports budget/verbose/compact flags
* **Bug Fixes**
  * Improved PR-diff discovery in nested repos, output-dir validation, range normalization, and line-metadata fallbacks
  * Reduced compact payload sizes by trimming oversized arrays
* **Documentation**
  * Docs and examples updated for review-compare and expanded pr_impact outputs
* **Tests**
  * New unit tests for CLI, review-compare, pr-impact, risk-ranking, and source-location behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->