### PR TITLE
Prepare v0.13.2 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-05-08
+
+### Fixed
+
+- **Native-agent compare fallback**: preserve exit-0 plain-text `compare --baseline-mode native_agent` runs as answer-only artifacts instead of misclassifying them as failures when Anthropic JSON usage blocks are unavailable.
+- **Release metadata alignment**: realigned the package version and changelog with the post-merge release tag workflow so GitHub release validation passes on the next tagged cut.
+
 ## [0.13.0] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to the TypeScript package will be documented in this file.
 - **Native-agent compare fallback**: preserve exit-0 plain-text `compare --baseline-mode native_agent` runs as answer-only artifacts instead of misclassifying them as failures when Anthropic JSON usage blocks are unavailable.
 - **Release metadata alignment**: realigned the package version and changelog with the post-merge release tag workflow so GitHub release validation passes on the next tagged cut.
 
+## [0.13.1] - 2026-05-08
+
+### Note
+
+- **Superseded release tag**: `v0.13.1` was published before `package.json` and `CHANGELOG.md` were advanced from `0.13.0`, so the release workflow rejected it. Use `v0.13.2` for the corrected post-merge release.
+
 ## [0.13.0] - 2026-05-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.13.0",
+    "version": "0.13.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.13.0",
+            "version": "0.13.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.13.0",
+    "version": "0.13.2",
     "description": "Build a local context plane and context compiler from code, docs, and mixed project folders.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump package metadata to 0.13.2 so the release workflow matches the next clean tag
- add changelog entries for the native-agent compare fix and the superseded v0.13.1 tag
- verify the release gate and package dry-run locally before cutting the next release

## Testing
- release tag/version/changelog validation snippet
- npm run typecheck
- npm run test:run
- npm run build
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preservation of baseline comparison results as answer artifacts when JSON processing is unavailable
  * Corrected release metadata alignment across package and changelog files for proper GitHub release validation
  * Added clarification about v0.13.1 supersession due to premature publication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->