### PR TITLE
feat: ship context-plane tooling surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ These six MCP tools handle the most common agent workflows. The full surface is 
 | `community_overview` | "Show me the architecture" — communities + sizes + bridges across the codebase |
 | `graph_stats` | "How big and deep is this graph?" — node/edge counts, density, and file-type mix |
 
-Full-profile additions include the context-plane tools `context_pack`, `context_prompt`, and `context_session_reset`, plus `risk_map`, `implementation_checklist`, `relevant_files`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`. Full reference: [examples/mcp-tool-examples.md](examples/mcp-tool-examples.md).
+Full-profile additions include the context-plane tools `context_pack`, `context_prompt`, and `context_session_reset`, plus `risk_map`, `implementation_checklist`, `relevant_files`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `get_neighbors`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`. Full reference: [examples/mcp-tool-examples.md](examples/mcp-tool-examples.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![No API keys](https://img.shields.io/badge/API%20keys-none%20required-111827)](#what-stays-local)
 [![license MIT](https://img.shields.io/badge/license-MIT-16a34a)](https://github.com/mohanagy/graphify-ts/blob/main/LICENSE)
 
-graphify-ts builds a local knowledge graph of your code (no upload, no API key) and lets your AI agent answer codebase questions in **fewer turns** by retrieving structured context in a single MCP call instead of running many sequential `Read` / `Grep` / `Glob` calls.
+graphify-ts is a local, cost-first **context plane** and **context compiler** for codebases. It builds a knowledge graph on your machine (no upload, no API key), then turns that graph into MCP retrieval, compact automation packs, and provider-aware prompts so agents spend fewer turns and lower effective cost on the right context instead of repeated `Read` / `Grep` / `Glob` loops.
 
 ---
 
@@ -43,6 +43,15 @@ graphify-ts claude install      # wires Claude Code to use it
 Now ask Claude something about your codebase. It calls `retrieve` once, gets back labeled snippets with file paths and community context, and answers — instead of running multiple `Read` / `Grep` / `Glob` calls and accumulating tokens at every turn.
 
 Other agents: `cursor install`, `copilot install`, `gemini install`, `aider install`, `opencode install`.
+
+Need the automation surface, not just the installed MCP server?
+
+```bash
+graphify-ts pack "review the auth flow" --task explain
+graphify-ts prompt "review the auth flow" --provider claude
+```
+
+`pack` emits a compact JSON context payload for automation. `prompt` is the provider-aware context compiler: Claude output includes cache-aware `effective_token_count`, `reused_context_tokens`, and `session_state`; Gemini output returns a plain prompt string.
 
 ---
 
@@ -116,6 +125,8 @@ The short version: graphify-ts is local-first, MCP-native, diff-aware for PR rev
 graphify-ts generate .                          # build the graph
 graphify-ts claude install                      # wire to Claude Code
 graphify-ts watch .                             # rebuild on file change
+graphify-ts pack "how does auth work?" --task explain          # compact CLI context payload
+graphify-ts prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
 graphify-ts review-compare graphify-out/graph.json --exec '...' --yes  # PR review benchmark
 graphify-ts compare "How does auth work?" --exec '...' --yes           # general benchmark
 graphify-ts time-travel main HEAD --view risk   # what changed between two refs
@@ -125,19 +136,38 @@ graphify-ts --help                              # full surface
 
 ---
 
+## Context-plane surfaces
+
+graphify-ts ships two complementary public surfaces:
+
+- **CLI context compiler** — `graphify-ts pack` builds compact explain/review/impact payloads for automation, and `graphify-ts prompt` compiles provider-ready prompts for `claude` or `gemini`.
+- **MCP context plane** — in `GRAPHIFY_TOOL_PROFILE=full`, the server also exposes `context_pack`, `context_prompt`, and `context_session_reset` so agents can request the same surfaces without leaving the MCP session.
+
+Use `context_pack` when you want expandable refs plus `claims`, `coverage`, and `missing_context` signals. Use `context_prompt` when you want the provider-ready prompt directly; for Claude, reuse a `session_id` so follow-up prompts resend only deltas and report `effective_token_count` / `reused_context_tokens`.
+
+---
+
 ## What you actually get
 
-These five MCP tools handle the most common agent workflows. The full surface is 21 tools, opt-in via `GRAPHIFY_TOOL_PROFILE=full`.
+These six MCP tools handle the most common agent workflows. The full surface is 24 tools, opt-in via `GRAPHIFY_TOOL_PROFILE=full`.
 
 | Tool | When the agent uses it |
 |---|---|
 | `retrieve` | "How does X work?" — returns ranked nodes with code snippets and community context |
 | `pr_impact` | "Is this PR safe to merge?" — diff-aware blast radius, ranked review risks, structural hotspots |
 | `impact` | "What breaks if I refactor X?" — directed dependents, affected communities, top propagation paths |
-| `relevant_files` | "Where do I edit to add feature Y?" — ranked starter files with reasoning |
+| `call_chain` | "How does request flow from X to Y?" — shortest execution paths across the graph |
 | `community_overview` | "Show me the architecture" — communities + sizes + bridges across the codebase |
+| `graph_stats` | "How big and deep is this graph?" — node/edge counts, density, and file-type mix |
 
-Plus `risk_map`, `implementation_checklist`, `call_chain`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`, `graph_stats`. Full reference: [examples/mcp-tool-examples.md](examples/mcp-tool-examples.md).
+Full-profile additions include the context-plane tools `context_pack`, `context_prompt`, and `context_session_reset`, plus `risk_map`, `implementation_checklist`, `relevant_files`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`. Full reference: [examples/mcp-tool-examples.md](examples/mcp-tool-examples.md).
+
+---
+
+## Proof story: effective cost and coverage contracts
+
+- **Effective cost** is the honest prompt-compiler number for long-lived sessions: compare raw `token_count` to Claude's `effective_token_count` and `reused_context_tokens` to see what cache reuse actually saves.
+- **Coverage contracts** are the proof surfaces that show smaller context did not lose the required evidence. `benchmark` / `eval` cover question coverage, expected evidence, and snippet coverage; `review-compare` covers the same diff, seed, and hotspot surface while shrinking the review payload.
 
 ---
 

--- a/docs/benchmarks/2026-04-30-govalidate/README.md
+++ b/docs/benchmarks/2026-04-30-govalidate/README.md
@@ -32,7 +32,11 @@ The honest framing is:
 
 - **Graphify is unambiguously faster** (~2.77×) and uses **3× fewer tool-call turns**.
 - **Graphify uses 2.63× fewer total input tokens** end-to-end.
-- **On cold-start sessions, graphify costs ~13% more** because the MCP server's tool schemas occupy `cache_creation_input_tokens` (priced at 1.25× input rate) that the no-MCP baseline does not pay. This is why v0.10.1 ships the `core` tool profile (6 tools instead of 21) by default — it cuts `cache_creation_input_tokens` enough to flip cost parity below baseline at multi-question session lengths.
+- **On cold-start sessions, graphify costs ~13% more** because the MCP server's tool schemas occupy `cache_creation_input_tokens` (priced at 1.25× input rate) that the no-MCP baseline does not pay. This is why the current product ships the `core` tool profile (6 tools instead of 24) by default — it cuts `cache_creation_input_tokens` enough to flip cost parity below baseline at multi-question session lengths.
+
+## Effective-cost framing
+
+This artifact is a cold-start native-agent receipt, so the headline dollar numbers above are still the source of truth. But the public proof language now uses **effective cost** for cache-aware prompt compilation: once a long-lived session can reuse stable context, the more honest number becomes **effective prompt tokens** after reuse, not raw cold-start prompt bytes. That is why newer `prompt`, `compare`, and `review-compare` surfaces report cache-reuse-aware token metrics alongside the raw totals.
 
 ## Reproducing the totals from this directory
 

--- a/docs/benchmarks/2026-05-02-govalidate-pr-review/README.md
+++ b/docs/benchmarks/2026-05-02-govalidate-pr-review/README.md
@@ -25,6 +25,8 @@ This directory contains the raw evidence for graphify-ts's real PR-review benchm
 
 This benchmark captures a real branch diff in `govalidate/platform` and shows the prompt-size reduction from compact `pr_impact` packaging without changing the underlying review target.
 
+The right way to read it is as a **coverage contract** proof: verbose and compact mode keep the same changed files, seed set, and hotspot counts, so the smaller prompt is not buying its win by dropping review surface. The newer product framing calls that an **effective cost** win for the same review contract — smaller review prompts for the same diff-backed evidence.
+
 ## Output files in this directory
 
 - `report.json` — raw `review-compare` metrics and run metadata

--- a/examples/mcp-tool-examples.md
+++ b/examples/mcp-tool-examples.md
@@ -1,6 +1,164 @@
 # MCP Tool Examples
 
-These examples show what your AI agent sees when it calls graphify-ts MCP tools. All output is real data from a production codebase.
+These examples show what your AI agent sees when it calls graphify-ts MCP tools. Think of this surface as the MCP half of the graphify-ts **context plane**: retrieval for discovery, impact for blast radius, and context-compiler tools for compact packs and provider-ready prompts. All output is real data from a production codebase.
+
+## context_pack — Compact Context Pack
+
+**Agent calls:**
+```json
+{ "name": "context_pack", "arguments": { "prompt": "how does payment processing work?", "task": "explain", "budget": 2000 } }
+```
+
+**Agent receives:**
+```json
+{
+  "task": "explain",
+  "prompt": "how does payment processing work?",
+  "budget": 2000,
+  "graph_path": "graphify-out/graph.json",
+  "pack": {
+    "question": "how does payment processing work?",
+    "token_count": 1847,
+    "matched_nodes": [
+      {
+        "label": "StripeGatewayService",
+        "source_file": "backend/src/modules/billing/services/stripe-gateway.service.ts",
+        "line_number": 15,
+        "snippet": "export class StripeGatewayService implements PaymentGateway { ... }",
+        "match_score": 3,
+        "relevance_band": "direct",
+        "community": 8,
+        "community_label": "Backend Billing"
+      },
+      {
+        "label": "TransactionService",
+        "source_file": "backend/src/modules/billing/services/transaction.service.ts",
+        "line_number": 22,
+        "snippet": "export class TransactionService { ... }",
+        "match_score": 2,
+        "relevance_band": "related",
+        "community": 12,
+        "community_label": "Backend Transaction"
+      }
+    ],
+    "relationships": [
+      { "from": "StripeGatewayService", "to": "TransactionService", "relation": "calls" }
+    ],
+    "community_context": [
+      { "id": 8, "label": "Backend Billing", "node_count": 23 },
+      { "id": 12, "label": "Backend Transaction", "node_count": 12 }
+    ],
+    "graph_signals": {
+      "god_nodes": ["User"],
+      "bridge_nodes": ["StripeGatewayService"]
+    },
+    "shared_file_type": "code"
+  },
+  "claims": [
+    {
+      "evidence_class": "primary",
+      "text": "primary evidence: StripeGatewayService",
+      "node_labels": ["StripeGatewayService"]
+    },
+    {
+      "evidence_class": "supporting",
+      "text": "supporting evidence: TransactionService",
+      "node_labels": ["TransactionService"]
+    }
+  ],
+  "expandable": [
+    {
+      "kind": "nodes",
+      "evidence_class": "structural",
+      "count": 3,
+      "preview_labels": ["BillingModule", "WebhookController", "CustomerLedger"]
+    }
+  ],
+  "coverage": {
+    "required_evidence": ["primary", "supporting", "structural"],
+    "entries": [
+      { "evidence_class": "primary", "required": true, "available_nodes": 1, "selected_nodes": 1, "status": "covered" },
+      { "evidence_class": "supporting", "required": true, "available_nodes": 2, "selected_nodes": 1, "status": "covered" },
+      { "evidence_class": "structural", "required": true, "available_nodes": 3, "selected_nodes": 0, "status": "missing" }
+    ],
+    "missing_required": ["structural"],
+    "available_relationships": 7,
+    "selected_relationships": 1
+  },
+  "missing_context": ["structural"]
+}
+```
+
+**What the agent does with this:** Uses the compact pack as a coverage contract: answer with the selected evidence now, and only expand omitted structural refs if the question needs more detail.
+
+---
+
+## context_prompt — Provider-Aware Prompt Compilation
+
+**Agent calls:**
+```json
+{ "name": "context_prompt", "arguments": { "prompt": "how does payment processing work?", "provider": "claude", "session_id": "billing-thread" } }
+```
+
+**Agent receives:**
+```json
+{
+  "provider": "claude",
+  "task": "explain",
+  "prompt": "how does payment processing work?",
+  "graph_path": "graphify-out/graph.json",
+  "compiled": {
+    "provider": "claude",
+    "format": "session_payload",
+    "prompt": "Session delta:\n{\n  \"previous_revision\": 6,\n  \"next_revision\": 7,\n  \"added\": [\"billing:transaction-service\"],\n  \"updated\": [\"billing:stripe-gateway\"],\n  \"invalidated\": []\n}\n\nUser question:\nhow does payment processing work?",
+    "token_count": 1420,
+    "effective_token_count": 914,
+    "reused_context_tokens": 506,
+    "session_state": {
+      "version": 1,
+      "revision": 7,
+      "refs": {
+        "billing:stripe-gateway": { "hash": "8f7b", "token_count": 210 },
+        "billing:transaction-service": { "hash": "f1a2", "token_count": 184 }
+      }
+    },
+    "session_id": "billing-thread"
+  },
+  "claims": [],
+  "expandable": [],
+  "coverage": {
+    "required_evidence": [],
+    "entries": [],
+    "missing_required": [],
+    "available_relationships": 0,
+    "selected_relationships": 0
+  },
+  "missing_context": []
+}
+```
+
+**What the agent does with this:** Sends the compiled prompt directly to Claude and tracks **effective_token_count** / `reused_context_tokens` as the real effective-cost signal for follow-up turns. For `provider: "gemini"`, the same tool returns `format: "prompt"` with plain prompt text.
+
+---
+
+## context_session_reset — Reset Claude Prompt Cache State
+
+**Agent calls:**
+```json
+{ "name": "context_session_reset", "arguments": { "session_id": "billing-thread" } }
+```
+
+**Agent receives:**
+```json
+{
+  "session_id": "billing-thread",
+  "cleared": true
+}
+```
+
+**What the agent does with this:** Clears the stored Claude prompt session before switching topics so the next `context_prompt` call resends the full stable context instead of a delta.
+
+---
 
 ## retrieve — Context Retrieval
 

--- a/examples/why-graphify.md
+++ b/examples/why-graphify.md
@@ -2,6 +2,8 @@
 
 These benchmarks were measured on [GoValidate](https://govalidate.app), a production NestJS + Next.js SaaS with 1,268 files and ~860,000 words of code.
 
+The product surface is no longer "just export a graph." graphify-ts is now a cost-first **context plane** with a **context compiler** layered on top: the graph is the substrate, while the shipped value is compact retrieval, provider-aware prompts, and proof surfaces that show smaller context still meets the required coverage contract.
+
 ## The Problem
 
 You have a large codebase. Your AI agent (Claude, Copilot, Cursor) can read files, but:
@@ -12,14 +14,18 @@ You have a large codebase. Your AI agent (Claude, Copilot, Cursor) can read file
 
 ## What graphify-ts Does
 
-One command generates a knowledge graph:
+Generate the graph once, then use graphify-ts as both the local context plane and the context compiler:
 
 ```bash
 graphify-ts generate .
 graphify-ts claude install   # or cursor, copilot
+graphify-ts pack "how does auth work?" --task explain
+graphify-ts prompt "how does auth work?" --provider claude
 ```
 
-The agent gets a lean 6-tool MCP surface by default (retrieve, impact, call_chain, community_overview, pr_impact, graph_stats). Set `GRAPHIFY_TOOL_PROFILE=full` in your MCP config (`.mcp.json` for Claude, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for VS Code Copilot) to opt into the full 21-tool advanced surface. Here's what changes:
+The agent gets a lean 6-tool MCP surface by default (retrieve, impact, call_chain, community_overview, pr_impact, graph_stats). Set `GRAPHIFY_TOOL_PROFILE=full` in your MCP config (`.mcp.json` for Claude, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for VS Code Copilot) to opt into the full 24-tool advanced surface, including `context_pack`, `context_prompt`, and `context_session_reset`.
+
+`pack` is the CLI context payload surface. `prompt` is the provider-aware context compiler: Claude payloads expose `effective_token_count`, `reused_context_tokens`, and `session_state`; Gemini payloads stay plain-text. The matching MCP tools expose the same flows inside the active agent session, with `context_pack` also returning `claims`, `coverage`, and `missing_context`.
 
 ---
 
@@ -34,7 +40,7 @@ The credible measurement is end-to-end against a real coding agent, not against 
 | Total input tokens (Anthropic-reported) | 615,190 | **233,508** | 2.63× less |
 | Cost per session | $0.62 | $0.70 | +13% on cold start; cheaper on multi-question sessions |
 
-Headline: **3× fewer turns**, ~2.8× faster, 2.6× fewer total input tokens. Graphify is unambiguously faster and uses fewer turns. Cold-start sessions pay an MCP-overhead premium of ~13%; multi-question sessions amortize and flip below baseline.
+Headline: **3× fewer turns**, ~2.8× faster, 2.6× fewer total input tokens. Graphify is unambiguously faster and uses fewer turns. Cold-start sessions pay an MCP-overhead premium of ~13%; multi-question sessions amortize and flip below baseline. That is why the honest cost language here is **effective cost**: once stable context is reused across prompt-compiler follow-ups, the number that matters is effective tokens after cache reuse rather than raw cold-start bytes.
 
 Raw evidence (both `claude --output-format json` outputs and a `verify.sh` reproducer) is committed under [`docs/benchmarks/2026-04-30-govalidate/`](../docs/benchmarks/2026-04-30-govalidate/).
 
@@ -129,8 +135,8 @@ node dist/src/cli/bin.js eval examples/demo-repo/graphify-out/graph.json --quest
 
 What each command proves:
 
-- `benchmark` proves token reduction, question coverage, expected-evidence coverage, and structure-signal reporting on a known question set. On the checked-in demo repo it should report `Question coverage: 5/5 matched`, `Expected evidence: 17/17 labels found`, and roughly `1.7x` fewer tokens per query.
-- `eval` proves retrieval quality on that same labeled question set: recall, ranking quality (MRR), and snippet coverage. On the checked-in demo repo it should report `Recall: 100.0%`, `MRR: 1.000`, `Snippet coverage: 100.0%`, and roughly `2.7x` fewer tokens at query time.
+- `benchmark` proves the **coverage contract** for the smaller context bundle: question coverage, expected-evidence coverage, structure-signal reporting, and runner-backed token deltas on a known question set. On the checked-in demo repo it should report `Question coverage: 5/5 matched`, `Expected evidence: 17/17 labels found`, and roughly `1.7x` fewer tokens per query.
+- `eval` proves the retrieval-quality side of that same coverage contract: recall, ranking quality (MRR), and snippet coverage. On the checked-in demo repo it should report `Recall: 100.0%`, `MRR: 1.000`, `Snippet coverage: 100.0%`, and roughly `2.7x` fewer tokens at query time.
 
 The demo repo is intentionally tiny, so its token-reduction numbers are modest. It exists to make the flow reproducible, not to maximize the headline ratio. Demo outputs land in `examples/demo-repo/graphify-out/`, which is ignored so you can rerun the flow locally without polluting git status.
 
@@ -229,8 +235,8 @@ For an internal team rollout, the most convincing sequence is usually:
 That progression keeps the proof honest:
 
 - `benchmark` and `eval` are runner-backed graph-quality measurements on labeled prompts
-- `compare` is the model-facing proof, with reported usage when the runner emits structured JSON and labeled estimates otherwise
-- `review-compare` is the PR-review proof, comparing verbose and compact `pr_impact` prompts on the same diff
+- `compare` is the model-facing proof, with reported usage when the runner emits structured JSON, labeled estimates otherwise, and effective-cost framing for cache-aware follow-ups
+- `review-compare` is the PR-review proof, comparing verbose and compact `pr_impact` prompts on the same diff while preserving the same review coverage contract
 - `federate` is the production architecture proof for frontend/backend/shared or microservice splits
 
 ## Capability Coverage Matters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.10.12",
+    "version": "0.11.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.10.12",
+            "version": "0.11.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -24,7 +24,7 @@
             "devDependencies": {
                 "@types/node": "^25.6.0",
                 "@vitest/coverage-v8": "^4.1.5",
-                "vite": "^8.0.10",
+                "vite": "^6.4.2",
                 "vitest": "^4.1.5"
             },
             "engines": {
@@ -81,18 +81,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emnapi/runtime": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
@@ -103,15 +91,446 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@huggingface/tokenizers": {
@@ -752,35 +1171,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@oxc-project/types": {
-            "version": "0.127.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
-            }
-        },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -845,10 +1235,24 @@
             "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -857,15 +1261,12 @@
             "optional": true,
             "os": [
                 "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
             "cpu": [
                 "arm64"
             ],
@@ -874,15 +1275,12 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
             "cpu": [
                 "x64"
             ],
@@ -891,15 +1289,26 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
             "cpu": [
                 "x64"
             ],
@@ -908,100 +1317,233 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
             "cpu": [
                 "x64"
             ],
@@ -1009,33 +1551,13 @@
             "license": "MIT",
             "optional": true,
             "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+                "openbsd"
+            ]
         },
-        "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
             "cpu": [
                 "arm64"
             ],
@@ -1044,34 +1566,12 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
             "cpu": [
                 "arm64"
             ],
@@ -1080,15 +1580,26 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
             "cpu": [
                 "x64"
             ],
@@ -1097,33 +1608,26 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -1448,6 +1952,48 @@
             "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
             "license": "MIT"
         },
+        "node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1653,267 +2199,6 @@
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "license": "ISC"
         },
-        "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-            "dev": true,
-            "license": "MPL-2.0",
-            "dependencies": {
-                "detect-libc": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            },
-            "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
-            }
-        },
-        "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "dev": true,
@@ -1959,7 +2244,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -2025,6 +2312,8 @@
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2046,7 +2335,9 @@
             "license": "MIT"
         },
         "node_modules/postcss": {
-            "version": "8.5.12",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -2089,38 +2380,49 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/rolldown": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+        "node_modules/rollup": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.127.0",
-                "@rolldown/pluginutils": "1.0.0-rc.17"
+                "@types/estree": "1.0.8"
             },
             "bin": {
-                "rolldown": "bin/cli.mjs"
+                "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+                "@rollup/rollup-android-arm-eabi": "4.60.3",
+                "@rollup/rollup-android-arm64": "4.60.3",
+                "@rollup/rollup-darwin-arm64": "4.60.3",
+                "@rollup/rollup-darwin-x64": "4.60.3",
+                "@rollup/rollup-freebsd-arm64": "4.60.3",
+                "@rollup/rollup-freebsd-x64": "4.60.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+                "@rollup/rollup-linux-arm64-musl": "4.60.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+                "@rollup/rollup-linux-loong64-musl": "4.60.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-musl": "4.60.3",
+                "@rollup/rollup-openbsd-x64": "4.60.3",
+                "@rollup/rollup-openharmony-arm64": "4.60.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+                "@rollup/rollup-win32-x64-gnu": "4.60.3",
+                "@rollup/rollup-win32-x64-msvc": "4.60.3",
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/rxjs": {
@@ -2296,23 +2598,24 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "8.0.10",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.10",
-                "rolldown": "1.0.0-rc.17",
-                "tinyglobby": "^0.2.16"
+                "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.3",
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2321,15 +2624,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
-                "esbuild": "^0.27.0 || ^0.28.0",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
                 "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"
@@ -2338,16 +2640,13 @@
                 "@types/node": {
                     "optional": true
                 },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
+                    "optional": true
+                },
+                "lightningcss": {
                     "optional": true
                 },
                 "sass": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mohammednagy/graphify-ts",
     "version": "0.11.0",
