### PR TITLE
chore: release v0.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.11] - 2026-05-02
+
+### Fixed
+
+- **Hosted retrieval benchmark warning color**: replaced the undefined `--amber-400` token in the 2026-04-30 benchmark page with the defined `--c-lemon` warning color so the published trade-off label renders consistently.
+- **Contributing guide clarity**: removed the circular repository-settings sentence from `CONTRIBUTING.md` so the public contribution guide stays concrete and user-facing.
+
 ## [0.10.10] - 2026-05-02
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,6 @@ Follow the process in [`SECURITY.md`](./SECURITY.md).
 
 This repository includes GitHub issue forms, a pull request template, `CODEOWNERS`, and a CI workflow to support a clean open-source contribution flow.
 
-If you maintain the repository, keep repository-level protections such as branch protection rules, required checks, and merge restrictions aligned with the current GitHub repository settings.
-
 ## License
 
 By contributing, you agree that your contributions are licensed under this project's MIT license.

--- a/docs/benchmarks/2026-04-30-govalidate/index.html
+++ b/docs/benchmarks/2026-04-30-govalidate/index.html
@@ -119,7 +119,7 @@
           <div class="bar-group">
             <div class="label-row">
               <span class="name">Cold-start session cost</span>
-              <span class="delta" style="color:var(--amber-400)">+13% trade-off</span>
+              <span class="delta" style="color:var(--c-lemon)">+13% trade-off</span>
             </div>
             <div class="bar-row">
               <span class="legend"><span class="swatch baseline" aria-hidden="true"></span>Without graphify-ts</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.10",
+    "version": "0.10.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.10.10",
+            "version": "0.10.11",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.10",
+    "version": "0.10.11",
     "description": "Build local knowledge graphs from code, docs, and mixed project folders with a TypeScript CLI.",
     "license": "MIT",
     "author": "mohanagy",

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -52,6 +52,12 @@ describe('public benchmark artifact (2026-04-30 govalidate)', () => {
     expect(readme).toContain(`$${graphify.total_cost_usd.toFixed(2)}`)
   })
 
+  it('hosted retrieval benchmark page uses only defined warning color tokens', () => {
+    const page = readFileSync(resolve(ARTIFACT_DIR, 'index.html'), 'utf8')
+    expect(page).not.toContain('var(--amber-400)')
+    expect(page).toContain('var(--c-lemon)')
+  })
+
   it('README does not contain the stale 384x/897x/397x marketing claims', () => {
     const lower = readme.toLowerCase()
     for (const stale of ['384x', '397x', '897x', '384×', '397×', '897×']) {

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -95,6 +95,12 @@ describe('package metadata', () => {
     expect(loadContributingGuide()).toContain("licensed under this project's MIT license")
   })
 
+  it('avoids circular maintainer guidance in the contributing guide', () => {
+    const contributingGuide = loadContributingGuide()
+
+    expect(contributingGuide).not.toContain('current GitHub repository settings')
+  })
+
   it('keeps the eval regression workflow aligned with runner-backed eval requirements', () => {
     const ciWorkflow = loadCiWorkflow()
 


### PR DESCRIPTION
## Summary
- fix the undefined warning color token in the hosted retrieval benchmark page
- remove the circular repository-settings sentence from CONTRIBUTING.md
- bump package metadata and changelog to 0.10.11

## Testing
- [x] npm run test:run -- tests/unit/benchmark-artifact.test.ts tests/unit/package-metadata.test.ts
- [x] npm run typecheck
- [x] npm run test:run
- [x] npm run build
- [x] npm pack --dry-run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.10.11

* **Bug Fixes**
  * Fixed color styling in benchmark visualization to display correctly.

* **Documentation**
  * Clarified contribution guidelines by removing redundant guidance.

* **Tests**
  * Added verification for color token consistency and documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->