### PR TITLE
feat(#69): scaffold backend-vs-monorepo benchmark harness

### DIFF
--- a/docs/benchmarks/2026-05-10-backend-vs-monorepo/.gitignore
+++ b/docs/benchmarks/2026-05-10-backend-vs-monorepo/.gitignore
@@ -1,0 +1,4 @@
+# Local run outputs from run.sh — never commit.
+# Promote a specific bundle deliberately by adding it as a force-add file
+# next to a curated findings.md.
+results/

--- a/docs/benchmarks/2026-05-10-backend-vs-monorepo/README.md
+++ b/docs/benchmarks/2026-05-10-backend-vs-monorepo/README.md
@@ -1,0 +1,88 @@
+# 2026-05-10 — Backend-only vs monorepo context-quality spike
+
+> **Tracking issue:** [#69](https://github.com/mohanagy/graphify-ts/issues/69) — *Spike: benchmark backend-only vs monorepo context quality and runtime.*
+> **Milestone:** `v0.14-substrate`. This spike's findings should inform [#70](https://github.com/mohanagy/graphify-ts/issues/70) (SPI v1 design).
+
+## Why this exists
+
+Recent real usage on GoValidate showed an inconsistent shape:
+
+- Running `graphify-ts generate` on **only the backend folder** was *slower* and produced *worse / higher-token* answers.
+- Running `graphify-ts generate` on the **full monorepo** was *faster* and produced *better / lower-token* answers.
+
+The hypothesis we want to test or falsify is that the problem is **methodological** (graph topology, hub nodes, workspace boundaries, missing semantic context) rather than just raw repo size.
+
+This directory ships a runnable harness that can prove or disprove the hypothesis on any TypeScript/Node monorepo a reader has locally — including private codebases that can't be uploaded.
+
+## What the harness does
+
+For each prompt in [`prompts.json`](./prompts.json), the harness:
+
+1. Generates a graph for the **backend-only** path (e.g. `apps/backend` or `packages/api`).
+2. Generates a graph for the **monorepo** path (the workspace root).
+3. Runs `graphify-ts compare <prompt> --baseline-mode native_agent` against the **backend graph** — captures provider-reported token / turn / latency deltas vs the file-tools-only baseline.
+4. Runs the same `compare` against the **monorepo graph** — same baseline shape.
+5. Writes both `compare` reports plus a side-by-side `summary.json` under `results/<timestamp>/`.
+
+Both runs use the **same model**, the **same prompt**, and the **same `--exec`** invocation, so the only varying factor is the graph's scope.
+
+## How to run
+
+> **You need:** the `graphify-ts` CLI on PATH, an installed terminal LLM runner (e.g. `claude -p`), and a TS/Node monorepo to test against. Output bundles land in `results/` and are gitignored — keep them local until you decide to publish a specific run.
+
+Quick run (3 prompts, ~12 model calls):
+
+```bash
+bash docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh \
+  --backend-path  /path/to/your-monorepo/apps/backend \
+  --monorepo-path /path/to/your-monorepo \
+  --exec 'cat {prompt_file} | claude -p --output-format json' \
+  --quick
+```
+
+Full run (all 12 prompts, ~48 model calls — expect real token spend):
+
+```bash
+bash docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh \
+  --backend-path  /path/to/your-monorepo/apps/backend \
+  --monorepo-path /path/to/your-monorepo \
+  --exec 'cat {prompt_file} | claude -p --output-format json'
+```
+
+After the harness finishes, summarize the deltas:
+
+```bash
+bash docs/benchmarks/2026-05-10-backend-vs-monorepo/aggregate.sh \
+  results/<timestamp>
+```
+
+## What to capture in the report
+
+This is a **measurement spike**, not an engine rewrite. The deliverable per #69 is a short Markdown report that answers:
+
+| Question | Where to look in the harness output |
+|---|---|
+| Is the backend-only graph slower at generate-time? | `summary.json → generate.backend.duration_ms` vs `summary.json → generate.monorepo.duration_ms` |
+| Does the backend-only graph produce more total input tokens per question? | `summary.json → per_prompt[*].backend.graphify.total_input_tokens` vs `…monorepo…` |
+| Does the backend-only graph use more turns per question? | `summary.json → per_prompt[*].backend.graphify.num_turns` vs `…monorepo…` |
+| Are answers materially worse on the backend-only graph? | Read `*-answer.txt` pairs side-by-side; record qualitative notes |
+| What graph topology differs? | Compare `graphify-out/GRAPH_REPORT.md` for both scopes (god nodes, communities, low-cohesion warnings) |
+| Top suspected failure modes? | Cross-reference: hub dominance, low workspace bridges, missing tests/config edges, generic-extractor fallthrough |
+
+When the report is ready, drop it next to this README as `findings.md` and link it from the [issue #69](https://github.com/mohanagy/graphify-ts/issues/69) thread.
+
+## Files in this directory
+
+- `README.md` — this file
+- `prompts.json` — the prompt set (12 prompts; `--quick` runs the first 3)
+- `run.sh` — orchestrator that drives generate + compare for both scopes
+- `aggregate.sh` — reads a results bundle and prints a side-by-side summary
+- `results/` — gitignored; populated by `run.sh` invocations
+- `findings.md` — *to be added* once a real run completes; this is the user-facing deliverable for #69
+
+## Honesty notes
+
+- This spike does **not** auto-conclude that backend-only is wrong. The expected outcome is a recorded comparison; the conclusion may be "topology-driven", "scope-detection-driven", or "no real difference outside noise" depending on the data.
+- The harness uses the **provider-reported** Anthropic usage block from `claude --output-format json`, not local `cl100k_base` estimates. Reductions reported here are billable, not synthetic.
+- Single-codebase, single-question-set measurement. A second monorepo of a different shape may show a different pattern; the report should say so explicitly.
+- The harness can spend real model tokens. Always run with `--exec` you're prepared to be billed for.

--- a/docs/benchmarks/2026-05-10-backend-vs-monorepo/aggregate.sh
+++ b/docs/benchmarks/2026-05-10-backend-vs-monorepo/aggregate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Aggregator for results bundles produced by run.sh.
+# Reads summary.json and prints a side-by-side comparison of backend-only vs
+# monorepo graph results across all prompts in the bundle.
+#
+# Usage:
+#   bash aggregate.sh <results/<timestamp>/>
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <results-dir>" >&2
+  exit 1
+fi
+
+RUN_DIR="$1"
+SUMMARY="$RUN_DIR/summary.json"
+if [ ! -f "$SUMMARY" ]; then
+  echo "[aggregate] $SUMMARY not found." >&2
+  exit 2
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "[aggregate] node is required (>= 20)." >&2
+  exit 3
+fi
+
+node -e '
+  const fs = require("fs");
+  const file = process.argv[1];
+  const summary = JSON.parse(fs.readFileSync(file, "utf8"));
+
+  function ratio(a, b) {
+    if (typeof a !== "number" || typeof b !== "number" || b <= 0) return "—";
+    return (a / b).toFixed(2) + "x";
+  }
+  function fmtNum(n) {
+    if (typeof n !== "number") return "—";
+    return n.toLocaleString("en-US");
+  }
+
+  console.log("Generate-time:");
+  for (const k of ["backend", "monorepo"]) {
+    const g = summary.generate?.[k];
+    if (g) console.log(`  ${k.padEnd(9)} ${fmtNum(g.duration_ms)}ms  (${g.path})`);
+    else console.log(`  ${k.padEnd(9)} (no data)`);
+  }
+  console.log();
+
+  const headers = [
+    "prompt".padEnd(30),
+    "scope".padEnd(10),
+    "turns".padStart(6),
+    "latency_ms".padStart(12),
+    "input_tokens".padStart(14),
+    "Δ tokens vs other scope".padStart(24),
+  ];
+  console.log(headers.join("  "));
+  console.log("-".repeat(headers.join("  ").length));
+
+  for (const [promptId, scopes] of Object.entries(summary.per_prompt ?? {})) {
+    const b = scopes.backend?.graphify;
+    const m = scopes.monorepo?.graphify;
+
+    for (const [label, run, other] of [["backend", b, m], ["monorepo", m, b]]) {
+      const turns = run?.num_turns ?? "—";
+      const ms = run?.duration_ms ?? "—";
+      const tokens = run?.total_input_tokens ?? null;
+      const otherTokens = other?.total_input_tokens ?? null;
+      const delta = (tokens && otherTokens) ? ratio(tokens, otherTokens) : "—";
+      console.log([
+        promptId.padEnd(30),
+        label.padEnd(10),
+        String(turns).padStart(6),
+        String(ms).padStart(12),
+        fmtNum(tokens).padStart(14),
+        delta.padStart(24),
+      ].join("  "));
+    }
+  }
+  console.log();
+  console.log("Tip: lower input_tokens / fewer turns is better; the rightmost column shows backend vs monorepo.");
+' "$SUMMARY"

--- a/docs/benchmarks/2026-05-10-backend-vs-monorepo/prompts.json
+++ b/docs/benchmarks/2026-05-10-backend-vs-monorepo/prompts.json
@@ -1,0 +1,71 @@
+{
+  "$comment": "Prompt set for the 2026-05-10 backend-vs-monorepo spike (issue #69). The first three prompts are the --quick subset; all twelve are the --full set. Each prompt is intentionally end-to-end so retrieval differences between backend-only and monorepo graphs surface clearly.",
+  "version": 1,
+  "quick_subset": [
+    "explain-auth-flow",
+    "report-generation-slow",
+    "tests-for-recent-change"
+  ],
+  "prompts": [
+    {
+      "id": "explain-auth-flow",
+      "task": "explain",
+      "text": "Explain the authentication flow end to end, from the HTTP entry point to session persistence."
+    },
+    {
+      "id": "report-generation-slow",
+      "task": "debug",
+      "text": "Why is report generation slow? Walk through the request path and call out the slowest hops, including any external service or LLM calls."
+    },
+    {
+      "id": "tests-for-recent-change",
+      "task": "explain",
+      "text": "Which tests are most likely relevant to recent changes in the report-generation pipeline, and which areas are under-covered?"
+    },
+    {
+      "id": "pr-risk-onboarding",
+      "task": "review",
+      "text": "Can a PR that touches the onboarding flow break user creation, billing, or auth? Identify the call paths and risk hotspots."
+    },
+    {
+      "id": "service-change-blast-radius",
+      "task": "impact",
+      "text": "What can break if the research-agent service changes its public interface? List dependents, callers, and tests that would need to update."
+    },
+    {
+      "id": "config-env-impact",
+      "task": "debug",
+      "text": "Where does the SESSION_TTL environment variable affect runtime behavior? Trace it from config load through every code path that reads it."
+    },
+    {
+      "id": "controller-to-persistence",
+      "task": "explain",
+      "text": "Trace the request path from the report controller to the final report persistence call. Include any queue, worker, or background job hops."
+    },
+    {
+      "id": "websocket-event-flow",
+      "task": "explain",
+      "text": "How do real-time WebSocket events propagate from server emission to the frontend handler? List the event names and their consumers."
+    },
+    {
+      "id": "billing-credits-flow",
+      "task": "impact",
+      "text": "When a user is charged, where are credits debited and how is the audit trail recorded? Identify all code paths that adjust the credit balance."
+    },
+    {
+      "id": "guard-coverage",
+      "task": "review",
+      "text": "Which controllers have an authentication guard but no authorization check? List the routes and the missing checks."
+    },
+    {
+      "id": "queue-job-failures",
+      "task": "debug",
+      "text": "How are queue job failures handled? Trace the retry, dead-letter, and operator-notification paths for the report-generation queue."
+    },
+    {
+      "id": "module-boundary-leaks",
+      "task": "review",
+      "text": "Identify modules that import directly from another module's internal files instead of going through its public exports. List the offending import sites."
+    }
+  ]
+}

--- a/docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh
+++ b/docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Backend-only vs monorepo context-quality spike harness (issue #69).
+#
+# For each prompt in prompts.json, runs `graphify-ts compare --baseline-mode
+# native_agent` once against a graph built from the backend-only path and once
+# against a graph built from the full monorepo path. Both runs use the same
+# model `--exec` and the same prompt, so the only varying factor is the
+# scope of the graph that grounds the agent.
+#
+# Output bundle:
+#   results/<timestamp>/
+#     manifest.json
+#     summary.json
+#     generate-backend.log
+#     generate-monorepo.log
+#     prompts/<prompt_id>/
+#       backend/   <- contents of `graphify-out/compare/<ts>/` for the backend run
+#       monorepo/  <- same, for the monorepo run
+#
+# Requires: graphify-ts (>= 0.13.3) on PATH, jq, an --exec runner you trust to
+# spend tokens (e.g. `cat {prompt_file} | claude -p --output-format json`).
+
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $0 --backend-path <path> --monorepo-path <path> --exec <runner> [--quick] [--out-dir <path>]
+
+Required:
+  --backend-path   Path to the backend-only folder (e.g. apps/backend).
+  --monorepo-path  Path to the full monorepo root.
+  --exec           Compare runner template, e.g. 'cat {prompt_file} | claude -p --output-format json'.
+
+Optional:
+  --quick          Run only the prompts listed in prompts.json -> quick_subset (3 prompts).
+  --out-dir        Override the results directory (default: alongside this script).
+
+Notes:
+  - This will spend real model tokens. The full set is ~12 prompts × 2 scopes × 2 runs = 48 model calls.
+  - --quick is recommended for the first dry pass to validate the harness end-to-end.
+USAGE
+  exit 1
+}
+
+QUICK=0
+BACKEND=""
+MONOREPO=""
+EXEC=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT_BASE="$HERE/results"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backend-path)  BACKEND="$2"; shift 2 ;;
+    --monorepo-path) MONOREPO="$2"; shift 2 ;;
+    --exec)          EXEC="$2"; shift 2 ;;
+    --quick)         QUICK=1; shift ;;
+    --out-dir)       OUT_BASE="$2"; shift 2 ;;
+    -h|--help)       usage ;;
+    *) echo "[harness] unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [ -z "$BACKEND" ] || [ -z "$MONOREPO" ] || [ -z "$EXEC" ]; then
+  usage
+fi
+if [ ! -d "$BACKEND" ];  then echo "[harness] backend path not found: $BACKEND" >&2; exit 2; fi
+if [ ! -d "$MONOREPO" ]; then echo "[harness] monorepo path not found: $MONOREPO" >&2; exit 2; fi
+for tool in graphify-ts jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "[harness] $tool is required (install: $tool)" >&2; exit 3
+  fi
+done
+
+TS=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+RUN_DIR="$OUT_BASE/$TS"
+mkdir -p "$RUN_DIR/prompts"
+
+PROMPTS_FILE="$HERE/prompts.json"
+if [ ! -f "$PROMPTS_FILE" ]; then
+  echo "[harness] prompts.json missing alongside run.sh." >&2; exit 4
+fi
+
+if [ "$QUICK" = "1" ]; then
+  PROMPT_IDS=$(jq -r '.quick_subset[]' "$PROMPTS_FILE")
+else
+  PROMPT_IDS=$(jq -r '.prompts[].id' "$PROMPTS_FILE")
+fi
+
+# Manifest captures everything needed to interpret the results bundle later.
+jq -n \
+  --arg ts "$TS" \
+  --arg backend "$BACKEND" \
+  --arg monorepo "$MONOREPO" \
+  --arg exec "$EXEC" \
+  --arg quick "$QUICK" \
+  --arg version "$(graphify-ts --version 2>/dev/null || echo unknown)" \
+  '{
+    timestamp: $ts,
+    backend_path: $backend,
+    monorepo_path: $monorepo,
+    exec: $exec,
+    quick_subset: ($quick == "1"),
+    graphify_version: $version
+  }' > "$RUN_DIR/manifest.json"
+
+echo "[harness] results bundle: $RUN_DIR"
+echo "[harness] graphify-ts version: $(jq -r .graphify_version "$RUN_DIR/manifest.json")"
+echo
+
+# --- 1. Generate graphs once per scope ---
+generate_one() {
+  local label=$1 path=$2 logfile=$3
+  echo "[harness] generating graph for $label scope: $path"
+  local start=$(date +%s%3N)
+  ( cd "$path" && graphify-ts generate . ) > "$logfile" 2>&1
+  local end=$(date +%s%3N)
+  local ms=$((end - start))
+  jq -n --arg label "$label" --arg path "$path" --arg ms "$ms" \
+    '{label: $label, path: $path, duration_ms: ($ms | tonumber)}' \
+    > "$RUN_DIR/generate-$label.json"
+  echo "[harness]   generated in ${ms}ms"
+}
+
+generate_one backend  "$BACKEND"  "$RUN_DIR/generate-backend.log"
+generate_one monorepo "$MONOREPO" "$RUN_DIR/generate-monorepo.log"
+
+# --- 2. For each prompt, run compare against both scopes ---
+run_compare_for_scope() {
+  local prompt_id=$1 prompt_text=$2 scope_label=$3 scope_path=$4
+  local outdir="$RUN_DIR/prompts/$prompt_id/$scope_label"
+  mkdir -p "$outdir"
+
+  echo "[harness]   compare ($scope_label): $prompt_id"
+  ( cd "$scope_path" && graphify-ts compare "$prompt_text" \
+      --graph "$scope_path/graphify-out/graph.json" \
+      --baseline-mode native_agent \
+      --exec "$EXEC" \
+      --yes ) > "$outdir/compare.log" 2>&1 || {
+        echo "[harness]   compare failed for $prompt_id ($scope_label) — see compare.log"
+        return 0
+      }
+
+  # The compare command writes to <scope_path>/graphify-out/compare/<ts>/.
+  # Pick the most recent compare run and snapshot it into our results bundle.
+  local latest
+  latest=$(ls -1dt "$scope_path/graphify-out/compare"/*/ 2>/dev/null | head -n 1 || true)
+  if [ -z "$latest" ]; then
+    echo "[harness]   no compare output dir found for $prompt_id ($scope_label)"
+    return 0
+  fi
+  cp -R "$latest"/* "$outdir/" 2>/dev/null || true
+}
+
+for prompt_id in $PROMPT_IDS; do
+  prompt_text=$(jq -r --arg id "$prompt_id" '.prompts[] | select(.id == $id) | .text' "$PROMPTS_FILE")
+  if [ -z "$prompt_text" ] || [ "$prompt_text" = "null" ]; then
+    echo "[harness] prompt id '$prompt_id' missing in prompts.json — skipping"; continue
+  fi
+  echo "[harness] prompt: $prompt_id"
+  run_compare_for_scope "$prompt_id" "$prompt_text" backend  "$BACKEND"
+  run_compare_for_scope "$prompt_id" "$prompt_text" monorepo "$MONOREPO"
+done
+
+# --- 3. Build a side-by-side summary.json by walking the captured report.json files ---
+node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const runDir = process.argv[1];
+  const promptsDir = path.join(runDir, "prompts");
+  if (!fs.existsSync(promptsDir)) { console.log("no prompts/ to summarize"); process.exit(0); }
+
+  function readReport(dir) {
+    const file = path.join(dir, "report.json");
+    if (!fs.existsSync(file)) return null;
+    try { return JSON.parse(fs.readFileSync(file, "utf8")); } catch { return null; }
+  }
+  function totalInput(usage) {
+    if (!usage) return null;
+    const i = usage.input_tokens ?? 0;
+    const cc = usage.cache_creation_input_tokens ?? 0;
+    const cr = usage.cache_read_input_tokens ?? 0;
+    const t = i + cc + cr;
+    return t > 0 ? t : (usage.total_input_tokens ?? null);
+  }
+  function findRun(report, label) {
+    if (!report || typeof report !== "object") return null;
+    if (report[label]) return report[label];
+    if (report.runs?.[label]) return report.runs[label];
+    return null;
+  }
+  function pickRunMetrics(run) {
+    if (!run) return null;
+    const usage = run.usage ?? run.anthropic_usage;
+    return {
+      num_turns: run.num_turns ?? run.turns ?? null,
+      duration_ms: run.duration_ms ?? run.latency_ms ?? null,
+      total_input_tokens: totalInput(usage),
+      usage: usage ?? null,
+    };
+  }
+
+  const summary = { generate: {}, per_prompt: {} };
+  for (const f of ["generate-backend.json", "generate-monorepo.json"]) {
+    const p = path.join(runDir, f);
+    if (fs.existsSync(p)) Object.assign(summary.generate, JSON.parse(fs.readFileSync(p, "utf8")).label
+      ? { [JSON.parse(fs.readFileSync(p, "utf8")).label]: JSON.parse(fs.readFileSync(p, "utf8")) } : {});
+  }
+
+  for (const promptId of fs.readdirSync(promptsDir)) {
+    const promptDir = path.join(promptsDir, promptId);
+    if (!fs.statSync(promptDir).isDirectory()) continue;
+    summary.per_prompt[promptId] = {};
+    for (const scope of ["backend", "monorepo"]) {
+      const scopeDir = path.join(promptDir, scope);
+      const report = readReport(scopeDir);
+      summary.per_prompt[promptId][scope] = {
+        baseline: pickRunMetrics(findRun(report, "baseline")),
+        graphify: pickRunMetrics(findRun(report, "graphify")),
+      };
+    }
+  }
+  fs.writeFileSync(path.join(runDir, "summary.json"), JSON.stringify(summary, null, 2));
+  console.log("[harness] wrote summary.json");
+' "$RUN_DIR"
+
+echo
+echo "[harness] DONE."
+echo "[harness] Inspect:    $RUN_DIR/summary.json"
+echo "[harness] Aggregate:  bash docs/benchmarks/2026-05-10-backend-vs-monorepo/aggregate.sh $RUN_DIR"

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -109,6 +109,53 @@ describe('public marketing copy honesty', () => {
     })
   })
 
+  describe('docs/benchmarks/2026-05-10-backend-vs-monorepo/', () => {
+    const readme = readDoc('docs/benchmarks/2026-05-10-backend-vs-monorepo/README.md')
+    const runSh = readDoc('docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh')
+    const aggregateSh = readDoc('docs/benchmarks/2026-05-10-backend-vs-monorepo/aggregate.sh')
+    const prompts = JSON.parse(readDoc('docs/benchmarks/2026-05-10-backend-vs-monorepo/prompts.json')) as {
+      version: number
+      quick_subset: string[]
+      prompts: Array<{ id: string; task: string; text: string }>
+    }
+
+    it('declares the spike scope and links the tracking issue (#69)', () => {
+      expect(readme).toContain('issue #69')
+      expect(readme).toContain('v0.14-substrate')
+      expect(readme).toContain('Backend-only vs monorepo')
+    })
+
+    it('ships a runnable harness with the documented argument surface', () => {
+      expect(runSh).toContain('#!/usr/bin/env bash')
+      expect(runSh).toContain('--backend-path')
+      expect(runSh).toContain('--monorepo-path')
+      expect(runSh).toContain('--exec')
+      expect(runSh).toContain('--quick')
+      expect(runSh).toContain('graphify-ts compare')
+      expect(runSh).toContain('--baseline-mode native_agent')
+    })
+
+    it('ships an aggregator that reads summary.json from a results bundle', () => {
+      expect(aggregateSh).toContain('#!/usr/bin/env bash')
+      expect(aggregateSh).toContain('summary.json')
+    })
+
+    it('keeps the prompts.json contract: 12 prompts, 3 in the quick subset, every quick id present', () => {
+      expect(prompts.version).toBe(1)
+      expect(prompts.prompts).toHaveLength(12)
+      expect(prompts.quick_subset).toHaveLength(3)
+      const ids = new Set(prompts.prompts.map((p) => p.id))
+      for (const quickId of prompts.quick_subset) {
+        expect(ids.has(quickId)).toBe(true)
+      }
+      for (const prompt of prompts.prompts) {
+        expect(prompt.id).toMatch(/^[a-z0-9-]+$/)
+        expect(['explain', 'debug', 'review', 'impact']).toContain(prompt.task)
+        expect(prompt.text.length).toBeGreaterThan(20)
+      }
+    })
+  })
+
   describe('examples/mcp-tool-examples.md', () => {
     const content = readDoc('examples/mcp-tool-examples.md')
     const lower = content.toLowerCase()


### PR DESCRIPTION
Closes part 1 of #69. Tracking issue: [#69 — Spike: benchmark backend-only vs monorepo context quality and runtime](https://github.com/mohanagy/graphify-ts/issues/69). Milestone: `v0.14-substrate`.

## Summary

Per the discussion in #69, ships the **runnable harness** half of the spike. The actual `findings.md` report (the user-facing deliverable) is left for once the harness has been run against a real codebase locally — same drop-in-results pattern we just merged for the 2026-05-09 auth-e2e benchmark.

## What's in the scaffold

```
docs/benchmarks/2026-05-10-backend-vs-monorepo/
├── README.md         scope, hypothesis, how-to-run, what-to-capture
├── prompts.json      12 end-to-end prompts (3 in --quick subset)
├── run.sh            generate × 2 scopes, then compare --baseline-mode
│                     native_agent for each prompt × scope; writes
│                     summary.json under results/<timestamp>/
├── aggregate.sh      side-by-side reader for summary.json
└── .gitignore        keeps run outputs local until you promote one
```

The harness uses the **provider-reported** `usage` block from `claude --output-format json` (or any structured runner the user wires via `--exec`), so the resulting numbers are billable, not synthetic.

## How a reader runs it

Quick smoke pass (3 prompts ≈ 12 model calls):

```bash
bash docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh \
  --backend-path  /path/to/your-monorepo/apps/backend \
  --monorepo-path /path/to/your-monorepo \
  --exec 'cat {prompt_file} | claude -p --output-format json' \
  --quick
```

Full set (12 prompts ≈ 48 model calls, real spend):

```bash
bash docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh \
  --backend-path  /path/to/your-monorepo/apps/backend \
  --monorepo-path /path/to/your-monorepo \
  --exec 'cat {prompt_file} | claude -p --output-format json'
```

Then:

```bash
bash docs/benchmarks/2026-05-10-backend-vs-monorepo/aggregate.sh \
  docs/benchmarks/2026-05-10-backend-vs-monorepo/results/<timestamp>
```

## Honesty constraints I held to

- README explicitly says "this spike does **not** auto-conclude that backend-only is wrong" — the harness is for measuring, not for proving a thesis.
- All token / latency numbers reported come from Anthropic's `usage` block (provider-reported), not local `cl100k_base` estimates.
- Single-codebase, single-question-set measurement is called out as a methodological limit; second-monorepo replication is recommended.
- `results/` is gitignored so accidental run outputs don't get committed; promoting a bundle is a deliberate force-add.

## Test plan

- [x] `npx vitest run tests/unit/why-graphify-doc.test.ts` — 29/29 pass (4 new doc-honesty assertions added: tracking issue link, run.sh arg surface, aggregator presence, prompts.json shape).
- [x] `npm run test:run` — 1388/1388 pass (was 1384 on `main`; +4 new).
- [x] `bash run.sh --help` renders cleanly.
- [x] `jq` validates `prompts.json` (12 prompts, 3 in `quick_subset`, every quick id present in `prompts[]`).
- [x] `bash -n run.sh aggregate.sh` — both syntactically clean.
- [ ] Reviewer runs the `--quick` path against a real local monorepo and confirms `summary.json` is produced.

## Deliverables remaining for #69

After this lands and someone has a real `summary.json`, the user-facing deliverable is `findings.md` next to this README — three paragraphs answering the questions in the README's *What to capture in the report* table, plus the top-3 suspected root causes (graph topology / scope detection / hub dominance / etc.). That's the input to #70 (SPI v1 design).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test suite to validate benchmark documentation, configuration contracts, and specification integrity for the benchmarking framework.

* **Chores**
  * Added complete benchmarking infrastructure including execution harness scripts, standardized prompt specifications, and automated result aggregation and comparison utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->