### PR TITLE
chore: release v0.11.0

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,33 @@
+name: Update contributors
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly safety net in case a push doesn't trigger (e.g. release tag pushes only).
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update contributors list in README
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          readme_path: README.md
+          image_size: 80
+          columns_per_row: 6
+          use_username: true
+          commit_message: 'docs: update contributors list'

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Update contributors list in README
-        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-05
+
+### Added
+
+- **OpenCode MCP installer support**: `graphify-ts opencode install` now wires graphify-ts into [OpenCode](https://opencode.ai), extending the agent-installer matrix beyond Claude Code, Cursor, Copilot, Gemini CLI, and Aider. Thanks to [@jamemackson](https://github.com/jamemackson) for contributing this feature in [#54](https://github.com/mohanagy/graphify-ts/pull/54) — the first community-contributed agent integration in graphify-ts.
+- **Auto-updating contributors list in README**: a new GitHub Actions workflow (`.github/workflows/contributors.yml`) regenerates the contributors table on every push to `main`, so new contributors are credited automatically without manual README maintenance.
+
 ## [0.10.12] - 2026-05-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ The only command that hits an external service is the optional `compare` / `revi
 
 graphify-ts is a Node/TypeScript implementation of the [original `graphify`](https://github.com/safishamsi/graphify) by [Safi Shamsi](https://github.com/safishamsi), adapted for local graph workflows and AI agent integration.
 
+## Contributors
+
+Thanks to everyone shaping graphify-ts. The list below is regenerated automatically on every push to `main` by [`.github/workflows/contributors.yml`](.github/workflows/contributors.yml).
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
+A specific shout-out to [@jamemackson](https://github.com/jamemackson) for [#54](https://github.com/mohanagy/graphify-ts/pull/54) — adding OpenCode MCP installer support, the first community-contributed feature in graphify-ts.
+
 ## License
 
 MIT. Use it, fork it, ship it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.12",
+    "version": "0.11.0",
     "description": "Build local knowledge graphs from code, docs, and mixed project folders with a TypeScript CLI.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

- Cuts **v0.11.0**, the first community-feature release of graphify-ts. Bundles [#54](https://github.com/mohanagy/graphify-ts/pull/54) (OpenCode MCP installer support, by @jamemackson — already merged to `main`) with new infrastructure for crediting contributors.
- Adds an **auto-updating contributors list** via GitHub Actions, replacing the static `Credit` handling with a real HTML table that regenerates on every push to `main`.
- Updates `CHANGELOG.md` and `package.json` to satisfy the release workflow's tag/version/changelog validation, so a `v0.11.0` tag will pass `Validate tag, package version, and changelog`.

## What's in this release

### Added — OpenCode MCP installer support (#54, @jamemackson)
`graphify-ts opencode install` now wires graphify-ts into [OpenCode](https://opencode.ai). The agent-installer matrix is now Claude Code · Cursor · Copilot · Gemini CLI · Aider · OpenCode. **First community-contributed agent integration.**

### Added — Auto-updating contributors workflow
- New `.github/workflows/contributors.yml` running [`akhilmhdh/contributors-readme-action@v2.3.10`](https://github.com/akhilmhdh/contributors-readme-action) on push to `main`, weekly cron (Mon 03:00 UTC), and `workflow_dispatch`.
- README `Contributors` section now uses the action's `<!-- readme: contributors -start/-end -->` markers; the action commits a regenerated HTML table back to `main` after the next push, with no manual maintenance going forward.
- One-line shout-out preserved for @jamemackson as the inaugural community contributor.

## Test plan

- [ ] CI passes (typecheck + tests + build + `npm pack --dry-run`)
- [ ] After merge to `main`: confirm the `Update contributors` workflow runs and commits a regenerated `Contributors` table containing both @mohanagy and @jamemackson
- [ ] Tag `v0.11.0` from `main` and confirm the `Release` workflow passes the validation step (`tag === v$VERSION`, CHANGELOG section present)
- [ ] Confirm the GitHub release is created with auto-generated notes
- [ ] (Manual / out-of-band) `npm publish` for `@mohammednagy/graphify-ts@0.11.0` once the GitHub release is live, unless an npm-publish workflow exists that I haven't seen

## Notes

- Version bump is a **minor** (0.10.12 → 0.11.0). Past releases have used patches for changes of similar size; treating a new agent integration as `minor` is more semver-correct and gives this release a clean narrative anchor for the launch post.
- The contributors automation needs `permissions: contents: write` to commit back to `main`. Already configured in the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for OpenCode agent-installer integration via the installer command.

* **Documentation**
  * Added a Contributors section to the README with an updated contributors list and a shout-out for a recent PR.

* **Chores**
  * Automated contributors list maintenance via a scheduled/triggerable workflow.
* **Release**
  * Bumped package version to v0.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->