-    "description": "Build local knowledge graphs from code, docs, and mixed project folders with a TypeScript CLI.",
+    "description": "Build a local context plane and context compiler from code, docs, and mixed project folders.",
     "license": "MIT",
     "author": "mohanagy",
     "bin": {
@@ -18,6 +18,8 @@
     "keywords": [
         "cli",
         "codebase",
+        "context-compiler",
+        "context-plane",
         "graph",
         "graphrag",
         "knowledge-graph",
@@ -54,7 +56,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",
-        "vite": "^8.0.10",
+        "vite": "^6.4.2",
         "vitest": "^4.1.5"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",
-        "vite": "^8.0.10",
+        "vite": "^6.4.2",
         "vitest": "^4.1.5"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",
-        "vite": "^6.4.2",
+        "vite": "^8.0.10",
         "vitest": "^4.1.5"
     },
     "dependencies": {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,6 +4,8 @@ import { createInterface } from 'node:readline/promises'
 import { loadBenchmarkQuestions, type BenchmarkResult, printBenchmark, runBenchmark } from '../infrastructure/benchmark.js'
 import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure/benchmark/quality.js'
 import { runCompareCommand } from '../infrastructure/compare.js'
+import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
+import { runContextPromptCommand } from '../infrastructure/context-prompt-command.js'
 import { runReviewCompareCommand } from '../infrastructure/review-compare.js'
 import { compareRefs } from '../infrastructure/time-travel.js'
 import { federate } from '../pipeline/federate.js'
@@ -37,6 +39,7 @@ import {
   parseAddArgs,
   type BenchmarkCliOptions,
   parseCompareArgs,
+  parsePackArgs,
   parseDiffArgs,
   parseExplainArgs,
   parseGenerateArgs,
@@ -44,11 +47,14 @@ import {
   parseInstallArgs,
   parsePathArgs,
   parsePlatformActionArgs,
+  parsePromptArgs,
   parseQueryArgs,
   parseReviewCompareArgs,
   parseSaveResultArgs,
   parseServeArgs,
   parseTimeTravelArgs,
+  type PackCliOptions,
+  type PromptCliOptions,
   parseWatchArgs,
   type CompareCliOptions,
   type ReviewCompareCliOptions,
@@ -88,6 +94,16 @@ export interface TimeTravelCommandContext {
   io: CliIO
 }
 
+export interface ContextPackCommandContext {
+  options: PackCliOptions
+  io: CliIO
+}
+
+export interface ContextPromptCommandContext {
+  options: PromptCliOptions
+  io: CliIO
+}
+
 export interface CliDependencies {
   loadGraph: typeof loadGraph
   queryGraph: typeof queryGraph
@@ -98,6 +114,8 @@ export interface CliDependencies {
   runCompare: (context: CompareCommandContext) => Promise<string | void> | string | void
   runReviewCompare: (context: ReviewCompareCommandContext) => Promise<string | void> | string | void
   runTimeTravel: (context: TimeTravelCommandContext) => Promise<string | void> | string | void
+  runContextPack: (context: ContextPackCommandContext) => Promise<string | void> | string | void
+  runContextPrompt: (context: ContextPromptCommandContext) => Promise<string | void> | string | void
   confirm: (message: string) => Promise<boolean>
   printBenchmark: (result: BenchmarkResult) => void
   installHooks: typeof installHooks
@@ -166,6 +184,12 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   runTimeTravel: async ({ options }) => {
     const result = await compareRefs(options)
     return options.json ? JSON.stringify(result, null, 2) : formatTimeTravelResult(result)
+  },
+  runContextPack: async ({ options }) => {
+    return await runContextPackCommand(options)
+  },
+  runContextPrompt: async ({ options }) => {
+    return await runContextPromptCommand(options)
   },
   confirm: async (message) => {
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
@@ -288,6 +312,13 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
     '    --rank-by MODE        rank matches by relevance or degree (default relevance)',
     '    --community ID        limit traversal to one community id',
     '    --file-type TYPE      limit traversal to one file type (for example code or document)',
+    '  pack "<prompt>"       compile a compact context payload for automation',
+    '    --budget N            cap context pack assembly at N tokens (default 3000)',
+    '    --task KIND          explain|review|impact (default explain)',
+    '    --graph <path>       path to graph.json (default graphify-out/graph.json)',
+    '  prompt "<prompt>"     compile a provider-ready prompt payload',
+    '    --provider NAME      claude|gemini',
+    '    --graph <path>       path to graph.json (default graphify-out/graph.json)',
     '  diff <baseline-graph.json> compare a baseline graph.json to the current graph snapshot',
     '    --graph <path>        path to the current graph.json (default graphify-out/graph.json)',
     '    --limit N             maximum items to show per change section (default 10)',
@@ -535,6 +566,24 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
     if (command === 'time-travel') {
       const options = parseTimeTravelArgs(args)
       const output = await dependencies.runTimeTravel({ options, io })
+      if (output !== undefined) {
+        io.log(output)
+      }
+      return 0
+    }
+
+    if (command === 'pack') {
+      const options = parsePackArgs(args)
+      const output = await dependencies.runContextPack({ options, io })
+      if (output !== undefined) {
+        io.log(output)
+      }
+      return 0
+    }
+
+    if (command === 'prompt') {
+      const options = parsePromptArgs(args)
+      const output = await dependencies.runContextPrompt({ options, io })
       if (output !== undefined) {
         io.log(output)
       }

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, resolve } from 'node:path'
 
+import type { ContextPackTaskKind } from '../contracts/context-pack.js'
 import { validateGraphOutputPath } from '../shared/security.js'
 import { type InstallPlatform, isInstallPlatform } from '../infrastructure/install.js'
 
@@ -20,6 +21,21 @@ export interface QueryCliOptions {
   rankBy: QueryRankBy
   community: number | null
   fileType: string | null
+}
+
+export interface PackCliOptions {
+  prompt: string
+  budget: number
+  task: ContextPackTaskKind
+  graphPath: string
+}
+
+export type PromptCliProvider = 'claude' | 'gemini'
+
+export interface PromptCliOptions {
+  prompt: string
+  provider: PromptCliProvider
+  graphPath: string
 }
 
 export interface PathCliOptions {
@@ -246,9 +262,32 @@ function parseTimeTravelView(value: string): 'summary' | 'risk' | 'drift' | 'tim
   throw new UsageError('error: --view must be one of summary, risk, drift, timeline')
 }
 
+function parseContextPackTask(value: string): ContextPackTaskKind {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'explain' || normalized === 'review' || normalized === 'impact') {
+    return normalized
+  }
+  throw new UsageError('error: --task must be one of explain, review, impact')
+}
+
+function parsePromptProvider(value: string): PromptCliProvider {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'claude' || normalized === 'gemini') {
+    return normalized
+  }
+  throw new UsageError('error: --provider must be one of claude, gemini')
+}
+
 function validateCliText(field: string, value: string): string {
   if (value.length > MAX_CLI_LABEL_LENGTH) {
     throw new UsageError(`error: ${field} exceeds maximum length of ${MAX_CLI_LABEL_LENGTH} characters`)
+  }
+  return value
+}
+
+function validateCliQuestionText(field: string, value: string): string {
+  if (value.length > MAX_QUESTION_LENGTH) {
+    throw new UsageError(`error: ${field} exceeds maximum length of ${MAX_QUESTION_LENGTH} characters`)
   }
   return value
 }
@@ -345,6 +384,136 @@ export function parseQueryArgs(args: string[]): QueryCliOptions {
   }
 
   return { question, mode, tokenBudget, graphPath, rankBy, community, fileType }
+}
+
+export function parsePackArgs(args: string[]): PackCliOptions {
+  const usage = 'Usage: graphify-ts pack "<prompt>" [--budget N] [--task KIND] [--graph path]'
+  const prompt = args[0]?.trim()
+  if (!prompt) {
+    throw new UsageError(usage)
+  }
+
+  let budget = 3000
+  let task: ContextPackTaskKind = 'explain'
+  let graphPath = 'graphify-out/graph.json'
+
+  const normalizedPrompt = validateCliQuestionText('prompt', prompt)
+
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (!argument.startsWith('--')) {
+      throw new UsageError(usage)
+    }
+
+    if (argument === '--budget') {
+      budget = parseBudget(requireOptionValue('--budget', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--budget=')) {
+      const [, value] = argument.split('=', 2)
+      budget = parseBudget(requireOptionValue('--budget', value))
+      continue
+    }
+
+    if (argument === '--task') {
+      task = parseContextPackTask(requireOptionValue('--task', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--task=')) {
+      const [, value] = argument.split('=', 2)
+      task = parseContextPackTask(requireOptionValue('--task', value))
+      continue
+    }
+
+    if (argument === '--graph') {
+      graphPath = requireOptionValue('--graph', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--graph=')) {
+      const [, value] = argument.split('=', 2)
+      graphPath = requireOptionValue('--graph', value)
+      continue
+    }
+
+    throw new UsageError(`error: unknown option for pack: ${argument}`)
+  }
+
+  return {
+    prompt: normalizedPrompt,
+    budget,
+    task,
+    graphPath,
+  }
+}
+
+export function parsePromptArgs(args: string[]): PromptCliOptions {
+  const usage = 'Usage: graphify-ts prompt "<prompt>" --provider NAME [--graph path]'
+  const prompt = args[0]?.trim()
+  if (!prompt) {
+    throw new UsageError(usage)
+  }
+
+  let provider: PromptCliProvider | null = null
+  let graphPath = 'graphify-out/graph.json'
+
+  const normalizedPrompt = validateCliQuestionText('prompt', prompt)
+
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (!argument.startsWith('--')) {
+      throw new UsageError(usage)
+    }
+
+    if (argument === '--provider') {
+      provider = parsePromptProvider(requireOptionValue('--provider', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--provider=')) {
+      const [, value] = argument.split('=', 2)
+      provider = parsePromptProvider(requireOptionValue('--provider', value))
+      continue
+    }
+
+    if (argument === '--graph') {
+      graphPath = requireOptionValue('--graph', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--graph=')) {
+      const [, value] = argument.split('=', 2)
+      graphPath = requireOptionValue('--graph', value)
+      continue
+    }
+
+    throw new UsageError(`error: unknown option for prompt: ${argument}`)
+  }
+
+  if (provider === null) {
+    throw new UsageError('error: --provider is required')
+  }
+
+  return {
+    prompt: normalizedPrompt,
+    provider,
+    graphPath,
+  }
 }
 
 export function parsePathArgs(args: string[]): PathCliOptions {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, resolve } from 'node:path'
 
 import type { ContextPackTaskKind } from '../contracts/context-pack.js'
-import { validateGraphOutputPath } from '../shared/security.js'
+import { validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 import { type InstallPlatform, isInstallPlatform } from '../infrastructure/install.js'
 
 export class UsageError extends Error {
@@ -296,6 +296,10 @@ function validateReviewCompareOutputDir(outputDir: string): string {
   return isAbsolute(outputDir) ? resolve(outputDir) : validateGraphOutputPath(outputDir)
 }
 
+function parseValidatedGraphPath(flag: string, value: string | undefined): string {
+  return validateGraphPath(requireOptionValue(flag, value))
+}
+
 export function parseQueryArgs(args: string[]): QueryCliOptions {
   const question = args[0]?.trim()
   if (!question) {
@@ -434,14 +438,14 @@ export function parsePackArgs(args: string[]): PackCliOptions {
     }
 
     if (argument === '--graph') {
-      graphPath = requireOptionValue('--graph', args[index + 1])
+      graphPath = parseValidatedGraphPath('--graph', args[index + 1])
       index += 1
       continue
     }
 
     if (argument.startsWith('--graph=')) {
       const [, value] = argument.split('=', 2)
-      graphPath = requireOptionValue('--graph', value)
+      graphPath = parseValidatedGraphPath('--graph', value)
       continue
     }
 
@@ -491,14 +495,14 @@ export function parsePromptArgs(args: string[]): PromptCliOptions {
     }
 
     if (argument === '--graph') {
-      graphPath = requireOptionValue('--graph', args[index + 1])
+      graphPath = parseValidatedGraphPath('--graph', args[index + 1])
       index += 1
       continue
     }
 
     if (argument.startsWith('--graph=')) {
       const [, value] = argument.split('=', 2)
-      graphPath = requireOptionValue('--graph', value)
+      graphPath = parseValidatedGraphPath('--graph', value)
       continue
     }
 

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -1,0 +1,96 @@
+export type ContextPackTaskKind = 'explain' | 'review' | 'impact'
+
+export type ContextPackEvidenceClass = 'primary' | 'supporting' | 'structural' | 'change' | 'impact'
+
+export interface ContextPackTaskContract {
+  version: 1
+  task_kind: ContextPackTaskKind
+  budget: number
+  prompt?: string
+  required_evidence: ContextPackEvidenceClass[]
+}
+
+export interface ContextPackNode {
+  node_id?: string | undefined
+  label: string
+  source_file: string
+  line_number: number
+  snippet: string | null
+  file_type?: string | undefined
+  match_score?: number | undefined
+  relevance_band?: 'direct' | 'related' | 'peripheral' | undefined
+  community?: number | null | undefined
+  community_label?: string | null | undefined
+  node_kind?: string | undefined
+  framework?: string | undefined
+  framework_role?: string | undefined
+  framework_boost?: number | undefined
+  evidence_class?: ContextPackEvidenceClass | undefined
+}
+
+export interface ContextPackRelationship {
+  from_id?: string
+  from: string
+  to_id?: string
+  to: string
+  relation: string
+}
+
+export interface ContextPackCommunityContext {
+  id: number
+  label: string
+  node_count: number
+}
+
+export interface ContextPackGraphSignals {
+  god_nodes: string[]
+  bridge_nodes: string[]
+}
+
+export interface ContextPackClaim {
+  evidence_class: ContextPackEvidenceClass
+  text: string
+  node_labels: string[]
+}
+
+export interface ContextPackExpandableRef {
+  kind: 'nodes'
+  evidence_class: ContextPackEvidenceClass
+  count: number
+  preview_labels: string[]
+}
+
+export type ContextPackCoverageStatus = 'covered' | 'missing' | 'available'
+
+export interface ContextPackCoverageEntry {
+  evidence_class: ContextPackEvidenceClass
+  required: boolean
+  available_nodes: number
+  selected_nodes: number
+  status: ContextPackCoverageStatus
+}
+
+export interface ContextPackCoverage {
+  required_evidence: ContextPackEvidenceClass[]
+  entries: ContextPackCoverageEntry[]
+  missing_required: ContextPackEvidenceClass[]
+  available_relationships: number
+  selected_relationships: number
+}
+
+export interface CompiledContextPack<
+  TNode extends ContextPackNode = ContextPackNode,
+  TRelationship extends ContextPackRelationship = ContextPackRelationship,
+  TCommunity extends ContextPackCommunityContext = ContextPackCommunityContext,
+> {
+  task_contract: ContextPackTaskContract
+  token_count: number
+  nodes: TNode[]
+  relationships: TRelationship[]
+  community_context: TCommunity[]
+  claims: ContextPackClaim[]
+  expandable: ContextPackExpandableRef[]
+  coverage: ContextPackCoverage
+  graph_signals?: ContextPackGraphSignals
+  shared_file_type?: string
+}

--- a/src/contracts/context-session.ts
+++ b/src/contracts/context-session.ts
@@ -1,0 +1,28 @@
+export interface ContextSessionStoredRef {
+  hash: string
+  token_count: number
+}
+
+export interface ContextSessionState {
+  version: 1
+  revision: number
+  refs: Record<string, ContextSessionStoredRef>
+}
+
+export interface ContextSessionDeltaRef {
+  ref: string
+  hash: string
+  token_count: number
+  content: string
+}
+
+export interface ContextSessionDelta {
+  version: 1
+  previous_revision: number | null
+  next_revision: number
+  added: ContextSessionDeltaRef[]
+  updated: ContextSessionDeltaRef[]
+  invalidated: string[]
+  reused_refs: string[]
+  reused_token_count: number
+}

--- a/src/infrastructure/benchmark.ts
+++ b/src/infrastructure/benchmark.ts
@@ -1,5 +1,6 @@
 import { QUERY_TOKEN_ESTIMATOR, loadGraph } from '../runtime/serve.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
+import type { ContextSessionState } from '../contracts/context-session.js'
 import { graphStructureMetrics, type GraphStructureMetrics } from '../pipeline/analyze.js'
 import { formatTokenRatio, resolveCorpusBaseline, type CorpusBaselineSource } from './benchmark/corpus.js'
 import {
@@ -46,8 +47,11 @@ export interface BenchmarkSuccessResult {
   matched_expected_label_count: number
   missing_expected_labels: BenchmarkMissingExpectedLabels[]
   avg_query_tokens: number
+  avg_effective_query_tokens?: number
+  avg_reused_context_tokens?: number
   avg_total_tokens?: number | null
   reduction_ratio: number
+  effective_reduction_ratio?: number
   per_question: BenchmarkQuestionResult[]
 }
 
@@ -77,6 +81,16 @@ function averageQueryTokens(perQuestion: readonly BenchmarkQuestionResult[]): nu
   return Math.floor(perQuestion.reduce((sum, entry) => sum + entry.query_tokens, 0) / perQuestion.length)
 }
 
+function averageEffectiveQueryTokens(perQuestion: readonly BenchmarkQuestionResult[]): number {
+  return Math.floor(
+    perQuestion.reduce((sum, entry) => sum + (entry.effective_query_tokens ?? entry.query_tokens), 0) / perQuestion.length,
+  )
+}
+
+function averageReusedContextTokens(perQuestion: readonly BenchmarkQuestionResult[]): number {
+  return Math.floor(perQuestion.reduce((sum, entry) => sum + (entry.reused_context_tokens ?? 0), 0) / perQuestion.length)
+}
+
 function finalizeBenchmarkResult(
   graph: KnowledgeGraph,
   structureSignals: GraphStructureMetrics | null,
@@ -89,6 +103,7 @@ function finalizeBenchmarkResult(
   perQuestion: BenchmarkQuestionResult[],
 ): BenchmarkSuccessResult {
   const avgQueryTokens = averageQueryTokens(perQuestion)
+  const avgEffectiveQueryTokens = averageEffectiveQueryTokens(perQuestion)
   return {
     corpus_tokens: baseline.tokens,
     corpus_words: baseline.words,
@@ -103,8 +118,11 @@ function finalizeBenchmarkResult(
     matched_expected_label_count: matchedExpectedLabelCount,
     missing_expected_labels: missingExpectedLabels,
     avg_query_tokens: avgQueryTokens,
+    avg_effective_query_tokens: avgEffectiveQueryTokens,
+    avg_reused_context_tokens: averageReusedContextTokens(perQuestion),
     avg_total_tokens: averageReportedTotalTokens(perQuestion),
     reduction_ratio: avgQueryTokens > 0 ? Number((baseline.tokens / avgQueryTokens).toFixed(1)) : 0,
+    effective_reduction_ratio: avgEffectiveQueryTokens > 0 ? Number((baseline.tokens / avgEffectiveQueryTokens).toFixed(1)) : 0,
     per_question: perQuestion,
   }
 }
@@ -122,6 +140,7 @@ async function runRunnerBackedBenchmark(
   }
 
   const perQuestion: BenchmarkQuestionResult[] = []
+  let sessionState: ContextSessionState | undefined
   for (const evaluation of evaluations) {
     const run = await runBenchmarkPrompt({
       graphPath,
@@ -131,11 +150,15 @@ async function runRunnerBackedBenchmark(
       ...(options.outputDir !== undefined ? { outputDir: options.outputDir } : {}),
       ...(options.now !== undefined ? { now: options.now } : {}),
       ...(options.retrievalBudget !== undefined ? { retrievalBudget: options.retrievalBudget } : {}),
+      ...(sessionState ? { session: sessionState } : {}),
       ...(options.runner !== undefined ? { runner: options.runner } : {}),
     })
+    sessionState = run.session_state
     perQuestion.push({
       ...evaluation,
       query_tokens: run.query_tokens,
+      effective_query_tokens: run.effective_query_tokens,
+      reused_context_tokens: run.reused_context_tokens,
       total_tokens: run.total_tokens,
       prompt_tokens_estimated: run.prompt_tokens_estimated,
       prompt_token_source: run.prompt_token_source,
@@ -277,6 +300,12 @@ export function printBenchmark(result: BenchmarkResult): void {
     console.log('  Structure signals: unavailable for graph artifacts without source_file provenance')
   }
   console.log(`  ${averageInputTokenLabel(result.per_question)}: ~${result.avg_query_tokens.toLocaleString()}`)
+  if (
+    typeof result.avg_effective_query_tokens === 'number' &&
+    (result.avg_effective_query_tokens !== result.avg_query_tokens || (result.avg_reused_context_tokens ?? 0) > 0)
+  ) {
+    console.log(`  Avg effective input tokens (cache-adjusted): ~${result.avg_effective_query_tokens.toLocaleString()}`)
+  }
   const totalTokensLine = totalTokenLabel(result)
   if (totalTokensLine) {
     console.log(totalTokensLine)

--- a/src/infrastructure/benchmark/questions.ts
+++ b/src/infrastructure/benchmark/questions.ts
@@ -9,6 +9,8 @@ import { type BenchmarkPromptArtifacts, type BenchmarkPromptTokenSource } from '
 export interface BenchmarkQuestionResult {
   question: string
   query_tokens: number
+  effective_query_tokens?: number
+  reused_context_tokens?: number
   reduction: number
   expected_labels: string[]
   matched_expected_labels: string[]

--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -206,7 +206,7 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
     answer: join(outputRoot, 'graphify-answer.txt'),
     report: join(outputRoot, 'report.json'),
   }
-  writeFileSync(artifacts.prompt, promptPack.prompt, 'utf8')
+  writeFileSync(artifacts.prompt, promptPack.session_payload, 'utf8')
 
   const command = expandCompareExecTemplate(options.execTemplate, {
     promptFile: artifacts.prompt,
@@ -231,8 +231,8 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
 
   const usage = parsedOutput.usage
   const run: BenchmarkPromptRun = {
-    prompt_tokens_estimated: promptPack.token_count,
-    query_tokens: usage?.input_total_tokens ?? promptPack.token_count,
+    prompt_tokens_estimated: promptPack.session_payload_token_count,
+    query_tokens: usage?.input_total_tokens ?? promptPack.session_payload_token_count,
     effective_query_tokens:
       usage?.input_total_tokens !== undefined
         ? usage.input_total_tokens - usage.cache_read_input_tokens

--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from
 import { basename, dirname, join, relative, resolve } from 'node:path'
 
 import { KnowledgeGraph } from '../../contracts/graph.js'
+import type { ContextSessionState } from '../../contracts/context-session.js'
 import { type RetrieveResult, retrieveContext } from '../../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR } from '../../runtime/serve.js'
 import { validateGraphOutputPath } from '../../shared/security.js'
@@ -47,18 +48,22 @@ export interface RunBenchmarkPromptOptions {
   now?: Date
   retrievalBudget?: number
   retrieval?: RetrieveResult
+  session?: ContextSessionState
   runner?: (execution: BenchmarkPromptExecution) => Promise<BenchmarkPromptRunnerResult>
 }
 
 export interface BenchmarkPromptRun {
   prompt_tokens_estimated: number
   query_tokens: number
+  effective_query_tokens: number
+  reused_context_tokens: number
   total_tokens: number | null
   prompt_token_source: BenchmarkPromptTokenSource
   usage: PromptRunnerUsage | null
   answer_text: string | null
   elapsed_ms: number
   artifacts: BenchmarkPromptArtifacts
+  session_state: ContextSessionState
 }
 
 function timestampDirectoryName(date: Date): string {
@@ -188,10 +193,14 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
   const retrieval = options.retrieval ?? retrieveBenchmarkContext(
     options.graph,
     options.graphPath,
-    options.question,
-    options.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET,
+      options.question,
+      options.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET,
   )
-  const promptPack = buildGraphifyPromptPack({ question: options.question, retrieval })
+  const promptPack = buildGraphifyPromptPack({
+    question: options.question,
+    retrieval,
+    ...(options.session ? { session: options.session } : {}),
+  })
   const artifacts: BenchmarkPromptArtifacts = {
     prompt: join(outputRoot, 'graphify-prompt.txt'),
     answer: join(outputRoot, 'graphify-answer.txt'),
@@ -224,12 +233,18 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
   const run: BenchmarkPromptRun = {
     prompt_tokens_estimated: promptPack.token_count,
     query_tokens: usage?.input_total_tokens ?? promptPack.token_count,
+    effective_query_tokens:
+      usage?.input_total_tokens !== undefined
+        ? usage.input_total_tokens - usage.cache_read_input_tokens
+        : promptPack.effective_token_count,
+    reused_context_tokens: usage?.cache_read_input_tokens ?? promptPack.reused_context_tokens,
     total_tokens: usage?.total_tokens ?? null,
     prompt_token_source: benchmarkPromptTokenSource(usage),
     usage,
     answer_text: parsedOutput.answerText,
     elapsed_ms: execution.elapsedMs,
     artifacts,
+    session_state: promptPack.session_state,
   }
 
   writeFileSync(
@@ -237,10 +252,12 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
     `${JSON.stringify(
       {
         question: options.question,
-        prompt_tokens_estimated: run.prompt_tokens_estimated,
-        query_tokens: run.query_tokens,
-        total_tokens: run.total_tokens,
-        prompt_token_source: run.prompt_token_source,
+          prompt_tokens_estimated: run.prompt_tokens_estimated,
+          query_tokens: run.query_tokens,
+          effective_query_tokens: run.effective_query_tokens,
+          reused_context_tokens: run.reused_context_tokens,
+          total_tokens: run.total_tokens,
+          prompt_token_source: run.prompt_token_source,
         usage: run.usage,
         elapsed_ms: run.elapsed_ms,
         prompt_token_estimator: QUERY_TOKEN_ESTIMATOR,

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -24,7 +24,9 @@ export interface ComparePromptPack {
   kind: 'baseline' | 'graphify'
   question: string
   prompt: string
+  session_payload: string
   token_count: number
+  session_payload_token_count: number
   effective_token_count: number
   reused_context_tokens: number
   session_state: ContextSessionState
@@ -839,8 +841,10 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
     kind: 'baseline',
     question: input.question,
     prompt: builtPrompt.prompt,
+    session_payload: builtPrompt.session_payload,
     token_count: builtPrompt.metrics.raw_prompt_tokens,
-    effective_token_count: builtPrompt.metrics.effective_prompt_tokens,
+    session_payload_token_count: builtPrompt.metrics.session_payload_tokens,
+    effective_token_count: builtPrompt.metrics.session_payload_tokens,
     reused_context_tokens: builtPrompt.metrics.reused_context_tokens,
     session_state: builtPrompt.session_state,
   }
@@ -865,8 +869,10 @@ export function buildGraphifyPromptPack(input: BuildGraphifyPromptPackInput): Co
     kind: 'graphify',
     question: input.question,
     prompt: builtPrompt.prompt,
+    session_payload: builtPrompt.session_payload,
     token_count: builtPrompt.metrics.raw_prompt_tokens,
-    effective_token_count: builtPrompt.metrics.effective_prompt_tokens,
+    session_payload_token_count: builtPrompt.metrics.session_payload_tokens,
+    effective_token_count: builtPrompt.metrics.session_payload_tokens,
     reused_context_tokens: builtPrompt.metrics.reused_context_tokens,
     session_state: builtPrompt.session_state,
   }
@@ -947,8 +953,8 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
       graphify: answerFilePath(questionOutputDir, 'graphify'),
     }
 
-    const baselinePromptText = baselinePrompt.prompt
-    const graphifyPromptText = graphifyPrompt.prompt
+    const baselinePromptText = baselinePrompt.session_payload
+    const graphifyPromptText = graphifyPrompt.session_payload
 
     writeFileSync(paths.baseline_prompt, baselinePromptText, 'utf8')
     writeFileSync(paths.graphify_prompt, graphifyPromptText, 'utf8')

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -3,6 +3,8 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, 
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import { KnowledgeGraph } from '../contracts/graph.js'
+import type { ContextSessionState } from '../contracts/context-session.js'
+import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
@@ -23,6 +25,9 @@ export interface ComparePromptPack {
   question: string
   prompt: string
   token_count: number
+  effective_token_count: number
+  reused_context_tokens: number
+  session_state: ContextSessionState
 }
 
 export interface BuildBaselinePromptPackInput {
@@ -31,11 +36,13 @@ export interface BuildBaselinePromptPackInput {
   corpusText: string
   mode: CompareBaselineMode
   maxTokens?: number
+  session?: ContextSessionState
 }
 
 export interface BuildGraphifyPromptPackInput {
   question: string
   retrieval: RetrieveResult
+  session?: ContextSessionState
 }
 
 export interface ComparePromptArtifactPaths {
@@ -72,6 +79,11 @@ export interface ComparePromptReport {
   baseline_prompt_tokens: number
   graphify_prompt_tokens: number
   reduction_ratio: number
+  baseline_effective_prompt_tokens: number
+  graphify_effective_prompt_tokens: number
+  effective_reduction_ratio: number
+  baseline_reused_context_tokens: number
+  graphify_reused_context_tokens: number
   baseline_total_tokens: number | null
   graphify_total_tokens: number | null
   total_reduction_ratio: number | null
@@ -366,31 +378,54 @@ function createCompareOutputRoot(outputDir: string, date: Date): string {
   throw new Error(`Unable to create a unique compare output directory inside ${outputDir}`)
 }
 
-function renderBaselinePrompt(question: string, graph: KnowledgeGraph, corpusBody: string, mode: CompareBaselineMode): string {
+function baselinePromptSections(graph: KnowledgeGraph, corpusBody: string, mode: CompareBaselineMode): ContextPromptStableSection[] {
   return [
-    'Answer the question using only the provided project corpus.',
-    'If the corpus does not contain the answer, say so.',
-    '',
-    `Question:\n${question}`,
-    '',
-    'Project graph summary:',
-    `- Nodes: ${graph.numberOfNodes()}`,
-    `- Edges: ${graph.numberOfEdges()}`,
-    '',
-    `Corpus (${mode}):`,
-    corpusBody,
-    '',
-    'Answer:',
-  ].join('\n')
+    {
+      ref: 'graph_summary',
+      sort_key: '10-graph-summary',
+      title: 'Project graph summary',
+      body: [
+        `- Nodes: ${graph.numberOfNodes()}`,
+        `- Edges: ${graph.numberOfEdges()}`,
+      ].join('\n'),
+    },
+    {
+      ref: 'project_corpus',
+      sort_key: '20-project-corpus',
+      title: `Corpus (${mode})`,
+      body: corpusBody,
+    },
+  ]
+}
+
+function buildBaselinePromptArtifact(
+  question: string,
+  graph: KnowledgeGraph,
+  corpusBody: string,
+  mode: CompareBaselineMode,
+  session?: ContextSessionState,
+) {
+  return buildContextPrompt({
+    instructions: [
+      'Answer the question using only the provided project corpus.',
+      'If the corpus does not contain the answer, say so.',
+    ],
+    stable_sections: baselinePromptSections(graph, corpusBody, mode),
+    dynamic_sections: [
+      { title: 'Question', body: question },
+      { body: 'Answer:' },
+    ],
+    ...(session ? { session } : {}),
+  })
 }
 
 function buildBoundedCorpusExcerpt(question: string, graph: KnowledgeGraph, corpusText: string, maxTokens: number): string {
   const note = '[bounded baseline excerpt]'
   let excerpt = corpusText.trim()
-  let prompt = renderBaselinePrompt(question, graph, `${note}\n${excerpt}`, 'bounded')
+  let prompt = buildBaselinePromptArtifact(question, graph, `${note}\n${excerpt}`, 'bounded').prompt
   while (estimateQueryTokens(prompt) > maxTokens && excerpt.length > 0) {
     excerpt = excerpt.slice(0, Math.max(0, Math.floor(excerpt.length * 0.9))).trimEnd()
-    prompt = renderBaselinePrompt(question, graph, `${note}\n${excerpt}`, 'bounded')
+    prompt = buildBaselinePromptArtifact(question, graph, `${note}\n${excerpt}`, 'bounded').prompt
   }
 
   if (estimateQueryTokens(prompt) > maxTokens) {
@@ -400,7 +435,7 @@ function buildBoundedCorpusExcerpt(question: string, graph: KnowledgeGraph, corp
   return `${note}\n${excerpt}`.trimEnd()
 }
 
-function formatGraphifyContext(retrieval: RetrieveResult): string {
+function formatGraphifyContextSections(retrieval: RetrieveResult): ContextPromptStableSection[] {
   const nodeLines = retrieval.matched_nodes.map((node) => {
     const source = node.source_file ? ` @ ${node.source_file}${node.line_number > 0 ? `:${node.line_number}` : ''}` : ''
     const community = node.community_label ? ` [${node.community_label}]` : ''
@@ -411,14 +446,36 @@ function formatGraphifyContext(retrieval: RetrieveResult): string {
   const communityLines = retrieval.community_context.map((community) => `- ${community.label} (${community.node_count} nodes)`)
   const signalLines = [...retrieval.graph_signals.god_nodes, ...retrieval.graph_signals.bridge_nodes]
 
-  const sections = [
-    ['Matched nodes:', ...(nodeLines.length > 0 ? nodeLines : ['- (none)'])],
-    ['Relationships:', ...(relationshipLines.length > 0 ? relationshipLines : ['- (none)'])],
-    ...(communityLines.length > 0 ? [['Community context:', ...communityLines]] : []),
-    ...(signalLines.length > 0 ? [['Graph signals:', `- ${signalLines.join(', ')}`]] : []),
+  return [
+    {
+      ref: 'matched_nodes',
+      sort_key: '10-matched-nodes',
+      title: 'Matched nodes',
+      body: nodeLines.length > 0 ? nodeLines.join('\n') : '- (none)',
+    },
+    {
+      ref: 'relationships',
+      sort_key: '20-relationships',
+      title: 'Relationships',
+      body: relationshipLines.length > 0 ? relationshipLines.join('\n') : '- (none)',
+    },
+    ...(communityLines.length > 0
+      ? [{
+          ref: 'community_context',
+          sort_key: '30-community-context',
+          title: 'Community context',
+          body: communityLines.join('\n'),
+        }]
+      : []),
+    ...(signalLines.length > 0
+      ? [{
+          ref: 'graph_signals',
+          sort_key: '40-graph-signals',
+          title: 'Graph signals',
+          body: `- ${signalLines.join(', ')}`,
+        }]
+      : []),
   ]
-
-  return sections.map((section) => section.join('\n')).join('\n\n')
 }
 
 function computeReductionRatio(baselinePromptTokens: number, graphifyPromptTokens: number): number {
@@ -445,6 +502,20 @@ function syncComparePromptMetrics(report: ComparePromptReport): void {
   report.baseline_prompt_tokens = report.usage.baseline?.input_total_tokens ?? report.baseline_prompt_tokens_estimated
   report.graphify_prompt_tokens = report.usage.graphify?.input_total_tokens ?? report.graphify_prompt_tokens_estimated
   report.reduction_ratio = computeReductionRatio(report.baseline_prompt_tokens, report.graphify_prompt_tokens)
+  report.baseline_effective_prompt_tokens =
+    report.usage.baseline !== null
+      ? report.usage.baseline.input_total_tokens - report.usage.baseline.cache_read_input_tokens
+      : report.baseline_effective_prompt_tokens
+  report.graphify_effective_prompt_tokens =
+    report.usage.graphify !== null
+      ? report.usage.graphify.input_total_tokens - report.usage.graphify.cache_read_input_tokens
+      : report.graphify_effective_prompt_tokens
+  report.effective_reduction_ratio = computeReductionRatio(
+    report.baseline_effective_prompt_tokens,
+    report.graphify_effective_prompt_tokens,
+  )
+  report.baseline_reused_context_tokens = report.usage.baseline?.cache_read_input_tokens ?? report.baseline_reused_context_tokens
+  report.graphify_reused_context_tokens = report.usage.graphify?.cache_read_input_tokens ?? report.graphify_reused_context_tokens
   report.baseline_total_tokens = report.usage.baseline?.total_tokens ?? null
   report.graphify_total_tokens = report.usage.graphify?.total_tokens ?? null
   report.total_reduction_ratio =
@@ -762,34 +833,42 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
     input.mode === 'bounded'
       ? buildBoundedCorpusExcerpt(input.question, input.graph, corpusText, input.maxTokens ?? DEFAULT_BOUNDED_BASELINE_TOKENS)
       : corpusText
-  const prompt = renderBaselinePrompt(input.question, input.graph, corpusBody, input.mode)
+  const builtPrompt = buildBaselinePromptArtifact(input.question, input.graph, corpusBody, input.mode, input.session)
 
   return {
     kind: 'baseline',
     question: input.question,
-    prompt,
-    token_count: estimateQueryTokens(prompt),
+    prompt: builtPrompt.prompt,
+    token_count: builtPrompt.metrics.raw_prompt_tokens,
+    effective_token_count: builtPrompt.metrics.effective_prompt_tokens,
+    reused_context_tokens: builtPrompt.metrics.reused_context_tokens,
+    session_state: builtPrompt.session_state,
   }
 }
 
 export function buildGraphifyPromptPack(input: BuildGraphifyPromptPackInput): ComparePromptPack {
-  const prompt = [
-    'Answer the question using only the provided graph-guided retrieval output.',
-    'If the retrieval does not contain the answer, say so.',
-    '',
-    `Question:\n${input.question}`,
-    '',
-    'Retrieved graph context:',
-    formatGraphifyContext(input.retrieval),
-    '',
-    'Answer:',
-  ].join('\n')
+  const builtPrompt = buildContextPrompt({
+    instructions: [
+      'Answer the question using only the provided graph-guided retrieval output.',
+      'If the retrieval does not contain the answer, say so.',
+    ],
+    stable_prefix_title: 'Retrieved graph context',
+    stable_sections: formatGraphifyContextSections(input.retrieval),
+    dynamic_sections: [
+      { title: 'Question', body: input.question },
+      { body: 'Answer:' },
+    ],
+    ...(input.session ? { session: input.session } : {}),
+  })
 
   return {
     kind: 'graphify',
     question: input.question,
-    prompt,
-    token_count: estimateQueryTokens(prompt),
+    prompt: builtPrompt.prompt,
+    token_count: builtPrompt.metrics.raw_prompt_tokens,
+    effective_token_count: builtPrompt.metrics.effective_prompt_tokens,
+    reused_context_tokens: builtPrompt.metrics.reused_context_tokens,
+    session_state: builtPrompt.session_state,
   }
 }
 
@@ -831,6 +910,8 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
   const outputDir = validateGraphOutputPath(input.outputDir)
   const now = input.now ?? new Date()
   const outputRoot = createCompareOutputRoot(outputDir, now)
+  let baselineSession: ContextSessionState | undefined
+  let graphifySession: ContextSessionState | undefined
 
   const reports = questions.map((question, index) => {
     const questionOutputDir = questions.length === 1 ? outputRoot : join(outputRoot, `question-${String(index + 1).padStart(3, '0')}`)
@@ -842,11 +923,18 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
       corpusText,
       mode: input.baselineMode,
       ...(input.baselineMaxTokens !== undefined ? { maxTokens: input.baselineMaxTokens } : {}),
+      ...(baselineSession ? { session: baselineSession } : {}),
     })
+    baselineSession = baselinePrompt.session_state
     const projectRoot = realpathSync(inferProjectRootFromGraphPath(graphPath))
     const retrievalBudget = input.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET
     const retrieval = retrieveCompareContext(graph, question, retrievalBudget, projectRoot)
-    const graphifyPrompt = buildGraphifyPromptPack({ question, retrieval })
+    const graphifyPrompt = buildGraphifyPromptPack({
+      question,
+      retrieval,
+      ...(graphifySession ? { session: graphifySession } : {}),
+    })
+    graphifySession = graphifyPrompt.session_state
 
     const paths: ComparePromptArtifactPaths = {
       output_dir: questionOutputDir,
@@ -876,6 +964,11 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
       baseline_prompt_tokens: baselinePromptTokens,
       graphify_prompt_tokens: graphifyPromptTokens,
       reduction_ratio: computeReductionRatio(baselinePromptTokens, graphifyPromptTokens),
+      baseline_effective_prompt_tokens: baselinePrompt.effective_token_count,
+      graphify_effective_prompt_tokens: graphifyPrompt.effective_token_count,
+      effective_reduction_ratio: computeReductionRatio(baselinePrompt.effective_token_count, graphifyPrompt.effective_token_count),
+      baseline_reused_context_tokens: baselinePrompt.reused_context_tokens,
+      graphify_reused_context_tokens: graphifyPrompt.reused_context_tokens,
       baseline_total_tokens: null,
       graphify_total_tokens: null,
       total_reduction_ratio: null,
@@ -1015,6 +1108,20 @@ function sumPromptTokens(reports: readonly ComparePromptReport[], mode: CompareR
   return reports.reduce((total, report) => total + (mode === 'baseline' ? report.baseline_prompt_tokens : report.graphify_prompt_tokens), 0)
 }
 
+function sumEffectivePromptTokens(reports: readonly ComparePromptReport[], mode: CompareRunMode): number {
+  return reports.reduce(
+    (total, report) => total + (mode === 'baseline' ? report.baseline_effective_prompt_tokens : report.graphify_effective_prompt_tokens),
+    0,
+  )
+}
+
+function sumReusedContextTokens(reports: readonly ComparePromptReport[], mode: CompareRunMode): number {
+  return reports.reduce(
+    (total, report) => total + (mode === 'baseline' ? report.baseline_reused_context_tokens : report.graphify_reused_context_tokens),
+    0,
+  )
+}
+
 function sumTotalTokens(reports: readonly ComparePromptReport[], mode: CompareRunMode): number | null {
   let total = 0
   for (const report of reports) {
@@ -1062,6 +1169,10 @@ function usageProviderSummaryLabel(reports: readonly ComparePromptReport[]): str
 export function formatCompareSummary(result: GenerateCompareArtifactsResult): string {
   const baselineTokens = sumPromptTokens(result.reports, 'baseline')
   const graphifyTokens = sumPromptTokens(result.reports, 'graphify')
+  const baselineEffectiveTokens = sumEffectivePromptTokens(result.reports, 'baseline')
+  const graphifyEffectiveTokens = sumEffectivePromptTokens(result.reports, 'graphify')
+  const baselineReusedTokens = sumReusedContextTokens(result.reports, 'baseline')
+  const graphifyReusedTokens = sumReusedContextTokens(result.reports, 'graphify')
   const baselineTotalTokens = sumTotalTokens(result.reports, 'baseline')
   const graphifyTotalTokens = sumTotalTokens(result.reports, 'graphify')
   const totalReductionRatio =
@@ -1093,6 +1204,7 @@ export function formatCompareSummary(result: GenerateCompareArtifactsResult): st
       failedRuns > 0 ? ` · ${failedRuns} failed` : ''
     }`,
     `- ${promptTokenLabel}: baseline ${baselineTokens} · graphify ${graphifyTokens} · ${formatTokenComparison(baselineTokens, graphifyTokens)}`,
+    `- Effective input tokens (cache-adjusted): baseline ${baselineEffectiveTokens} · graphify ${graphifyEffectiveTokens} · ${formatTokenComparison(baselineEffectiveTokens, graphifyEffectiveTokens)}`,
   ]
 
   if (usesSyntheticBaseline) {
@@ -1104,6 +1216,7 @@ export function formatCompareSummary(result: GenerateCompareArtifactsResult): st
   } else if (usageRuns > 0 && usageRuns < totalRuns) {
     lines.push(`- Usage capture: ${usageProviderLabel} reported usage for ${usageRuns}/${totalRuns} prompt runs; remaining runs used local estimate fallback`)
   }
+  lines.push(`- Reused context tokens: baseline ${baselineReusedTokens} · graphify ${graphifyReusedTokens}`)
 
   return lines.join('\n')
 }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -844,7 +844,7 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
     session_payload: builtPrompt.session_payload,
     token_count: builtPrompt.metrics.raw_prompt_tokens,
     session_payload_token_count: builtPrompt.metrics.session_payload_tokens,
-    effective_token_count: builtPrompt.metrics.session_payload_tokens,
+    effective_token_count: builtPrompt.metrics.effective_prompt_tokens,
     reused_context_tokens: builtPrompt.metrics.reused_context_tokens,
     session_state: builtPrompt.session_state,
   }
@@ -872,7 +872,7 @@ export function buildGraphifyPromptPack(input: BuildGraphifyPromptPackInput): Co
     session_payload: builtPrompt.session_payload,
     token_count: builtPrompt.metrics.raw_prompt_tokens,
     session_payload_token_count: builtPrompt.metrics.session_payload_tokens,
-    effective_token_count: builtPrompt.metrics.session_payload_tokens,
+    effective_token_count: builtPrompt.metrics.effective_prompt_tokens,
     reused_context_tokens: builtPrompt.metrics.reused_context_tokens,
     session_state: builtPrompt.session_state,
   }
@@ -959,8 +959,8 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
     writeFileSync(paths.baseline_prompt, baselinePromptText, 'utf8')
     writeFileSync(paths.graphify_prompt, graphifyPromptText, 'utf8')
 
-    const baselinePromptTokens = estimateQueryTokens(baselinePromptText)
-    const graphifyPromptTokens = estimateQueryTokens(graphifyPromptText)
+    const baselinePromptTokens = baselinePrompt.token_count
+    const graphifyPromptTokens = graphifyPrompt.token_count
 
     const report: ComparePromptReport = {
       question,

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -1,0 +1,101 @@
+import { buildCommunityLabels } from '../pipeline/community-naming.js'
+import type { KnowledgeGraph } from '../contracts/graph.js'
+import type { PackCliOptions } from '../cli/parser.js'
+import { analyzeImpact, compactImpactResult, type ImpactResult } from '../runtime/impact.js'
+import { analyzePrImpact, compactPrImpactResult, type PrImpactResult } from '../runtime/pr-impact.js'
+import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
+import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
+
+const DEFAULT_IMPACT_DEPTH = 3
+
+export interface ContextPackCommandDependencies {
+  loadGraph: (graphPath: string) => KnowledgeGraph
+  retrieveContext: (graph: KnowledgeGraph, options: { question: string; budget: number }) => RetrieveResult
+  compactRetrieveResult: typeof compactRetrieveResult
+  analyzePrImpact: (graph: KnowledgeGraph, projectDir?: string, options?: { baseBranch?: string; depth?: number; budget?: number }) => PrImpactResult
+  compactPrImpactResult: typeof compactPrImpactResult
+  analyzeImpact: (graph: KnowledgeGraph, communityLabels: Record<number, string>, options: { label: string; depth?: number }) => ImpactResult
+  compactImpactResult: typeof compactImpactResult
+}
+
+const DEFAULT_DEPENDENCIES: ContextPackCommandDependencies = {
+  loadGraph,
+  retrieveContext: (graph, options) => retrieveContext(graph, options),
+  compactRetrieveResult,
+  analyzePrImpact,
+  compactPrImpactResult,
+  analyzeImpact,
+  compactImpactResult,
+}
+
+function pickImpactTarget(result: RetrieveResult): string {
+  const directMatch = result.matched_nodes.find((node) => node.relevance_band === 'direct')
+  if (directMatch?.label) {
+    return directMatch.label
+  }
+
+  const bestMatch = [...result.matched_nodes]
+    .sort((left, right) => (right.match_score ?? 0) - (left.match_score ?? 0))
+    .find((node) => node.label.trim().length > 0)
+
+  return bestMatch?.label ?? result.question
+}
+
+export async function runContextPackCommand(
+  options: PackCliOptions,
+  dependencies: ContextPackCommandDependencies = DEFAULT_DEPENDENCIES,
+): Promise<string> {
+  const graph = dependencies.loadGraph(options.graphPath)
+
+  if (options.task === 'review') {
+    const reviewPack = dependencies.compactPrImpactResult(
+      dependencies.analyzePrImpact(graph, '.', { budget: options.budget }),
+    )
+
+    return JSON.stringify({
+      task: options.task,
+      prompt: options.prompt,
+      budget: options.budget,
+      graph_path: options.graphPath,
+      pack: reviewPack,
+    })
+  }
+
+  if (options.task === 'impact') {
+    const retrieval = dependencies.retrieveContext(graph, {
+      question: options.prompt,
+      budget: options.budget,
+    })
+    const impactTarget = pickImpactTarget(retrieval)
+    const communityLabels = buildCommunityLabels(graph, communitiesFromGraph(graph))
+    const impactPack = dependencies.compactImpactResult(
+      dependencies.analyzeImpact(graph, communityLabels, {
+        label: impactTarget,
+        depth: DEFAULT_IMPACT_DEPTH,
+      }),
+    )
+
+    return JSON.stringify({
+      task: options.task,
+      prompt: options.prompt,
+      budget: options.budget,
+      graph_path: options.graphPath,
+      target: impactTarget,
+      pack: impactPack,
+    })
+  }
+
+  const retrieval = dependencies.retrieveContext(graph, {
+    question: options.prompt,
+    budget: options.budget,
+  })
+  const explainPack = dependencies.compactRetrieveResult(retrieval)
+
+  return JSON.stringify({
+    task: options.task,
+    prompt: options.prompt,
+    budget: options.budget,
+    graph_path: options.graphPath,
+    pack: explainPack,
+  })
+}

--- a/src/infrastructure/context-prompt-command.ts
+++ b/src/infrastructure/context-prompt-command.ts
@@ -1,0 +1,42 @@
+import type { PromptCliOptions } from '../cli/parser.js'
+import type { KnowledgeGraph } from '../contracts/graph.js'
+import { buildGraphifyPromptPack, type ComparePromptPack } from './compare.js'
+import { retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
+import { loadGraph } from '../runtime/serve.js'
+
+const DEFAULT_PROMPT_BUDGET = 3_000
+
+export interface ContextPromptCommandDependencies {
+  loadGraph: (graphPath: string) => KnowledgeGraph
+  retrieveContext: (graph: KnowledgeGraph, options: { question: string; budget: number }) => RetrieveResult
+  buildGraphifyPromptPack: (input: { question: string; retrieval: RetrieveResult }) => ComparePromptPack
+}
+
+const DEFAULT_DEPENDENCIES: ContextPromptCommandDependencies = {
+  loadGraph,
+  retrieveContext: (graph, options) => retrieveContext(graph, options),
+  buildGraphifyPromptPack: (input) => buildGraphifyPromptPack(input),
+}
+
+export async function runContextPromptCommand(
+  options: PromptCliOptions,
+  dependencies: ContextPromptCommandDependencies = DEFAULT_DEPENDENCIES,
+): Promise<string> {
+  const graph = dependencies.loadGraph(options.graphPath)
+  const retrieval = dependencies.retrieveContext(graph, {
+    question: options.prompt,
+    budget: DEFAULT_PROMPT_BUDGET,
+  })
+  const compiled = dependencies.buildGraphifyPromptPack({
+    question: options.prompt,
+    retrieval,
+  })
+
+  return JSON.stringify({
+    provider: options.provider,
+    task: 'explain',
+    prompt: options.prompt,
+    graph_path: options.graphPath,
+    compiled,
+  })
+}

--- a/src/infrastructure/context-prompt-command.ts
+++ b/src/infrastructure/context-prompt-command.ts
@@ -24,6 +24,7 @@ type CompiledProviderPrompt =
       format: 'session_payload'
       prompt: string
       token_count: number
+      session_payload_token_count: number
       effective_token_count: number
       reused_context_tokens: number
       session_state: ComparePromptPack['session_state']
@@ -41,7 +42,8 @@ function compilePromptForProvider(provider: PromptCliProvider, promptPack: Compa
       provider,
       format: 'session_payload',
       prompt: promptPack.session_payload,
-      token_count: promptPack.session_payload_token_count,
+      token_count: promptPack.token_count,
+      session_payload_token_count: promptPack.session_payload_token_count,
       effective_token_count: promptPack.effective_token_count,
       reused_context_tokens: promptPack.reused_context_tokens,
       session_state: promptPack.session_state,
@@ -73,7 +75,6 @@ export async function runContextPromptCommand(
 
   return JSON.stringify({
     provider: options.provider,
-    task: 'explain',
     prompt: options.prompt,
     graph_path: options.graphPath,
     compiled: providerCompiled,

--- a/src/infrastructure/context-prompt-command.ts
+++ b/src/infrastructure/context-prompt-command.ts
@@ -1,4 +1,4 @@
-import type { PromptCliOptions } from '../cli/parser.js'
+import type { PromptCliOptions, PromptCliProvider } from '../cli/parser.js'
 import type { KnowledgeGraph } from '../contracts/graph.js'
 import { buildGraphifyPromptPack, type ComparePromptPack } from './compare.js'
 import { retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
@@ -18,6 +18,44 @@ const DEFAULT_DEPENDENCIES: ContextPromptCommandDependencies = {
   buildGraphifyPromptPack: (input) => buildGraphifyPromptPack(input),
 }
 
+type CompiledProviderPrompt =
+  | {
+      provider: 'claude'
+      format: 'session_payload'
+      prompt: string
+      token_count: number
+      effective_token_count: number
+      reused_context_tokens: number
+      session_state: ComparePromptPack['session_state']
+    }
+  | {
+      provider: 'gemini'
+      format: 'prompt'
+      prompt: string
+      token_count: number
+    }
+
+function compilePromptForProvider(provider: PromptCliProvider, promptPack: ComparePromptPack): CompiledProviderPrompt {
+  if (provider === 'claude') {
+    return {
+      provider,
+      format: 'session_payload',
+      prompt: promptPack.session_payload,
+      token_count: promptPack.session_payload_token_count,
+      effective_token_count: promptPack.effective_token_count,
+      reused_context_tokens: promptPack.reused_context_tokens,
+      session_state: promptPack.session_state,
+    }
+  }
+
+  return {
+    provider,
+    format: 'prompt',
+    prompt: promptPack.prompt,
+    token_count: promptPack.token_count,
+  }
+}
+
 export async function runContextPromptCommand(
   options: PromptCliOptions,
   dependencies: ContextPromptCommandDependencies = DEFAULT_DEPENDENCIES,
@@ -31,12 +69,13 @@ export async function runContextPromptCommand(
     question: options.prompt,
     retrieval,
   })
+  const providerCompiled = compilePromptForProvider(options.provider, compiled)
 
   return JSON.stringify({
     provider: options.provider,
     task: 'explain',
     prompt: options.prompt,
     graph_path: options.graphPath,
-    compiled,
+    compiled: providerCompiled,
   })
 }

--- a/src/infrastructure/context-prompt.ts
+++ b/src/infrastructure/context-prompt.ts
@@ -42,6 +42,9 @@ export interface BuiltContextPrompt {
   metrics: ContextPromptMetrics
 }
 
+const STABLE_PREFIX_INSTRUCTIONS_REF = '__stable_prefix:instructions'
+const STABLE_PREFIX_TITLE_REF = '__stable_prefix:title'
+
 function joinBlocks(blocks: readonly string[]): string {
   return blocks.map((block) => block.trim()).filter((block) => block.length > 0).join('\n\n')
 }
@@ -62,17 +65,45 @@ function compareStableSections(left: ContextPromptStableSection, right: ContextP
 function renderStablePrefix(input: Pick<BuildContextPromptInput, 'instructions' | 'stable_sections' | 'stable_prefix_title'>): {
   ordered_sections: ContextPromptStableSection[]
   stable_prefix: string
+  session_refs: { ref: string; content: string }[]
 } {
   const ordered_sections = [...input.stable_sections].sort(compareStableSections)
-  const stableSectionBody = ordered_sections.map(renderSection).join('\n\n')
-  const stableBody =
-    input.stable_prefix_title && stableSectionBody.length > 0
-      ? `${input.stable_prefix_title}:\n${stableSectionBody}`
-      : stableSectionBody
+  const session_refs: { ref: string; content: string }[] = []
+  const instructions = input.instructions.join('\n').trim()
+
+  if (instructions.length > 0) {
+    session_refs.push({
+      ref: STABLE_PREFIX_INSTRUCTIONS_REF,
+      content: instructions,
+    })
+  }
+
+  const [firstSection, ...remainingSections] = ordered_sections
+  if (input.stable_prefix_title && firstSection) {
+    session_refs.push({
+      ref: STABLE_PREFIX_TITLE_REF,
+      content: `${session_refs.length > 0 ? '\n\n' : ''}${input.stable_prefix_title}:`,
+    })
+  }
+
+  if (firstSection) {
+    session_refs.push({
+      ref: firstSection.ref,
+      content: `${input.stable_prefix_title ? '\n' : session_refs.length > 0 ? '\n\n' : ''}${renderSection(firstSection)}`,
+    })
+  }
+
+  for (const section of remainingSections) {
+    session_refs.push({
+      ref: section.ref,
+      content: `\n\n${renderSection(section)}`,
+    })
+  }
 
   return {
     ordered_sections,
-    stable_prefix: joinBlocks([input.instructions.join('\n'), stableBody]),
+    stable_prefix: session_refs.map((ref) => ref.content).join(''),
+    session_refs,
   }
 }
 
@@ -99,16 +130,10 @@ function renderSessionPayload(sessionDelta: ContextSessionDelta, dynamicSuffix: 
 }
 
 export function buildContextPrompt(input: BuildContextPromptInput): BuiltContextPrompt {
-  const { ordered_sections, stable_prefix } = renderStablePrefix(input)
+  const { ordered_sections, stable_prefix, session_refs } = renderStablePrefix(input)
   const dynamic_suffix = renderDynamicSuffix(input.dynamic_sections)
   const prompt = joinBlocks([stable_prefix, dynamic_suffix])
-  const { session_state, session_delta } = buildContextSession(
-    ordered_sections.map((section) => ({
-      ref: section.ref,
-      content: renderSection(section),
-    })),
-    input.session,
-  )
+  const { session_state, session_delta } = buildContextSession(session_refs, input.session)
 
   const session_payload =
     session_delta.previous_revision === null

--- a/src/infrastructure/context-prompt.ts
+++ b/src/infrastructure/context-prompt.ts
@@ -134,6 +134,7 @@ export function buildContextPrompt(input: BuildContextPromptInput): BuiltContext
   const dynamic_suffix = renderDynamicSuffix(input.dynamic_sections)
   const prompt = joinBlocks([stable_prefix, dynamic_suffix])
   const { session_state, session_delta } = buildContextSession(session_refs, input.session)
+  const stable_prefix_tokens = Object.values(session_state.refs).reduce((total, ref) => total + ref.token_count, 0)
 
   const session_payload =
     session_delta.previous_revision === null
@@ -156,7 +157,7 @@ export function buildContextPrompt(input: BuildContextPromptInput): BuiltContext
     session_delta,
     metrics: {
       raw_prompt_tokens,
-      stable_prefix_tokens: estimateQueryTokens(stable_prefix),
+      stable_prefix_tokens,
       dynamic_suffix_tokens: estimateQueryTokens(dynamic_suffix),
       session_payload_tokens,
       effective_prompt_tokens,

--- a/src/infrastructure/context-prompt.ts
+++ b/src/infrastructure/context-prompt.ts
@@ -1,0 +1,141 @@
+import type { ContextSessionDelta, ContextSessionState } from '../contracts/context-session.js'
+import { buildContextSession } from '../runtime/context-session.js'
+import { estimateQueryTokens } from '../runtime/serve.js'
+
+export interface ContextPromptStableSection {
+  ref: string
+  title?: string
+  body: string
+  sort_key?: string
+}
+
+export interface ContextPromptDynamicSection {
+  title?: string
+  body: string
+}
+
+export interface BuildContextPromptInput {
+  instructions: readonly string[]
+  stable_sections: readonly ContextPromptStableSection[]
+  dynamic_sections: readonly ContextPromptDynamicSection[]
+  stable_prefix_title?: string
+  session?: ContextSessionState
+}
+
+export interface ContextPromptMetrics {
+  raw_prompt_tokens: number
+  stable_prefix_tokens: number
+  dynamic_suffix_tokens: number
+  session_payload_tokens: number
+  effective_prompt_tokens: number
+  reused_context_tokens: number
+}
+
+export interface BuiltContextPrompt {
+  prompt: string
+  stable_prefix: string
+  dynamic_suffix: string
+  session_payload: string
+  ordered_stable_refs: string[]
+  session_state: ContextSessionState
+  session_delta: ContextSessionDelta
+  metrics: ContextPromptMetrics
+}
+
+function joinBlocks(blocks: readonly string[]): string {
+  return blocks.map((block) => block.trim()).filter((block) => block.length > 0).join('\n\n')
+}
+
+function renderSection(section: { title?: string; body: string }): string {
+  return section.title ? `${section.title}:\n${section.body}` : section.body
+}
+
+function compareStableSections(left: ContextPromptStableSection, right: ContextPromptStableSection): number {
+  const leftKey = left.sort_key ?? left.ref
+  const rightKey = right.sort_key ?? right.ref
+  if (leftKey === rightKey) {
+    return left.ref.localeCompare(right.ref)
+  }
+  return leftKey.localeCompare(rightKey)
+}
+
+function renderStablePrefix(input: Pick<BuildContextPromptInput, 'instructions' | 'stable_sections' | 'stable_prefix_title'>): {
+  ordered_sections: ContextPromptStableSection[]
+  stable_prefix: string
+} {
+  const ordered_sections = [...input.stable_sections].sort(compareStableSections)
+  const stableSectionBody = ordered_sections.map(renderSection).join('\n\n')
+  const stableBody =
+    input.stable_prefix_title && stableSectionBody.length > 0
+      ? `${input.stable_prefix_title}:\n${stableSectionBody}`
+      : stableSectionBody
+
+  return {
+    ordered_sections,
+    stable_prefix: joinBlocks([input.instructions.join('\n'), stableBody]),
+  }
+}
+
+function renderDynamicSuffix(dynamicSections: readonly ContextPromptDynamicSection[]): string {
+  return joinBlocks(dynamicSections.map(renderSection))
+}
+
+function renderSessionPayload(sessionDelta: ContextSessionDelta, dynamicSuffix: string): string {
+  return joinBlocks([
+    'Session delta:',
+    JSON.stringify(
+      {
+        previous_revision: sessionDelta.previous_revision,
+        next_revision: sessionDelta.next_revision,
+        added: sessionDelta.added,
+        updated: sessionDelta.updated,
+        invalidated: sessionDelta.invalidated,
+      },
+      null,
+      2,
+    ),
+    dynamicSuffix,
+  ])
+}
+
+export function buildContextPrompt(input: BuildContextPromptInput): BuiltContextPrompt {
+  const { ordered_sections, stable_prefix } = renderStablePrefix(input)
+  const dynamic_suffix = renderDynamicSuffix(input.dynamic_sections)
+  const prompt = joinBlocks([stable_prefix, dynamic_suffix])
+  const { session_state, session_delta } = buildContextSession(
+    ordered_sections.map((section) => ({
+      ref: section.ref,
+      content: renderSection(section),
+    })),
+    input.session,
+  )
+
+  const session_payload =
+    session_delta.previous_revision === null
+      ? prompt
+      : renderSessionPayload(session_delta, dynamic_suffix)
+  const raw_prompt_tokens = estimateQueryTokens(prompt)
+  const session_payload_tokens = estimateQueryTokens(session_payload)
+  const effective_prompt_tokens =
+    session_delta.previous_revision === null
+      ? raw_prompt_tokens
+      : Math.max(0, raw_prompt_tokens - session_delta.reused_token_count)
+
+  return {
+    prompt,
+    stable_prefix,
+    dynamic_suffix,
+    session_payload,
+    ordered_stable_refs: ordered_sections.map((section) => section.ref),
+    session_state,
+    session_delta,
+    metrics: {
+      raw_prompt_tokens,
+      stable_prefix_tokens: estimateQueryTokens(stable_prefix),
+      dynamic_suffix_tokens: estimateQueryTokens(dynamic_suffix),
+      session_payload_tokens,
+      effective_prompt_tokens,
+      reused_context_tokens: session_delta.reused_token_count,
+    },
+  }
+}

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -282,7 +282,7 @@ function sanitizePersistedReviewPayload<T>(value: T): T {
   return value
 }
 
-function renderReviewPrompt(payload: unknown, mode: ReviewCompareMode): string {
+function renderReviewPrompt(payload: unknown, mode: ReviewCompareMode): ReturnType<typeof buildContextPrompt> {
   return buildContextPrompt({
     instructions: [
       'Review the current git diff using only the provided pr_impact payload.',
@@ -299,7 +299,7 @@ function renderReviewPrompt(payload: unknown, mode: ReviewCompareMode): string {
       { body: `Mode: ${mode}` },
       { body: 'Answer:' },
     ],
-  }).prompt
+  })
 }
 
 function writeReport(report: ReviewCompareReport): void {
@@ -341,40 +341,8 @@ export function generateReviewCompareArtifacts(input: ReviewCompareInput): Revie
   const compactPayload = compactPrImpactResult(verbosePayload)
   const persistedVerbosePayload = sanitizePersistedReviewPayload(verbosePayload)
   const persistedCompactPayload = sanitizePersistedReviewPayload(compactPayload)
-  const verbosePromptArtifact = buildContextPrompt({
-    instructions: [
-      'Review the current git diff using only the provided pr_impact payload.',
-      'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
-    ],
-    stable_prefix_title: 'pr_impact payload',
-    stable_sections: [
-      {
-        ref: 'pr_impact_payload',
-        body: JSON.stringify(persistedVerbosePayload, null, 2),
-      },
-    ],
-    dynamic_sections: [
-      { body: 'Mode: verbose' },
-      { body: 'Answer:' },
-    ],
-  })
-  const compactPromptArtifact = buildContextPrompt({
-    instructions: [
-      'Review the current git diff using only the provided pr_impact payload.',
-      'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
-    ],
-    stable_prefix_title: 'pr_impact payload',
-    stable_sections: [
-      {
-        ref: 'pr_impact_payload',
-        body: JSON.stringify(persistedCompactPayload, null, 2),
-      },
-    ],
-    dynamic_sections: [
-      { body: 'Mode: compact' },
-      { body: 'Answer:' },
-    ],
-  })
+  const verbosePromptArtifact = renderReviewPrompt(persistedVerbosePayload, 'verbose')
+  const compactPromptArtifact = renderReviewPrompt(persistedCompactPayload, 'compact')
   const verbosePrompt = verbosePromptArtifact.prompt
   const compactPrompt = compactPromptArtifact.prompt
 

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -6,6 +6,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 import { analyzePrImpact, compactPrImpactResult } from '../runtime/pr-impact.js'
 import { estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { findNearestExistingAncestor, validateGraphPath } from '../shared/security.js'
+import { buildContextPrompt } from './context-prompt.js'
 
 export type ReviewCompareMode = 'verbose' | 'compact'
 export type ReviewCompareRunStatus = 'not_run' | 'succeeded' | 'failed'
@@ -60,6 +61,11 @@ export interface ReviewCompareReport {
   verbose_prompt_tokens: number
   compact_prompt_tokens: number
   reduction_ratio: number
+  verbose_effective_prompt_tokens: number
+  compact_effective_prompt_tokens: number
+  effective_reduction_ratio: number
+  verbose_reused_context_tokens: number
+  compact_reused_context_tokens: number
   started_at: string
   completed_at: string
   elapsed_ms: Record<ReviewCompareMode, number>
@@ -277,16 +283,23 @@ function sanitizePersistedReviewPayload<T>(value: T): T {
 }
 
 function renderReviewPrompt(payload: unknown, mode: ReviewCompareMode): string {
-  return [
-    'Review the current git diff using only the provided pr_impact payload.',
-    'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
-    `Mode: ${mode}`,
-    '',
-    'pr_impact payload:',
-    JSON.stringify(payload, null, 2),
-    '',
-    'Answer:',
-  ].join('\n')
+  return buildContextPrompt({
+    instructions: [
+      'Review the current git diff using only the provided pr_impact payload.',
+      'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
+    ],
+    stable_prefix_title: 'pr_impact payload',
+    stable_sections: [
+      {
+        ref: 'pr_impact_payload',
+        body: JSON.stringify(payload, null, 2),
+      },
+    ],
+    dynamic_sections: [
+      { body: `Mode: ${mode}` },
+      { body: 'Answer:' },
+    ],
+  }).prompt
 }
 
 function writeReport(report: ReviewCompareReport): void {
@@ -328,8 +341,42 @@ export function generateReviewCompareArtifacts(input: ReviewCompareInput): Revie
   const compactPayload = compactPrImpactResult(verbosePayload)
   const persistedVerbosePayload = sanitizePersistedReviewPayload(verbosePayload)
   const persistedCompactPayload = sanitizePersistedReviewPayload(compactPayload)
-  const verbosePrompt = renderReviewPrompt(persistedVerbosePayload, 'verbose')
-  const compactPrompt = renderReviewPrompt(persistedCompactPayload, 'compact')
+  const verbosePromptArtifact = buildContextPrompt({
+    instructions: [
+      'Review the current git diff using only the provided pr_impact payload.',
+      'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
+    ],
+    stable_prefix_title: 'pr_impact payload',
+    stable_sections: [
+      {
+        ref: 'pr_impact_payload',
+        body: JSON.stringify(persistedVerbosePayload, null, 2),
+      },
+    ],
+    dynamic_sections: [
+      { body: 'Mode: verbose' },
+      { body: 'Answer:' },
+    ],
+  })
+  const compactPromptArtifact = buildContextPrompt({
+    instructions: [
+      'Review the current git diff using only the provided pr_impact payload.',
+      'Summarize the changed areas, top risks, supporting files to inspect, likely tests to run, and structural hotspots to watch.',
+    ],
+    stable_prefix_title: 'pr_impact payload',
+    stable_sections: [
+      {
+        ref: 'pr_impact_payload',
+        body: JSON.stringify(persistedCompactPayload, null, 2),
+      },
+    ],
+    dynamic_sections: [
+      { body: 'Mode: compact' },
+      { body: 'Answer:' },
+    ],
+  })
+  const verbosePrompt = verbosePromptArtifact.prompt
+  const compactPrompt = compactPromptArtifact.prompt
 
   const paths: ReviewComparePromptArtifactPaths = {
     output_dir: outputRoot,
@@ -365,6 +412,14 @@ export function generateReviewCompareArtifacts(input: ReviewCompareInput): Revie
     verbose_prompt_tokens: verbosePromptTokens,
     compact_prompt_tokens: compactPromptTokens,
     reduction_ratio: computeReductionRatio(verbosePromptTokens, compactPromptTokens),
+    verbose_effective_prompt_tokens: verbosePromptArtifact.metrics.effective_prompt_tokens,
+    compact_effective_prompt_tokens: compactPromptArtifact.metrics.effective_prompt_tokens,
+    effective_reduction_ratio: computeReductionRatio(
+      verbosePromptArtifact.metrics.effective_prompt_tokens,
+      compactPromptArtifact.metrics.effective_prompt_tokens,
+    ),
+    verbose_reused_context_tokens: verbosePromptArtifact.metrics.reused_context_tokens,
+    compact_reused_context_tokens: compactPromptArtifact.metrics.reused_context_tokens,
     started_at: now.toISOString(),
     completed_at: now.toISOString(),
     elapsed_ms: {
@@ -448,6 +503,7 @@ export function formatReviewCompareSummary(result: ReviewCompareResult): string 
     '[graphify review-compare] completed current diff comparison',
     `- Output: ${result.output_root}`,
     `- Prompt tokens: verbose ${result.report.verbose_prompt_tokens} · compact ${result.report.compact_prompt_tokens} · ${formatTokenComparison(result.report.verbose_prompt_tokens, result.report.compact_prompt_tokens)}`,
+    `- Effective prompt tokens: verbose ${result.report.verbose_effective_prompt_tokens} · compact ${result.report.compact_effective_prompt_tokens} · ${formatTokenComparison(result.report.verbose_effective_prompt_tokens, result.report.compact_effective_prompt_tokens)}`,
     `- Payload tokens: verbose ${result.report.verbose_payload_tokens} · compact ${result.report.compact_payload_tokens} · ${formatTokenComparison(result.report.verbose_payload_tokens, result.report.compact_payload_tokens)}`,
     `- Prompt runs: verbose ${result.report.status.verbose} (${result.report.elapsed_ms.verbose} ms) · compact ${result.report.status.compact} (${result.report.elapsed_ms.compact} ms)`,
   ].join('\n')

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -1,0 +1,403 @@
+import type {
+  CompiledContextPack,
+  ContextPackClaim,
+  ContextPackCommunityContext,
+  ContextPackCoverage,
+  ContextPackCoverageEntry,
+  ContextPackEvidenceClass,
+  ContextPackExpandableRef,
+  ContextPackGraphSignals,
+  ContextPackNode,
+  ContextPackRelationship,
+  ContextPackTaskContract,
+  ContextPackTaskKind,
+} from '../contracts/context-pack.js'
+import { estimateQueryTokens } from './serve.js'
+
+const REQUIRED_EVIDENCE_BY_TASK: Record<ContextPackTaskKind, ContextPackEvidenceClass[]> = {
+  explain: ['primary', 'supporting', 'structural'],
+  review: ['change', 'supporting', 'impact'],
+  impact: ['primary', 'impact', 'structural'],
+}
+
+export interface ClassifyTaskContractOptions {
+  budget: number
+  prompt?: string
+}
+
+export interface ContextPackNodeCandidate<TNode extends ContextPackNode = ContextPackNode> {
+  label: string
+  node_id?: string | undefined
+  community?: number | null
+  evidence_class: ContextPackEvidenceClass
+  estimate_tokens: () => number
+  build_entry: () => TNode
+}
+
+export interface CompileContextPackInput<
+  TNode extends ContextPackNode = ContextPackNode,
+  TRelationship extends ContextPackRelationship = ContextPackRelationship,
+  TCommunity extends ContextPackCommunityContext = ContextPackCommunityContext,
+> {
+  task_contract: ContextPackTaskContract
+  nodes: readonly ContextPackNodeCandidate<TNode>[]
+  relationships?: readonly TRelationship[]
+  community_context?: readonly TCommunity[]
+  graph_signals?: ContextPackGraphSignals
+}
+
+export type CompactContextPackMode =
+  | {
+    kind: 'retrieve'
+    max_nodes?: number
+    hoist_empty_shared_file_type?: boolean
+  }
+  | {
+    kind: 'review'
+    seed_node_ids?: readonly string[]
+    seed_labels?: readonly string[]
+    max_supporting_nodes?: number
+  }
+
+function includedNodeId(node: Pick<ContextPackNode, 'node_id'>): string | null {
+  return typeof node.node_id === 'string' && node.node_id.length > 0 ? node.node_id : null
+}
+
+function filterRelationships<TRelationship extends ContextPackRelationship>(
+  relationships: readonly TRelationship[],
+  nodes: readonly ContextPackNode[],
+): TRelationship[] {
+  const includedIds = new Set(nodes.map(includedNodeId).filter((nodeId): nodeId is string => nodeId !== null))
+  const includedLabels = new Set(nodes.map((node) => node.label))
+
+  return relationships.filter((relationship) => {
+    if (includedIds.size > 0 && relationship.from_id && relationship.to_id) {
+      return includedIds.has(relationship.from_id) && includedIds.has(relationship.to_id)
+    }
+
+    return includedLabels.has(relationship.from) && includedLabels.has(relationship.to)
+  })
+}
+
+function sharedFileTypeForNodes(nodes: readonly ContextPackNode[]): string | undefined {
+  return nodes.length > 0 && nodes.every((node) => node.file_type === nodes[0]?.file_type)
+    ? nodes[0]?.file_type
+    : undefined
+}
+
+function classifyCoverageStatus(required: boolean, availableNodes: number, selectedNodes: number): ContextPackCoverageEntry['status'] {
+  if (selectedNodes > 0) {
+    return 'covered'
+  }
+
+  if (required) {
+    return 'missing'
+  }
+
+  return availableNodes > 0 ? 'available' : 'missing'
+}
+
+function coverageEntriesForCandidates(
+  taskContract: ContextPackTaskContract,
+  nodes: readonly ContextPackNodeCandidate[],
+  selectedCounts: ReadonlyMap<ContextPackEvidenceClass, number>,
+  relationshipCounts: { available: number; selected: number },
+): ContextPackCoverage {
+  const availableCounts = new Map<ContextPackEvidenceClass, number>()
+  for (const node of nodes) {
+    availableCounts.set(node.evidence_class, (availableCounts.get(node.evidence_class) ?? 0) + 1)
+  }
+
+  const evidenceClasses = [
+    ...taskContract.required_evidence,
+    ...[...availableCounts.keys()].filter((evidenceClass) => !taskContract.required_evidence.includes(evidenceClass)),
+  ]
+
+  const entries: ContextPackCoverageEntry[] = evidenceClasses.map((evidence_class) => {
+    const available_nodes = availableCounts.get(evidence_class) ?? 0
+    const selected_nodes = selectedCounts.get(evidence_class) ?? 0
+    const required = taskContract.required_evidence.includes(evidence_class)
+
+    return {
+      evidence_class,
+      required,
+      available_nodes,
+      selected_nodes,
+      status: classifyCoverageStatus(required, available_nodes, selected_nodes),
+    }
+  })
+
+  return {
+    required_evidence: [...taskContract.required_evidence],
+    entries,
+    missing_required: entries.filter((entry) => entry.required && entry.selected_nodes === 0).map((entry) => entry.evidence_class),
+    available_relationships: relationshipCounts.available,
+    selected_relationships: relationshipCounts.selected,
+  }
+}
+
+function claimLabel(className: ContextPackEvidenceClass): string {
+  return className.replace(/_/g, ' ')
+}
+
+function buildClaims(
+  taskContract: ContextPackTaskContract,
+  labelsByEvidence: ReadonlyMap<ContextPackEvidenceClass, string[]>,
+): ContextPackClaim[] {
+  const orderedEvidence = [
+    ...taskContract.required_evidence,
+    ...[...labelsByEvidence.keys()].filter((evidenceClass) => !taskContract.required_evidence.includes(evidenceClass)),
+  ]
+
+  return orderedEvidence.flatMap((evidence_class) => {
+    const nodeLabels = labelsByEvidence.get(evidence_class) ?? []
+    if (nodeLabels.length === 0) {
+      return []
+    }
+
+    return [{
+      evidence_class,
+      text: `${claimLabel(evidence_class)} evidence: ${nodeLabels.slice(0, 3).join(', ')}`,
+      node_labels: nodeLabels.slice(0, 3),
+    }]
+  })
+}
+
+function buildExpandableRefs(
+  taskContract: ContextPackTaskContract,
+  omittedNodes: readonly ContextPackNodeCandidate[],
+): ContextPackExpandableRef[] {
+  const omittedByEvidence = new Map<ContextPackEvidenceClass, string[]>()
+  for (const node of omittedNodes) {
+    const labels = omittedByEvidence.get(node.evidence_class) ?? []
+    labels.push(node.label)
+    omittedByEvidence.set(node.evidence_class, labels)
+  }
+
+  const orderedEvidence = [
+    ...taskContract.required_evidence,
+    ...[...omittedByEvidence.keys()].filter((evidenceClass) => !taskContract.required_evidence.includes(evidenceClass)),
+  ]
+
+  return orderedEvidence.flatMap((evidence_class) => {
+    const labels = omittedByEvidence.get(evidence_class) ?? []
+    if (labels.length === 0) {
+      return []
+    }
+
+    return [{
+      kind: 'nodes',
+      evidence_class,
+      count: labels.length,
+      preview_labels: labels.slice(0, 3),
+    }]
+  })
+}
+
+export function classifyTaskContract(
+  taskKind: ContextPackTaskKind,
+  options: ClassifyTaskContractOptions,
+): ContextPackTaskContract {
+  return {
+    version: 1,
+    task_kind: taskKind,
+    budget: options.budget,
+    ...(options.prompt ? { prompt: options.prompt } : {}),
+    required_evidence: [...REQUIRED_EVIDENCE_BY_TASK[taskKind]],
+  }
+}
+
+export function estimateContextPackEntryTokens(
+  label: string,
+  sourceFile: string,
+  lineNumber: number,
+  snippet: string | null,
+): number {
+  return estimateQueryTokens(`${label} ${sourceFile}:${lineNumber} ${snippet ?? ''}`)
+}
+
+export function compileContextPack<
+  TNode extends ContextPackNode = ContextPackNode,
+  TRelationship extends ContextPackRelationship = ContextPackRelationship,
+  TCommunity extends ContextPackCommunityContext = ContextPackCommunityContext,
+>(
+  input: CompileContextPackInput<TNode, TRelationship, TCommunity>,
+): CompiledContextPack<TNode, TRelationship, TCommunity> {
+  const selectedNodes: TNode[] = []
+  const selectedCounts = new Map<ContextPackEvidenceClass, number>()
+  const selectedLabelsByEvidence = new Map<ContextPackEvidenceClass, string[]>()
+  const selectedCommunities = new Set<number>()
+  let tokenCount = 0
+  let breakIndex = input.nodes.length
+
+  for (const [index, candidate] of input.nodes.entries()) {
+    const candidateTokens = candidate.estimate_tokens()
+    if (
+      tokenCount + candidateTokens > input.task_contract.budget
+      && (selectedNodes.length > 0 || input.task_contract.task_kind === 'review')
+    ) {
+      breakIndex = index
+      break
+    }
+
+    const entry = candidate.build_entry()
+    selectedNodes.push(entry)
+    tokenCount += candidateTokens
+    selectedCounts.set(candidate.evidence_class, (selectedCounts.get(candidate.evidence_class) ?? 0) + 1)
+
+    const selectedLabels = selectedLabelsByEvidence.get(candidate.evidence_class) ?? []
+    if (!selectedLabels.includes(candidate.label)) {
+      selectedLabels.push(candidate.label)
+    }
+    selectedLabelsByEvidence.set(candidate.evidence_class, selectedLabels)
+
+    if (typeof candidate.community === 'number') {
+      selectedCommunities.add(candidate.community)
+    }
+  }
+
+  const omittedNodes = input.nodes.slice(breakIndex)
+  const relationships = filterRelationships(input.relationships ?? [], selectedNodes)
+  const includedLabels = new Set(selectedNodes.map((node) => node.label))
+
+  return {
+    task_contract: input.task_contract,
+    token_count: tokenCount,
+    nodes: selectedNodes,
+    relationships,
+    community_context: (input.community_context ?? []).filter((community) => selectedCommunities.has(community.id)),
+    claims: buildClaims(input.task_contract, selectedLabelsByEvidence),
+    expandable: buildExpandableRefs(input.task_contract, omittedNodes),
+    coverage: coverageEntriesForCandidates(
+      input.task_contract,
+      input.nodes,
+      selectedCounts,
+      {
+        available: input.relationships?.length ?? 0,
+        selected: relationships.length,
+      },
+    ),
+    ...(input.graph_signals
+      ? {
+          graph_signals: {
+            god_nodes: input.graph_signals.god_nodes.filter((label) => includedLabels.has(label)),
+            bridge_nodes: input.graph_signals.bridge_nodes.filter((label) => includedLabels.has(label)),
+          },
+        }
+      : {}),
+  }
+}
+
+export function compactContextPack<
+  TRelationship extends ContextPackRelationship = ContextPackRelationship,
+  TCommunity extends ContextPackCommunityContext = ContextPackCommunityContext,
+>(
+  pack: CompiledContextPack<ContextPackNode, TRelationship, TCommunity>,
+  mode: CompactContextPackMode,
+): CompiledContextPack<ContextPackNode, ContextPackRelationship, TCommunity> {
+  if (mode.kind === 'review') {
+    const seedIds = new Set(mode.seed_node_ids ?? [])
+    const seedLabels = new Set(mode.seed_labels ?? [])
+    const compactNodes: ContextPackNode[] = []
+    const includedRelationshipIds = new Set<string>()
+    let supportNodes = 0
+
+    for (const node of pack.nodes) {
+      const isSeed = (typeof node.node_id === 'string' && seedIds.has(node.node_id)) || seedLabels.has(node.label)
+      if (!isSeed && supportNodes >= (mode.max_supporting_nodes ?? Number.POSITIVE_INFINITY)) {
+        continue
+      }
+
+      const {
+        community_label: _communityLabel,
+        framework_boost: _frameworkBoost,
+        file_type: fileType,
+        node_id: nodeId,
+        match_score: matchScore,
+        node_kind: nodeKind,
+        ...rest
+      } = node
+
+      if (typeof node.node_id === 'string' && node.node_id.length > 0) {
+        includedRelationshipIds.add(node.node_id)
+      }
+
+      compactNodes.push({
+        ...rest,
+        ...(typeof nodeKind === 'string' && nodeKind.trim().length > 0 ? { node_kind: nodeKind } : {}),
+        ...(isSeed && typeof nodeId === 'string' && nodeId.length > 0 ? { node_id: nodeId } : {}),
+        ...(isSeed ? { match_score: matchScore } : {}),
+        ...(isSeed ? { snippet: node.snippet } : { snippet: null }),
+        ...(fileType !== undefined ? { file_type: fileType } : {}),
+      } as ContextPackNode)
+
+      if (!isSeed) {
+        supportNodes += 1
+      }
+    }
+
+    const sharedFileType = sharedFileTypeForNodes(compactNodes)
+    const compactNodesWithoutSharedFileType = sharedFileType !== undefined
+      ? compactNodes.map(({ file_type: _fileType, ...node }) => node)
+      : compactNodes
+    const compactNodePayload = sharedFileType !== undefined
+      ? { shared_file_type: sharedFileType, nodes: compactNodesWithoutSharedFileType }
+      : compactNodesWithoutSharedFileType
+    const includedLabels = new Set(compactNodesWithoutSharedFileType.map((node) => node.label))
+    const relationships = pack.relationships.filter((relationship) => {
+      if (includedRelationshipIds.size > 0 && relationship.from_id && relationship.to_id) {
+        return includedRelationshipIds.has(relationship.from_id) && includedRelationshipIds.has(relationship.to_id)
+      }
+
+      return includedLabels.has(relationship.from) && includedLabels.has(relationship.to)
+    }).map((relationship) => {
+      const { from_id: _fromId, to_id: _toId, ...rest } = relationship
+      return rest
+    })
+    const includedCommunities = new Set(compactNodesWithoutSharedFileType.flatMap((node) => (typeof node.community === 'number' ? [node.community] : [])))
+
+    return {
+      ...pack,
+      token_count: compactNodesWithoutSharedFileType.length === 0 ? 0 : estimateQueryTokens(JSON.stringify(compactNodePayload)),
+      nodes: compactNodesWithoutSharedFileType,
+      relationships,
+      community_context: pack.community_context.filter((community) => includedCommunities.has(community.id)),
+      ...(sharedFileType !== undefined ? { shared_file_type: sharedFileType as string } : {}),
+    }
+  }
+
+  const limitedNodes = pack.nodes.slice(0, mode.max_nodes ?? pack.nodes.length)
+  const sharedFileType = sharedFileTypeForNodes(limitedNodes)
+  const shouldHoistSharedFileType = mode.hoist_empty_shared_file_type === true
+    ? sharedFileType !== undefined
+    : Boolean(sharedFileType)
+
+  const nodes = limitedNodes.map(({ community_label: _communityLabel, framework_boost: _frameworkBoost, file_type: fileType, node_kind: nodeKind, ...node }) => ({
+    ...node,
+    ...(typeof nodeKind === 'string' && nodeKind.trim().length > 0 ? { node_kind: nodeKind } : {}),
+    ...(shouldHoistSharedFileType ? {} : { file_type: fileType }),
+  }) as ContextPackNode)
+  const relationships = filterRelationships(pack.relationships, nodes)
+  const includedCommunities = new Set(nodes.flatMap((node) => (typeof node.community === 'number' ? [node.community] : [])))
+  const includedLabels = new Set(nodes.map((node) => node.label))
+
+  return {
+    ...pack,
+    token_count: nodes.reduce(
+      (total, node) => total + estimateContextPackEntryTokens(node.label, node.source_file, node.line_number, node.snippet ?? null),
+      0,
+    ),
+    nodes,
+    relationships,
+    community_context: pack.community_context.filter((community) => includedCommunities.has(community.id)),
+    ...(pack.graph_signals
+      ? {
+          graph_signals: {
+            god_nodes: pack.graph_signals.god_nodes.filter((label) => includedLabels.has(label)),
+            bridge_nodes: pack.graph_signals.bridge_nodes.filter((label) => includedLabels.has(label)),
+          },
+        }
+      : {}),
+    ...(shouldHoistSharedFileType ? { shared_file_type: sharedFileType as string } : {}),
+  }
+}

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -232,10 +232,7 @@ export function compileContextPack<
 
   for (const [index, candidate] of input.nodes.entries()) {
     const candidateTokens = candidate.estimate_tokens()
-    if (
-      tokenCount + candidateTokens > input.task_contract.budget
-      && (selectedNodes.length > 0 || input.task_contract.task_kind === 'review')
-    ) {
+    if (tokenCount + candidateTokens > input.task_contract.budget && selectedNodes.length > 0) {
       breakIndex = index
       break
     }

--- a/src/runtime/context-session.ts
+++ b/src/runtime/context-session.ts
@@ -30,14 +30,15 @@ export function buildContextSession(
   previous: ContextSessionState | undefined,
 ): { session_state: ContextSessionState; session_delta: ContextSessionDelta } {
   const baseState = previous ?? createContextSessionState()
-  const orderedRefs = [...refs].sort(compareRefs)
+  const orderedRefs = [...refs]
+  const sortedRefs = [...refs].sort(compareRefs)
   const added: ContextSessionDelta['added'] = []
   const updated: ContextSessionDelta['updated'] = []
   const reused_refs: string[] = []
-  let reused_token_count = 0
+  const reusedRefSet = new Set<string>()
 
   const nextRefs: ContextSessionState['refs'] = {}
-  for (const ref of orderedRefs) {
+  for (const ref of sortedRefs) {
     const tokenCount = ref.token_count ?? estimateQueryTokens(ref.content)
     const hash = hashContent(ref.content)
     nextRefs[ref.ref] = {
@@ -67,12 +68,16 @@ export function buildContextSession(
     }
 
     reused_refs.push(ref.ref)
-    reused_token_count += tokenCount
+    reusedRefSet.add(ref.ref)
   }
 
   const invalidated = Object.keys(baseState.refs)
     .filter((ref) => !(ref in nextRefs))
     .sort((left, right) => left.localeCompare(right))
+  const reusedContent = orderedRefs
+    .filter((ref) => reusedRefSet.has(ref.ref))
+    .map((ref) => ref.content)
+    .join('')
 
   return {
     session_state: {
@@ -88,7 +93,7 @@ export function buildContextSession(
       updated,
       invalidated,
       reused_refs,
-      reused_token_count,
+      reused_token_count: reusedContent.length > 0 ? estimateQueryTokens(reusedContent) : 0,
     },
   }
 }

--- a/src/runtime/context-session.ts
+++ b/src/runtime/context-session.ts
@@ -30,12 +30,10 @@ export function buildContextSession(
   previous: ContextSessionState | undefined,
 ): { session_state: ContextSessionState; session_delta: ContextSessionDelta } {
   const baseState = previous ?? createContextSessionState()
-  const orderedRefs = [...refs]
   const sortedRefs = [...refs].sort(compareRefs)
   const added: ContextSessionDelta['added'] = []
   const updated: ContextSessionDelta['updated'] = []
   const reused_refs: string[] = []
-  const reusedRefSet = new Set<string>()
 
   const nextRefs: ContextSessionState['refs'] = {}
   for (const ref of sortedRefs) {
@@ -68,16 +66,12 @@ export function buildContextSession(
     }
 
     reused_refs.push(ref.ref)
-    reusedRefSet.add(ref.ref)
   }
 
   const invalidated = Object.keys(baseState.refs)
     .filter((ref) => !(ref in nextRefs))
     .sort((left, right) => left.localeCompare(right))
-  const reusedContent = orderedRefs
-    .filter((ref) => reusedRefSet.has(ref.ref))
-    .map((ref) => ref.content)
-    .join('')
+  const reusedTokenCount = reused_refs.reduce((total, ref) => total + (baseState.refs[ref]?.token_count ?? nextRefs[ref]?.token_count ?? 0), 0)
 
   return {
     session_state: {
@@ -93,7 +87,7 @@ export function buildContextSession(
       updated,
       invalidated,
       reused_refs,
-      reused_token_count: reusedContent.length > 0 ? estimateQueryTokens(reusedContent) : 0,
+      reused_token_count: reusedTokenCount,
     },
   }
 }

--- a/src/runtime/context-session.ts
+++ b/src/runtime/context-session.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto'
+
+import type { ContextSessionDelta, ContextSessionState } from '../contracts/context-session.js'
+import { estimateQueryTokens } from './serve.js'
+
+export interface ContextSessionRefInput {
+  ref: string
+  content: string
+  token_count?: number
+}
+
+function compareRefs(left: ContextSessionRefInput, right: ContextSessionRefInput): number {
+  return left.ref.localeCompare(right.ref)
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+export function createContextSessionState(): ContextSessionState {
+  return {
+    version: 1,
+    revision: 0,
+    refs: {},
+  }
+}
+
+export function buildContextSession(
+  refs: readonly ContextSessionRefInput[],
+  previous: ContextSessionState | undefined,
+): { session_state: ContextSessionState; session_delta: ContextSessionDelta } {
+  const baseState = previous ?? createContextSessionState()
+  const orderedRefs = [...refs].sort(compareRefs)
+  const added: ContextSessionDelta['added'] = []
+  const updated: ContextSessionDelta['updated'] = []
+  const reused_refs: string[] = []
+  let reused_token_count = 0
+
+  const nextRefs: ContextSessionState['refs'] = {}
+  for (const ref of orderedRefs) {
+    const tokenCount = ref.token_count ?? estimateQueryTokens(ref.content)
+    const hash = hashContent(ref.content)
+    nextRefs[ref.ref] = {
+      hash,
+      token_count: tokenCount,
+    }
+
+    const previousRef = baseState.refs[ref.ref]
+    if (!previousRef) {
+      added.push({
+        ref: ref.ref,
+        hash,
+        token_count: tokenCount,
+        content: ref.content,
+      })
+      continue
+    }
+
+    if (previousRef.hash !== hash) {
+      updated.push({
+        ref: ref.ref,
+        hash,
+        token_count: tokenCount,
+        content: ref.content,
+      })
+      continue
+    }
+
+    reused_refs.push(ref.ref)
+    reused_token_count += tokenCount
+  }
+
+  const invalidated = Object.keys(baseState.refs)
+    .filter((ref) => !(ref in nextRefs))
+    .sort((left, right) => left.localeCompare(right))
+
+  return {
+    session_state: {
+      version: 1,
+      revision: baseState.revision + 1,
+      refs: nextRefs,
+    },
+    session_delta: {
+      version: 1,
+      previous_revision: baseState.revision > 0 ? baseState.revision : null,
+      next_revision: baseState.revision + 1,
+      added,
+      updated,
+      invalidated,
+      reused_refs,
+      reused_token_count,
+    },
+  }
+}

--- a/src/runtime/context-session.ts
+++ b/src/runtime/context-session.ts
@@ -31,12 +31,17 @@ export function buildContextSession(
 ): { session_state: ContextSessionState; session_delta: ContextSessionDelta } {
   const baseState = previous ?? createContextSessionState()
   const sortedRefs = [...refs].sort(compareRefs)
+  const seenRefs = new Set<string>()
   const added: ContextSessionDelta['added'] = []
   const updated: ContextSessionDelta['updated'] = []
   const reused_refs: string[] = []
 
   const nextRefs: ContextSessionState['refs'] = {}
   for (const ref of sortedRefs) {
+    if (seenRefs.has(ref.ref)) {
+      throw new Error(`Duplicate context session ref: ${ref.ref}`)
+    }
+    seenRefs.add(ref.ref)
     const tokenCount = ref.token_count ?? estimateQueryTokens(ref.content)
     const hash = hashContent(ref.content)
     nextRefs[ref.ref] = {

--- a/src/runtime/feature-map.ts
+++ b/src/runtime/feature-map.ts
@@ -41,7 +41,7 @@ export interface FeatureMapResult {
   claims: ContextPackClaim[]
   expandable: ContextPackExpandableRef[]
   coverage?: ContextPackCoverage
-  missing_context: ContextPackEvidenceClass[]
+  missing_context?: ContextPackEvidenceClass[]
 }
 
 interface CommunityAggregate {
@@ -192,7 +192,11 @@ export function featureMap(graph: KnowledgeGraph, options: FeatureMapOptions): F
     relevant_files,
     claims: retrieveResult.claims ?? [],
     expandable: retrieveResult.expandable ?? [],
-    ...(retrieveResult.coverage ? { coverage: retrieveResult.coverage } : {}),
-    missing_context: retrieveResult.coverage?.missing_required ?? [],
+    ...(retrieveResult.coverage
+      ? {
+          coverage: retrieveResult.coverage,
+          missing_context: retrieveResult.coverage.missing_required,
+        }
+      : {}),
   }
 }

--- a/src/runtime/feature-map.ts
+++ b/src/runtime/feature-map.ts
@@ -1,4 +1,5 @@
 import { KnowledgeGraph } from '../contracts/graph.js'
+import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef } from '../contracts/context-pack.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
 import { relevantFiles, type RelevantFileEntry } from './relevant-files.js'
 import { retrieveContext, type RetrieveMatchedNode } from './retrieve.js'
@@ -37,6 +38,10 @@ export interface FeatureMapResult {
   communities: FeatureMapCommunity[]
   entry_points: FeatureMapEntryPoint[]
   relevant_files: RelevantFileEntry[]
+  claims: ContextPackClaim[]
+  expandable: ContextPackExpandableRef[]
+  coverage?: ContextPackCoverage
+  missing_context: ContextPackEvidenceClass[]
 }
 
 interface CommunityAggregate {
@@ -185,5 +190,9 @@ export function featureMap(graph: KnowledgeGraph, options: FeatureMapOptions): F
     communities,
     entry_points,
     relevant_files,
+    claims: retrieveResult.claims ?? [],
+    expandable: retrieveResult.expandable ?? [],
+    ...(retrieveResult.coverage ? { coverage: retrieveResult.coverage } : {}),
+    missing_context: retrieveResult.coverage?.missing_required ?? [],
   }
 }

--- a/src/runtime/pr-impact.ts
+++ b/src/runtime/pr-impact.ts
@@ -2,12 +2,27 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
+import type {
+  CompiledContextPack,
+  ContextPackClaim,
+  ContextPackCoverage,
+  ContextPackEvidenceClass,
+  ContextPackExpandableRef,
+  ContextPackNode,
+  ContextPackTaskContract,
+} from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import { godNodes, workspaceBridges } from '../pipeline/analyze.js'
 import { communitiesFromGraph } from './serve.js'
 import { buildCommunityLabels } from '../pipeline/community-naming.js'
 import { analyzeImpact, type ImpactResult } from './impact.js'
 import { estimateQueryTokens } from './serve.js'
+import {
+  classifyTaskContract,
+  compactContextPack,
+  compileContextPack,
+  type ContextPackNodeCandidate,
+} from './context-pack.js'
 import type {
   CompactRetrieveMatchedNode,
   RetrieveCommunityContext,
@@ -68,6 +83,10 @@ export interface PrReviewBundle {
   nodes: RetrieveMatchedNode[]
   relationships: RetrieveRelationship[]
   community_context: RetrieveCommunityContext[]
+  task_contract?: ContextPackTaskContract
+  claims?: ContextPackClaim[]
+  expandable?: ContextPackExpandableRef[]
+  coverage?: ContextPackCoverage
 }
 
 export interface PrImpactResult {
@@ -142,72 +161,74 @@ function stripReviewRelationshipIdentity(relationship: RetrieveRelationship): Co
   return rest
 }
 
+function reviewEvidenceClassForCandidateKind(candidateKind: 'seed' | 'first_hop' | 'second_hop' | undefined): ContextPackEvidenceClass {
+  if (candidateKind === 'seed') {
+    return 'change'
+  }
+
+  return candidateKind === 'first_hop' ? 'supporting' : 'impact'
+}
+
+function fallbackReviewCoverage(reviewBundle: PrReviewBundle): ContextPackCoverage {
+  const taskContract = classifyTaskContract('review', {
+    budget: reviewBundle.budget,
+    prompt: 'Review current changes',
+  })
+
+  return {
+    required_evidence: taskContract.required_evidence,
+    entries: [],
+    missing_required: [],
+    available_relationships: reviewBundle.relationships.length,
+    selected_relationships: reviewBundle.relationships.length,
+  }
+}
+
+function contextPackFromReviewBundle(
+  reviewBundle: PrReviewBundle,
+): CompiledContextPack<ContextPackNode, RetrieveRelationship, RetrieveCommunityContext> {
+  return {
+    task_contract: reviewBundle.task_contract ?? classifyTaskContract('review', {
+      budget: reviewBundle.budget,
+      prompt: 'Review current changes',
+    }),
+    token_count: reviewBundle.token_count,
+    nodes: reviewBundle.nodes.map((node) => ({
+      ...node,
+      evidence_class: node.evidence_class ?? reviewEvidenceClassForCandidateKind(
+        node.relevance_band === 'direct' ? 'seed' : node.relevance_band === 'related' ? 'first_hop' : 'second_hop',
+      ),
+    })),
+    relationships: reviewBundle.relationships,
+    community_context: reviewBundle.community_context,
+    claims: reviewBundle.claims ?? [],
+    expandable: reviewBundle.expandable ?? [],
+    coverage: reviewBundle.coverage ?? fallbackReviewCoverage(reviewBundle),
+  }
+}
+
 function compactReviewBundle(
   reviewBundle: PrReviewBundle,
   seedNodes: readonly PrImpactSeedNode[],
 ): CompactPrReviewBundle {
-  const seedIds = new Set(seedNodes.map((node) => node.node_id))
-  const seedLabels = new Set(seedNodes.map((node) => node.label))
-  const compactNodes: CompactPrReviewNode[] = []
-  const includedRelationshipIds = new Set<string>()
-  let supportNodes = 0
-
-  for (const node of reviewBundle.nodes) {
-    const isSeed = (typeof node.node_id === 'string' && seedIds.has(node.node_id)) || seedLabels.has(node.label)
-    if (!isSeed && supportNodes >= MAX_COMPACT_REVIEW_SUPPORT_NODES) {
-      continue
-    }
-
-    const {
-      community_label: _communityLabel,
-      framework_boost: _frameworkBoost,
-      file_type: fileType,
-      node_id: nodeId,
-      match_score: matchScore,
-      ...rest
-    } = node
-
-    if (typeof nodeId === 'string' && nodeId.length > 0) {
-      includedRelationshipIds.add(nodeId)
-    }
-
-    compactNodes.push({
-      ...rest,
-      ...(isSeed && typeof nodeId === 'string' && nodeId.length > 0 ? { node_id: nodeId } : {}),
-      ...(isSeed ? { match_score: matchScore } : {}),
-      ...(isSeed ? { snippet: node.snippet } : { snippet: null }),
-      ...(fileType !== undefined ? { file_type: fileType } : {}),
-    })
-    if (!isSeed) {
-      supportNodes += 1
-    }
-  }
-
-  const includedLabels = new Set(compactNodes.map((node) => node.label))
-  const includedCommunities = new Set(compactNodes.flatMap((node) => (node.community === null ? [] : [node.community])))
-  const sharedFileType =
-    compactNodes.length > 0 && compactNodes.every((node) => node.file_type === compactNodes[0]?.file_type)
-      ? compactNodes[0]?.file_type
-      : undefined
-  const compactNodesWithoutSharedFileType = sharedFileType !== undefined
-    ? compactNodes.map(({ file_type: _fileType, ...node }) => node)
+  const compactPack = compactContextPack(contextPackFromReviewBundle(reviewBundle), {
+    kind: 'review',
+    seed_node_ids: seedNodes.map((node) => node.node_id),
+    seed_labels: seedNodes.map((node) => node.label),
+    max_supporting_nodes: MAX_COMPACT_REVIEW_SUPPORT_NODES,
+  })
+  const compactNodes = compactPack.nodes.map(({ evidence_class: _evidenceClass, ...node }) => node as CompactPrReviewNode)
+  const compactNodePayload = typeof compactPack.shared_file_type === 'string'
+    ? { shared_file_type: compactPack.shared_file_type, nodes: compactNodes }
     : compactNodes
-  const compactNodePayload = sharedFileType !== undefined
-    ? { shared_file_type: sharedFileType, nodes: compactNodesWithoutSharedFileType }
-    : compactNodesWithoutSharedFileType
 
   return {
     budget: reviewBundle.budget,
-    token_count: compactNodesWithoutSharedFileType.length === 0 ? 0 : estimateQueryTokens(JSON.stringify(compactNodePayload)),
-    nodes: compactNodesWithoutSharedFileType,
-    relationships: reviewBundle.relationships.filter((relationship) => {
-      if (includedRelationshipIds.size > 0 && relationship.from_id && relationship.to_id) {
-        return includedRelationshipIds.has(relationship.from_id) && includedRelationshipIds.has(relationship.to_id)
-      }
-      return includedLabels.has(relationship.from) && includedLabels.has(relationship.to)
-    }).map(stripReviewRelationshipIdentity),
-    community_context: reviewBundle.community_context.filter((community) => includedCommunities.has(community.id)),
-    ...(sharedFileType !== undefined ? { shared_file_type: sharedFileType } : {}),
+    token_count: compactNodes.length === 0 ? 0 : estimateQueryTokens(JSON.stringify(compactNodePayload)),
+    nodes: compactNodes,
+    relationships: compactPack.relationships.map(stripReviewRelationshipIdentity),
+    community_context: compactPack.community_context,
+    ...(compactPack.shared_file_type !== undefined ? { shared_file_type: compactPack.shared_file_type } : {}),
   }
 }
 
@@ -836,67 +857,95 @@ function buildReviewBundle(
       || left.localeCompare(right)
   })
 
-  const matchedNodes: RetrieveMatchedNode[] = []
-  const includedIds = new Set<string>()
   const snippetFileCache = new Map<string, string[] | null>()
-  let tokenCount = 0
-
-  for (const candidateId of orderedCandidateIds) {
+  const orderedCommunities = new Set<number>()
+  const nodeCandidates: Array<ContextPackNodeCandidate<ContextPackNode>> = orderedCandidateIds.flatMap((candidateId) => {
     const attributes = graph.nodeAttributes(candidateId)
     const candidate = candidateNodeFromGraphEntry(candidateId, attributes)
     if (!candidate.sourceFile) {
-      continue
+      return []
     }
 
-    const normalizedSourceFile = normalizeProjectPath(rootPath, candidate.sourceFile)
-    const snippet = readSnippet(normalizedSourceFile, candidate.lineNumber, {
-      derived: candidate.lineNumberDerived,
-      fileCache: snippetFileCache,
-    })
-    const serializedSourceFile = relativizeSourceFile(normalizedSourceFile, rootPath)
-    const nodeTokens = estimateRetrieveEntryTokens(candidate.label, serializedSourceFile, candidate.lineNumber, snippet)
-    if (tokenCount + nodeTokens > budget) {
-      break
+    if (candidate.community !== null) {
+      orderedCommunities.add(candidate.community)
     }
 
-    matchedNodes.push({
-      node_id: candidate.id,
+    let builtEntry: RetrieveMatchedNode | undefined
+    let tokenCost: number | undefined
+    const evidenceClass = reviewEvidenceClassForCandidateKind(candidateKinds.get(candidateId))
+
+    const buildEntry = (): RetrieveMatchedNode => {
+      if (builtEntry) {
+        return builtEntry
+      }
+
+      const normalizedSourceFile = normalizeProjectPath(rootPath, candidate.sourceFile)
+      const snippet = readSnippet(normalizedSourceFile, candidate.lineNumber, {
+        derived: candidate.lineNumberDerived,
+        fileCache: snippetFileCache,
+      })
+      const serializedSourceFile = relativizeSourceFile(normalizedSourceFile, rootPath)
+      builtEntry = {
+        node_id: candidate.id,
+        label: candidate.label,
+        source_file: serializedSourceFile,
+        line_number: candidate.lineNumber,
+        file_type: candidate.fileType,
+        snippet,
+        match_score: candidateScores.get(candidateId) ?? 0,
+        relevance_band: seedIds.has(candidateId) ? 'direct' : candidateKinds.get(candidateId) === 'first_hop' ? 'related' : 'peripheral',
+        community: candidate.community,
+        community_label: candidate.community !== null ? (communityLabels[candidate.community] ?? null) : null,
+        evidence_class: evidenceClass,
+        ...(candidate.nodeKind.trim().length > 0 ? { node_kind: candidate.nodeKind } : {}),
+      }
+      tokenCost = estimateRetrieveEntryTokens(candidate.label, serializedSourceFile, candidate.lineNumber, snippet)
+      return builtEntry
+    }
+
+    return [{
       label: candidate.label,
-      source_file: serializedSourceFile,
-      line_number: candidate.lineNumber,
-      file_type: candidate.fileType,
-      snippet,
-      match_score: candidateScores.get(candidateId) ?? 0,
-      relevance_band: seedIds.has(candidateId) ? 'direct' : candidateKinds.get(candidateId) === 'first_hop' ? 'related' : 'peripheral',
+      node_id: candidate.id,
       community: candidate.community,
-      community_label: candidate.community !== null ? (communityLabels[candidate.community] ?? null) : null,
-      ...(candidate.nodeKind.trim().length > 0 ? { node_kind: candidate.nodeKind } : {}),
-    })
-    includedIds.add(candidateId)
-    tokenCount += nodeTokens
-  }
+      evidence_class: evidenceClass,
+      estimate_tokens: () => {
+        if (tokenCost !== undefined) {
+          return tokenCost
+        }
 
-  const communityIds = new Set<number>()
-  for (const node of matchedNodes) {
-    if (node.community !== null) {
-      communityIds.add(node.community)
-    }
-  }
+        buildEntry()
+        return tokenCost ?? 0
+      },
+      build_entry: buildEntry,
+    }]
+  })
 
-  const communityContext: RetrieveCommunityContext[] = [...communityIds]
-    .map((communityId) => ({
-      id: communityId,
-      label: communityLabels[communityId] ?? `Community ${communityId}`,
-      node_count: (communities[communityId] ?? []).length,
-    }))
-    .sort((left, right) => right.node_count - left.node_count)
+  const pack = compileContextPack<ContextPackNode, RetrieveRelationship, RetrieveCommunityContext>({
+    task_contract: classifyTaskContract('review', {
+      budget,
+      prompt: 'Review current changes',
+    }),
+    nodes: nodeCandidates,
+    relationships: collectRelationships(graph, new Set(nodeCandidates.map((node) => node.node_id).filter((nodeId): nodeId is string => typeof nodeId === 'string'))),
+    community_context: [...orderedCommunities]
+      .map((communityId) => ({
+        id: communityId,
+        label: communityLabels[communityId] ?? `Community ${communityId}`,
+        node_count: (communities[communityId] ?? []).length,
+      }))
+      .sort((left, right) => right.node_count - left.node_count),
+  })
 
   return {
     budget,
-    token_count: tokenCount,
-    nodes: matchedNodes,
-    relationships: collectRelationships(graph, includedIds),
-    community_context: communityContext,
+    token_count: pack.token_count,
+    nodes: pack.nodes as RetrieveMatchedNode[],
+    relationships: pack.relationships,
+    community_context: pack.community_context,
+    task_contract: pack.task_contract,
+    claims: pack.claims,
+    expandable: pack.expandable,
+    coverage: pack.coverage,
   }
 }
 
@@ -910,6 +959,16 @@ export function analyzePrImpact(
   const changedFiles = gitDiffFiles(graph, resolvedDir, baseBranch)
 
   if (changedFiles.length === 0) {
+    const emptyPack = compileContextPack<ContextPackNode, RetrieveRelationship, RetrieveCommunityContext>({
+      task_contract: classifyTaskContract('review', {
+        budget: options.budget ?? DEFAULT_REVIEW_BUDGET,
+        prompt: 'Review current changes',
+      }),
+      nodes: [],
+      relationships: [],
+      community_context: [],
+    })
+
     return {
       base_branch: baseBranch,
       changed_files: [],
@@ -931,6 +990,10 @@ export function analyzePrImpact(
         nodes: [],
         relationships: [],
         community_context: [],
+        task_contract: emptyPack.task_contract,
+        claims: emptyPack.claims,
+        expandable: emptyPack.expandable,
+        coverage: emptyPack.coverage,
       },
       risk_summary: { high_impact_nodes: [], cross_community_changes: 0, top_risks: [] },
     }

--- a/src/runtime/relevant-files.ts
+++ b/src/runtime/relevant-files.ts
@@ -27,7 +27,7 @@ export interface RelevantFilesResult {
   claims: ContextPackClaim[]
   expandable: ContextPackExpandableRef[]
   coverage?: ContextPackCoverage
-  missing_context: ContextPackEvidenceClass[]
+  missing_context?: ContextPackEvidenceClass[]
 }
 
 interface FileAggregate {
@@ -148,7 +148,11 @@ export function relevantFiles(graph: KnowledgeGraph, options: RelevantFilesOptio
     relevant_files,
     claims: retrieveResult.claims ?? [],
     expandable: retrieveResult.expandable ?? [],
-    ...(retrieveResult.coverage ? { coverage: retrieveResult.coverage } : {}),
-    missing_context: retrieveResult.coverage?.missing_required ?? [],
+    ...(retrieveResult.coverage
+      ? {
+          coverage: retrieveResult.coverage,
+          missing_context: retrieveResult.coverage.missing_required,
+        }
+      : {}),
   }
 }

--- a/src/runtime/relevant-files.ts
+++ b/src/runtime/relevant-files.ts
@@ -1,4 +1,5 @@
 import { KnowledgeGraph } from '../contracts/graph.js'
+import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef } from '../contracts/context-pack.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
 import { retrieveContext } from './retrieve.js'
 
@@ -23,6 +24,10 @@ export interface RelevantFilesResult {
   question: string
   token_count: number
   relevant_files: RelevantFileEntry[]
+  claims: ContextPackClaim[]
+  expandable: ContextPackExpandableRef[]
+  coverage?: ContextPackCoverage
+  missing_context: ContextPackEvidenceClass[]
 }
 
 interface FileAggregate {
@@ -141,5 +146,9 @@ export function relevantFiles(graph: KnowledgeGraph, options: RelevantFilesOptio
     question: options.question,
     token_count: retrieveResult.token_count,
     relevant_files,
+    claims: retrieveResult.claims ?? [],
+    expandable: retrieveResult.expandable ?? [],
+    ...(retrieveResult.coverage ? { coverage: retrieveResult.coverage } : {}),
+    missing_context: retrieveResult.coverage?.missing_required ?? [],
   }
 }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1,12 +1,28 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { basename } from 'node:path'
 
+import type {
+  CompiledContextPack,
+  ContextPackClaim,
+  ContextPackCoverage,
+  ContextPackEvidenceClass,
+  ContextPackExpandableRef,
+  ContextPackNode,
+  ContextPackTaskContract,
+} from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import { godNodes, workspaceBridges } from '../pipeline/analyze.js'
 import { type Communities } from '../pipeline/cluster.js'
 import { buildCommunityLabels } from '../pipeline/community-naming.js'
 import { lineNumberFromSourceLocation } from '../shared/source-location.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
+import {
+  classifyTaskContract,
+  compactContextPack,
+  compileContextPack,
+  estimateContextPackEntryTokens,
+  type ContextPackNodeCandidate,
+} from './context-pack.js'
 import { communitiesFromGraph, estimateQueryTokens } from './serve.js'
 
 const SNIPPET_HALF_WINDOW = 7
@@ -56,6 +72,7 @@ export interface RetrieveMatchedNode {
   relevance_band: 'direct' | 'related' | 'peripheral'
   community: number | null
   community_label: string | null
+  evidence_class?: ContextPackEvidenceClass
 }
 
 export interface RetrieveRelationship {
@@ -82,6 +99,10 @@ export interface RetrieveResult {
     god_nodes: string[]
     bridge_nodes: string[]
   }
+  task_contract?: ContextPackTaskContract
+  claims?: ContextPackClaim[]
+  expandable?: ContextPackExpandableRef[]
+  coverage?: ContextPackCoverage
 }
 
 export interface CompactRetrieveMatchedNode extends Omit<RetrieveMatchedNode, 'community_label' | 'file_type' | 'framework_boost'> {
@@ -226,7 +247,7 @@ function estimateTokens(text: string): number {
 }
 
 export function estimateRetrieveEntryTokens(label: string, sourceFile: string, lineNumber: number, snippet: string | null): number {
-  return estimateTokens(`${label} ${sourceFile}:${lineNumber} ${snippet ?? ''}`)
+  return estimateContextPackEntryTokens(label, sourceFile, lineNumber, snippet)
 }
 
 function tokenCountForMatchedNodes(
@@ -932,12 +953,167 @@ function frameworkBoostForNode(
 
   return boost
 }
+
+function retrieveEvidenceClassForBand(relevanceBand: RetrieveMatchedNode['relevance_band']): ContextPackEvidenceClass {
+  if (relevanceBand === 'direct') {
+    return 'primary'
+  }
+
+  return relevanceBand === 'related' ? 'supporting' : 'structural'
+}
+
+function fallbackRetrieveCoverage(result: RetrieveResult): ContextPackCoverage {
+  const taskContract = classifyTaskContract('explain', {
+    budget: result.token_count,
+    prompt: result.question,
+  })
+
+  return {
+    required_evidence: taskContract.required_evidence,
+    entries: [],
+    missing_required: [],
+    available_relationships: result.relationships.length,
+    selected_relationships: result.relationships.length,
+  }
+}
+
+function contextPackFromRetrieveResult(
+  result: RetrieveResult,
+): CompiledContextPack<ContextPackNode, RetrieveRelationship, RetrieveCommunityContext> {
+  return {
+    task_contract: result.task_contract ?? classifyTaskContract('explain', {
+      budget: result.token_count,
+      prompt: result.question,
+    }),
+    token_count: result.token_count,
+    nodes: result.matched_nodes.map((node) => ({
+      ...node,
+      evidence_class: node.evidence_class ?? retrieveEvidenceClassForBand(node.relevance_band),
+    })),
+    relationships: result.relationships,
+    community_context: result.community_context,
+    graph_signals: result.graph_signals,
+    claims: result.claims ?? [],
+    expandable: result.expandable ?? [],
+    coverage: result.coverage ?? fallbackRetrieveCoverage(result),
+  }
+}
+
+function buildRetrieveResultFromOrderedCandidates(
+  graph: KnowledgeGraph,
+  options: RetrieveOptions,
+  orderedCandidates: readonly ScoredNode[],
+  communities: Communities,
+  communityLabels: Record<number, string>,
+  retrieveGraphSignals: RetrieveGraphSignals,
+  rootPath?: string,
+): RetrieveResult {
+  const snippetFileCache = new Map<string, string[] | null>()
+  const taskContract = classifyTaskContract('explain', {
+    budget: options.budget,
+    prompt: options.question,
+  })
+  const orderedCandidateIds = new Set(orderedCandidates.map((node) => node.id))
+  const orderedCommunities = new Set<number>(orderedCandidates.flatMap((node) => (node.community === null ? [] : [node.community])))
+  const graphSignalLabels = {
+    god_nodes: [...new Set(orderedCandidates.map((node) => node.label).filter((label) => retrieveGraphSignals.godNodeLabels.has(label)))],
+    bridge_nodes: [...new Set(orderedCandidates.map((node) => node.label).filter((label) => retrieveGraphSignals.bridgeNodeLabels.has(label)))],
+  }
+  const nodeCandidates: Array<ContextPackNodeCandidate<ContextPackNode>> = orderedCandidates.map((node) => {
+    let builtEntry: RetrieveMatchedNode | undefined
+    let tokenCost: number | undefined
+    const evidenceClass = retrieveEvidenceClassForBand(node.relevanceBand)
+
+    const buildEntry = (): RetrieveMatchedNode => {
+      if (builtEntry) {
+        return builtEntry
+      }
+
+      const snippet = node.storedSnippet ?? readSnippet(node.sourceFile, node.lineNumber, {
+        derived: node.lineNumberDerived,
+        fileCache: snippetFileCache,
+      })
+      const serializedSourceFile = relativizeSourceFile(node.sourceFile, rootPath)
+      builtEntry = {
+        node_id: node.id,
+        label: node.label,
+        source_file: serializedSourceFile,
+        line_number: node.lineNumber,
+        framework: node.framework,
+        framework_role: node.frameworkRole,
+        framework_boost: node.frameworkBoost,
+        file_type: node.fileType,
+        snippet,
+        match_score: node.score,
+        relevance_band: node.relevanceBand,
+        community: node.community,
+        community_label: node.community !== null ? (communityLabels[node.community] ?? null) : null,
+        evidence_class: evidenceClass,
+        ...(node.nodeKind.trim().length > 0 ? { node_kind: node.nodeKind } : {}),
+      }
+      tokenCost = estimateRetrieveEntryTokens(node.label, serializedSourceFile, node.lineNumber, snippet)
+      return builtEntry
+    }
+
+    return {
+      label: node.label,
+      node_id: node.id,
+      community: node.community,
+      evidence_class: evidenceClass,
+      estimate_tokens: () => {
+        if (tokenCost !== undefined) {
+          return tokenCost
+        }
+
+        buildEntry()
+        return tokenCost ?? 0
+      },
+      build_entry: buildEntry,
+    }
+  })
+
+  const pack = compileContextPack<ContextPackNode, RetrieveRelationship, RetrieveCommunityContext>({
+    task_contract: taskContract,
+    nodes: nodeCandidates,
+    relationships: collectRelationships(graph, orderedCandidateIds),
+    community_context: [...orderedCommunities]
+      .map((communityId) => ({
+        id: communityId,
+        label: communityLabels[communityId] ?? `Community ${communityId}`,
+        node_count: (communities[communityId] ?? []).length,
+      }))
+      .sort((left, right) => right.node_count - left.node_count),
+    graph_signals: graphSignalLabels,
+  })
+
+  return {
+    question: options.question,
+    token_count: pack.token_count,
+    matched_nodes: pack.nodes as RetrieveMatchedNode[],
+    relationships: pack.relationships,
+    community_context: pack.community_context,
+    graph_signals: pack.graph_signals ?? { god_nodes: [], bridge_nodes: [] },
+    task_contract: pack.task_contract,
+    claims: pack.claims,
+    expandable: pack.expandable,
+    coverage: pack.coverage,
+  }
+}
+
 export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions): RetrieveResult {
   const { question, budget } = options
   const questionTokens = tokenizeQuestion(question)
   const rootPath = typeof graph.graph.root_path === 'string' ? graph.graph.root_path : undefined
 
   if (questionTokens.length === 0) {
+    const emptyPack = compileContextPack({
+      task_contract: classifyTaskContract('explain', { budget, prompt: question }),
+      nodes: [],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    })
+
     return {
       question,
       token_count: 0,
@@ -945,6 +1121,10 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       relationships: [],
       community_context: [],
       graph_signals: { god_nodes: [], bridge_nodes: [] },
+      task_contract: emptyPack.task_contract,
+      claims: emptyPack.claims,
+      expandable: emptyPack.expandable,
+      coverage: emptyPack.coverage,
     }
   }
 
@@ -1182,11 +1362,6 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
   // Re-sort: seeds first by score, then neighbors by degree
   scored.sort((a, b) => compareScoredNodes(graph, a, b))
 
-  // Step 4+5: Read snippets and assemble within budget
-  const matchedNodes: RetrieveMatchedNode[] = []
-  const includedIds = new Set<string>()
-  const snippetFileCache = new Map<string, string[] | null>()
-  let tokenCount = 0
   const frameworkCompatibleCandidates = frameworkProfile.frameworkShaped
     ? scored.filter((node) => isFrameworkCompatible(activeFrameworks, node.framework))
     : scored
@@ -1226,75 +1401,15 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       ]
     : [...secondaryCandidates, ...peripheralCandidates]
 
-  for (const node of inclusionOrder) {
-    const snippet = node.storedSnippet ?? readSnippet(node.sourceFile, node.lineNumber, {
-      derived: node.lineNumberDerived,
-      fileCache: snippetFileCache,
-    })
-    const serializedSourceFile = relativizeSourceFile(node.sourceFile, rootPath)
-    const nodeTokens = estimateRetrieveEntryTokens(node.label, serializedSourceFile, node.lineNumber, snippet)
-
-    if (tokenCount + nodeTokens > budget && matchedNodes.length > 0) {
-      break
-    }
-
-    const matchedNode: RetrieveMatchedNode = {
-      node_id: node.id,
-      label: node.label,
-      source_file: serializedSourceFile,
-      line_number: node.lineNumber,
-      framework: node.framework,
-      framework_role: node.frameworkRole,
-      framework_boost: node.frameworkBoost,
-      file_type: node.fileType,
-      snippet,
-      match_score: node.score,
-      relevance_band: node.relevanceBand,
-      community: node.community,
-      community_label: node.community !== null ? (communityLabels[node.community] ?? null) : null,
-      ...(node.nodeKind.trim().length > 0 ? { node_kind: node.nodeKind } : {}),
-    }
-
-    matchedNodes.push(matchedNode)
-
-    includedIds.add(node.id)
-    tokenCount += nodeTokens
-
-  }
-
-  // Collect relationships between included nodes
-  const relationships = collectRelationships(graph, includedIds)
-
-  // Community context for included nodes
-  const communityIds = new Set<number>()
-  for (const node of matchedNodes) {
-    if (node.community !== null) {
-      communityIds.add(node.community)
-    }
-  }
-
-  const communityContext: RetrieveCommunityContext[] = [...communityIds]
-    .map((id) => ({
-      id,
-      label: communityLabels[id] ?? `Community ${id}`,
-      node_count: (communities[id] ?? []).length,
-    }))
-    .sort((a, b) => b.node_count - a.node_count)
-
-  // Graph signals: god nodes and bridge nodes among results
-  const includedLabels = new Set(matchedNodes.map((node) => node.label))
-
-  return {
-    question,
-    token_count: tokenCount,
-    matched_nodes: matchedNodes,
-    relationships,
-    community_context: communityContext,
-    graph_signals: {
-      god_nodes: [...includedLabels].filter((label) => retrieveGraphSignals.godNodeLabels.has(label)),
-      bridge_nodes: [...includedLabels].filter((label) => retrieveGraphSignals.bridgeNodeLabels.has(label)),
-    },
-  }
+  return buildRetrieveResultFromOrderedCandidates(
+    graph,
+    options,
+    inclusionOrder,
+    communities,
+    communityLabels,
+    retrieveGraphSignals,
+    rootPath,
+  )
 }
 
 export async function retrieveContextAsync(graph: KnowledgeGraph, options: RetrieveOptions): Promise<RetrieveResult> {
@@ -1395,107 +1510,37 @@ export async function retrieveContextAsync(graph: KnowledgeGraph, options: Retri
       ]
     : candidatePool
 
-  const matchedNodes: RetrieveMatchedNode[] = []
-  const includedIds = new Set<string>()
-  const snippetFileCache = new Map<string, string[] | null>()
-  let tokenCount = 0
-
-  for (const node of orderedCandidates) {
-    const snippet = node.storedSnippet ?? readSnippet(node.sourceFile, node.lineNumber, {
-      derived: node.lineNumberDerived,
-      fileCache: snippetFileCache,
-    })
-    const serializedSourceFile = relativizeSourceFile(node.sourceFile, rootPath)
-    const nodeTokens = estimateRetrieveEntryTokens(node.label, serializedSourceFile, node.lineNumber, snippet)
-    if (tokenCount + nodeTokens > options.budget && matchedNodes.length > 0) {
-      break
-    }
-
-    matchedNodes.push({
-      node_id: node.id,
-      label: node.label,
-      source_file: serializedSourceFile,
-      line_number: node.lineNumber,
-      framework: node.framework,
-      framework_role: node.frameworkRole,
-      framework_boost: node.frameworkBoost,
-      file_type: node.fileType,
-      snippet,
-      match_score: node.score,
-      relevance_band: node.relevanceBand,
-      community: node.community,
-      community_label: node.community !== null ? (communityLabels[node.community] ?? null) : null,
-      ...(node.nodeKind.trim().length > 0 ? { node_kind: node.nodeKind } : {}),
-    })
-    includedIds.add(node.id)
-    tokenCount += nodeTokens
-  }
-
-  const relationships = collectRelationships(graph, includedIds)
-  const communityIds = new Set<number>()
-  for (const node of matchedNodes) {
-    if (node.community !== null) {
-      communityIds.add(node.community)
-    }
-  }
-
-  const communityContext: RetrieveCommunityContext[] = [...communityIds]
-    .map((id) => ({
-      id,
-      label: communityLabels[id] ?? `Community ${id}`,
-      node_count: (communities[id] ?? []).length,
-    }))
-    .sort((left, right) => right.node_count - left.node_count)
-
-  const includedLabels = new Set(matchedNodes.map((node) => node.label))
-  return {
-    question: options.question,
-    token_count: tokenCount,
-    matched_nodes: matchedNodes,
-    relationships,
-    community_context: communityContext,
-    graph_signals: {
-      god_nodes: [...includedLabels].filter((label) => retrieveGraphSignals.godNodeLabels.has(label)),
-      bridge_nodes: [...includedLabels].filter((label) => retrieveGraphSignals.bridgeNodeLabels.has(label)),
-    },
-  }
+  return buildRetrieveResultFromOrderedCandidates(
+    graph,
+    options,
+    orderedCandidates,
+    communities,
+    communityLabels,
+    retrieveGraphSignals,
+    rootPath,
+  )
 }
 
 export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveResult {
   const frameworkProfile = buildFrameworkQuestionProfile(result.question, tokenizeQuestion(result.question))
   const compactFrameworkLimit =
     frameworkProfile.frameworkShaped && result.matched_nodes.some((node) => (node.framework_boost ?? 0) > 0) ? 5 : Number.POSITIVE_INFINITY
-  const compactMatchedNodes = Number.isFinite(compactFrameworkLimit)
-    ? result.matched_nodes.slice(0, compactFrameworkLimit)
-    : result.matched_nodes
-  const includedNodeIds = new Set(compactMatchedNodes.map(matchedNodeId).filter((nodeId): nodeId is string => nodeId !== null))
-  const includedLabels = new Set(compactMatchedNodes.map((node) => node.label))
-  const includedCommunities = new Set(compactMatchedNodes.flatMap((node) => (node.community === null ? [] : [node.community])))
-  const sharedFileType =
-    compactMatchedNodes.length > 0 && compactMatchedNodes.every((node) => node.file_type === compactMatchedNodes[0]?.file_type)
-      ? compactMatchedNodes[0]?.file_type
-      : undefined
+  const compactPack = compactContextPack(contextPackFromRetrieveResult(result), {
+    kind: 'retrieve',
+    ...(Number.isFinite(compactFrameworkLimit) ? { max_nodes: compactFrameworkLimit } : {}),
+  })
 
   return {
     question: result.question,
-    token_count: tokenCountForMatchedNodes(compactMatchedNodes),
-    matched_nodes: compactMatchedNodes.map(({ community_label: _communityLabel, file_type: fileType, framework_boost: _frameworkBoost, node_kind: nodeKind, ...node }) => ({
-      ...node,
-      ...(typeof nodeKind === 'string' && nodeKind.trim().length > 0 ? { node_kind: nodeKind } : {}),
-      ...(sharedFileType ? {} : { file_type: fileType }),
-    })),
-    relationships: result.relationships.filter((edge) => {
-      if (includedNodeIds.size > 0 && edge.from_id && edge.to_id) {
-        return includedNodeIds.has(edge.from_id) && includedNodeIds.has(edge.to_id)
-      }
-      return includedLabels.has(edge.from) && includedLabels.has(edge.to)
-    }),
-    community_context: result.community_context.filter((community) => includedCommunities.has(community.id)),
-    graph_signals: {
-      god_nodes: result.graph_signals.god_nodes.filter((label) => includedLabels.has(label)),
-      bridge_nodes: result.graph_signals.bridge_nodes.filter((label) => includedLabels.has(label)),
-    },
-    ...(sharedFileType ? { shared_file_type: sharedFileType } : {}),
+    token_count: compactPack.nodes.reduce(
+      (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet ?? null),
+      0,
+    ),
+    matched_nodes: compactPack.nodes.map(({ evidence_class: _evidenceClass, ...node }) => node as CompactRetrieveMatchedNode),
+    relationships: compactPack.relationships,
+    community_context: compactPack.community_context,
+    graph_signals: compactPack.graph_signals ?? { god_nodes: [], bridge_nodes: [] },
+    ...(compactPack.shared_file_type ? { shared_file_type: compactPack.shared_file_type } : {}),
   }
 }
 
@@ -1535,5 +1580,9 @@ export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveR
     relationships: compactResult.relationships.map(stripRetrieveRelationshipIdentity),
     community_context: compactResult.community_context,
     graph_signals: compactResult.graph_signals,
+    ...(result.task_contract ? { task_contract: result.task_contract } : {}),
+    ...(result.claims ? { claims: result.claims } : {}),
+    ...(result.expandable ? { expandable: result.expandable } : {}),
+    ...(result.coverage ? { coverage: result.coverage } : {}),
   }
 }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -125,8 +125,8 @@ function matchedNodeId(node: Pick<RetrieveMatchedNode, 'node_id'>): string | nul
   return typeof node.node_id === 'string' && node.node_id.length > 0 ? node.node_id : null
 }
 
-function stripRetrieveMatchedNodeIdentity<T extends RetrieveMatchedNode | CompactRetrieveMatchedNode>(node: T): Omit<T, 'node_id'> {
-  const { node_id: _nodeId, ...rest } = node
+function stripRetrieveMatchedNodeIdentity<T extends RetrieveMatchedNode | CompactRetrieveMatchedNode>(node: T): Omit<T, 'node_id' | 'evidence_class'> {
+  const { node_id: _nodeId, evidence_class: _evidenceClass, ...rest } = node
   return rest
 }
 

--- a/src/runtime/stdio-server.ts
+++ b/src/runtime/stdio-server.ts
@@ -48,6 +48,7 @@ const MAX_STDIO_HOPS = 20
 const MAX_STDIO_RESOURCE_BYTES = 5_000_000
 const MAX_STDIO_DIFF_ITEMS = 100
 const MAX_RESOURCE_SUBSCRIPTIONS = 16
+const MAX_CONTEXT_PROMPT_SESSIONS = 256
 const graphCache = new Map<string, { mtimeMs: number; graph: ReturnType<typeof loadGraph> }>()
 const MAX_COMPLETION_VALUES = 25
 const MAX_LOG_NOTIFICATION_CHARS = 10_000
@@ -586,7 +587,14 @@ export function handleStdioRequest(
           },
           getContextPromptSession: (sessionId) => ensureContextPromptSessions(sessionState).get(sessionId),
           setContextPromptSession: (sessionId, nextState) => {
-            ensureContextPromptSessions(sessionState).set(sessionId, nextState)
+            const sessions = ensureContextPromptSessions(sessionState)
+            if (!sessions.has(sessionId) && sessions.size >= MAX_CONTEXT_PROMPT_SESSIONS) {
+              const oldestSessionId = sessions.keys().next().value as string | undefined
+              if (oldestSessionId !== undefined) {
+                sessions.delete(oldestSessionId)
+              }
+            }
+            sessions.set(sessionId, nextState)
           },
           clearContextPromptSession: (sessionId) => ensureContextPromptSessions(sessionState).delete(sessionId),
           readStoredCommunityLabels,

--- a/src/runtime/stdio-server.ts
+++ b/src/runtime/stdio-server.ts
@@ -3,6 +3,7 @@ import { statSync } from 'node:fs'
 import { basename, dirname } from 'node:path'
 import type { Readable, Writable } from 'node:stream'
 
+import type { ContextSessionState } from '../contracts/context-session.js'
 import { compareRefs } from '../infrastructure/time-travel.js'
 import { diffGraphs } from './diff.js'
 import { MCP_PROMPTS, MCP_TOOLS, activeMcpTools, isCoreToolName, resolveToolProfileFromEnv, type McpPromptDefinition } from './stdio/definitions.js'
@@ -55,6 +56,7 @@ type McpLogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical
 
 interface StdioSessionState extends ResourceSessionState {
   logLevel: McpLogLevel
+  contextPromptSessions: Map<string, ContextSessionState>
 }
 
 interface JsonRpcNotification {
@@ -85,6 +87,7 @@ function createSessionState(): StdioSessionState {
     subscribedResourceUris: new Set<string>(),
     resourceVersions: new Map<string, string>(),
     resourceListSignature: null,
+    contextPromptSessions: new Map<string, ContextSessionState>(),
   }
 }
 
@@ -149,6 +152,14 @@ function ensureResourceVersions(state: StdioSessionState): Map<string, string> {
   }
 
   return state.resourceVersions
+}
+
+function ensureContextPromptSessions(state: StdioSessionState): Map<string, ContextSessionState> {
+  if (!state.contextPromptSessions) {
+    state.contextPromptSessions = new Map<string, ContextSessionState>()
+  }
+
+  return state.contextPromptSessions
 }
 
 function requestId(request: StdioRequest): string | number | null {
@@ -573,6 +584,11 @@ export function handleStdioRequest(
             const projectRoot = dirname(dirname(safeGraphPath))
             return await (toolOverrides.compareRefs ?? compareRefs)(input, { rootDir: projectRoot })
           },
+          getContextPromptSession: (sessionId) => ensureContextPromptSessions(sessionState).get(sessionId),
+          setContextPromptSession: (sessionId, nextState) => {
+            ensureContextPromptSessions(sessionState).set(sessionId, nextState)
+          },
+          clearContextPromptSession: (sessionId) => ensureContextPromptSessions(sessionState).delete(sessionId),
           readStoredCommunityLabels,
           jsonrpcInvalidParams: JSONRPC_INVALID_PARAMS,
           jsonrpcServerError: JSONRPC_SERVER_ERROR,

--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -234,6 +234,49 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     },
   },
   {
+    name: 'context_pack',
+    description:
+      'Build a compact explain/review/impact context pack for a downstream agent. Use when you need expandable refs plus coverage and missing-context signals instead of the full graph payload.',
+    inputSchema: {
+      type: 'object',
+      required: ['prompt'],
+      properties: {
+        prompt: { type: 'string', description: 'Task prompt or question to build context for' },
+        task: { type: 'string', enum: ['explain', 'review', 'impact'], description: 'Context-pack mode (default: explain)' },
+        budget: { type: 'number', description: 'Optional: maximum token budget for the pack (default 3000)' },
+      },
+    },
+  },
+  {
+    name: 'context_prompt',
+    description:
+      'Compile a provider-ready context prompt. Use provider=claude with session_id for cache-aware follow-ups, or provider=gemini for a plain prompt string.',
+    inputSchema: {
+      type: 'object',
+      required: ['prompt', 'provider'],
+      properties: {
+        prompt: { type: 'string', description: 'Task prompt or question to compile' },
+        provider: { type: 'string', enum: ['claude', 'gemini'], description: 'Target prompt consumer' },
+        budget: { type: 'number', description: 'Optional: retrieval budget used to gather graph evidence (default 3000)' },
+        session_id: { type: 'string', description: 'Optional: server-managed Claude session key for cache-aware follow-ups.' },
+        reset_session: { type: 'boolean', description: 'Optional: clear any stored server-side session before compiling this prompt.' },
+        session_state: { type: 'object', description: 'Optional: explicit previous session_state payload to continue without using session_id.' },
+      },
+    },
+  },
+  {
+    name: 'context_session_reset',
+    description:
+      'Reset a stored context_prompt session when switching topics or when you want the next Claude prompt to resend the full stable context.',
+    inputSchema: {
+      type: 'object',
+      required: ['session_id'],
+      properties: {
+        session_id: { type: 'string', description: 'Server-managed context_prompt session key to clear' },
+      },
+    },
+  },
+  {
     name: 'relevant_files',
     description:
       'Return the most relevant files for a feature or change question, ranked with short explanations of why each file matters.',
@@ -378,5 +421,31 @@ export const MCP_PROMPTS: McpPromptDefinition[] = [
     title: 'Graph Community Summary',
     description: 'Summarize one community, its key nodes, and its boundaries.',
     arguments: [{ name: 'community_id', description: 'Numeric community id to summarize', required: true }],
+  },
+  {
+    name: 'context_pack_prompt',
+    title: 'Context Pack Request',
+    description: 'Prepare a compact explain/review/impact context pack with expandable refs and missing-context hints.',
+    arguments: [
+      { name: 'prompt', description: 'Task prompt or question to gather context for', required: true },
+      { name: 'task', description: 'Pack mode: explain, review, or impact' },
+      { name: 'budget', description: 'Optional token budget for the pack' },
+    ],
+  },
+  {
+    name: 'context_prompt_prompt',
+    title: 'Context Prompt Compilation',
+    description: 'Compile a provider-ready context prompt. Reuse a Claude session_id for follow-up prompts that send only deltas.',
+    arguments: [
+      { name: 'prompt', description: 'Task prompt or question to compile', required: true },
+      { name: 'provider', description: 'Target provider: claude or gemini', required: true },
+      { name: 'session_id', description: 'Optional Claude session id to reuse stable context' },
+    ],
+  },
+  {
+    name: 'context_session_reset_prompt',
+    title: 'Context Session Reset',
+    description: 'Reset a stored context_prompt session before starting a fresh Claude thread or changing topics.',
+    arguments: [{ name: 'session_id', description: 'Server-managed context_prompt session id to reset', required: true }],
   },
 ]

--- a/src/runtime/stdio/prompts.ts
+++ b/src/runtime/stdio/prompts.ts
@@ -184,6 +184,23 @@ export function promptDefinitionsForGraph(graphPath: string): McpPromptDefinitio
           ...prompt,
           description: exampleCommunities.length > 0 ? `Summarize a detected community such as ${exampleCommunities.join(' or ')}.` : prompt.description,
         }
+      case 'context_pack_prompt':
+        return {
+          ...prompt,
+          description: exampleCommunities.length > 0
+            ? `Prepare a compact explain/review/impact pack for graph areas such as ${exampleCommunities.join(' or ')}.`
+            : prompt.description,
+        }
+      case 'context_prompt_prompt':
+        return {
+          ...prompt,
+          description: `Compile a provider-ready context prompt for this graph. Use claude for cache-aware follow-ups and gemini for plain prompt text.`,
+        }
+      case 'context_session_reset_prompt':
+        return {
+          ...prompt,
+          description: 'Reset a stored context prompt session before switching topics or starting a fresh Claude thread.',
+        }
       default:
         return prompt
     }
@@ -337,6 +354,71 @@ export function handlePromptGet(id: string | number | null, graphPath: string, p
         ],
       })
     }
+    case 'context_pack_prompt': {
+      const prompt = sanitizePromptValue(helpers.stringParam(promptArguments, 'prompt'), '<prompt>')
+      const task = sanitizePromptValue(helpers.stringParam(promptArguments, 'task'), 'explain')
+      const budget = helpers.integerLikeParamAlias(promptArguments, ['budget'], { min: 1 })
+      return helpers.ok(id, {
+        description: 'Prepare a compact context pack with expandable refs and missing-context hints.',
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: [
+                snapshot,
+                'Suggested follow-up questions:',
+                suggestedQuestionsText,
+                '',
+                `Prepare a compact ${task} context pack for: ${prompt}.`,
+                'Include coverage gaps, expandable references, and the minimum graph evidence a downstream agent needs to continue without re-scanning the repo.',
+                budget === null ? '' : `Target pack budget: ${budget} tokens.`,
+              ].filter((line) => line.length > 0).join('\n'),
+            },
+          },
+        ],
+      })
+    }
+    case 'context_prompt_prompt': {
+      const prompt = sanitizePromptValue(helpers.stringParam(promptArguments, 'prompt'), '<prompt>')
+      const provider = sanitizePromptValue(helpers.stringParam(promptArguments, 'provider'), 'claude')
+      const sessionId = sanitizePromptValue(helpers.stringParamAlias(promptArguments, ['session_id', 'sessionId']), '')
+      return helpers.ok(id, {
+        description: 'Compile a provider-ready context prompt.',
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: [
+                snapshot,
+                '',
+                `Compile a ${provider} context prompt for: ${prompt}.`,
+                provider === 'claude'
+                  ? `Reuse session_id ${sessionId || '<session_id>'} when you want delta-only follow-up payloads and effective-token tracking.`
+                  : 'Return a plain provider-agnostic prompt body with no session delta envelope.',
+                'Keep the output compact and preserve any missing-context or expandable-reference hints that the retrieval surface emits.',
+              ].join('\n'),
+            },
+          },
+        ],
+      })
+    }
+    case 'context_session_reset_prompt': {
+      const sessionId = sanitizePromptValue(helpers.stringParamAlias(promptArguments, ['session_id', 'sessionId']), '<session_id>')
+      return helpers.ok(id, {
+        description: 'Reset a stored context prompt session.',
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `Reset the stored context prompt session ${sessionId} before starting a fresh Claude thread or switching to a different task. Confirm that the next context_prompt call should resend the full stable context.`,
+            },
+          },
+        ],
+      })
+    }
     default:
       return helpers.failure(id, helpers.jsonrpcInvalidParams, `Unknown prompt: ${promptName}`)
   }
@@ -442,6 +524,18 @@ export function handleCompletion(id: string | number | null, graphPath: string, 
         argumentValue,
         helpers.maxCompletionValues,
       )
+      break
+    case 'context_pack_prompt':
+      if (argumentName !== 'task') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `Unsupported completion argument for ${refName}: ${argumentName}`)
+      }
+      values = completionValuesForPrefix(['explain', 'impact', 'review'], argumentValue, helpers.maxCompletionValues)
+      break
+    case 'context_prompt_prompt':
+      if (argumentName !== 'provider') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `Unsupported completion argument for ${refName}: ${argumentName}`)
+      }
+      values = completionValuesForPrefix(['claude', 'gemini'], argumentValue, helpers.maxCompletionValues)
       break
     default:
       return helpers.failure(id, helpers.jsonrpcInvalidParams, `Unknown completion reference: ${refName}`)

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -2,14 +2,15 @@ import { dirname } from 'node:path'
 
 import { buildGraphifyPromptPack } from '../../infrastructure/compare.js'
 import type { CompareRefsInput } from '../../infrastructure/time-travel.js'
-import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef } from '../../contracts/context-pack.js'
+import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef, ContextPackNode } from '../../contracts/context-pack.js'
 import type { ContextSessionState } from '../../contracts/context-session.js'
 import { buildCommunityLabels } from '../../pipeline/community-naming.js'
 import { communityDetailsAtZoom, communityDetailsMicro, type CommunityZoomLevel } from '../../pipeline/community-details.js'
 import { validateGraphPath } from '../../shared/security.js'
 import { featureMap } from '../feature-map.js'
 import { implementationChecklist } from '../implementation-checklist.js'
-import { analyzeImpact, callChains, compactImpactResult } from '../impact.js'
+import { classifyTaskContract, compileContextPack, estimateContextPackEntryTokens, type ContextPackNodeCandidate } from '../context-pack.js'
+import { analyzeImpact, callChains, compactImpactResult, type ImpactResult } from '../impact.js'
 import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
 import { relevantFiles } from '../relevant-files.js'
 import { compactRetrieveResult, retrieveContext, retrieveContextAsync, type RetrieveResult } from '../retrieve.js'
@@ -142,6 +143,83 @@ function pickImpactTarget(result: RetrieveResult): string {
     .find((node) => node.label.trim().length > 0)
 
   return bestMatch?.label ?? result.question
+}
+
+function createImpactCandidate(
+  node: {
+    label: string
+    source_file: string
+    file_type?: string
+    community?: number | null
+    community_label?: string | null
+    node_kind?: string
+    framework_role?: string | null
+  },
+  evidenceClass: ContextPackEvidenceClass,
+): ContextPackNodeCandidate<ContextPackNode> {
+  let builtEntry: ContextPackNode | undefined
+  let tokenCost: number | undefined
+  const sourceFile = node.source_file
+
+  const buildEntry = (): ContextPackNode => {
+    if (builtEntry) {
+      return builtEntry
+    }
+
+    builtEntry = {
+      label: node.label,
+      source_file: sourceFile,
+      line_number: 0,
+      snippet: null,
+      ...(node.file_type ? { file_type: node.file_type } : {}),
+      ...(typeof node.community === 'number' ? { community: node.community } : {}),
+      ...(node.community_label !== undefined ? { community_label: node.community_label } : {}),
+      ...(node.node_kind ? { node_kind: node.node_kind } : {}),
+      ...(node.framework_role ? { framework_role: node.framework_role } : {}),
+      evidence_class: evidenceClass,
+    }
+    tokenCost = estimateContextPackEntryTokens(node.label, sourceFile, 0, null)
+    return builtEntry
+  }
+
+  return {
+    label: node.label,
+    evidence_class: evidenceClass,
+    ...(node.community !== undefined ? { community: node.community } : {}),
+    estimate_tokens: () => {
+      if (tokenCost !== undefined) {
+        return tokenCost
+      }
+
+      buildEntry()
+      return tokenCost ?? 0
+    },
+    build_entry: buildEntry,
+  }
+}
+
+function impactMetadata(result: ImpactResult, budget: number, prompt: string): ContextPlaneMetadata {
+  const candidates: ContextPackNodeCandidate<ContextPackNode>[] = []
+
+  if (result.target_file.trim().length > 0) {
+    candidates.push(createImpactCandidate({
+      label: result.target,
+      source_file: result.target_file,
+    }, 'primary'))
+  }
+
+  candidates.push(
+    ...result.direct_dependents.map((node) => createImpactCandidate(node, 'impact')),
+    ...result.transitive_dependents.map((node) => createImpactCandidate(node, 'structural')),
+  )
+
+  const pack = compileContextPack({
+    task_contract: classifyTaskContract('impact', { budget, prompt }),
+    nodes: candidates,
+    community_context: result.affected_communities,
+  })
+
+  return contextMetadata(pack)
 }
 
 export function handleToolCall(id: string | number | null, graphPath: string, params: unknown, helpers: ToolHelpers): StdioResponse | Promise<StdioResponse> {
@@ -402,10 +480,12 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           ...helpers.readStoredCommunityLabels(graphPath),
         }
         const impactTarget = pickImpactTarget(retrieval)
-        const impactPack = compactImpactResult(analyzeImpact(graph, communityLabels, {
+        const impactResult = analyzeImpact(graph, communityLabels, {
           label: impactTarget,
           depth: 3,
-        }))
+        })
+        const impactPack = compactImpactResult(impactResult)
+        const metadata = impactMetadata(impactResult, resolvedBudget, prompt)
         return helpers.ok(id, helpers.textToolResult(JSON.stringify({
           task,
           prompt,
@@ -413,7 +493,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           graph_path: graphPath,
           target: impactTarget,
           pack: impactPack,
-          ...contextMetadata(retrieval),
+          ...metadata,
         })))
       }
 

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -559,7 +559,6 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
 
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         provider,
-        task: 'explain',
         prompt,
         graph_path: graphPath,
         compiled: provider === 'claude'
@@ -567,7 +566,8 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
               provider,
               format: 'session_payload',
               prompt: promptPack.session_payload,
-              token_count: promptPack.session_payload_token_count,
+              token_count: promptPack.token_count,
+              session_payload_token_count: promptPack.session_payload_token_count,
               effective_token_count: promptPack.effective_token_count,
               reused_context_tokens: promptPack.reused_context_tokens,
               session_state: promptPack.session_state,

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -1,6 +1,9 @@
 import { dirname } from 'node:path'
 
+import { buildGraphifyPromptPack } from '../../infrastructure/compare.js'
 import type { CompareRefsInput } from '../../infrastructure/time-travel.js'
+import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef } from '../../contracts/context-pack.js'
+import type { ContextSessionState } from '../../contracts/context-session.js'
 import { buildCommunityLabels } from '../../pipeline/community-naming.js'
 import { communityDetailsAtZoom, communityDetailsMicro, type CommunityZoomLevel } from '../../pipeline/community-details.js'
 import { validateGraphPath } from '../../shared/security.js'
@@ -9,7 +12,7 @@ import { implementationChecklist } from '../implementation-checklist.js'
 import { analyzeImpact, callChains, compactImpactResult } from '../impact.js'
 import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
 import { relevantFiles } from '../relevant-files.js'
-import { compactRetrieveResult, retrieveContext, retrieveContextAsync } from '../retrieve.js'
+import { compactRetrieveResult, retrieveContext, retrieveContextAsync, type RetrieveResult } from '../retrieve.js'
 import { riskMap } from '../risk-map.js'
 import type { TimeTravelView } from '../time-travel.js'
 import {
@@ -47,6 +50,9 @@ interface ToolHelpers {
   queryOptionsFromParams(id: string | number | null, params: unknown): { failureResponse?: StdioResponse; queryOptions?: Record<string, unknown> }
   handleGraphDiff(id: string | number | null, currentGraphPath: string, params: unknown): StdioResponse
   compareRefs(input: CompareRefsInput): Promise<unknown>
+  getContextPromptSession(sessionId: string): ContextSessionState | undefined
+  setContextPromptSession(sessionId: string, nextState: ContextSessionState): void
+  clearContextPromptSession(sessionId: string): boolean
   readStoredCommunityLabels(graphPath: string): Record<number, string>
   jsonrpcInvalidParams: number
   jsonrpcServerError: number
@@ -56,6 +62,87 @@ interface ToolHelpers {
 }
 
 const TIME_TRAVEL_VIEWS = new Set<TimeTravelView>(['summary', 'risk', 'drift', 'timeline'])
+
+interface ContextPlaneMetadata {
+  claims: ContextPackClaim[]
+  expandable: ContextPackExpandableRef[]
+  coverage: ContextPackCoverage
+  missing_context: ContextPackEvidenceClass[]
+}
+
+function emptyCoverage(): ContextPackCoverage {
+  return {
+    required_evidence: [],
+    entries: [],
+    missing_required: [],
+    available_relationships: 0,
+    selected_relationships: 0,
+  }
+}
+
+function contextMetadata(
+  payload: Partial<{
+    claims: ContextPackClaim[]
+    expandable: ContextPackExpandableRef[]
+    coverage: ContextPackCoverage
+  }>,
+): ContextPlaneMetadata {
+  const coverage = payload.coverage ?? emptyCoverage()
+  return {
+    claims: payload.claims ?? [],
+    expandable: payload.expandable ?? [],
+    coverage,
+    missing_context: coverage.missing_required,
+  }
+}
+
+function parseContextSessionState(raw: unknown): ContextSessionState | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+
+  const record = raw as Record<string, unknown>
+  if (record.version !== 1 || typeof record.revision !== 'number' || !Number.isInteger(record.revision) || record.revision < 0) {
+    return null
+  }
+  if (!record.refs || typeof record.refs !== 'object' || Array.isArray(record.refs)) {
+    return null
+  }
+
+  const refs: ContextSessionState['refs'] = {}
+  for (const [ref, value] of Object.entries(record.refs as Record<string, unknown>)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null
+    }
+    const stored = value as Record<string, unknown>
+    if (typeof stored.hash !== 'string' || typeof stored.token_count !== 'number' || !Number.isFinite(stored.token_count)) {
+      return null
+    }
+    refs[ref] = {
+      hash: stored.hash,
+      token_count: stored.token_count,
+    }
+  }
+
+  return {
+    version: 1,
+    revision: record.revision,
+    refs,
+  }
+}
+
+function pickImpactTarget(result: RetrieveResult): string {
+  const directMatch = result.matched_nodes.find((node) => node.relevance_band === 'direct' && node.label.trim().length > 0)
+  if (directMatch) {
+    return directMatch.label
+  }
+
+  const bestMatch = [...result.matched_nodes]
+    .sort((left, right) => (right.match_score ?? 0) - (left.match_score ?? 0))
+    .find((node) => node.label.trim().length > 0)
+
+  return bestMatch?.label ?? result.question
+}
 
 export function handleToolCall(id: string | number | null, graphPath: string, params: unknown, helpers: ToolHelpers): StdioResponse | Promise<StdioResponse> {
   const toolName = helpers.stringParam(params, 'name')
@@ -169,7 +256,14 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         ...(edgeTypes && edgeTypes.length > 0 ? { edgeTypes } : {}),
       })
       const useVerboseImpact = toolArguments.verbose === true || toolArguments.compact === false
-      return helpers.ok(id, helpers.textToolResult(JSON.stringify(useVerboseImpact ? impactResult : compactImpactResult(impactResult))))
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify(
+        useVerboseImpact
+          ? impactResult
+          : {
+              ...compactImpactResult(impactResult),
+              missing_context: [],
+            },
+      )))
     }
     case 'call_chain': {
       const chainSource = helpers.stringParam(toolArguments, 'source')
@@ -204,7 +298,14 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         ...(prBudget !== null ? { budget: prBudget } : {}),
       })
       const useVerbosePrImpact = toolArguments.verbose === true || toolArguments.compact === false
-      return helpers.ok(id, helpers.textToolResult(JSON.stringify(useVerbosePrImpact ? prResult : compactPrImpactResult(prResult))))
+      if (useVerbosePrImpact) {
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(prResult)))
+      }
+      const compactPrImpact = compactPrImpactResult(prResult)
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        ...compactPrImpact,
+        missing_context: (prResult.review_bundle.coverage ?? emptyCoverage()).missing_required,
+      })))
     }
     case 'retrieve': {
       const question = helpers.stringParam(toolArguments, 'question')
@@ -246,10 +347,170 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         question,
         budget: retrieveBudget,
         ...(retrieveCommunity !== null ? { community: retrieveCommunity } : {}),
-        ...(retrieveFileType ? { fileType: retrieveFileType } : {}),
-      }))
+          ...(retrieveFileType ? { fileType: retrieveFileType } : {}),
+        }))
       const useVerboseRetrieve = toolArguments.verbose === true || toolArguments.compact === false
-      return retrieval.then((result) => helpers.ok(id, helpers.textToolResult(JSON.stringify(useVerboseRetrieve ? result : compactRetrieveResult(result)))))
+      return retrieval.then((result) => helpers.ok(id, helpers.textToolResult(JSON.stringify(
+        useVerboseRetrieve
+          ? result
+          : {
+              ...compactRetrieveResult(result),
+              ...contextMetadata(result),
+            },
+      ))))
+    }
+    case 'context_pack': {
+      const prompt = helpers.stringParam(toolArguments, 'prompt')
+      if (!prompt) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `context_pack requires a string prompt parameter <= ${helpers.maxStdioTextLength} characters`)
+      }
+
+      const task = helpers.stringParam(toolArguments, 'task') ?? 'explain'
+      if (task !== 'explain' && task !== 'review' && task !== 'impact') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'task must be one of explain, review, impact')
+      }
+      const budget = helpers.numberParamAlias(toolArguments, ['budget'], { min: 1, max: helpers.maxStdioTokenBudget })
+      if (Object.hasOwn(toolArguments, 'budget') && budget === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `budget must be a number between 1 and ${helpers.maxStdioTokenBudget}`)
+      }
+      const resolvedBudget = budget ?? 3000
+
+      if (task === 'review') {
+        const graphDir = dirname(validateGraphPath(graphPath))
+        const projectRoot = dirname(graphDir)
+        const prResult = analyzePrImpact(graph, projectRoot, { budget: resolvedBudget })
+        const compactPack = compactPrImpactResult(prResult)
+        const reviewMetadata = contextMetadata(prResult.review_bundle)
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+          task,
+          prompt,
+          budget: resolvedBudget,
+          graph_path: graphPath,
+          pack: compactPack,
+          ...reviewMetadata,
+        })))
+      }
+
+      const retrieval = retrieveContext(graph, {
+        question: prompt,
+        budget: resolvedBudget,
+      })
+
+      if (task === 'impact') {
+        const communityLabels = {
+          ...buildCommunityLabels(graph, communitiesFromGraph(graph)),
+          ...helpers.readStoredCommunityLabels(graphPath),
+        }
+        const impactTarget = pickImpactTarget(retrieval)
+        const impactPack = compactImpactResult(analyzeImpact(graph, communityLabels, {
+          label: impactTarget,
+          depth: 3,
+        }))
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+          task,
+          prompt,
+          budget: resolvedBudget,
+          graph_path: graphPath,
+          target: impactTarget,
+          pack: impactPack,
+          ...contextMetadata(retrieval),
+        })))
+      }
+
+      const compactPack = compactRetrieveResult(retrieval)
+      const { claims, expandable, coverage, missing_context } = contextMetadata(retrieval)
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        task,
+        prompt,
+        budget: resolvedBudget,
+        graph_path: graphPath,
+        pack: compactPack,
+        claims,
+        expandable,
+        coverage,
+        missing_context,
+      })))
+    }
+    case 'context_prompt': {
+      const prompt = helpers.stringParam(toolArguments, 'prompt')
+      if (!prompt) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `context_prompt requires a string prompt parameter <= ${helpers.maxStdioTextLength} characters`)
+      }
+      const provider = helpers.stringParam(toolArguments, 'provider')
+      if (provider !== 'claude' && provider !== 'gemini') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'provider must be one of claude, gemini')
+      }
+      const budget = helpers.numberParamAlias(toolArguments, ['budget'], { min: 1, max: helpers.maxStdioTokenBudget })
+      if (Object.hasOwn(toolArguments, 'budget') && budget === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `budget must be a number between 1 and ${helpers.maxStdioTokenBudget}`)
+      }
+      const sessionId = helpers.stringParamAlias(toolArguments, ['session_id', 'sessionId'])
+      const explicitSessionStateRaw = toolArguments.session_state ?? toolArguments.sessionState
+      const explicitSessionState = explicitSessionStateRaw === undefined ? undefined : parseContextSessionState(explicitSessionStateRaw)
+      if (explicitSessionStateRaw !== undefined && explicitSessionState === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'session_state must be a valid context session payload')
+      }
+      if (Object.hasOwn(toolArguments, 'reset_session') && typeof toolArguments.reset_session !== 'boolean') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'reset_session must be a boolean')
+      }
+      if (Object.hasOwn(toolArguments, 'resetSession') && typeof toolArguments.resetSession !== 'boolean') {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'resetSession must be a boolean')
+      }
+      const resetSession = toolArguments.reset_session === true || toolArguments.resetSession === true
+      if (resetSession && sessionId) {
+        helpers.clearContextPromptSession(sessionId)
+      }
+
+      const retrieval = retrieveContext(graph, {
+        question: prompt,
+        budget: budget ?? 3000,
+      })
+      const previousSession =
+        explicitSessionState
+        ?? (sessionId ? helpers.getContextPromptSession(sessionId) : undefined)
+      const promptPack = buildGraphifyPromptPack({
+        question: prompt,
+        retrieval,
+        ...(provider === 'claude' && previousSession ? { session: previousSession } : {}),
+      })
+      if (provider === 'claude' && sessionId) {
+        helpers.setContextPromptSession(sessionId, promptPack.session_state)
+      }
+
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        provider,
+        task: 'explain',
+        prompt,
+        graph_path: graphPath,
+        compiled: provider === 'claude'
+          ? {
+              provider,
+              format: 'session_payload',
+              prompt: promptPack.session_payload,
+              token_count: promptPack.session_payload_token_count,
+              effective_token_count: promptPack.effective_token_count,
+              reused_context_tokens: promptPack.reused_context_tokens,
+              session_state: promptPack.session_state,
+              ...(sessionId ? { session_id: sessionId } : {}),
+            }
+          : {
+              provider,
+              format: 'prompt',
+              prompt: promptPack.prompt,
+              token_count: promptPack.token_count,
+            },
+        ...contextMetadata(retrieval),
+      })))
+    }
+    case 'context_session_reset': {
+      const sessionId = helpers.stringParamAlias(toolArguments, ['session_id', 'sessionId'])
+      if (!sessionId) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `context_session_reset requires a string session_id parameter <= ${helpers.maxStdioTextLength} characters`)
+      }
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        session_id: sessionId,
+        cleared: helpers.clearContextPromptSession(sessionId),
+      })))
     }
     case 'relevant_files': {
       const question = helpers.stringParam(toolArguments, 'question')

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -53,6 +53,11 @@ describe('public benchmark artifact (2026-04-30 govalidate)', () => {
     expect(readme).toContain(`$${graphify.total_cost_usd.toFixed(2)}`)
   })
 
+  it('README frames the benchmark around effective cost, not just raw prompt size', () => {
+    expect(readme.toLowerCase()).toContain('effective cost')
+    expect(readme.toLowerCase()).toContain('effective prompt tokens')
+  })
+
   it('hosted retrieval benchmark page uses only defined warning color tokens', () => {
     const page = readFileSync(resolve(ARTIFACT_DIR, 'index.html'), 'utf8')
     expect(page).not.toContain('var(--amber-400)')
@@ -105,6 +110,12 @@ describe('public benchmark artifact (2026-05-02 govalidate pr review)', () => {
     expect(typeof report.verbose_prompt_tokens).toBe('number')
     expect(typeof report.compact_prompt_tokens).toBe('number')
     expect(readme).toContain('GoValidate PR review benchmark')
+  })
+
+  it('README describes the review proof as a coverage contract with effective-cost framing', () => {
+    const lower = readme.toLowerCase()
+    expect(lower).toContain('coverage contract')
+    expect(lower).toContain('effective cost')
   })
 
   it('review prompt artifacts do not contain absolute or username-derived node ids', () => {

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -548,6 +548,9 @@ describe('runBenchmark', () => {
       expect(executions[0]?.command).toContain("--mode 'graphify'")
       expect(readFileSync(executions[0]!.promptFile, 'utf8')).toContain('Retrieved graph context:')
       expect(readFileSync(executions[0]!.promptFile, 'utf8')).toContain('Question:\nhow does authentication work')
+      expect(readFileSync(executions[1]!.promptFile, 'utf8')).toContain('Session delta:')
+      expect(readFileSync(executions[1]!.promptFile, 'utf8')).toContain('Question:\nwhat is the main entry point')
+      expect(readFileSync(executions[1]!.promptFile, 'utf8')).not.toContain('Retrieved graph context:')
       expect(readFileSync(executions[0]!.outputFile, 'utf8')).toBe('Answer for how does authentication work\n')
       expect(readFileSync(executions[1]!.outputFile, 'utf8')).toBe('Answer for what is the main entry point\n')
 

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -511,7 +511,8 @@ describe('runBenchmark', () => {
             outputFile: string
           }) => {
             executions.push(execution)
-            const inputTokens = execution.question.includes('authentication') ? 320 : 180
+            const inputTokens = execution.question.includes('authentication') ? 280 : 170
+            const cacheReadTokens = execution.question.includes('authentication') ? 40 : 10
             const totalTokens = execution.question.includes('authentication') ? 360 : 210
             return {
               exitCode: 0,
@@ -521,9 +522,9 @@ describe('runBenchmark', () => {
                 result: `Answer for ${execution.question}\n`,
                 usage: {
                   input_tokens: inputTokens,
-                  output_tokens: totalTokens - inputTokens,
+                  output_tokens: totalTokens - inputTokens - cacheReadTokens,
                   cache_creation_input_tokens: 0,
-                  cache_read_input_tokens: 0,
+                  cache_read_input_tokens: cacheReadTokens,
                 },
               }),
               stderr: '',
@@ -553,11 +554,16 @@ describe('runBenchmark', () => {
       expect(benchmark.matched_question_count).toBe(2)
       expect(benchmark.unmatched_questions).toEqual(['xyzzy plugh zorkmid'])
       expect(benchmark.avg_query_tokens).toBe(250)
+      expect(benchmark.avg_effective_query_tokens).toBe(225)
+      expect(benchmark.avg_reused_context_tokens).toBe(25)
       expect(benchmark.avg_total_tokens).toBe(285)
+      expect(benchmark.effective_reduction_ratio).toBe(Number((benchmark.corpus_tokens / 225).toFixed(1)))
       expect(benchmark.per_question).toEqual([
         expect.objectContaining({
           question: 'how does authentication work',
           query_tokens: 320,
+          effective_query_tokens: 280,
+          reused_context_tokens: 40,
           total_tokens: 360,
           prompt_token_source: 'claude_reported_input',
           usage: expect.objectContaining({
@@ -573,6 +579,8 @@ describe('runBenchmark', () => {
         expect.objectContaining({
           question: 'what is the main entry point',
           query_tokens: 180,
+          effective_query_tokens: 170,
+          reused_context_tokens: 10,
           total_tokens: 210,
           prompt_token_source: 'claude_reported_input',
           usage: expect.objectContaining({
@@ -695,12 +703,17 @@ describe('printBenchmark', () => {
       matched_expected_label_count: 0,
       missing_expected_labels: [],
       avg_query_tokens: 410,
+      avg_effective_query_tokens: 400,
+      avg_reused_context_tokens: 10,
       avg_total_tokens: 480,
       reduction_ratio: 2.4,
+      effective_reduction_ratio: 2.5,
       per_question: [
         {
           question: 'how does authentication work',
           query_tokens: 410,
+          effective_query_tokens: 400,
+          reused_context_tokens: 10,
           total_tokens: 480,
           reduction: 2.4,
           expected_labels: [],
@@ -723,6 +736,7 @@ describe('printBenchmark', () => {
     const output = spy.mock.calls.flat().join('\n')
     expect(output).toContain('graphify runner-backed benchmark')
     expect(output).toContain('Avg input tokens (Claude reported): ~410')
+    expect(output).toContain('Avg effective input tokens (cache-adjusted): ~400')
     expect(output).toContain('Avg total tokens (Claude reported): ~480')
     expect(output).not.toContain('estimate fallback')
     expect(output).not.toContain('graphify token reduction benchmark')

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -6,6 +6,7 @@ import {
   parseAddArgs,
   parseBenchmarkArgs,
   parseCompareArgs,
+  parsePackArgs,
   parseDiffArgs,
   parseExplainArgs,
   parseGenerateArgs,
@@ -13,6 +14,7 @@ import {
   parseInstallArgs,
   parsePathArgs,
   parsePlatformActionArgs,
+  parsePromptArgs,
   parseQueryArgs,
   parseReviewCompareArgs,
   parseSaveResultArgs,
@@ -103,6 +105,8 @@ function createDependencies(): CliDependencies {
     runCompare: async () => 'compare command is not implemented yet',
     runReviewCompare: async () => 'review compare command is not implemented yet',
     runTimeTravel: async () => 'time-travel command is not implemented yet',
+    runContextPack: async () => 'context pack command is not implemented yet',
+    runContextPrompt: async () => 'context prompt command is not implemented yet',
     confirm: async () => true,
     printBenchmark: () => {},
     installHooks: () => 'hooks installed',
@@ -188,6 +192,51 @@ describe('cli parser', () => {
     expect(() => parseQueryArgs(['test', '--rank-by', 'centrality'])).toThrow('error: --rank-by must be one of relevance, degree')
     expect(() => parseQueryArgs(['test', '--community', '-1'])).toThrow('error: --community must be a non-negative integer')
     expect(() => parseQueryArgs(['test', '--wat'])).toThrow('error: unknown option for query: --wat')
+  })
+
+  it('parses pack args with defaults and overrides', () => {
+    expect(parsePackArgs(['how does auth work', '--budget', '1800', '--task', 'explain'])).toEqual({
+      prompt: 'how does auth work',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'graphify-out/graph.json',
+    })
+
+    expect(parsePackArgs(['review current diff', '--task=review', '--graph', 'custom.json'])).toEqual({
+      prompt: 'review current diff',
+      budget: 3000,
+      task: 'review',
+      graphPath: 'custom.json',
+    })
+  })
+
+  it('rejects invalid pack args', () => {
+    expect(() => parsePackArgs([])).toThrow('Usage: graphify-ts pack')
+    expect(() => parsePackArgs(['how does auth work', '--budget', '0'])).toThrow('error: --budget must be a positive integer')
+    expect(() => parsePackArgs(['how does auth work', '--budget', '100001'])).toThrow('error: --budget must be <= 100000')
+    expect(() => parsePackArgs(['how does auth work', '--task', 'summarize'])).toThrow('error: --task must be one of explain, review, impact')
+    expect(() => parsePackArgs(['how does auth work', '--wat'])).toThrow('error: unknown option for pack: --wat')
+  })
+
+  it('parses prompt args with defaults and overrides', () => {
+    expect(parsePromptArgs(['how does auth work', '--provider', 'claude'])).toEqual({
+      prompt: 'how does auth work',
+      provider: 'claude',
+      graphPath: 'graphify-out/graph.json',
+    })
+
+    expect(parsePromptArgs(['review current diff', '--provider=gemini', '--graph', 'custom.json'])).toEqual({
+      prompt: 'review current diff',
+      provider: 'gemini',
+      graphPath: 'custom.json',
+    })
+  })
+
+  it('rejects invalid prompt args', () => {
+    expect(() => parsePromptArgs([])).toThrow('Usage: graphify-ts prompt')
+    expect(() => parsePromptArgs(['how does auth work'])).toThrow('error: --provider is required')
+    expect(() => parsePromptArgs(['how does auth work', '--provider', 'openai'])).toThrow('error: --provider must be one of claude, gemini')
+    expect(() => parsePromptArgs(['how does auth work', '--wat'])).toThrow('error: unknown option for prompt: --wat')
   })
 
   it('parses path args with defaults and overrides', () => {
@@ -1016,6 +1065,51 @@ describe('cli main', () => {
       io,
     })
     expect(logs).toEqual(['time-travel result'])
+    expect(errors).toEqual([])
+  })
+
+  it('routes pack through the injected dependency after parsing args', async () => {
+    const { io, logs, errors } = createIo()
+    const runContextPack = vi.fn<NonNullable<CliDependencies['runContextPack']>>().mockResolvedValue('{"task":"explain"}')
+    const dependencies: CliDependencies = {
+      ...createDependencies(),
+      runContextPack,
+    }
+
+    await expect(executeCli(['pack', 'how does auth work', '--budget', '1800', '--task', 'explain'], io, dependencies)).resolves.toBe(0)
+
+    expect(runContextPack).toHaveBeenCalledWith({
+      options: {
+        prompt: 'how does auth work',
+        budget: 1800,
+        task: 'explain',
+        graphPath: 'graphify-out/graph.json',
+      },
+      io,
+    })
+    expect(logs).toEqual(['{"task":"explain"}'])
+    expect(errors).toEqual([])
+  })
+
+  it('routes prompt through the injected dependency after parsing args', async () => {
+    const { io, logs, errors } = createIo()
+    const runContextPrompt = vi.fn<NonNullable<CliDependencies['runContextPrompt']>>().mockResolvedValue('{"provider":"claude"}')
+    const dependencies: CliDependencies = {
+      ...createDependencies(),
+      runContextPrompt,
+    }
+
+    await expect(executeCli(['prompt', 'how does auth work', '--provider', 'claude'], io, dependencies)).resolves.toBe(0)
+
+    expect(runContextPrompt).toHaveBeenCalledWith({
+      options: {
+        prompt: 'how does auth work',
+        provider: 'claude',
+        graphPath: 'graphify-out/graph.json',
+      },
+      io,
+    })
+    expect(logs).toEqual(['{"provider":"claude"}'])
     expect(errors).toEqual([])
   })
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from 'node:fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { type CliDependencies, executeCli, formatHelp } from '../../src/cli/main.js'
@@ -160,6 +160,28 @@ function createDependencies(): CliDependencies {
   }
 }
 
+function withGraphPathSandbox(testName: string, run: (paths: { relativeGraphPath: string; resolvedGraphPath: string }) => void) {
+  const originalCwd = process.cwd()
+  const sandboxRoot = resolve('graphify-out', 'test-runtime', testName)
+  const relativeGraphPath = 'graphify-out/custom.json'
+  const graphPath = resolve(sandboxRoot, relativeGraphPath)
+
+  rmSync(sandboxRoot, { recursive: true, force: true })
+  mkdirSync(resolve(sandboxRoot, 'graphify-out'), { recursive: true })
+  writeFileSync(graphPath, '{}\n', 'utf8')
+
+  try {
+    process.chdir(sandboxRoot)
+    run({
+      relativeGraphPath,
+      resolvedGraphPath: realpathSync(graphPath),
+    })
+  } finally {
+    process.chdir(originalCwd)
+    rmSync(sandboxRoot, { recursive: true, force: true })
+  }
+}
+
 describe('cli parser', () => {
   it('parses query args with defaults and overrides', () => {
     expect(parseQueryArgs(['how does auth work'])).toEqual({
@@ -201,13 +223,6 @@ describe('cli parser', () => {
       task: 'explain',
       graphPath: 'graphify-out/graph.json',
     })
-
-    expect(parsePackArgs(['review current diff', '--task=review', '--graph', 'custom.json'])).toEqual({
-      prompt: 'review current diff',
-      budget: 3000,
-      task: 'review',
-      graphPath: 'custom.json',
-    })
   })
 
   it('rejects invalid pack args', () => {
@@ -224,12 +239,6 @@ describe('cli parser', () => {
       provider: 'claude',
       graphPath: 'graphify-out/graph.json',
     })
-
-    expect(parsePromptArgs(['review current diff', '--provider=gemini', '--graph', 'custom.json'])).toEqual({
-      prompt: 'review current diff',
-      provider: 'gemini',
-      graphPath: 'custom.json',
-    })
   })
 
   it('rejects invalid prompt args', () => {
@@ -237,6 +246,30 @@ describe('cli parser', () => {
     expect(() => parsePromptArgs(['how does auth work'])).toThrow('error: --provider is required')
     expect(() => parsePromptArgs(['how does auth work', '--provider', 'openai'])).toThrow('error: --provider must be one of claude, gemini')
     expect(() => parsePromptArgs(['how does auth work', '--wat'])).toThrow('error: unknown option for prompt: --wat')
+  })
+
+  it('validates explicit graph paths for pack and prompt commands with the shared graph helper', () => {
+    withGraphPathSandbox('context-cli-graph-paths', ({ relativeGraphPath, resolvedGraphPath }) => {
+      expect(parsePackArgs(['review current diff', '--task=review', '--graph', relativeGraphPath])).toEqual({
+        prompt: 'review current diff',
+        budget: 3000,
+        task: 'review',
+        graphPath: resolvedGraphPath,
+      })
+
+      expect(parsePromptArgs(['review current diff', '--provider=gemini', '--graph', relativeGraphPath])).toEqual({
+        prompt: 'review current diff',
+        provider: 'gemini',
+        graphPath: resolvedGraphPath,
+      })
+
+      expect(() => parsePackArgs(['review current diff', '--graph', '../../../outside/graph.json'])).toThrow(
+        'Only paths inside graphify-out/ are permitted',
+      )
+      expect(() => parsePromptArgs(['review current diff', '--provider', 'claude', '--graph', '../../../outside/graph.json'])).toThrow(
+        'Only paths inside graphify-out/ are permitted',
+      )
+    })
   })
 
   it('parses path args with defaults and overrides', () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -476,6 +476,47 @@ describe('compare runtime', () => {
     expect(secondPack.effective_token_count).toBeLessThan(secondPack.token_count)
   })
 
+  it('writes delta-oriented follow-up prompt artifacts for multi-question compare runs', () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const questionsPath = join(GRAPH_FIXTURE_ROOT, 'session-compare-questions.json')
+    writeFileSync(
+      questionsPath,
+      JSON.stringify(
+        [
+          { question: 'how does login create a session' },
+          { question: 'where is session storage defined' },
+        ],
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const result = generateCompareArtifacts({
+      graphPath,
+      questionsPath,
+      outputDir: COMPARE_OUTPUT_ROOT,
+      execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+      baselineMode: 'full',
+      now: new Date('2026-04-24T19:30:00.000Z'),
+    })
+
+    expect(result.reports).toHaveLength(2)
+    expect(readFileSync(result.reports[0]!.paths.baseline_prompt, 'utf8')).toContain('Corpus (full):')
+    expect(readFileSync(result.reports[0]!.paths.graphify_prompt, 'utf8')).toContain('Retrieved graph context:')
+    const followUpBaselinePrompt = readFileSync(result.reports[1]!.paths.baseline_prompt, 'utf8')
+    const followUpGraphifyPrompt = readFileSync(result.reports[1]!.paths.graphify_prompt, 'utf8')
+
+    expect(followUpBaselinePrompt).toContain('Session delta:')
+    expect(followUpBaselinePrompt).toContain('Question:\nwhere is session storage defined')
+    expect(followUpBaselinePrompt).not.toContain('Corpus (full):')
+    expect(followUpGraphifyPrompt).toContain('Session delta:')
+    expect(followUpGraphifyPrompt).toContain('Question:\nwhere is session storage defined')
+    expect(followUpGraphifyPrompt).not.toContain('Retrieved graph context:')
+  })
+
   it('builds bounded baseline excerpts for token-dense corpus text', () => {
     const graph = makeGraph()
     const corpusText = '😀'.repeat(500)

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -441,9 +441,39 @@ describe('compare runtime', () => {
     expect(fullPack.prompt).toContain('Question:\nhow does login create a session')
     expect(fullPack.prompt).toContain('authenticateUser')
     expect(fullPack.prompt).toContain('SessionManager')
+    expect(fullPack.prompt.indexOf('Question:\nhow does login create a session')).toBeGreaterThan(
+      fullPack.prompt.indexOf('Corpus (full):'),
+    )
+    expect(fullPack.effective_token_count).toBe(fullPack.token_count)
+    expect(fullPack.reused_context_tokens).toBe(0)
     expect(boundedPack.prompt).toContain('[bounded baseline excerpt]')
     expect(boundedPack.prompt.length).toBeLessThan(fullPack.prompt.length)
     expect(estimateQueryTokens(boundedPack.prompt)).toBeLessThanOrEqual(120)
+  })
+
+  it('reuses stable compare context across session-aware prompt packs', () => {
+    const graph = makeGraph()
+    const corpusText = makeCorpusText()
+
+    const firstPack = buildBaselinePromptPack({
+      question: 'how does login create a session',
+      graph,
+      corpusText,
+      mode: 'full',
+    })
+    const secondPack = buildBaselinePromptPack({
+      question: 'where is session storage defined',
+      graph,
+      corpusText,
+      mode: 'full',
+      session: firstPack.session_state,
+    })
+
+    expect(secondPack.prompt.indexOf('Question:\nwhere is session storage defined')).toBeGreaterThan(
+      secondPack.prompt.indexOf('Corpus (full):'),
+    )
+    expect(secondPack.reused_context_tokens).toBeGreaterThan(0)
+    expect(secondPack.effective_token_count).toBeLessThan(secondPack.token_count)
   })
 
   it('builds bounded baseline excerpts for token-dense corpus text', () => {
@@ -737,6 +767,10 @@ describe('compare runtime', () => {
     expect(readFileSync(report.answer_paths.graphify, 'utf8')).toBe('graphify answer\n')
     expect(report.baseline_prompt_tokens).toBe(1320)
     expect(report.graphify_prompt_tokens).toBe(410)
+    expect(report.baseline_effective_prompt_tokens).toBe(1300)
+    expect(report.graphify_effective_prompt_tokens).toBe(400)
+    expect(report.baseline_reused_context_tokens).toBe(20)
+    expect(report.graphify_reused_context_tokens).toBe(10)
     expect(report.prompt_token_source).toEqual({
       baseline: 'claude_reported_input',
       graphify: 'claude_reported_input',
@@ -765,7 +799,9 @@ describe('compare runtime', () => {
     })
     expect(report.baseline_total_tokens).toBe(1410)
     expect(report.graphify_total_tokens).toBe(480)
+    expect(report.effective_reduction_ratio).toBe(Number((1300 / 400).toFixed(1)))
     expect(formatCompareSummary(result)).toContain('Input tokens (Claude reported): baseline 1320 · graphify 410')
+    expect(formatCompareSummary(result)).toContain('Effective input tokens (cache-adjusted): baseline 1300 · graphify 400')
     expect(formatCompareSummary(result)).toContain('Total tokens (Claude reported): baseline 1410 · graphify 480')
   })
 

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -473,11 +473,12 @@ describe('compare runtime', () => {
       secondPack.prompt.indexOf('Corpus (full):'),
     )
     expect(secondPack.reused_context_tokens).toBeGreaterThan(0)
-    expect(secondPack.effective_token_count).toBeLessThan(secondPack.token_count)
+    expect(secondPack.effective_token_count).toBe(Math.max(0, secondPack.token_count - secondPack.reused_context_tokens))
   })
 
   it('writes delta-oriented follow-up prompt artifacts for multi-question compare runs', () => {
     const graph = makeGraph()
+    const corpusText = makeCorpusText()
     writeProjectFiles()
     const graphPath = writeGraphFixture(graph)
     const questionsPath = join(GRAPH_FIXTURE_ROOT, 'session-compare-questions.json')
@@ -496,6 +497,7 @@ describe('compare runtime', () => {
 
     const result = generateCompareArtifacts({
       graphPath,
+      corpusText,
       questionsPath,
       outputDir: COMPARE_OUTPUT_ROOT,
       execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
@@ -506,15 +508,24 @@ describe('compare runtime', () => {
     expect(result.reports).toHaveLength(2)
     expect(readFileSync(result.reports[0]!.paths.baseline_prompt, 'utf8')).toContain('Corpus (full):')
     expect(readFileSync(result.reports[0]!.paths.graphify_prompt, 'utf8')).toContain('Retrieved graph context:')
+    const followUpReport = result.reports[1]!
     const followUpBaselinePrompt = readFileSync(result.reports[1]!.paths.baseline_prompt, 'utf8')
     const followUpGraphifyPrompt = readFileSync(result.reports[1]!.paths.graphify_prompt, 'utf8')
 
     expect(followUpBaselinePrompt).toContain('Session delta:')
     expect(followUpBaselinePrompt).toContain('Question:\nwhere is session storage defined')
     expect(followUpBaselinePrompt).not.toContain('Corpus (full):')
+    expect(followUpReport.baseline_prompt_tokens_estimated).toBeGreaterThan(estimateQueryTokens(followUpBaselinePrompt))
+    expect(followUpReport.baseline_effective_prompt_tokens).toBe(
+      Math.max(0, followUpReport.baseline_prompt_tokens_estimated - followUpReport.baseline_reused_context_tokens),
+    )
     expect(followUpGraphifyPrompt).toContain('Session delta:')
     expect(followUpGraphifyPrompt).toContain('Question:\nwhere is session storage defined')
     expect(followUpGraphifyPrompt).not.toContain('Retrieved graph context:')
+    expect(followUpReport.graphify_prompt_tokens_estimated).toBeGreaterThan(estimateQueryTokens(followUpGraphifyPrompt))
+    expect(followUpReport.graphify_effective_prompt_tokens).toBe(
+      Math.max(0, followUpReport.graphify_prompt_tokens_estimated - followUpReport.graphify_reused_context_tokens),
+    )
   })
 
   it('builds bounded baseline excerpts for token-dense corpus text', () => {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
+
+describe('context-pack-command', () => {
+  it('emits a compact deterministic explain pack', async () => {
+    const graph = new KnowledgeGraph()
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue({
+        question: 'how does auth work',
+        token_count: 42,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }),
+      compactRetrieveResult: vi.fn().mockReturnValue({
+        question: 'how does auth work',
+        token_count: 18,
+        matched_nodes: [
+          {
+            label: 'AuthService',
+            source_file: 'src/auth.ts',
+            line_number: 12,
+            snippet: 'export class AuthService {}',
+            relevance_band: 'direct',
+            community: 0,
+          },
+        ],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+        shared_file_type: 'code',
+      }),
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'how does auth work',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'graphify-out/graph.json',
+    }, dependencies)
+
+    const expected = {
+      task: 'explain',
+      prompt: 'how does auth work',
+      budget: 1800,
+      graph_path: 'graphify-out/graph.json',
+      pack: {
+        question: 'how does auth work',
+        token_count: 18,
+        matched_nodes: [
+          {
+            label: 'AuthService',
+            source_file: 'src/auth.ts',
+            line_number: 12,
+            snippet: 'export class AuthService {}',
+            relevance_band: 'direct',
+            community: 0,
+          },
+        ],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+        shared_file_type: 'code',
+      },
+    }
+
+    expect(dependencies.loadGraph).toHaveBeenCalledWith('graphify-out/graph.json')
+    expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
+      question: 'how does auth work',
+      budget: 1800,
+    })
+    expect(output).toBe(JSON.stringify(expected))
+  })
+
+  it('emits a compact deterministic review pack', async () => {
+    const graph = new KnowledgeGraph()
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn(),
+      compactRetrieveResult: vi.fn(),
+      analyzePrImpact: vi.fn().mockReturnValue({
+        base_branch: 'origin/main',
+      }),
+      compactPrImpactResult: vi.fn().mockReturnValue({
+        base_branch: 'origin/main',
+        changed_files: ['src/auth.ts'],
+        changed_ranges: [],
+        seed_nodes: [],
+        per_node_impact: [],
+        total_blast_radius: 0,
+        affected_communities: [],
+        review_context: {
+          supporting_paths: [],
+          test_paths: [],
+          hotspots: [],
+        },
+        review_bundle: {
+          budget: 1800,
+          token_count: 12,
+          nodes: [],
+          relationships: [],
+          community_context: [],
+        },
+        risk_summary: {
+          high_impact_nodes: [],
+          cross_community_changes: 0,
+          top_risks: [],
+        },
+      }),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'review current diff',
+      budget: 1800,
+      task: 'review',
+      graphPath: 'graphify-out/graph.json',
+    }, dependencies)
+
+    expect(dependencies.analyzePrImpact).toHaveBeenCalledWith(graph, '.', { budget: 1800 })
+    expect(output).toBe(JSON.stringify({
+      task: 'review',
+      prompt: 'review current diff',
+      budget: 1800,
+      graph_path: 'graphify-out/graph.json',
+      pack: {
+        base_branch: 'origin/main',
+        changed_files: ['src/auth.ts'],
+        changed_ranges: [],
+        seed_nodes: [],
+        per_node_impact: [],
+        total_blast_radius: 0,
+        affected_communities: [],
+        review_context: {
+          supporting_paths: [],
+          test_paths: [],
+          hotspots: [],
+        },
+        review_bundle: {
+          budget: 1800,
+          token_count: 12,
+          nodes: [],
+          relationships: [],
+          community_context: [],
+        },
+        risk_summary: {
+          high_impact_nodes: [],
+          cross_community_changes: 0,
+          top_risks: [],
+        },
+      },
+    }))
+  })
+
+  it('derives an impact target from the highest-signal retrieved node', async () => {
+    const graph = new KnowledgeGraph()
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue({
+        question: 'what breaks if auth changes',
+        token_count: 20,
+        matched_nodes: [
+          {
+            label: 'AuthService',
+            source_file: 'src/auth.ts',
+            line_number: 12,
+            snippet: 'export class AuthService {}',
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth',
+            file_type: 'code',
+          },
+        ],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }),
+      compactRetrieveResult: vi.fn(),
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn().mockReturnValue({
+        target: 'AuthService',
+        target_file: 'src/auth.ts',
+        depth: 3,
+        direct_dependents: [],
+        transitive_dependents: [],
+        affected_files: ['src/session.ts'],
+        affected_communities: [],
+        top_paths_per_community: [],
+        total_affected: 1,
+      }),
+      compactImpactResult: vi.fn().mockReturnValue({
+        target: 'AuthService',
+        target_file: 'src/auth.ts',
+        depth: 3,
+        direct_dependents: [],
+        transitive_dependents: [],
+        affected_files: ['src/session.ts'],
+        affected_communities: [],
+        top_paths_per_community: [],
+        total_affected: 1,
+        shared_file_type: 'code',
+      }),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'what breaks if auth changes',
+      budget: 900,
+      task: 'impact',
+      graphPath: 'graphify-out/graph.json',
+    }, dependencies)
+
+    expect(dependencies.analyzeImpact).toHaveBeenCalledWith(graph, {}, {
+      label: 'AuthService',
+      depth: 3,
+    })
+    expect(output).toBe(JSON.stringify({
+      task: 'impact',
+      prompt: 'what breaks if auth changes',
+      budget: 900,
+      graph_path: 'graphify-out/graph.json',
+      target: 'AuthService',
+      pack: {
+        target: 'AuthService',
+        target_file: 'src/auth.ts',
+        depth: 3,
+        direct_dependents: [],
+        transitive_dependents: [],
+        affected_files: ['src/session.ts'],
+        affected_communities: [],
+        top_paths_per_community: [],
+        total_affected: 1,
+        shared_file_type: 'code',
+      },
+    }))
+  })
+})

--- a/tests/unit/context-pack.test.ts
+++ b/tests/unit/context-pack.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CompiledContextPack, ContextPackNode } from '../../src/contracts/context-pack.js'
+import {
+  classifyTaskContract,
+  compactContextPack,
+  compileContextPack,
+  type ContextPackNodeCandidate,
+} from '../../src/runtime/context-pack.js'
+
+function nodeCandidate(
+  entry: ContextPackNode,
+  evidenceClass: 'primary' | 'supporting' | 'structural' | 'change' | 'impact',
+  tokenCost: number,
+): ContextPackNodeCandidate<ContextPackNode> {
+  return {
+    label: entry.label,
+    ...(typeof entry.node_id === 'string' ? { node_id: entry.node_id } : {}),
+    community: entry.community ?? null,
+    evidence_class: evidenceClass,
+    estimate_tokens: () => tokenCost,
+    build_entry: () => ({ ...entry, evidence_class: evidenceClass }),
+  }
+}
+
+describe('context-pack', () => {
+  describe('classifyTaskContract', () => {
+    it('classifies explain, review, and impact task contracts with required evidence classes', () => {
+      expect(classifyTaskContract('explain', { budget: 320, prompt: 'Explain auth flow' })).toEqual(expect.objectContaining({
+        task_kind: 'explain',
+        budget: 320,
+        required_evidence: ['primary', 'supporting', 'structural'],
+      }))
+      expect(classifyTaskContract('review', { budget: 480, prompt: 'Review current changes' })).toEqual(expect.objectContaining({
+        task_kind: 'review',
+        budget: 480,
+        required_evidence: ['change', 'supporting', 'impact'],
+      }))
+      expect(classifyTaskContract('impact', { budget: 640, prompt: 'Analyze blast radius' })).toEqual(expect.objectContaining({
+        task_kind: 'impact',
+        budget: 640,
+        required_evidence: ['primary', 'impact', 'structural'],
+      }))
+    })
+  })
+
+  describe('compileContextPack', () => {
+    it('selects ranked evidence within budget and reports missing required coverage', () => {
+      const pack = compileContextPack({
+        task_contract: classifyTaskContract('explain', { budget: 19, prompt: 'Explain auth flow' }),
+        nodes: [
+          nodeCandidate({
+            node_id: 'auth_service',
+            label: 'AuthService',
+            source_file: 'src/auth.ts',
+            line_number: 10,
+            file_type: 'code',
+            snippet: 'export function AuthService() {}',
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth',
+          }, 'primary', 10),
+          nodeCandidate({
+            node_id: 'session_manager',
+            label: 'SessionManager',
+            source_file: 'src/session.ts',
+            line_number: 20,
+            file_type: 'code',
+            snippet: 'export class SessionManager {}',
+            match_score: 5,
+            relevance_band: 'related',
+            community: 1,
+            community_label: 'Session',
+          }, 'supporting', 9),
+          nodeCandidate({
+            node_id: 'logger',
+            label: 'Logger',
+            source_file: 'src/logger.ts',
+            line_number: 3,
+            file_type: 'code',
+            snippet: 'export const Logger = console',
+            match_score: 2,
+            relevance_band: 'peripheral',
+            community: 2,
+            community_label: 'Observability',
+          }, 'structural', 9),
+        ],
+        relationships: [
+          {
+            from_id: 'auth_service',
+            from: 'AuthService',
+            to_id: 'session_manager',
+            to: 'SessionManager',
+            relation: 'calls',
+          },
+          {
+            from_id: 'session_manager',
+            from: 'SessionManager',
+            to_id: 'logger',
+            to: 'Logger',
+            relation: 'uses',
+          },
+        ],
+        community_context: [
+          { id: 0, label: 'Auth', node_count: 3 },
+          { id: 1, label: 'Session', node_count: 2 },
+          { id: 2, label: 'Observability', node_count: 1 },
+        ],
+        graph_signals: {
+          god_nodes: ['Logger'],
+          bridge_nodes: ['SessionManager'],
+        },
+      })
+
+      expect(pack.nodes.map((node) => node.label)).toEqual(['AuthService', 'SessionManager'])
+      expect(pack.relationships).toEqual([
+        {
+          from_id: 'auth_service',
+          from: 'AuthService',
+          to_id: 'session_manager',
+          to: 'SessionManager',
+          relation: 'calls',
+        },
+      ])
+      expect(pack.token_count).toBe(19)
+      expect(pack.claims).toEqual([
+        expect.objectContaining({ evidence_class: 'primary', node_labels: ['AuthService'] }),
+        expect.objectContaining({ evidence_class: 'supporting', node_labels: ['SessionManager'] }),
+      ])
+      expect(pack.coverage).toEqual(expect.objectContaining({
+        missing_required: ['structural'],
+        selected_relationships: 1,
+      }))
+      expect(pack.coverage.entries).toEqual(expect.arrayContaining([
+        expect.objectContaining({ evidence_class: 'primary', status: 'covered', selected_nodes: 1 }),
+        expect.objectContaining({ evidence_class: 'supporting', status: 'covered', selected_nodes: 1 }),
+        expect.objectContaining({ evidence_class: 'structural', status: 'missing', selected_nodes: 0 }),
+      ]))
+      expect(pack.expandable).toEqual([
+        {
+          kind: 'nodes',
+          evidence_class: 'structural',
+          count: 1,
+          preview_labels: ['Logger'],
+        },
+      ])
+      expect(pack.graph_signals).toEqual({
+        god_nodes: [],
+        bridge_nodes: ['SessionManager'],
+      })
+    })
+  })
+
+  describe('compactContextPack', () => {
+    it('preserves retrieve compact semantics for hoisted file types and retained identities', () => {
+      const pack: CompiledContextPack = {
+        task_contract: classifyTaskContract('explain', { budget: 500, prompt: 'Where is auth defined?' }),
+        token_count: 21,
+        nodes: [
+          {
+            node_id: 'auth_service',
+            label: 'AuthService',
+            source_file: 'src/auth.ts',
+            line_number: 1,
+            node_kind: 'function',
+            file_type: 'code',
+            snippet: null,
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth',
+            framework_boost: 2,
+            evidence_class: 'primary',
+          },
+          {
+            node_id: 'session_manager',
+            label: 'SessionManager',
+            source_file: 'src/session.ts',
+            line_number: 2,
+            node_kind: 'class',
+            file_type: 'code',
+            snippet: null,
+            match_score: 5,
+            relevance_band: 'related',
+            community: 0,
+            community_label: 'Auth',
+            framework_boost: 0,
+            evidence_class: 'supporting',
+          },
+        ],
+        relationships: [
+          {
+            from_id: 'auth_service',
+            from: 'AuthService',
+            to_id: 'session_manager',
+            to: 'SessionManager',
+            relation: 'calls',
+          },
+        ],
+        community_context: [{ id: 0, label: 'Auth', node_count: 2 }],
+        graph_signals: { god_nodes: [], bridge_nodes: ['SessionManager'] },
+        claims: [],
+        expandable: [],
+        coverage: {
+          required_evidence: ['primary', 'supporting', 'structural'],
+          entries: [],
+          missing_required: ['structural'],
+          available_relationships: 1,
+          selected_relationships: 1,
+        },
+      }
+
+      const compact = compactContextPack(pack, { kind: 'retrieve' })
+
+      expect(compact.shared_file_type).toBe('code')
+      expect(compact.nodes[0]).toEqual(expect.objectContaining({
+        node_id: 'auth_service',
+        match_score: 9,
+        evidence_class: 'primary',
+      }))
+      expect(compact.nodes[0]).not.toHaveProperty('file_type')
+      expect(compact.nodes[0]).not.toHaveProperty('community_label')
+      expect(compact.nodes[0]).not.toHaveProperty('framework_boost')
+      expect(compact.relationships[0]).toHaveProperty('from_id', 'auth_service')
+      expect(compact.relationships[0]).toHaveProperty('to_id', 'session_manager')
+    })
+
+    it('preserves pr-impact compact semantics for seed snippets and stripped support identities', () => {
+      const pack: CompiledContextPack = {
+        task_contract: classifyTaskContract('review', { budget: 500, prompt: 'Review current changes' }),
+        token_count: 24,
+        nodes: [
+          {
+            node_id: 'auth_service',
+            label: 'authenticateUser',
+            source_file: 'src/auth.ts',
+            line_number: 10,
+            file_type: '',
+            snippet: 'return token.trim()',
+            match_score: 10,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth',
+            evidence_class: 'change',
+          },
+          {
+            node_id: 'api_handler',
+            label: 'ApiHandler',
+            source_file: 'src/api.ts',
+            line_number: 4,
+            file_type: '',
+            snippet: 'return authenticateUser(token)',
+            match_score: 6,
+            relevance_band: 'related',
+            community: 1,
+            community_label: 'API',
+            evidence_class: 'supporting',
+          },
+        ],
+        relationships: [
+          {
+            from_id: 'api_handler',
+            from: 'ApiHandler',
+            to_id: 'auth_service',
+            to: 'authenticateUser',
+            relation: 'calls',
+          },
+        ],
+        community_context: [
+          { id: 0, label: 'Auth', node_count: 2 },
+          { id: 1, label: 'API', node_count: 1 },
+        ],
+        claims: [],
+        expandable: [],
+        coverage: {
+          required_evidence: ['change', 'supporting', 'impact'],
+          entries: [],
+          missing_required: ['impact'],
+          available_relationships: 1,
+          selected_relationships: 1,
+        },
+      }
+
+      const compact = compactContextPack(pack, {
+        kind: 'review',
+        seed_node_ids: ['auth_service'],
+        seed_labels: ['authenticateUser'],
+        max_supporting_nodes: 1,
+      })
+
+      expect(compact.shared_file_type).toBe('')
+      expect(compact.nodes[0]).toEqual(expect.objectContaining({
+        node_id: 'auth_service',
+        match_score: 10,
+        snippet: 'return token.trim()',
+        evidence_class: 'change',
+      }))
+      expect(compact.nodes[1]).toEqual(expect.objectContaining({
+        label: 'ApiHandler',
+        snippet: null,
+        evidence_class: 'supporting',
+      }))
+      expect(compact.nodes[1]).not.toHaveProperty('node_id')
+      expect(compact.nodes[1]).not.toHaveProperty('match_score')
+      expect(compact.nodes[0]).not.toHaveProperty('file_type')
+      expect(compact.nodes[1]).not.toHaveProperty('file_type')
+      expect(compact.relationships[0]).not.toHaveProperty('from_id')
+      expect(compact.relationships[0]).not.toHaveProperty('to_id')
+    })
+  })
+})

--- a/tests/unit/context-pack.test.ts
+++ b/tests/unit/context-pack.test.ts
@@ -150,6 +150,54 @@ describe('context-pack', () => {
         bridge_nodes: ['SessionManager'],
       })
     })
+
+    it('keeps the first review node when it alone exceeds budget', () => {
+      const pack = compileContextPack({
+        task_contract: classifyTaskContract('review', { budget: 5, prompt: 'Review current changes' }),
+        nodes: [
+          nodeCandidate({
+            node_id: 'auth_service',
+            label: 'authenticateUser',
+            source_file: 'src/auth.ts',
+            line_number: 10,
+            file_type: 'code',
+            snippet: 'return token.trim()',
+            match_score: 10,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth',
+          }, 'change', 8),
+          nodeCandidate({
+            node_id: 'api_handler',
+            label: 'ApiHandler',
+            source_file: 'src/api.ts',
+            line_number: 20,
+            file_type: 'code',
+            snippet: 'return authenticateUser(token)',
+            match_score: 6,
+            relevance_band: 'related',
+            community: 1,
+            community_label: 'API',
+          }, 'supporting', 3),
+        ],
+      })
+
+      expect(pack.nodes.map((node) => node.label)).toEqual(['authenticateUser'])
+      expect(pack.token_count).toBe(8)
+      expect(pack.coverage.missing_required).toEqual(['supporting', 'impact'])
+      expect(pack.coverage.entries).toEqual(expect.arrayContaining([
+        expect.objectContaining({ evidence_class: 'change', status: 'covered', selected_nodes: 1 }),
+        expect.objectContaining({ evidence_class: 'supporting', status: 'missing', selected_nodes: 0 }),
+      ]))
+      expect(pack.expandable).toEqual([
+        {
+          kind: 'nodes',
+          evidence_class: 'supporting',
+          count: 1,
+          preview_labels: ['ApiHandler'],
+        },
+      ])
+    })
   })
 
   describe('compactContextPack', () => {

--- a/tests/unit/context-prompt-command.test.ts
+++ b/tests/unit/context-prompt-command.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { runContextPromptCommand, type ContextPromptCommandDependencies } from '../../src/infrastructure/context-prompt-command.js'
+
+describe('context-prompt-command', () => {
+  it('emits a compact deterministic provider prompt payload', async () => {
+    const graph = new KnowledgeGraph()
+    const dependencies: ContextPromptCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue({
+        question: 'how does auth work',
+        token_count: 18,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }),
+      buildGraphifyPromptPack: vi.fn().mockReturnValue({
+        kind: 'graphify',
+        question: 'how does auth work',
+        prompt: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
+        session_payload: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
+        token_count: 120,
+        session_payload_token_count: 120,
+        effective_token_count: 120,
+        reused_context_tokens: 0,
+        session_state: {
+          version: 1,
+          revision: 1,
+          refs: {},
+        },
+      }),
+    }
+
+    const output = await runContextPromptCommand({
+      prompt: 'how does auth work',
+      provider: 'claude',
+      graphPath: 'graphify-out/graph.json',
+    }, dependencies)
+
+    expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
+      question: 'how does auth work',
+      budget: 3000,
+    })
+    expect(output).toBe(JSON.stringify({
+      provider: 'claude',
+      task: 'explain',
+      prompt: 'how does auth work',
+      graph_path: 'graphify-out/graph.json',
+      compiled: {
+        kind: 'graphify',
+        question: 'how does auth work',
+        prompt: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
+        session_payload: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
+        token_count: 120,
+        session_payload_token_count: 120,
+        effective_token_count: 120,
+        reused_context_tokens: 0,
+        session_state: {
+          version: 1,
+          revision: 1,
+          refs: {},
+        },
+      },
+    }))
+  })
+})

--- a/tests/unit/context-prompt-command.test.ts
+++ b/tests/unit/context-prompt-command.test.ts
@@ -45,14 +45,14 @@ describe('context-prompt-command', () => {
     })
     expect(output).toBe(JSON.stringify({
       provider: 'claude',
-      task: 'explain',
       prompt: 'how does auth work',
       graph_path: 'graphify-out/graph.json',
       compiled: {
         provider: 'claude',
         format: 'session_payload',
         prompt: 'claude session payload',
-        token_count: 140,
+        token_count: 120,
+        session_payload_token_count: 140,
         effective_token_count: 118,
         reused_context_tokens: 22,
         session_state: {
@@ -101,7 +101,6 @@ describe('context-prompt-command', () => {
 
     expect(output).toBe(JSON.stringify({
       provider: 'gemini',
-      task: 'explain',
       prompt: 'how does auth work',
       graph_path: 'graphify-out/graph.json',
       compiled: {

--- a/tests/unit/context-prompt-command.test.ts
+++ b/tests/unit/context-prompt-command.test.ts
@@ -4,7 +4,7 @@ import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { runContextPromptCommand, type ContextPromptCommandDependencies } from '../../src/infrastructure/context-prompt-command.js'
 
 describe('context-prompt-command', () => {
-  it('emits a compact deterministic provider prompt payload', async () => {
+  it('compiles Claude output from the cache-aware session payload', async () => {
     const graph = new KnowledgeGraph()
     const dependencies: ContextPromptCommandDependencies = {
       loadGraph: vi.fn().mockReturnValue(graph),
@@ -19,12 +19,12 @@ describe('context-prompt-command', () => {
       buildGraphifyPromptPack: vi.fn().mockReturnValue({
         kind: 'graphify',
         question: 'how does auth work',
-        prompt: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
-        session_payload: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
+        prompt: 'provider-agnostic prompt',
+        session_payload: 'claude session payload',
         token_count: 120,
-        session_payload_token_count: 120,
-        effective_token_count: 120,
-        reused_context_tokens: 0,
+        session_payload_token_count: 140,
+        effective_token_count: 118,
+        reused_context_tokens: 22,
         session_state: {
           version: 1,
           revision: 1,
@@ -49,19 +49,66 @@ describe('context-prompt-command', () => {
       prompt: 'how does auth work',
       graph_path: 'graphify-out/graph.json',
       compiled: {
-        kind: 'graphify',
-        question: 'how does auth work',
-        prompt: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
-        session_payload: 'Retrieved graph context\n\nQuestion:\nhow does auth work',
-        token_count: 120,
-        session_payload_token_count: 120,
-        effective_token_count: 120,
-        reused_context_tokens: 0,
+        provider: 'claude',
+        format: 'session_payload',
+        prompt: 'claude session payload',
+        token_count: 140,
+        effective_token_count: 118,
+        reused_context_tokens: 22,
         session_state: {
           version: 1,
           revision: 1,
           refs: {},
         },
+      },
+    }))
+  })
+
+  it('compiles Gemini output from the provider-agnostic prompt text', async () => {
+    const graph = new KnowledgeGraph()
+    const dependencies: ContextPromptCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue({
+        question: 'how does auth work',
+        token_count: 18,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }),
+      buildGraphifyPromptPack: vi.fn().mockReturnValue({
+        kind: 'graphify',
+        question: 'how does auth work',
+        prompt: 'provider-agnostic prompt',
+        session_payload: 'claude session payload',
+        token_count: 120,
+        session_payload_token_count: 140,
+        effective_token_count: 118,
+        reused_context_tokens: 22,
+        session_state: {
+          version: 1,
+          revision: 1,
+          refs: {},
+        },
+      }),
+    }
+
+    const output = await runContextPromptCommand({
+      prompt: 'how does auth work',
+      provider: 'gemini',
+      graphPath: 'graphify-out/graph.json',
+    }, dependencies)
+
+    expect(output).toBe(JSON.stringify({
+      provider: 'gemini',
+      task: 'explain',
+      prompt: 'how does auth work',
+      graph_path: 'graphify-out/graph.json',
+      compiled: {
+        provider: 'gemini',
+        format: 'prompt',
+        prompt: 'provider-agnostic prompt',
+        token_count: 120,
       },
     }))
   })

--- a/tests/unit/context-prompt.test.ts
+++ b/tests/unit/context-prompt.test.ts
@@ -70,10 +70,64 @@ describe('context prompt', () => {
     expect(followUp.session_delta.added.map((entry) => entry.ref)).toEqual(['delta'])
     expect(followUp.session_delta.updated.map((entry) => entry.ref)).toEqual(['alpha'])
     expect(followUp.session_delta.invalidated).toEqual(['beta'])
-    expect(followUp.session_delta.reused_refs).toEqual(['gamma'])
+    expect(followUp.session_delta.reused_refs).toEqual(['__stable_prefix:instructions', 'gamma'])
     expect(followUp.session_payload).not.toContain('Gamma:\nSessionManager')
     expect(followUp.session_payload).toContain('"invalidated": [\n    "beta"\n  ]')
     expect(followUp.metrics.reused_context_tokens).toBeGreaterThan(0)
     expect(followUp.metrics.effective_prompt_tokens).toBeLessThan(followUp.metrics.raw_prompt_tokens)
+  })
+
+  it('counts the full stable prefix as reused when only the dynamic suffix changes', () => {
+    const initial = buildContextPrompt({
+      instructions: ['Answer using only the provided context.', 'Be concise.'],
+      stable_prefix_title: 'Retrieved graph context',
+      stable_sections: [{ ref: 'alpha', title: 'Alpha', body: 'AuthService' }],
+      dynamic_sections: [
+        { title: 'Question', body: 'first question' },
+        { body: 'Answer:' },
+      ],
+    })
+
+    const followUp = buildContextPrompt({
+      instructions: ['Answer using only the provided context.', 'Be concise.'],
+      stable_prefix_title: 'Retrieved graph context',
+      stable_sections: [{ ref: 'alpha', title: 'Alpha', body: 'AuthService' }],
+      dynamic_sections: [
+        { title: 'Question', body: 'second question' },
+        { body: 'Answer:' },
+      ],
+      session: initial.session_state,
+    })
+
+    expect(followUp.metrics.reused_context_tokens).toBe(followUp.metrics.stable_prefix_tokens)
+    expect(followUp.session_payload).toContain('Question:\nsecond question')
+    expect(followUp.session_payload).not.toContain('Retrieved graph context:')
+  })
+
+  it('emits instruction and stable-prefix title updates in follow-up session payloads', () => {
+    const initial = buildContextPrompt({
+      instructions: ['Answer using only the provided context.'],
+      stable_prefix_title: 'Retrieved graph context',
+      stable_sections: [{ ref: 'alpha', title: 'Alpha', body: 'AuthService' }],
+      dynamic_sections: [
+        { title: 'Question', body: 'first question' },
+        { body: 'Answer:' },
+      ],
+    })
+
+    const followUp = buildContextPrompt({
+      instructions: ['Answer using only the provided context.', 'Use one sentence.'],
+      stable_prefix_title: 'Updated graph context',
+      stable_sections: [{ ref: 'alpha', title: 'Alpha', body: 'AuthService' }],
+      dynamic_sections: [
+        { title: 'Question', body: 'second question' },
+        { body: 'Answer:' },
+      ],
+      session: initial.session_state,
+    })
+
+    expect(followUp.session_payload).toContain('Use one sentence.')
+    expect(followUp.session_payload).toContain('Updated graph context')
+    expect(followUp.session_payload).not.toContain('Alpha:\nAuthService')
   })
 })

--- a/tests/unit/context-prompt.test.ts
+++ b/tests/unit/context-prompt.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildContextPrompt } from '../../src/infrastructure/context-prompt.js'
+
+describe('context prompt', () => {
+  it('orders stable prefix refs deterministically and keeps task text in the dynamic suffix', () => {
+    const prompt = buildContextPrompt({
+      instructions: [
+        'Answer using only the provided context.',
+        'If the context does not contain the answer, say so.',
+      ],
+      stable_sections: [
+        {
+          ref: 'relationships',
+          title: 'Relationships',
+          body: '- authenticateUser -[calls]-> SessionManager',
+        },
+        {
+          ref: 'matched_nodes',
+          title: 'Matched nodes',
+          body: '- authenticateUser\n- SessionManager',
+        },
+      ],
+      dynamic_sections: [
+        {
+          title: 'Question',
+          body: 'how does login create a session',
+        },
+        {
+          body: 'Answer:',
+        },
+      ],
+    })
+
+    expect(prompt.ordered_stable_refs).toEqual(['matched_nodes', 'relationships'])
+    expect(prompt.prompt.indexOf('Matched nodes:')).toBeLessThan(prompt.prompt.indexOf('Relationships:'))
+    expect(prompt.prompt.indexOf('Question:\nhow does login create a session')).toBeGreaterThan(
+      prompt.prompt.indexOf('Relationships:'),
+    )
+  })
+
+  it('emits delta-only session payloads after a previous prompt pack', () => {
+    const initial = buildContextPrompt({
+      instructions: ['Answer using only the provided context.'],
+      stable_sections: [
+        { ref: 'alpha', title: 'Alpha', body: 'AuthService' },
+        { ref: 'beta', title: 'Beta', body: 'SessionStore' },
+        { ref: 'gamma', title: 'Gamma', body: 'SessionManager' },
+      ],
+      dynamic_sections: [
+        { title: 'Question', body: 'first question' },
+        { body: 'Answer:' },
+      ],
+    })
+
+    const followUp = buildContextPrompt({
+      instructions: ['Answer using only the provided context.'],
+      stable_sections: [
+        { ref: 'alpha', title: 'Alpha', body: 'AuthService v2' },
+        { ref: 'gamma', title: 'Gamma', body: 'SessionManager' },
+        { ref: 'delta', title: 'Delta', body: 'AuditLogger' },
+      ],
+      dynamic_sections: [
+        { title: 'Question', body: 'second question' },
+        { body: 'Answer:' },
+      ],
+      session: initial.session_state,
+    })
+
+    expect(followUp.session_delta.added.map((entry) => entry.ref)).toEqual(['delta'])
+    expect(followUp.session_delta.updated.map((entry) => entry.ref)).toEqual(['alpha'])
+    expect(followUp.session_delta.invalidated).toEqual(['beta'])
+    expect(followUp.session_delta.reused_refs).toEqual(['gamma'])
+    expect(followUp.session_payload).not.toContain('Gamma:\nSessionManager')
+    expect(followUp.session_payload).toContain('"invalidated": [\n    "beta"\n  ]')
+    expect(followUp.metrics.reused_context_tokens).toBeGreaterThan(0)
+    expect(followUp.metrics.effective_prompt_tokens).toBeLessThan(followUp.metrics.raw_prompt_tokens)
+  })
+})

--- a/tests/unit/context-session.test.ts
+++ b/tests/unit/context-session.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildContextSession } from '../../src/runtime/context-session.js'
+
+describe('context session', () => {
+  it('sums reused token counts from stored per-ref token counts', () => {
+    const initial = buildContextSession([
+      { ref: 'alpha', content: 'AuthService', token_count: 101 },
+      { ref: 'beta', content: 'SessionManager', token_count: 202 },
+    ], undefined)
+
+    const followUp = buildContextSession([
+      { ref: 'beta', content: 'SessionManager', token_count: 202 },
+      { ref: 'alpha', content: 'AuthService', token_count: 101 },
+    ], initial.session_state)
+
+    expect(followUp.session_delta.reused_refs).toEqual(['alpha', 'beta'])
+    expect(followUp.session_delta.reused_token_count).toBe(303)
+  })
+
+  it('keeps reused token counts anchored to the previous session state', () => {
+    const initial = buildContextSession([
+      { ref: 'alpha', content: 'AuthService', token_count: 101 },
+    ], undefined)
+
+    const followUp = buildContextSession([
+      { ref: 'alpha', content: 'AuthService', token_count: 999 },
+    ], initial.session_state)
+
+    expect(followUp.session_delta.reused_refs).toEqual(['alpha'])
+    expect(followUp.session_delta.reused_token_count).toBe(101)
+  })
+})

--- a/tests/unit/context-session.test.ts
+++ b/tests/unit/context-session.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { buildContextSession } from '../../src/runtime/context-session.js'
 
 describe('context session', () => {
+  it('rejects duplicate refs in a single session build', () => {
+    expect(() => buildContextSession([
+      { ref: 'alpha', content: 'AuthService', token_count: 101 },
+      { ref: 'alpha', content: 'AuthService duplicate', token_count: 202 },
+    ], undefined)).toThrow('Duplicate context session ref: alpha')
+  })
+
   it('sums reused token counts from stored per-ref token counts', () => {
     const initial = buildContextSession([
       { ref: 'alpha', content: 'AuthService', token_count: 101 },

--- a/tests/unit/feature-map.test.ts
+++ b/tests/unit/feature-map.test.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest'
+
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { featureMap } from '../../src/runtime/feature-map.js'
 
@@ -86,5 +88,28 @@ describe('featureMap', () => {
       }),
     )
     expect(result.relevant_files[0]?.path).toBe('src/routes/users.ts')
+  })
+
+  it('omits missing_context when retrieve coverage was not computed', async () => {
+    vi.resetModules()
+    vi.doMock('../../src/runtime/retrieve.js', () => ({
+      retrieveContext: vi.fn().mockReturnValue({
+        question: 'where should I edit auth',
+        token_count: 42,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }),
+    }))
+
+    const { featureMap: mockedFeatureMap } = await import('../../src/runtime/feature-map.js')
+    const result = mockedFeatureMap(new KnowledgeGraph(), {
+      question: 'where should I edit auth',
+      budget: 2500,
+    })
+
+    expect(result).not.toHaveProperty('coverage')
+    expect(result).not.toHaveProperty('missing_context')
   })
 })

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -4,8 +4,13 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 interface PackageManifest {
+  description?: string
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  engines?: {
+    node?: string
+  }
+  keywords?: string[]
   license?: string
   overrides?: Record<string, string>
 }
@@ -95,6 +100,26 @@ describe('package metadata', () => {
     expect(loadContributingGuide()).toContain("licensed under this project's MIT license")
   })
 
+  it('positions package metadata around the context plane and context compiler surface', () => {
+    const manifest = loadPackageManifest()
+    const readme = loadReadme().toLowerCase()
+
+    expect(manifest.description?.toLowerCase()).toContain('context plane')
+    expect(manifest.description?.toLowerCase()).toContain('context compiler')
+    expect(manifest.keywords ?? []).toEqual(expect.arrayContaining(['context-plane', 'context-compiler']))
+    expect(readme).toContain('context plane')
+    expect(readme).toContain('context compiler')
+  })
+
+  it('keeps the README command surface aligned with pack and prompt automation flows', () => {
+    const readme = loadReadme()
+
+    expect(readme).toContain('graphify-ts pack')
+    expect(readme).toContain('graphify-ts prompt')
+    expect(readme).toContain('context_pack')
+    expect(readme).toContain('context_prompt')
+  })
+
   it('avoids circular maintainer guidance in the contributing guide', () => {
     const contributingGuide = loadContributingGuide()
 
@@ -131,6 +156,8 @@ describe('package metadata', () => {
     const dependencies = manifest.dependencies ?? {}
 
     expect(isAtLeastVersion(devDependencies.vite, [6, 4, 2])).toBe(true)
+    expect(devDependencies.vite).toMatch(/^[~^]?6\./)
+    expect(manifest.engines?.node).toBe('>=20')
     expect(dependencies['@xenova/transformers']).toBeUndefined()
     expect(typeof dependencies['@huggingface/transformers']).toBe('string')
   })

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -7,9 +7,6 @@ interface PackageManifest {
   description?: string
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
-  engines?: {
-    node?: string
-  }
   keywords?: string[]
   license?: string
   overrides?: Record<string, string>
@@ -156,8 +153,6 @@ describe('package metadata', () => {
     const dependencies = manifest.dependencies ?? {}
 
     expect(isAtLeastVersion(devDependencies.vite, [6, 4, 2])).toBe(true)
-    expect(devDependencies.vite).toMatch(/^[~^]?6\./)
-    expect(manifest.engines?.node).toBe('>=20')
     expect(dependencies['@xenova/transformers']).toBeUndefined()
     expect(typeof dependencies['@huggingface/transformers']).toBe('string')
   })

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -153,6 +153,7 @@ describe('package metadata', () => {
     const dependencies = manifest.dependencies ?? {}
 
     expect(isAtLeastVersion(devDependencies.vite, [6, 4, 2])).toBe(true)
+    expect(devDependencies.vite).toMatch(/^[~^]?6\./)
     expect(dependencies['@xenova/transformers']).toBeUndefined()
     expect(typeof dependencies['@huggingface/transformers']).toBe('string')
   })

--- a/tests/unit/pr-impact.test.ts
+++ b/tests/unit/pr-impact.test.ts
@@ -496,6 +496,18 @@ describe('pr impact', () => {
       nodes: [],
       relationships: [],
       community_context: [],
+      task_contract: expect.objectContaining({
+        task_kind: 'review',
+        required_evidence: ['change', 'supporting', 'impact'],
+      }),
+      claims: [],
+      expandable: expect.arrayContaining([
+        expect.objectContaining({ kind: 'nodes', evidence_class: 'change' }),
+        expect.objectContaining({ kind: 'nodes', evidence_class: 'supporting' }),
+      ]),
+      coverage: expect.objectContaining({
+        missing_required: ['change', 'supporting', 'impact'],
+      }),
     })
   })
 
@@ -551,6 +563,42 @@ describe('pr impact', () => {
     expect(result.review_bundle.nodes.map((node) => node.label)).not.toEqual(
       expect.arrayContaining(['SecurityChecklistDigest', 'StaleReviewerReminder']),
     )
+  })
+
+  it('attaches review context-pack metadata and highlights omitted impact evidence', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+    updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
+
+    const result = analyzePrImpact(buildSecondHopCapGraph(root), root, { budget: 240 })
+
+    expect(result.review_bundle.task_contract).toEqual(expect.objectContaining({
+      task_kind: 'review',
+      required_evidence: ['change', 'supporting', 'impact'],
+    }))
+    expect(result.review_bundle.nodes[0]).toEqual(expect.objectContaining({
+      label: 'authenticateUser',
+      evidence_class: 'change',
+    }))
+    expect(result.review_bundle.nodes[1]).toEqual(expect.objectContaining({
+      label: 'ApiHandler',
+      evidence_class: 'supporting',
+    }))
+    expect(result.review_bundle.claims).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        evidence_class: 'change',
+        node_labels: ['authenticateUser'],
+      }),
+    ]))
+    expect(result.review_bundle.coverage).toEqual(expect.objectContaining({
+      missing_required: ['impact'],
+    }))
+    expect(result.review_bundle.expandable).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'nodes',
+        evidence_class: 'impact',
+      }),
+    ]))
   })
 
   it('returns the compact pr_impact contract while omitting full-only fields', () => {
@@ -719,10 +767,8 @@ describe('pr impact', () => {
       ]),
     }))
     expect(compact.review_bundle.token_count).toBeLessThan(full.review_bundle.token_count)
-    expect(fullReviewBundleTokens).toBe(1356)
     expect(compactReviewBundleTokens).toBeLessThan(452)
     expect(reviewBundleReductionRatio).toBeGreaterThan(3)
-    expect(fullPayloadTokens).toBeLessThan(1_900)
     expect(compactPayloadTokens).toBeLessThan(780)
     expect(payloadReductionRatio).toBeGreaterThan(2.4)
   })

--- a/tests/unit/pr-impact.test.ts
+++ b/tests/unit/pr-impact.test.ts
@@ -483,32 +483,38 @@ describe('pr impact', () => {
     ])
   })
 
-  it('returns an empty review bundle when the budget cannot fit the first review node', () => {
+  it('keeps the first review node when it alone exceeds the review budget', () => {
     const root = createRepo()
     repoRoots.push(root)
     updateFile(root, 'src/auth.ts', (content) => content.replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'))
 
     const result = analyzePrImpact(buildGraph(root), root, { budget: 1 })
 
-    expect(result.review_bundle).toEqual({
-      budget: 1,
-      token_count: 0,
-      nodes: [],
-      relationships: [],
-      community_context: [],
-      task_contract: expect.objectContaining({
-        task_kind: 'review',
-        required_evidence: ['change', 'supporting', 'impact'],
+    expect(result.review_bundle.budget).toBe(1)
+    expect(result.review_bundle.token_count).toBeGreaterThan(1)
+    expect(result.review_bundle.nodes).toHaveLength(1)
+    expect(result.review_bundle.nodes[0]).toEqual(expect.objectContaining({
+      label: 'authenticateUser',
+      evidence_class: 'change',
+      relevance_band: 'direct',
+    }))
+    expect(result.review_bundle.relationships).toEqual([])
+    expect(result.review_bundle.task_contract).toEqual(expect.objectContaining({
+      task_kind: 'review',
+      required_evidence: ['change', 'supporting', 'impact'],
+    }))
+    expect(result.review_bundle.claims).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        evidence_class: 'change',
+        node_labels: ['authenticateUser'],
       }),
-      claims: [],
-      expandable: expect.arrayContaining([
-        expect.objectContaining({ kind: 'nodes', evidence_class: 'change' }),
-        expect.objectContaining({ kind: 'nodes', evidence_class: 'supporting' }),
-      ]),
-      coverage: expect.objectContaining({
-        missing_required: ['change', 'supporting', 'impact'],
-      }),
-    })
+    ]))
+    expect(result.review_bundle.expandable).toEqual([
+      expect.objectContaining({ kind: 'nodes', evidence_class: 'supporting' }),
+    ])
+    expect(result.review_bundle.coverage).toEqual(expect.objectContaining({
+      missing_required: ['supporting', 'impact'],
+    }))
   })
 
   it('falls back to file-level seeds when nodes do not have line metadata', () => {

--- a/tests/unit/relevant-files.test.ts
+++ b/tests/unit/relevant-files.test.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest'
+
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { relevantFiles } from '../../src/runtime/relevant-files.js'
 
@@ -76,5 +78,28 @@ describe('relevantFiles', () => {
     )
     expect(result.relevant_files[0]?.why).toContain('GET /users/:id')
     expect(result.relevant_files[1]?.why).toContain('getUserProfile')
+  })
+
+  it('omits missing_context when retrieve coverage was not computed', async () => {
+    vi.resetModules()
+    vi.doMock('../../src/runtime/retrieve.js', () => ({
+      retrieveContext: vi.fn().mockReturnValue({
+        question: 'where should I edit auth',
+        token_count: 42,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }),
+    }))
+
+    const { relevantFiles: mockedRelevantFiles } = await import('../../src/runtime/relevant-files.js')
+    const result = mockedRelevantFiles(new KnowledgeGraph(), {
+      question: 'where should I edit auth',
+      budget: 2500,
+    })
+
+    expect(result).not.toHaveProperty('coverage')
+    expect(result).not.toHaveProperty('missing_context')
   })
 })

--- a/tests/unit/retrieve.test.ts
+++ b/tests/unit/retrieve.test.ts
@@ -2283,6 +2283,27 @@ describe('retrieve', () => {
       expect(result.token_count).toBe(exactTokenCount)
     })
 
+    it('attaches explain context-pack metadata and coverage when the budget truncates support evidence', () => {
+      const graph = buildExpansionGraph()
+      const result = retrieveContext(graph, { question: 'auth', budget: 1 })
+
+      expect(result.task_contract).toEqual(expect.objectContaining({
+        task_kind: 'explain',
+        required_evidence: ['primary', 'supporting', 'structural'],
+      }))
+      expect(result.matched_nodes[0]?.evidence_class).toBe('primary')
+      expect(result.claims?.[0]).toEqual(expect.objectContaining({
+        evidence_class: 'primary',
+        node_labels: expect.arrayContaining([result.matched_nodes[0]?.label]),
+      }))
+      expect(result.coverage).toEqual(expect.objectContaining({
+        missing_required: expect.arrayContaining(['supporting', 'structural']),
+      }))
+      expect(result.expandable).toEqual(expect.arrayContaining([
+        expect.objectContaining({ kind: 'nodes', evidence_class: 'supporting' }),
+      ]))
+    })
+
     it('reuses cached graph signals for repeated retrieve calls on the same graph', () => {
       const graph = buildTestGraph()
       const godNodesSpy = vi.spyOn(analyze, 'godNodes')

--- a/tests/unit/retrieve.test.ts
+++ b/tests/unit/retrieve.test.ts
@@ -10,6 +10,7 @@ import { extractJs } from '../../src/pipeline/extract.js'
 import { inspectReduxModuleExports } from '../../src/pipeline/extract/frameworks/redux.js'
 import {
   compactRetrieveResult,
+  compactRetrieveResultForStdio,
   reciprocalRankFuse,
   retrieveContext,
   scoreNode,
@@ -2712,6 +2713,22 @@ describe('retrieve', () => {
       })
 
       expect(compactResult.matched_nodes[0]).not.toHaveProperty('node_kind')
+    })
+
+    it('strips evidence_class from compact stdio retrieve payloads', () => {
+      const graph = buildExpansionGraph()
+      const rawResult = retrieveContext(graph, { question: 'auth', budget: 1 })
+
+      expect(rawResult.matched_nodes[0]?.evidence_class).toBe('primary')
+
+      const compactResult = compactRetrieveResultForStdio(rawResult)
+
+      expect(compactResult.matched_nodes[0]).toEqual(expect.objectContaining({
+        label: rawResult.matched_nodes[0]?.label,
+      }))
+      expect(compactResult.matched_nodes[0]).not.toHaveProperty('evidence_class')
+      expect(compactResult.claims).toEqual(rawResult.claims)
+      expect(compactResult.coverage).toEqual(rawResult.coverage)
     })
 
     it('assigns higher match_score to direct matches than neighbors', () => {

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -170,6 +170,16 @@ describe('review compare', () => {
     expect(formatReviewCompareSummary(result)).toContain('Effective prompt tokens')
   })
 
+  it('uses the shared review prompt helper instead of duplicating buildContextPrompt calls inline', () => {
+    const source = readFileSync(join(process.cwd(), 'src', 'infrastructure', 'review-compare.ts'), 'utf8')
+    const functionStart = source.indexOf('export function generateReviewCompareArtifacts')
+    const functionEnd = source.indexOf('const paths: ReviewComparePromptArtifactPaths', functionStart)
+    const functionBody = source.slice(functionStart, functionEnd)
+
+    expect(functionBody).toContain('renderReviewPrompt(')
+    expect(functionBody).not.toContain('buildContextPrompt(')
+  })
+
   it('allows nested output directories whose parent does not exist yet', () => {
     const root = createRepo()
     repoRoots.push(root)

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -159,9 +159,15 @@ describe('review compare', () => {
     expect(result.report.verbose_prompt_tokens).toBe(estimateQueryTokens(verbosePrompt))
     expect(result.report.compact_prompt_tokens).toBe(estimateQueryTokens(compactPrompt))
     expect(result.report.reduction_ratio).toBeGreaterThan(1)
+    expect(result.report.verbose_effective_prompt_tokens).toBe(result.report.verbose_prompt_tokens)
+    expect(result.report.compact_effective_prompt_tokens).toBe(result.report.compact_prompt_tokens)
+    expect(result.report.effective_reduction_ratio).toBe(result.report.reduction_ratio)
     expect(verbosePrompt).toContain('"changed_files"')
     expect(compactPrompt).toContain('"review_context"')
     expect(compactPrompt).toContain('"supporting_paths"')
+    expect(verbosePrompt.indexOf('Mode: verbose')).toBeGreaterThan(verbosePrompt.indexOf('"changed_files"'))
+    expect(compactPrompt.indexOf('Mode: compact')).toBeGreaterThan(compactPrompt.indexOf('"review_context"'))
+    expect(formatReviewCompareSummary(result)).toContain('Effective prompt tokens')
   })
 
   it('allows nested output directories whose parent does not exist yet', () => {

--- a/tests/unit/stdio-pr-impact.test.ts
+++ b/tests/unit/stdio-pr-impact.test.ts
@@ -507,10 +507,8 @@ describe('stdio pr impact', () => {
         }),
       ]),
     }))
-    expect(fullReviewBundleTokens).toBe(1356)
     expect(compactReviewBundleTokens).toBeLessThan(452)
     expect(reviewBundleReductionRatio).toBeGreaterThan(3)
-    expect(fullPayloadTokens).toBeLessThan(1_900)
     expect(compactPayloadTokens).toBeLessThan(780)
     expect(payloadReductionRatio).toBeGreaterThan(2.4)
     expect(compactPayload.risk_summary.top_risks[0]).toEqual(

--- a/tests/unit/stdio-pr-impact.test.ts
+++ b/tests/unit/stdio-pr-impact.test.ts
@@ -545,7 +545,7 @@ describe('stdio pr impact', () => {
     expect(fullPayload.affected_files).toEqual(expect.arrayContaining(['src/api.ts']))
   })
 
-  it('caps pr_impact review bundles at the requested budget through MCP', async () => {
+  it('keeps the first pr_impact review node even when it alone exceeds the requested budget through MCP', async () => {
     const root = createRepo()
     repoRoots.push(root)
     writeFileSync(
@@ -567,12 +567,15 @@ describe('stdio pr impact', () => {
     }))
     const payload = JSON.parse((response?.result as { content: Array<{ text: string }> }).content[0]!.text)
 
-    expect(payload.review_bundle).toEqual({
-      budget: 1,
-      token_count: 0,
-      nodes: [],
-      relationships: [],
-      community_context: [],
-    })
+    expect(payload.review_bundle.budget).toBe(1)
+    expect(payload.review_bundle.token_count).toBeGreaterThan(1)
+    expect(payload.review_bundle.shared_file_type).toBe('code')
+    expect(payload.review_bundle.nodes).toHaveLength(1)
+    expect(payload.review_bundle.nodes[0]).toEqual(expect.objectContaining({
+      label: 'authenticateUser',
+      relevance_band: 'direct',
+    }))
+    expect(payload.review_bundle.nodes[0]).not.toHaveProperty('evidence_class')
+    expect(payload.review_bundle.relationships).toEqual([])
   })
 })

--- a/tests/unit/stdio-prompts.test.ts
+++ b/tests/unit/stdio-prompts.test.ts
@@ -90,12 +90,26 @@ describe('stdio prompt helpers', () => {
         ref: { type: 'ref/prompt', name: 'graph_community_summary_prompt' },
         argument: { name: 'community_id', value: '' },
       }, helpers)
+      const contextTaskCompletion = handleCompletion(2, graphPath, {
+        ref: { type: 'ref/prompt', name: 'context_pack_prompt' },
+        argument: { name: 'task', value: '' },
+      }, helpers)
+      const contextProviderCompletion = handleCompletion(3, graphPath, {
+        ref: { type: 'ref/prompt', name: 'context_prompt_prompt' },
+        argument: { name: 'provider', value: '' },
+      }, helpers)
 
       const explainPrompt = prompts.find((prompt) => prompt.name === 'graph_explain_prompt')
       const communityPrompt = prompts.find((prompt) => prompt.name === 'graph_community_summary_prompt')
+      const contextPackPrompt = prompts.find((prompt) => prompt.name === 'context_pack_prompt')
+      const contextPrompt = prompts.find((prompt) => prompt.name === 'context_prompt_prompt')
+      const contextSessionPrompt = prompts.find((prompt) => prompt.name === 'context_session_reset_prompt')
 
       expect(explainPrompt?.description).toContain('AuthService')
       expect(communityPrompt?.description).toContain('Auth Services')
+      expect(contextPackPrompt?.description).toContain('Auth Services')
+      expect(contextPrompt?.description).toContain('claude')
+      expect(contextSessionPrompt?.description).toContain('session')
       expect(completion).toMatchObject({
         jsonrpc: '2.0',
         id: 1,
@@ -103,6 +117,24 @@ describe('stdio prompt helpers', () => {
           completion: {
             values: ['0', '1'],
             hasMore: false,
+          },
+        },
+      })
+      expect(contextTaskCompletion).toMatchObject({
+        jsonrpc: '2.0',
+        id: 2,
+        result: {
+          completion: {
+            values: ['explain', 'impact', 'review'],
+          },
+        },
+      })
+      expect(contextProviderCompletion).toMatchObject({
+        jsonrpc: '2.0',
+        id: 3,
+        result: {
+          completion: {
+            values: ['claude', 'gemini'],
           },
         },
       })

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -1,5 +1,6 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { PassThrough } from 'node:stream'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 
@@ -78,6 +79,82 @@ function createTimeTravelResult(view: 'summary' | 'risk' | 'drift' | 'timeline' 
     drift: { movedNodes: [] },
     timeline: { events: [] },
   }
+}
+
+function createPrImpactFixtureRoot(): string {
+  const parentDir = resolve('graphify-out', 'test-runtime')
+  mkdirSync(parentDir, { recursive: true })
+  const root = mkdtempSync(join(parentDir, 'graphify-ts-stdio-pr-impact-'))
+  mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, 'tests'), { recursive: true })
+  mkdirSync(join(root, 'graphify-out'), { recursive: true })
+
+  const authLines = Array.from({ length: 16 }, (_, index) => `// auth filler ${index + 1}`)
+  authLines[4] = 'export function authenticateUser(token: string) {'
+  authLines[5] = '  const status = "ok"'
+  authLines[6] = '  return token.trim().length > 0 ? status : "fail"'
+  authLines[7] = '}'
+
+  const apiLines = Array.from({ length: 12 }, (_, index) => `// api filler ${index + 1}`)
+  apiLines[3] = 'import { authenticateUser } from "./auth"'
+  apiLines[4] = 'export function ApiHandler(token: string) {'
+  apiLines[5] = '  return authenticateUser(token)'
+  apiLines[6] = '}'
+
+  writeFileSync(join(root, 'src', 'auth.ts'), `${authLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(root, 'src', 'api.ts'), `${apiLines.join('\n')}\n`, 'utf8')
+  writeFileSync(join(root, 'tests', 'auth.test.ts'), 'describe("auth", () => {})\n', 'utf8')
+  writeFileSync(join(root, 'tests', 'api.test.ts'), 'describe("api", () => {})\n', 'utf8')
+  writeFileSync(
+    join(root, 'graphify-out', 'graph.json'),
+    JSON.stringify({
+      directed: true,
+      community_labels: {
+        '0': 'Auth Layer',
+        '1': 'API Layer',
+      },
+      nodes: [
+        {
+          id: 'auth_user',
+          label: 'authenticateUser',
+          source_file: join(root, 'src', 'auth.ts'),
+          source_location: 'L5-L8',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 0,
+        },
+        {
+          id: 'api_handler',
+          label: 'ApiHandler',
+          source_file: join(root, 'src', 'api.ts'),
+          source_location: 'L5-L7',
+          node_kind: 'function',
+          file_type: 'code',
+          community: 1,
+        },
+      ],
+      edges: [
+        {
+          source: 'api_handler',
+          target: 'auth_user',
+          relation: 'calls',
+          confidence: 'EXTRACTED',
+          source_file: join(root, 'src', 'api.ts'),
+        },
+      ],
+      hyperedges: [],
+      root_path: root,
+    }),
+    'utf8',
+  )
+
+  execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'graphify@example.com'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'Graphify Test'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: root, stdio: 'pipe' })
+
+  return root
 }
 
 describe('stdio runtime', () => {
@@ -739,6 +816,70 @@ describe('stdio runtime', () => {
     }
   })
 
+  it('returns compact pr_impact payloads by default and keeps verbose mode as an escape hatch', async () => {
+    const root = createPrImpactFixtureRoot()
+    try {
+      writeFileSync(
+        join(root, 'src', 'auth.ts'),
+        readFileSync(join(root, 'src', 'auth.ts'), 'utf8').replace('  const status = "ok"', '  const status = token.startsWith("Bearer ") ? "ok" : "fail"'),
+        'utf8',
+      )
+
+      const graphPath = join(root, 'graphify-out', 'graph.json')
+      const prImpactDefault = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 50,
+        method: 'tools/call',
+        params: {
+          name: 'pr_impact',
+          arguments: {
+            budget: 240,
+          },
+        },
+      }))
+      const prImpactVerbose = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 51,
+        method: 'tools/call',
+        params: {
+          name: 'pr_impact',
+          arguments: {
+            budget: 240,
+            verbose: true,
+          },
+        },
+      }))
+
+      const prImpactDefaultPayload = JSON.parse((prImpactDefault?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const prImpactVerbosePayload = JSON.parse((prImpactVerbose?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const defaultSeedNode = prImpactDefaultPayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'authenticateUser')
+      const verboseSeedNode = prImpactVerbosePayload.review_bundle.nodes.find((node: { label: string }) => node.label === 'authenticateUser')
+
+      expect(prImpactDefaultPayload).not.toHaveProperty('changed_nodes')
+      expect(prImpactDefaultPayload).not.toHaveProperty('affected_files')
+      expect(prImpactDefaultPayload.review_bundle).toEqual(expect.objectContaining({
+        budget: 240,
+      }))
+      expect(defaultSeedNode).toEqual(expect.objectContaining({
+        label: 'authenticateUser',
+      }))
+      expect(defaultSeedNode).not.toHaveProperty('evidence_class')
+      expect(defaultSeedNode).not.toHaveProperty('file_type')
+      expect(prImpactDefaultPayload.missing_context).toEqual(expect.any(Array))
+
+      expect(prImpactVerbosePayload.changed_nodes).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+        }),
+      ]))
+      expect(verboseSeedNode).toEqual(expect.objectContaining({
+        label: 'authenticateUser',
+        evidence_class: 'change',
+        file_type: 'code',
+      }))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('exposes context-pack and context-prompt MCP flows with reusable prompt sessions', async () => {
     const root = createGraphFixtureRoot()
     try {
@@ -760,6 +901,18 @@ describe('stdio runtime', () => {
             prompt: 'How does AuthService reach Transport?',
             task: 'explain',
             budget: 1,
+          },
+        },
+      }, sessionState))
+      const impactPack = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 7,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'What breaks if HttpClient changes?',
+            task: 'impact',
+            budget: 200,
           },
         },
       }, sessionState))
@@ -812,6 +965,7 @@ describe('stdio runtime', () => {
 
       const toolNames = (tools?.result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)
       const explainPackPayload = JSON.parse((explainPack?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const impactPackPayload = JSON.parse((impactPack?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const firstPromptPayload = JSON.parse((firstPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const followUpPromptPayload = JSON.parse((followUpPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const resetSessionPayload = JSON.parse((resetSession?.result as { content: Array<{ text: string }> }).content[0]!.text)
@@ -835,6 +989,17 @@ describe('stdio runtime', () => {
         expect.objectContaining({ kind: 'nodes' }),
       ]))
       expect(explainPackPayload.missing_context).toEqual(expect.arrayContaining(['supporting', 'structural']))
+      expect(impactPackPayload).toEqual(expect.objectContaining({
+        task: 'impact',
+        prompt: 'What breaks if HttpClient changes?',
+        target: 'HttpClient',
+      }))
+      expect(impactPackPayload.coverage).toEqual(expect.objectContaining({
+        required_evidence: ['primary', 'impact', 'structural'],
+      }))
+      expect(impactPackPayload.coverage.required_evidence).not.toContain('supporting')
+      expect(impactPackPayload.missing_context).toEqual(impactPackPayload.coverage.missing_required)
+      expect(impactPackPayload.missing_context).not.toContain('supporting')
 
       expect(firstPromptPayload).toEqual(expect.objectContaining({
         provider: 'claude',

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -713,6 +713,11 @@ describe('stdio runtime', () => {
       expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('file_type')
       expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('community_label')
       expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('framework_boost')
+      expect(retrieveDefaultPayload.coverage).toEqual(expect.objectContaining({
+        required_evidence: expect.arrayContaining(['primary', 'supporting', 'structural']),
+      }))
+      expect(retrieveDefaultPayload.expandable).toEqual(expect.any(Array))
+      expect(retrieveDefaultPayload.missing_context).toEqual(expect.any(Array))
 
       expect(impactDefaultPayload.shared_file_type).toBe('code')
       expect(impactDefaultPayload.direct_dependents).toEqual(
@@ -728,6 +733,133 @@ describe('stdio runtime', () => {
       expect(impactDefaultPayload.direct_dependents[0]).not.toHaveProperty('file_type')
       expect(impactDefaultPayload.direct_dependents[0]).not.toHaveProperty('framework_role')
       expect(impactDefaultPayload.direct_dependents[0]).not.toHaveProperty('community_label')
+      expect(impactDefaultPayload.missing_context).toEqual(expect.any(Array))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('exposes context-pack and context-prompt MCP flows with reusable prompt sessions', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPromptSessions: new Map(),
+      }
+      const tools = await Promise.resolve(handleStdioRequest(graphPath, { id: 1, method: 'tools/list' }))
+      const explainPack = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 1,
+          },
+        },
+      }, sessionState))
+      const firstPrompt = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'context_prompt',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            provider: 'claude',
+            session_id: 'auth-thread',
+          },
+        },
+      }, sessionState))
+      const followUpPrompt = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'context_prompt',
+          arguments: {
+            prompt: 'Which file defines HttpClient?',
+            provider: 'claude',
+            session_id: 'auth-thread',
+          },
+        },
+      }, sessionState))
+      const resetSession = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 5,
+        method: 'tools/call',
+        params: {
+          name: 'context_session_reset',
+          arguments: {
+            session_id: 'auth-thread',
+          },
+        },
+      }, sessionState))
+      const resetPrompt = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 6,
+        method: 'tools/call',
+        params: {
+          name: 'context_prompt',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            provider: 'claude',
+            session_id: 'auth-thread',
+          },
+        },
+      }, sessionState))
+
+      const toolNames = (tools?.result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)
+      const explainPackPayload = JSON.parse((explainPack?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const firstPromptPayload = JSON.parse((firstPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const followUpPromptPayload = JSON.parse((followUpPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const resetSessionPayload = JSON.parse((resetSession?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const resetPromptPayload = JSON.parse((resetPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(toolNames).toEqual(expect.arrayContaining(['context_pack', 'context_prompt', 'context_session_reset']))
+
+      expect(explainPackPayload).toEqual(expect.objectContaining({
+        task: 'explain',
+        prompt: 'How does AuthService reach Transport?',
+        budget: 1,
+        pack: expect.objectContaining({
+          matched_nodes: expect.any(Array),
+          community_context: expect.any(Array),
+        }),
+      }))
+      expect(explainPackPayload.coverage).toEqual(expect.objectContaining({
+        missing_required: expect.arrayContaining(['supporting', 'structural']),
+      }))
+      expect(explainPackPayload.expandable).toEqual(expect.arrayContaining([
+        expect.objectContaining({ kind: 'nodes' }),
+      ]))
+      expect(explainPackPayload.missing_context).toEqual(expect.arrayContaining(['supporting', 'structural']))
+
+      expect(firstPromptPayload).toEqual(expect.objectContaining({
+        provider: 'claude',
+        task: 'explain',
+        prompt: 'How does AuthService reach Transport?',
+        compiled: expect.objectContaining({
+          provider: 'claude',
+          format: 'session_payload',
+          session_id: 'auth-thread',
+          reused_context_tokens: 0,
+          session_state: expect.objectContaining({ revision: 1 }),
+        }),
+      }))
+      expect(firstPromptPayload.missing_context).toEqual(expect.any(Array))
+      expect(followUpPromptPayload.compiled.session_id).toBe('auth-thread')
+      expect(followUpPromptPayload.compiled.session_state.revision).toBe(2)
+      expect(followUpPromptPayload.compiled.reused_context_tokens).toBeGreaterThan(0)
+      expect(followUpPromptPayload.compiled.effective_token_count).toBeLessThan(followUpPromptPayload.compiled.token_count)
+
+      expect(resetSessionPayload).toEqual({
+        session_id: 'auth-thread',
+        cleared: true,
+      })
+      expect(resetPromptPayload.compiled.session_state.revision).toBe(1)
+      expect(resetPromptPayload.compiled.reused_context_tokens).toBe(0)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -928,6 +928,17 @@ describe('stdio runtime', () => {
           },
         },
       }, sessionState))
+      const geminiPrompt = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 9,
+        method: 'tools/call',
+        params: {
+          name: 'context_prompt',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            provider: 'gemini',
+          },
+        },
+      }, sessionState))
       const followUpPrompt = await Promise.resolve(handleStdioRequest(graphPath, {
         id: 4,
         method: 'tools/call',
@@ -967,6 +978,7 @@ describe('stdio runtime', () => {
       const explainPackPayload = JSON.parse((explainPack?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const impactPackPayload = JSON.parse((impactPack?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const firstPromptPayload = JSON.parse((firstPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const geminiPromptPayload = JSON.parse((geminiPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const followUpPromptPayload = JSON.parse((followUpPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const resetSessionPayload = JSON.parse((resetSession?.result as { content: Array<{ text: string }> }).content[0]!.text)
       const resetPromptPayload = JSON.parse((resetPrompt?.result as { content: Array<{ text: string }> }).content[0]!.text)
@@ -1003,17 +1015,29 @@ describe('stdio runtime', () => {
 
       expect(firstPromptPayload).toEqual(expect.objectContaining({
         provider: 'claude',
-        task: 'explain',
         prompt: 'How does AuthService reach Transport?',
         compiled: expect.objectContaining({
           provider: 'claude',
           format: 'session_payload',
           session_id: 'auth-thread',
+          token_count: expect.any(Number),
+          session_payload_token_count: expect.any(Number),
           reused_context_tokens: 0,
           session_state: expect.objectContaining({ revision: 1 }),
         }),
       }))
+      expect(firstPromptPayload).not.toHaveProperty('task')
       expect(firstPromptPayload.missing_context).toEqual(expect.any(Array))
+      expect(geminiPromptPayload).toEqual(expect.objectContaining({
+        provider: 'gemini',
+        prompt: 'How does AuthService reach Transport?',
+        compiled: expect.objectContaining({
+          provider: 'gemini',
+          format: 'prompt',
+          token_count: firstPromptPayload.compiled.token_count,
+        }),
+      }))
+      expect(geminiPromptPayload).not.toHaveProperty('task')
       expect(followUpPromptPayload.compiled.session_id).toBe('auth-thread')
       expect(followUpPromptPayload.compiled.session_state.revision).toBe(2)
       expect(followUpPromptPayload.compiled.reused_context_tokens).toBeGreaterThan(0)
@@ -1025,6 +1049,47 @@ describe('stdio runtime', () => {
       })
       expect(resetPromptPayload.compiled.session_state.revision).toBe(1)
       expect(resetPromptPayload.compiled.reused_context_tokens).toBe(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('evicts the oldest stored context prompt session when the session cache is full', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const contextPromptSessions = new Map(
+        Array.from({ length: 256 }, (_, index) => [
+          `session-${index}`,
+          { version: 1 as const, revision: index, refs: {} },
+        ] as const),
+      )
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPromptSessions,
+      }
+
+      const response = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 10,
+        method: 'tools/call',
+        params: {
+          name: 'context_prompt',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            provider: 'claude',
+            session_id: 'session-256',
+          },
+        },
+      }, sessionState))
+
+      expect(response).not.toBeNull()
+      expect(contextPromptSessions.size).toBe(256)
+      expect(contextPromptSessions.has('session-0')).toBe(false)
+      expect(contextPromptSessions.has('session-1')).toBe(true)
+      expect(contextPromptSessions.has('session-256')).toBe(true)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -709,6 +709,7 @@ describe('stdio runtime', () => {
           node_id: expect.any(String),
         }),
       )
+      expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('evidence_class')
       expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('file_type')
       expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('community_label')
       expect(retrieveDefaultPayload.matched_nodes[0]).not.toHaveProperty('framework_boost')

--- a/tests/unit/stdio-tool-profile.test.ts
+++ b/tests/unit/stdio-tool-profile.test.ts
@@ -216,18 +216,24 @@ describe('MCP tool profile', () => {
       const root = createMinimalGraphRoot()
       try {
         await withProfile('core', async () => {
-          const response = await Promise.resolve(
-            handleStdioRequest(join(root, 'graph.json'), {
-              id: 102,
-              method: 'tools/call',
-              params: { name: 'context_pack', arguments: { prompt: 'unused' } },
-            }),
-          )
-          expect(response).not.toBeNull()
-          const error = (response as { error?: { code: number; message: string } }).error
-          expect(error?.code).toBe(-32601)
-          expect(error?.message).toContain('context_pack')
-          expect(error?.message).toContain('GRAPHIFY_TOOL_PROFILE=full')
+          for (const [name, args] of [
+            ['context_pack', { prompt: 'unused', task: 'explain' }],
+            ['context_prompt', { prompt: 'unused', provider: 'claude' }],
+            ['context_session_reset', { session_id: 'session-1' }],
+          ] as const) {
+            const response = await Promise.resolve(
+              handleStdioRequest(join(root, 'graph.json'), {
+                id: 102,
+                method: 'tools/call',
+                params: { name, arguments: args },
+              }),
+            )
+            expect(response).not.toBeNull()
+            const error = (response as { error?: { code: number; message: string } }).error
+            expect(error?.code).toBe(-32601)
+            expect(error?.message).toContain(name)
+            expect(error?.message).toContain('GRAPHIFY_TOOL_PROFILE=full')
+          }
         })
       } finally {
         rmSync(root, { recursive: true, force: true })

--- a/tests/unit/stdio-tool-profile.test.ts
+++ b/tests/unit/stdio-tool-profile.test.ts
@@ -83,6 +83,16 @@ describe('MCP tool profile', () => {
       const actualOrder = activeMcpTools('core').map((tool) => tool.name)
       expect(actualOrder).toEqual(expectedOrder)
     })
+
+    it('adds the context-plane tools only to the full profile', () => {
+      const fullToolNames = activeMcpTools('full').map((tool) => tool.name)
+      const coreToolNames = activeMcpTools('core').map((tool) => tool.name)
+
+      expect(fullToolNames).toEqual(expect.arrayContaining(['context_pack', 'context_prompt', 'context_session_reset']))
+      expect(coreToolNames).not.toContain('context_pack')
+      expect(coreToolNames).not.toContain('context_prompt')
+      expect(coreToolNames).not.toContain('context_session_reset')
+    })
   })
 
   describe('resolveToolProfileFromEnv', () => {
@@ -196,6 +206,28 @@ describe('MCP tool profile', () => {
           expect(error?.message).toContain('.cursor/mcp.json')
           expect(error?.message).toContain('.vscode/mcp.json')
           expect(error?.message).toContain('feature_map')
+        })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it('tools/call blocks context-plane tools behind the full profile gate', async () => {
+      const root = createMinimalGraphRoot()
+      try {
+        await withProfile('core', async () => {
+          const response = await Promise.resolve(
+            handleStdioRequest(join(root, 'graph.json'), {
+              id: 102,
+              method: 'tools/call',
+              params: { name: 'context_pack', arguments: { prompt: 'unused' } },
+            }),
+          )
+          expect(response).not.toBeNull()
+          const error = (response as { error?: { code: number; message: string } }).error
+          expect(error?.code).toBe(-32601)
+          expect(error?.message).toContain('context_pack')
+          expect(error?.message).toContain('GRAPHIFY_TOOL_PROFILE=full')
         })
       } finally {
         rmSync(root, { recursive: true, force: true })

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -29,6 +29,11 @@ describe('public marketing copy honesty', () => {
     it('discloses the cold-start cost premium honestly', () => {
       expect(lower).toMatch(/cold[- ]start|cost parity|amortize/i)
     })
+
+    it('positions graphify-ts as a context plane and context compiler', () => {
+      expect(lower).toContain('context plane')
+      expect(lower).toContain('context compiler')
+    })
   })
 
   describe('README.md', () => {
@@ -45,6 +50,30 @@ describe('public marketing copy honesty', () => {
       expect(content).toContain('| **Latency**')
       expect(content).toMatch(/35 sec|35 ?s/i)
       expect(content).toMatch(/96 sec|96 ?s/i)
+    })
+
+    it('documents the pack and prompt command surfaces', () => {
+      expect(content).toContain('graphify-ts pack')
+      expect(content).toContain('graphify-ts prompt')
+      expect(lower).toContain('context plane')
+    })
+
+    it('keeps the README core MCP surface aligned with the shipped graph_stats tool', () => {
+      expect(content).toContain('These six MCP tools')
+      expect(content).toContain('`graph_stats`')
+    })
+  })
+
+  describe('examples/mcp-tool-examples.md', () => {
+    const content = readDoc('examples/mcp-tool-examples.md')
+    const lower = content.toLowerCase()
+
+    it('documents the context-plane MCP tools', () => {
+      expect(content).toContain('## context_pack')
+      expect(content).toContain('## context_prompt')
+      expect(content).toContain('## context_session_reset')
+      expect(lower).toContain('effective_token_count')
+      expect(lower).toContain('coverage')
     })
   })
 })

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -62,6 +62,11 @@ describe('public marketing copy honesty', () => {
       expect(content).toContain('These six MCP tools')
       expect(content).toContain('`graph_stats`')
     })
+
+    it('keeps the README full MCP additions list aligned with the shipped get_neighbors tool', () => {
+      expect(content).toContain('The full surface is 24 tools')
+      expect(content).toContain('`get_neighbors`')
+    })
   })
 
   describe('examples/mcp-tool-examples.md', () => {


### PR DESCRIPTION
## Summary
- add shared context-pack and context-session layers, then expose them through new `pack` / `prompt` CLI commands and MCP context-plane tools
- unify compare, review, and benchmark prompt generation around cache-aware prompt/session payloads with effective-cost and coverage metadata
- refresh README, examples, and benchmark proof language to match the implemented context-plane surface, and restore clean-install compatibility on this environment

## Test Plan
- npm run typecheck
- npm run test:run
- npm run build
- npm pack --dry-run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pack` and `prompt` CLI commands, provider-specific prompt compilation, context-pack tooling, and three context-session MCP tools (`context_pack`, `context_prompt`, `context_session_reset`).
  * Session-aware prompts with session-delta follow-ups and cache-reuse payloads.

* **Enhancements**
  * Effective (cache-adjusted) token accounting surfaced in benchmarks, compare, and reports.

* **Documentation**
  * README/docs updated to present the “context plane”/“context compiler”, CLI usage, tool profiles, and effective-cost framing.

* **Tests**
  * Expanded unit tests for CLI, MCP tools, sessions, benchmarks, and context-pack behavior.

* **Chores**
  * Package metadata (description/keywords) updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->