### PR TITLE
chore: release v0.10.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.12] - 2026-05-03
+
+### Fixed
+
+- **Benchmark chart readability**: the hosted benchmark comparison bars now use dedicated saturated fill tokens instead of the faint legend-chip tint, so the measured width differences read clearly at a glance.
+- **Terminal command visibility**: benchmark `<pre><code>` blocks now strip the inline-code chip styling, preventing pale overlays from obscuring commands inside the dark terminal reproducer panels.
+
 ## [0.10.11] - 2026-05-02
 
 ### Fixed

--- a/docs/benchmarks/styles.css
+++ b/docs/benchmarks/styles.css
@@ -42,10 +42,14 @@
   --c-lemon-edge:    rgba(155, 104, 41, 0.25);
 
   /* Bar viz fills (light mode) */
+  /* Swatch tints — subtle, used in the small 12px legend chips */
   --bar-baseline:        rgba(100, 116, 141, 0.18);
   --bar-baseline-edge:   rgba(100, 116, 141, 0.55);
   --bar-graphify:        rgba(83, 58, 253, 0.18);
   --bar-graphify-edge:   var(--c-purple);
+  /* Bar fills — saturated, used in the actual chart so the proportion reads at a glance */
+  --bar-baseline-fill:   rgba(100, 116, 141, 0.55);
+  --bar-graphify-fill:   rgba(83, 58, 253, 0.70);
 
   /* ---- Type ----------------------------------------------------------- */
   /* Inter is the open-source stand-in for sohne-var; both ship "ss01" + "tnum" */
@@ -483,11 +487,11 @@ code {
   transform-origin: left;
 }
 .bar-row .bar .fill.baseline {
-  background: var(--bar-baseline);
+  background: var(--bar-baseline-fill);
   box-shadow: inset 0 0 0 1px var(--bar-baseline-edge);
 }
 .bar-row .bar .fill.graphify {
-  background: var(--bar-graphify);
+  background: var(--bar-graphify-fill);
   box-shadow: inset 0 0 0 1px var(--bar-graphify-edge);
 }
 .bar-row .value {
@@ -633,6 +637,20 @@ code {
 .terminal .prompt { color: var(--c-purple-light); user-select: none; margin-right: 0.5em; }
 .terminal .cmd    { color: rgba(255, 255, 255, 0.96); }
 .terminal .comment{ color: rgba(255, 255, 255, 0.45); }
+
+/* Strip the inline-code chip styling when <code> is inside a <pre> block —
+   otherwise the near-white chip background overlays the dark terminal and
+   hides the actual command text behind opaque bars. */
+.terminal code,
+pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  border-radius: 0;
+}
 
 /* ==========================================================================
    Evidence files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.10.11",
+            "version": "0.10.12",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "description": "Build local knowledge graphs from code, docs, and mixed project folders with a TypeScript CLI.",
     "license": "MIT",
     "author": "mohanagy",

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 const ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-04-30-govalidate')
 const REVIEW_ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-05-02-govalidate-pr-review')
+const BENCHMARK_STYLESHEET = resolve('docs', 'benchmarks', 'styles.css')
 
 describe('public benchmark artifact (2026-04-30 govalidate)', () => {
   const baseline = JSON.parse(readFileSync(resolve(ARTIFACT_DIR, 'baseline-session.json'), 'utf8')) as {
@@ -119,5 +120,22 @@ describe('public benchmark artifact (2026-05-02 govalidate pr review)', () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('verbose_prompt_tokens')
     expect(result.stdout).toContain('compact_prompt_tokens')
+  })
+})
+
+describe('hosted benchmark stylesheet', () => {
+  const styles = readFileSync(BENCHMARK_STYLESHEET, 'utf8')
+
+  it('uses dedicated saturated fill tokens for the comparison bars', () => {
+    expect(styles).toContain('--bar-baseline-fill:   rgba(100, 116, 141, 0.55);')
+    expect(styles).toContain('--bar-graphify-fill:   rgba(83, 58, 253, 0.70);')
+    expect(styles).toMatch(/\.bar-row \.bar \.fill\.baseline \{\s+background: var\(--bar-baseline-fill\);/s)
+    expect(styles).toMatch(/\.bar-row \.bar \.fill\.graphify \{\s+background: var\(--bar-graphify-fill\);/s)
+    expect(styles).not.toMatch(/\.bar-row \.bar \.fill\.baseline \{\s+background: var\(--bar-baseline\);/s)
+    expect(styles).not.toMatch(/\.bar-row \.bar \.fill\.graphify \{\s+background: var\(--bar-graphify\);/s)
+  })
+
+  it('removes inline code chip styling inside terminal pre blocks', () => {
+    expect(styles).toMatch(/\.terminal code,\s*pre code \{\s*background: transparent;\s*border: 0;\s*padding: 0;\s*color: inherit;\s*font-weight: inherit;\s*font-size: inherit;\s*border-radius: 0;\s*\}/s)
   })
 })


### PR DESCRIPTION
## Summary
- improve benchmark chart fills so the comparison bars read clearly
- strip inline code chip styling inside terminal/pre blocks on the hosted benchmark pages
- add stylesheet regression coverage and bump release metadata to 0.10.12

## Verification
- npm run test:run -- tests/unit/benchmark-artifact.test.ts
- npm run typecheck
- npm run test:run
- npm run build
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted benchmark chart readability with clearer visual distinctions for comparing results
  * Enhanced terminal reproducer command visibility by refining code display styling

* **Tests**
  * Added test coverage for benchmark styling updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->