### PR TITLE
fix(benchmarks): render comparison bar fills

### DIFF
--- a/docs/benchmarks/styles.css
+++ b/docs/benchmarks/styles.css
@@ -485,6 +485,7 @@ code {
 }
 .bar-row .bar .fill {
   height: 100%;
+  display: block;
   border-radius: var(--r-sm);
   animation: bar-grow 700ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
   transform-origin: left;

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -140,6 +140,10 @@ describe('hosted benchmark stylesheet', () => {
     expect(styles).not.toMatch(/\.bar-row \.bar \.fill\.graphify \{\s+background: var\(--bar-graphify\);/s)
   })
 
+  it('makes the fill element block-level so inline width styles render visible bars', () => {
+    expect(styles).toMatch(/\.bar-row \.bar \.fill \{\s+height: 100%;\s+display: block;/s)
+  })
+
   it('removes inline code chip styling inside terminal pre blocks', () => {
     expect(styles).toMatch(/\.terminal code,\s*pre code \{\s*background: transparent;\s*border: 0;\s*padding: 0;\s*color: inherit;\s*font-weight: inherit;\s*font-size: inherit;\s*border-radius: 0;\s*\}/s)
   })


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Testing

<!-- Paste commands or explain verification. -->

- [ ] `npm run test:run`
- [ ] `npm run typecheck`
- [ ] `npm run build`
- [ ] `npm pack --dry-run` (if packaging or install behavior changed)

## Checklist

- [ ] I updated docs for any user-visible change
- [ ] I added or updated tests when behavior changed
- [ ] I did not commit secrets, private corpora, or accidental generated artifacts
- [ ] I kept this PR focused on a single change or tightly related set of changes

## Related issues

<!-- Closes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display rendering of comparison bars in benchmark visualizations to ensure proper visibility.

* **Tests**
  * Added stylesheet assertion test to verify correct styling and display behavior for benchmark comparison bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->