### PR TITLE
fix(ci): grant contributors workflow permission to open PRs

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-contributors:


### PR DESCRIPTION
## Summary

- The `Update contributors` workflow failed on its first run after [#55](https://github.com/mohanagy/graphify-ts/pull/55) merged to `main`, with `Resource not accessible by integration`.
- Root cause: branch protection on `main` triggers the action's `auto_detect_branch_protection` fallback (open a PR instead of pushing directly), but the workflow only had `contents: write` — it lacked `pull-requests: write`.
- This PR adds `pull-requests: write` to the workflow permissions block.

## Repo-level setting also flipped

The repo-level switch **"Allow GitHub Actions to create and approve pull requests"** was previously off (`can_approve_pull_request_reviews: false`). It has been enabled — without that, no per-workflow `pull-requests: write` can take effect.

Both conditions are now in place:
- Repo: `can_approve_pull_request_reviews: true`
- Workflow: `pull-requests: write` (this PR)

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to `main`: `Update contributors` workflow runs successfully and opens a `docs(contributor): contributors readme action update` PR with the populated HTML table for @mohanagy and @jamemackson
- [ ] That auto-generated PR is merged, populating the README contributors section in `main`
- [ ] After both are landed, tag `v0.11.0` from `main` so the npm package ships with a real contributors table

## Notes

- The orphaned side branch `contributors-readme-action-e8pGzCw-Ox` left by the failed first run has already been deleted.
- This is a follow-up to [#55](https://github.com/mohanagy/graphify-ts/pull/55) — the actual `v0.11.0` tag is held until this lands and the contributors table is populated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support additional automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->