### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-08
+
+### Added
+
+- **Task-context planner release**: added task-intent classification, task-specific evidence recipes, semantic coverage reporting, stable expandable handles, and planner-backed `task_intent` / `plan` metadata across compact context-pack surfaces.
+- **Executable MCP expansion**: added the full-profile `context_expand` MCP tool so agents can reopen omitted context slices from a prior `context_pack` response inside the same MCP session.
+
+### Changed
+
+- **Context-pack/runtime alignment**: aligned CLI `pack` and MCP `context_pack` around planner-aware metadata, normalized budget handling, and consistent impact-target selection.
+- **Docs and examples**: refreshed the README, proof workflows, and MCP examples so the 25-tool full surface, `context_expand`, semantic coverage, and provider/runtime proof disclosures match the shipped runtime.
+
+### Fixed
+
+- **Provider-proof honesty**: corrected compare and benchmark proof reporting so zero-cache provider usage is no longer described as provider-reported cache-read evidence.
+- **Impact and expansion metadata**: preserved `target_file_type` in compact impact payloads, trimmed impact target labels before follow-up lookup, hardened fallback line-range handling, and reject malformed stored `context_expand` handles instead of failing with generic runtime errors.
+- **Workspace hygiene**: added `.test-artifacts/` to `.gitignore` so local test artifacts stay out of release branches and PRs.
+
 ## [0.12.0] - 2026-05-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.12.0",
+            "version": "0.13.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Build a local context plane and context compiler from code, docs, and mixed project folders.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

- bump the package version to `0.13.0`
- add the `0.13.0` changelog entry for the task-context planner release and follow-up fixes
- include the `.test-artifacts/` ignore cleanup in the release notes

## Testing

- [x] `npm run test:run`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm pack --dry-run`

## Notes

- This release captures the merged task-context planner work from #60 plus the `.test-artifacts/` ignore cleanup from #61.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task-context planning with intent classification
  * Semantic coverage reporting
  * Full-profile context expansion tool for MCP
  * Stable expandable handles

* **Bug Fixes**
  * Fixed provider-proof reporting accuracy
  * Preserved target_file_type in compact payloads
  * Improved line-range fallback handling
  * Enhanced validation for stored context handles

* **Documentation**
  * Updated examples and documentation for new capabilities

* **Chores**
  * Workspace hygiene improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->