### PR TITLE
Handle answer-only native compare runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ graphify-ts federate frontend/graph.json backend/graph.json  # multi-repo merge
 graphify-ts --help                              # full surface
 ```
 
+For `compare --baseline-mode native_agent`, use a structured Anthropic runner like `cat {prompt_file} | claude -p --output-format json` when you want billed-token reductions. Plain-text Claude runs still save both answers, but the report becomes answer-only and cannot compute provider-proof reductions.
+
 ---
 
 ## Context-plane surfaces

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -36,6 +36,8 @@ node dist/src/cli/bin.js compare "How does login create a session?" \
   --yes
 ```
 
+If you switch to `--baseline-mode native_agent`, prefer a structured Anthropic runner such as `cat {prompt_file} | claude -p --output-format json`. Plain-text Claude runs still save paired answers, but the report cannot compute Anthropic-billed reductions without the trailing JSON usage block.
+
 Gemini-safe installed-CLI invocation:
 
 ```bash

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -356,7 +356,7 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
     '    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}',
     '    --questions PATH      load questions from a JSON file instead of a positional question',
     '    --output-dir DIR      compare output directory (default graphify-out/compare)',
-    '    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice and reports Anthropic-billed usage)',
+    '    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
     '    --yes                 skip confirmation before running the paid prompt comparison',
     '    --limit N             cap processed prompts/questions for the comparison run',
     '  review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff',

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1317,7 +1317,7 @@ export async function runCompareCommand(
 ): Promise<string> {
   if (input.baselineMode === 'native_agent') {
     const nativeResult = await executeNativeAgentCompare(input, dependencies)
-    const failed = nativeResult.reports.filter((report) => report.baseline.kind !== 'succeeded' || report.graphify.kind !== 'succeeded').length
+    const failed = nativeResult.reports.filter((report) => isNativeAgentRunFailure(report.baseline) || isNativeAgentRunFailure(report.graphify)).length
     if (failed > 0) {
       throw new Error(`[graphify compare] ${failed} native_agent run(s) failed. Partial artifacts were saved under ${nativeResult.output_root}`)
     }
@@ -1379,6 +1379,7 @@ export interface AnthropicResultEvent {
 
 export type NativeAgentRunStatus =
   | { kind: 'succeeded'; model: string | null; usage: AnthropicUsageBlock; total_input_tokens_anthropic_exact: number; total_cost_usd: number | null; num_turns: number; duration_ms: number; result_path: string }
+  | { kind: 'answer_only'; evidence: string | null; exit_code: number; stderr: string | null; result_path: string }
   | { kind: 'runner_error'; evidence: string | null; exit_code: number | null; stderr: string | null }
 
 export interface NativeAgentCompareReport {
@@ -1596,6 +1597,10 @@ function computeReduction(baseline: number, graphify: number): number | null {
   return Number((baseline / graphify).toFixed(2))
 }
 
+function isNativeAgentRunFailure(run: NativeAgentRunStatus): boolean {
+  return run.kind === 'runner_error'
+}
+
 function totalAnthropicInputTokens(usage: AnthropicUsageBlock): number {
   return usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
 }
@@ -1708,12 +1713,21 @@ export async function executeNativeAgentCompare(
           }
           ensureCompareAnswerFile(baselineAnswerPath, event.result ?? baselineRun.stdout)
         } else {
-          reportShell.baseline = {
-            kind: 'runner_error',
-            evidence: baselineRun.stdout.slice(0, 2000),
-            exit_code: baselineRun.exitCode,
-            stderr: sanitizeCompareStderr(baselineRun.stderr),
-          }
+          reportShell.baseline =
+            baselineRun.exitCode === 0
+              ? {
+                  kind: 'answer_only',
+                  evidence: baselineRun.stdout.slice(0, 2000),
+                  exit_code: baselineRun.exitCode,
+                  stderr: sanitizeCompareStderr(baselineRun.stderr),
+                  result_path: baselineAnswerPath,
+                }
+              : {
+                  kind: 'runner_error',
+                  evidence: baselineRun.stdout.slice(0, 2000),
+                  exit_code: baselineRun.exitCode,
+                  stderr: sanitizeCompareStderr(baselineRun.stderr),
+                }
           ensureCompareAnswerFile(baselineAnswerPath, baselineRun.stdout)
         }
       }
@@ -1772,12 +1786,21 @@ export async function executeNativeAgentCompare(
         }
         ensureCompareAnswerFile(graphifyAnswerPath, event.result ?? graphifyRun.stdout)
       } else {
-        reportShell.graphify = {
-          kind: 'runner_error',
-          evidence: graphifyRun.stdout.slice(0, 2000),
-          exit_code: graphifyRun.exitCode,
-          stderr: sanitizeCompareStderr(graphifyRun.stderr),
-        }
+        reportShell.graphify =
+          graphifyRun.exitCode === 0
+            ? {
+                kind: 'answer_only',
+                evidence: graphifyRun.stdout.slice(0, 2000),
+                exit_code: graphifyRun.exitCode,
+                stderr: sanitizeCompareStderr(graphifyRun.stderr),
+                result_path: graphifyAnswerPath,
+              }
+            : {
+                kind: 'runner_error',
+                evidence: graphifyRun.stdout.slice(0, 2000),
+                exit_code: graphifyRun.exitCode,
+                stderr: sanitizeCompareStderr(graphifyRun.stderr),
+              }
         ensureCompareAnswerFile(graphifyAnswerPath, graphifyRun.stdout)
       }
     }
@@ -1845,16 +1868,28 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
     `- Output: ${result.output_root}`,
   ]
   for (const report of result.reports) {
-    if (report.baseline.kind !== 'succeeded' || report.graphify.kind !== 'succeeded') {
+    if (isNativeAgentRunFailure(report.baseline) || isNativeAgentRunFailure(report.graphify)) {
       lines.push(`- "${report.question}" → runner error (see ${portablePath(report.paths.report)})`)
       continue
     }
+    if (report.baseline.kind === 'answer_only' || report.graphify.kind === 'answer_only') {
+      lines.push(`- "${report.question}" → answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed (see ${portablePath(report.paths.report)})`)
+      continue
+    }
+
+    const baseline = report.baseline
+    const graphify = report.graphify
+    if (baseline.kind !== 'succeeded' || graphify.kind !== 'succeeded') {
+      lines.push(`- "${report.question}" → runner error (see ${portablePath(report.paths.report)})`)
+      continue
+    }
+
     const reductions = report.reductions
     lines.push(
       `- "${report.question}"`,
-      `    num_turns: baseline ${report.baseline.num_turns} → graphify ${report.graphify.num_turns}${reductions?.num_turns ? ` (${reductions.num_turns}x fewer)` : ''}`,
-      `    latency:   baseline ${report.baseline.duration_ms}ms → graphify ${report.graphify.duration_ms}ms${reductions?.duration_ms ? ` (${reductions.duration_ms}x faster)` : ''}`,
-      `    input_tokens (Anthropic-reported): baseline ${report.baseline.total_input_tokens_anthropic_exact} → graphify ${report.graphify.total_input_tokens_anthropic_exact}${reductions?.input_tokens ? ` (${reductions.input_tokens}x less)` : ''}`,
+      `    num_turns: baseline ${baseline.num_turns} → graphify ${graphify.num_turns}${reductions?.num_turns ? ` (${reductions.num_turns}x fewer)` : ''}`,
+      `    latency:   baseline ${baseline.duration_ms}ms → graphify ${graphify.duration_ms}ms${reductions?.duration_ms ? ` (${reductions.duration_ms}x faster)` : ''}`,
+      `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → graphify ${graphify.total_input_tokens_anthropic_exact}${reductions?.input_tokens ? ` (${reductions.input_tokens}x less)` : ''}`,
       `    provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs`,
     )
   }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -786,7 +786,7 @@ describe('cli main', () => {
     expect(help).toContain('    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}')
     expect(help).toContain('    --questions PATH      load questions from a JSON file instead of a positional question')
     expect(help).toContain('    --output-dir DIR      compare output directory (default graphify-out/compare)')
-    expect(help).toContain('    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice and reports Anthropic-billed usage)')
+    expect(help).toContain('    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)')
     expect(help).toContain('    --yes                 skip confirmation before running the paid prompt comparison')
     expect(help).toContain('    --limit N             cap processed prompts/questions for the comparison run')
     expect(help).toContain('review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff')

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -324,7 +324,7 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
-  it('falls back to runner_error when stdout has no parseable result event', async () => {
+  it('preserves answer-only runs when stdout has no parseable result event but the runner exits cleanly', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     try {
       const garbledRunner: NativeAgentRunner = async () => ({
@@ -349,10 +349,12 @@ describe('executeNativeAgentCompare', () => {
       )
 
       const report = result.reports[0] as NativeAgentCompareReport
-      expect(report.baseline.kind).toBe('runner_error')
-      if (report.baseline.kind === 'runner_error') {
+      expect(report.baseline.kind).toBe('answer_only')
+      if (report.baseline.kind === 'answer_only') {
         expect(report.baseline.evidence).toContain('not JSON')
+        expect(report.baseline.exit_code).toBe(0)
       }
+      expect(report.graphify.kind).toBe('answer_only')
       expect(report.reductions).toBeNull()
     } finally {
       rmSync(projectDir, { recursive: true, force: true })

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1533,6 +1533,52 @@ describe('compare runtime', () => {
     ).resolves.toContain('context overflow')
   })
 
+  it('does not fail native_agent compare when the runner returns plain-text answers without provider usage metadata', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const outputTimestamp = '2026-04-24T19-30-00'
+
+    await expect(
+      runCompareCommand(
+        {
+          graphPath,
+          question: 'how does login create a session',
+          outputDir: COMPARE_OUTPUT_ROOT,
+          execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+          baselineMode: 'native_agent',
+          now: new Date('2026-04-24T19:30:00.000Z'),
+        },
+        {
+          now: () => new Date('2026-04-24T19:30:00.000Z'),
+          runner: async (execution) => ({
+            exitCode: 0,
+            stdout: execution.mode === 'baseline' ? 'baseline answer\n' : 'graphify answer\n',
+            stderr: '',
+            elapsedMs: 5,
+          }),
+        },
+      ),
+    ).resolves.toContain('no Anthropic usage block')
+
+    const report = JSON.parse(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'report.json'), 'utf8')) as Record<string, unknown>
+    expect(report).toEqual(
+      expect.objectContaining({
+        baseline: expect.objectContaining({
+          kind: 'answer_only',
+          exit_code: 0,
+        }),
+        graphify: expect.objectContaining({
+          kind: 'answer_only',
+          exit_code: 0,
+        }),
+        reductions: null,
+      }),
+    )
+    expect(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'baseline-answer.txt'), 'utf8')).toBe('baseline answer\n')
+    expect(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'graphify-answer.txt'), 'utf8')).toBe('graphify answer\n')
+  })
+
   it('marks invalid compare placeholders as failed runs in persisted reports', async () => {
     const graph = makeGraph()
     writeProjectFiles()


### PR DESCRIPTION
## Summary
- treat native-agent compare exit-0 plain-text Claude runs as answer-only artifacts instead of runner failures
- keep Anthropic JSON usage behavior unchanged while clarifying when provider-proof reductions are unavailable
- add regression coverage and update compare/native-agent guidance in help and docs

## Testing
- npm run typecheck
- npm run test:run
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified how to use `--baseline-mode native_agent` with structured Anthropic runners for token reduction metrics versus plain-text runners for answer-only artifacts
  * Updated CLI help text to reflect this behavior distinction

* **Bug Fixes**
  * The `compare` command now gracefully handles plain-text runner outputs lacking token usage metadata, storing them as answer-only artifacts instead of reporting errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->