### PR TITLE
feat(#71): current-vs-slicing experiment scaffold + portable timing fix

### DIFF
--- a/docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh
+++ b/docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh
@@ -113,9 +113,9 @@ echo
 generate_one() {
   local label=$1 path=$2 logfile=$3
   echo "[harness] generating graph for $label scope: $path"
-  local start=$(date +%s%3N)
+  local start=$(node -e 'process.stdout.write(String(Date.now()))')
   ( cd "$path" && graphify-ts generate . ) > "$logfile" 2>&1
-  local end=$(date +%s%3N)
+  local end=$(node -e 'process.stdout.write(String(Date.now()))')
   local ms=$((end - start))
   jq -n --arg label "$label" --arg path "$path" --arg ms "$ms" \
     '{label: $label, path: $path, duration_ms: ($ms | tonumber)}' \

--- a/docs/experiments/2026-05-10-current-vs-slicing/.gitignore
+++ b/docs/experiments/2026-05-10-current-vs-slicing/.gitignore
@@ -1,0 +1,4 @@
+# Local run outputs from run.sh — never commit.
+# Promote a specific bundle deliberately by force-adding it next to a curated
+# findings.md.
+results/

--- a/docs/experiments/2026-05-10-current-vs-slicing/README.md
+++ b/docs/experiments/2026-05-10-current-vs-slicing/README.md
@@ -1,0 +1,106 @@
+# 2026-05-10 — Current retrieval vs task-conditioned slicing experiment
+
+> **Tracking issue:** [#71](https://github.com/mohanagy/graphify-ts/issues/71) — *Research spike: compare current graph retrieval vs task-conditioned program slicing.*
+> **Milestone:** `v0.14-substrate`. Findings here gate [#73](https://github.com/mohanagy/graphify-ts/issues/73) (slicer prototype) and inform [#70](https://github.com/mohanagy/graphify-ts/issues/70) (SPI v1 design).
+> **Scope of this scaffold:** strategies 1, 2, and 4 are runnable today. Strategy 3 (slicer) is intentionally a stub — it ships when #73 lands. The honest framing of this experiment is "what we can already measure" plus "what the slicer needs to beat."
+
+## Why this exists
+
+#71 asks: *should graphify-ts move from `repo → graph → retrieval` to `task → anchors → program slice → budgeted context pack`?* That's an architectural pivot, not an optimization. Before any rewrite, we need a measured comparison of:
+
+1. **Current graphify-ts retrieval** (`graphify-ts pack`) — today's behavior.
+2. **Lexical baseline** — ripgrep + window expansion. The dumb-but-fast strawman.
+3. **Task-conditioned slicer prototype** — the candidate replacement. *Stub only until #73.*
+4. **Full-context baseline** *(optional)* — concatenate every TS file under a budget. The "what could the agent have known" upper bound.
+
+The experiment compares the four context packs side-by-side on the same prompt set. If strategy 1 ≈ strategy 2 in quality, the current retrieval isn't pulling its weight. If strategy 4 ≫ strategy 1, the agent is starving for context. If strategy 3 (when it lands) ≫ strategy 1, the slicing pivot is justified.
+
+## Strategy adapter contract
+
+Every strategy is a script under `strategies/` that accepts:
+
+```bash
+strategies/<name>.sh \
+  --prompt "<text>" \
+  --workspace <abs path to repo under test> \
+  --out <abs path to output dir>
+```
+
+…and writes:
+
+- `<out>/context.txt` — the context pack as plain text (concatenated snippets, code blocks, summaries; the literal bytes that would be sent to the model).
+- `<out>/meta.json` — `{ strategy, duration_ms, est_tokens, file_count, notes }`. `est_tokens` uses the same `gpt-tokenizer` (`cl100k_base`) shape as the rest of graphify-ts so numbers are comparable across strategies.
+
+The orchestrator (`run.sh`) calls each adapter for each prompt, optionally pipes the resulting `context.txt` through a model runner via `--exec`, and writes one `summary.json` per run bundle.
+
+## How to run
+
+> **You need:** `graphify-ts` (≥ 0.13.3) on PATH for strategy 1, `rg` (ripgrep) for strategy 2, `node` ≥ 20, `jq`, and a TS/Node monorepo to test against. If you pass `--exec`, you also need that runner installed (e.g. `claude -p`).
+
+Quick run, no model spend (just produce context packs):
+
+```bash
+bash docs/experiments/2026-05-10-current-vs-slicing/run.sh \
+  --workspace /path/to/your-monorepo \
+  --strategies current-graphify,lexical-baseline,full-context
+```
+
+Quick run, with model answers (recommended for the actual recommendation):
+
+```bash
+bash docs/experiments/2026-05-10-current-vs-slicing/run.sh \
+  --workspace /path/to/your-monorepo \
+  --strategies current-graphify,lexical-baseline,full-context \
+  --exec 'cat {prompt_file} | claude -p --output-format json'
+```
+
+Once the slicer prototype from #73 exists, add it:
+
+```bash
+bash docs/experiments/2026-05-10-current-vs-slicing/run.sh \
+  --workspace /path/to/your-monorepo \
+  --strategies current-graphify,lexical-baseline,slicer-stub,full-context \
+  --exec 'cat {prompt_file} | claude -p --output-format json'
+```
+
+After the harness finishes, summarize:
+
+```bash
+bash docs/experiments/2026-05-10-current-vs-slicing/aggregate.sh \
+  results/<timestamp>
+```
+
+## What to capture in the report
+
+This is a **research spike**, not an engine rewrite. The deliverable is a `findings.md` next to this README that answers:
+
+| Question | Where to look |
+|---|---|
+| Is current retrieval materially better than ripgrep on the same budget? | `summary.json → per_prompt[*].current-graphify.est_tokens` vs `…lexical-baseline…`, plus side-by-side `context.txt` for the same prompt |
+| Is current retrieval close to full-context quality at a fraction of the tokens? | `est_tokens` ratio + qualitative answer comparison if `--exec` was used |
+| What does current retrieval miss that lexical catches (or vice versa)? | Diff `context.txt` files for the same prompt — record systematic gaps |
+| Where does retrieval pull in noise (hubs, barrels, generated files)? | Inspect `current-graphify` `context.txt` for top-token contributors |
+| Recommendation: keep current method, adjust it, or pivot to slicing? | Concluding paragraph in `findings.md` with concrete next-steps for #73 / #70 |
+
+The recommendation is the load-bearing output. Without it, this spike has not paid back the work that went into running it.
+
+## Files in this directory
+
+- `README.md` — this file
+- `prompts.json` — the prompt set (8 prompts spanning explain / debug / review / impact tasks)
+- `strategies/`
+  - `current-graphify.sh` — strategy 1, runnable today
+  - `lexical-baseline.sh` — strategy 2, runnable today (needs `rg`)
+  - `slicer-stub.sh` — strategy 3, intentionally exits with "blocked on #73"
+  - `full-context.sh` — strategy 4, runnable today
+- `run.sh` — orchestrator
+- `aggregate.sh` — side-by-side summary printer
+- `results/` — gitignored; run outputs land here
+- `findings.md` — *to be added* once a real run completes; this is the user-facing deliverable for #71
+
+## Honesty notes
+
+- The slicer adapter is a stub. The recommendation in `findings.md` cannot be "pivot to slicing" until strategy 3 produces measurable output. Until then the spike answers the *narrower* question: "is current retrieval clearly better than dumb lexical at the same budget?"
+- All token estimates use `cl100k_base` (the existing graphify-ts tokenizer). They're not provider-billed unless you also pass `--exec` and the runner emits a JSON usage block.
+- `--exec` calls spend real model tokens. Always use `--strategies` to limit the run; don't let an accidentally broad set 4× your bill.
+- Single-codebase, single-prompt-set measurement. A second monorepo of a different shape may show a different pattern; the report should say so explicitly.

--- a/docs/experiments/2026-05-10-current-vs-slicing/aggregate.sh
+++ b/docs/experiments/2026-05-10-current-vs-slicing/aggregate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Aggregator for results bundles produced by run.sh (issue #71).
+# Reads summary.json and prints a side-by-side per-prompt comparison across
+# every strategy that ran.
+#
+# Usage:
+#   bash aggregate.sh <results/<timestamp>/>
+
+set -euo pipefail
+[ $# -ge 1 ] || { echo "Usage: $0 <results-dir>" >&2; exit 1; }
+RUN_DIR="$1"
+SUMMARY="$RUN_DIR/summary.json"
+[ -f "$SUMMARY" ] || { echo "[aggregate] $SUMMARY not found." >&2; exit 2; }
+command -v node >/dev/null 2>&1 || { echo "[aggregate] node is required." >&2; exit 3; }
+
+node -e '
+    (() => {
+      const fs = require("fs");
+      const file = process.argv[1];
+      const summary = JSON.parse(fs.readFileSync(file, "utf8"));
+
+      const per = summary.per_prompt || {};
+      const promptIds = Object.keys(per);
+      if (promptIds.length === 0) { console.log("[aggregate] no prompts in summary."); return; }
+      const strategies = [...new Set(promptIds.flatMap((p) => Object.keys(per[p] || {})))].sort();
+
+    function fmtNum(n) { return typeof n === "number" ? n.toLocaleString("en-US") : "—"; }
+    function fmtState(s) {
+      if (!s) return "missing";
+      if (s.exit === 78) return "stub";
+      if (s.exit !== null && s.exit !== 0) return `failed (rc=${s.exit})`;
+      return "ok";
+    }
+
+    const colWidth = 28;
+    const promptCol = 30;
+    console.log("Strategies: " + strategies.join(", "));
+    console.log();
+
+    // Header row.
+    const head = ["prompt".padEnd(promptCol)];
+    for (const s of strategies) head.push(s.padEnd(colWidth));
+    console.log(head.join(""));
+    console.log("-".repeat(head.join("").length));
+
+    for (const id of promptIds) {
+      const row = [id.padEnd(promptCol)];
+      for (const s of strategies) {
+        const entry = per[id][s];
+        if (!entry) { row.push("—".padEnd(colWidth)); continue; }
+        if (entry.exit === 78) { row.push("(stub)".padEnd(colWidth)); continue; }
+        const meta = entry.meta || {};
+        const tokens = fmtNum(meta.est_tokens);
+        const ms = fmtNum(meta.duration_ms);
+        const files = fmtNum(meta.file_count);
+        row.push(`${tokens}t / ${files}f / ${ms}ms`.padEnd(colWidth));
+      }
+      console.log(row.join(""));
+    }
+
+      console.log();
+      console.log("Legend: <est_tokens>t / <file_count>f / <duration_ms>ms");
+      console.log("Lower est_tokens at comparable answer quality is what wins. Inspect");
+      console.log("context.txt and answer.json side-by-side to judge quality differences.");
+    })();
+' "$SUMMARY"

--- a/docs/experiments/2026-05-10-current-vs-slicing/prompts.json
+++ b/docs/experiments/2026-05-10-current-vs-slicing/prompts.json
@@ -1,0 +1,46 @@
+{
+  "$comment": "Prompt set for the 2026-05-10 current-vs-slicing experiment (issue #71). 8 prompts across the four task modes #71 calls out (explain / debug / review / impact). Designed so each prompt has at least one obvious failure mode for naive retrieval (hub-dominated) and one obvious slicing win (cross-module behavior path).",
+  "version": 1,
+  "prompts": [
+    {
+      "id": "explain-auth-flow",
+      "task": "explain",
+      "text": "Explain the authentication flow end to end, from the HTTP entry point to session persistence."
+    },
+    {
+      "id": "explain-controller-to-persistence",
+      "task": "explain",
+      "text": "Trace the request path from the report controller to the final report persistence call. Include any queue, worker, or background job hops."
+    },
+    {
+      "id": "debug-report-slow",
+      "task": "debug",
+      "text": "Why is report generation slow? Walk through the request path and call out the slowest hops, including any external service or LLM calls."
+    },
+    {
+      "id": "debug-config-env",
+      "task": "debug",
+      "text": "Where does the SESSION_TTL environment variable affect runtime behavior? Trace it from config load through every code path that reads it."
+    },
+    {
+      "id": "review-pr-onboarding",
+      "task": "review",
+      "text": "Can a PR that touches the onboarding flow break user creation, billing, or auth? Identify the call paths and risk hotspots."
+    },
+    {
+      "id": "review-guard-coverage",
+      "task": "review",
+      "text": "Which controllers have an authentication guard but no authorization check? List the routes and the missing checks."
+    },
+    {
+      "id": "impact-service-change",
+      "task": "impact",
+      "text": "What can break if the research-agent service changes its public interface? List dependents, callers, and tests that would need to update."
+    },
+    {
+      "id": "impact-billing-credits",
+      "task": "impact",
+      "text": "When a user is charged, where are credits debited and how is the audit trail recorded? Identify all code paths that adjust the credit balance."
+    }
+  ]
+}

--- a/docs/experiments/2026-05-10-current-vs-slicing/run.sh
+++ b/docs/experiments/2026-05-10-current-vs-slicing/run.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Current retrieval vs task-conditioned slicing experiment harness (issue #71).
+#
+# For each prompt in prompts.json, runs each enabled strategy adapter to
+# produce a context pack, then optionally pipes the pack through an --exec
+# runner to capture a model answer + provider usage. Writes a per-run bundle
+# under results/<timestamp>/.
+
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $0 --workspace <path> --strategies <csv> [--exec <runner>] [--prompt-ids <csv>] [--out-dir <path>]
+
+Required:
+  --workspace   Path to the repo under test (must contain graphify-out/graph.json
+                if you include the current-graphify strategy).
+  --strategies  Comma-separated list of strategy names (matching scripts in strategies/).
+                Examples:
+                  current-graphify,lexical-baseline,full-context
+                  current-graphify,lexical-baseline,slicer-stub,full-context
+
+Optional:
+  --exec        Runner template for piping the strategy's context.txt through a
+                model, e.g. 'cat {prompt_file} | claude -p --output-format json'.
+                The {prompt_file} placeholder is replaced with the per-strategy
+                merged-prompt file. Omit to skip model answers entirely.
+  --prompt-ids  Comma-separated prompt ids to limit the run to. Default: all.
+  --out-dir     Override the results directory (default: alongside this script).
+
+Notes:
+  - Without --exec, this is local-only (no model spend).
+  - With --exec, you spend tokens for every prompt × every strategy. Be deliberate.
+USAGE
+  exit 1
+}
+
+WORKSPACE="" STRATEGIES="" EXEC="" PROMPT_IDS=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT_BASE="$HERE/results"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workspace)   WORKSPACE="$2"; shift 2 ;;
+    --strategies)  STRATEGIES="$2"; shift 2 ;;
+    --exec)        EXEC="$2"; shift 2 ;;
+    --prompt-ids)  PROMPT_IDS="$2"; shift 2 ;;
+    --out-dir)     OUT_BASE="$2"; shift 2 ;;
+    -h|--help)     usage ;;
+    *) echo "[harness] unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [ -z "$WORKSPACE" ] || [ -z "$STRATEGIES" ]; then usage; fi
+if [ ! -d "$WORKSPACE" ]; then echo "[harness] workspace not found: $WORKSPACE" >&2; exit 2; fi
+for tool in node jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "[harness] $tool is required" >&2; exit 3
+  fi
+done
+
+PROMPTS_FILE="$HERE/prompts.json"
+[ -f "$PROMPTS_FILE" ] || { echo "[harness] prompts.json missing alongside run.sh" >&2; exit 4; }
+
+# Validate every requested strategy script exists before spending any time.
+IFS=',' read -ra STRAT_ARR <<< "$STRATEGIES"
+for s in "${STRAT_ARR[@]}"; do
+  if [ ! -x "$HERE/strategies/$s.sh" ]; then
+    echo "[harness] strategy not found or not executable: strategies/$s.sh" >&2; exit 5
+  fi
+done
+
+if [ -n "$PROMPT_IDS" ]; then
+  IFS=',' read -ra ID_ARR <<< "$PROMPT_IDS"
+else
+  mapfile -t ID_ARR < <(jq -r '.prompts[].id' "$PROMPTS_FILE")
+fi
+
+TS=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+RUN_DIR="$OUT_BASE/$TS"
+mkdir -p "$RUN_DIR/prompts"
+
+jq -n \
+  --arg ts "$TS" \
+  --arg workspace "$WORKSPACE" \
+  --arg strategies "$STRATEGIES" \
+  --arg exec "$EXEC" \
+  --arg version "$(graphify-ts --version 2>/dev/null || echo unknown)" \
+  '{
+    timestamp: $ts,
+    workspace: $workspace,
+    strategies: ($strategies | split(",")),
+    exec: ($exec // ""),
+    graphify_version: $version
+  }' > "$RUN_DIR/manifest.json"
+
+echo "[harness] results bundle: $RUN_DIR"
+echo "[harness] strategies: $STRATEGIES"
+echo "[harness] prompts: ${#ID_ARR[@]}"
+echo "[harness] exec: ${EXEC:-<none, context-only>}"
+echo
+
+run_strategy_for_prompt() {
+  local prompt_id=$1 prompt_text=$2 strategy=$3
+  local outdir="$RUN_DIR/prompts/$prompt_id/$strategy"
+  mkdir -p "$outdir"
+  echo "[harness]   $strategy"
+
+  set +e
+  "$HERE/strategies/$strategy.sh" \
+    --prompt    "$prompt_text" \
+    --workspace "$WORKSPACE" \
+    --out       "$outdir" \
+    > "$outdir/strategy.log" 2>&1
+  local rc=$?
+  set -e
+  echo "$rc" > "$outdir/strategy.exit"
+
+  # If the strategy explicitly stubbed out (rc == 78), skip the model call.
+  if [ "$rc" -eq 78 ]; then return 0; fi
+  if [ "$rc" -ne 0 ]; then
+    echo "[harness]     strategy exited rc=$rc (see $outdir/strategy.log)"
+    return 0
+  fi
+
+  if [ -n "$EXEC" ] && [ -f "$outdir/context.txt" ]; then
+    # Build a single combined prompt for the runner: question + context.
+    {
+      printf 'Question:\n%s\n\nContext:\n' "$prompt_text"
+      cat "$outdir/context.txt"
+    } > "$outdir/merged-prompt.txt"
+    local runner="${EXEC//\{prompt_file\}/$outdir/merged-prompt.txt}"
+    set +e
+    bash -c "$runner" > "$outdir/answer.json" 2> "$outdir/answer.log"
+    local arc=$?
+    set -e
+    echo "$arc" > "$outdir/answer.exit"
+  fi
+}
+
+for prompt_id in "${ID_ARR[@]}"; do
+  prompt_text=$(jq -r --arg id "$prompt_id" '.prompts[] | select(.id == $id) | .text' "$PROMPTS_FILE")
+  if [ -z "$prompt_text" ] || [ "$prompt_text" = "null" ]; then
+    echo "[harness] prompt id '$prompt_id' missing in prompts.json — skipping"
+    continue
+  fi
+  echo "[harness] prompt: $prompt_id"
+  for s in "${STRAT_ARR[@]}"; do
+    run_strategy_for_prompt "$prompt_id" "$prompt_text" "$s"
+  done
+done
+
+# Build summary.json.
+node -e '
+  (() => {
+    const fs = require("fs");
+    const path = require("path");
+    const runDir = process.argv[1];
+    const promptsRoot = path.join(runDir, "prompts");
+    const out = { per_prompt: {} };
+    if (fs.existsSync(promptsRoot)) {
+      for (const promptId of fs.readdirSync(promptsRoot)) {
+        const promptDir = path.join(promptsRoot, promptId);
+        if (!fs.statSync(promptDir).isDirectory()) continue;
+        out.per_prompt[promptId] = {};
+        for (const strategy of fs.readdirSync(promptDir)) {
+          const sDir = path.join(promptDir, strategy);
+          if (!fs.statSync(sDir).isDirectory()) continue;
+          const metaPath = path.join(sDir, "meta.json");
+          const exitPath = path.join(sDir, "strategy.exit");
+          let meta = null;
+          try { meta = JSON.parse(fs.readFileSync(metaPath, "utf8")); } catch {}
+          const exit = fs.existsSync(exitPath) ? Number(fs.readFileSync(exitPath, "utf8").trim()) : null;
+          out.per_prompt[promptId][strategy] = { meta, exit };
+        }
+      }
+    }
+    fs.writeFileSync(path.join(runDir, "summary.json"), JSON.stringify(out, null, 2));
+    console.log("[harness] wrote summary.json");
+  })();
+' "$RUN_DIR"
+
+echo
+echo "[harness] DONE."
+echo "[harness] Inspect:    $RUN_DIR/summary.json"
+echo "[harness] Aggregate:  bash $HERE/aggregate.sh $RUN_DIR"

--- a/docs/experiments/2026-05-10-current-vs-slicing/strategies/current-graphify.sh
+++ b/docs/experiments/2026-05-10-current-vs-slicing/strategies/current-graphify.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Strategy 1: current graphify-ts retrieval (`graphify-ts pack`).
+# Adapter contract: see ../README.md "Strategy adapter contract".
+
+set -euo pipefail
+PROMPT="" WORKSPACE="" OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt)    PROMPT="$2"; shift 2 ;;
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    *) echo "[current-graphify] unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$PROMPT" ] && [ -n "$WORKSPACE" ] && [ -n "$OUT" ] || {
+  echo "[current-graphify] usage: $0 --prompt <text> --workspace <path> --out <dir>" >&2; exit 1; }
+
+mkdir -p "$OUT"
+GRAPH="$WORKSPACE/graphify-out/graph.json"
+if [ ! -f "$GRAPH" ]; then
+  echo "[current-graphify] graph.json missing at $GRAPH — run 'graphify-ts generate .' inside $WORKSPACE first." >&2
+  exit 2
+fi
+if ! command -v graphify-ts >/dev/null 2>&1; then
+  echo "[current-graphify] graphify-ts CLI required on PATH." >&2; exit 3
+fi
+
+START=$(node -e 'process.stdout.write(String(Date.now()))')
+( cd "$WORKSPACE" && graphify-ts pack "$PROMPT" --task explain ) > "$OUT/pack.json" 2> "$OUT/pack.log" || {
+  echo "[current-graphify] graphify-ts pack failed — see $OUT/pack.log" >&2
+  echo "" > "$OUT/context.txt"
+  END=$(node -e 'process.stdout.write(String(Date.now()))')
+  printf '{ "strategy": "current-graphify", "duration_ms": %d, "est_tokens": 0, "file_count": 0, "notes": "pack command failed" }\n' \
+    "$((END - START))" > "$OUT/meta.json"
+  exit 0
+}
+END=$(node -e 'process.stdout.write(String(Date.now()))')
+
+# Render pack.json into a flat context.txt by concatenating every text-bearing
+# entry (claims, snippets, expandable refs). Falls back to the raw JSON if the
+# shape doesn't match the expected pack contract — we never silently emit
+# nothing.
+node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const out = process.argv[1];
+  const packPath = path.join(out, "pack.json");
+  const txt = path.join(out, "context.txt");
+  let pack;
+  try { pack = JSON.parse(fs.readFileSync(packPath, "utf8")); }
+  catch { fs.writeFileSync(txt, fs.readFileSync(packPath, "utf8")); return; }
+
+  const lines = [];
+  function pushSnippet(s) {
+    if (!s) return;
+    if (typeof s === "string") { lines.push(s); return; }
+    if (typeof s.text === "string") { lines.push(s.text); return; }
+    if (typeof s.content === "string") { lines.push(s.content); return; }
+  }
+  function walk(o) {
+    if (o == null) return;
+    if (Array.isArray(o)) { o.forEach(walk); return; }
+    if (typeof o === "object") {
+      if (o.snippet || o.snippets || o.body || o.claim || o.text) {
+        pushSnippet(o.snippet ?? o.body ?? o.claim ?? o.text);
+        if (Array.isArray(o.snippets)) o.snippets.forEach(pushSnippet);
+      }
+      Object.values(o).forEach(walk);
+    }
+  }
+  walk(pack);
+  if (lines.length === 0) {
+    fs.writeFileSync(txt, JSON.stringify(pack, null, 2));
+  } else {
+    fs.writeFileSync(txt, lines.join("\n\n---\n\n"));
+  }
+' "$OUT"
+
+EST_TOKENS=$(node -e '
+  const fs = require("fs"), path = require("path");
+  try {
+    const { encode } = require("gpt-tokenizer");
+    const text = fs.readFileSync(path.join(process.argv[1], "context.txt"), "utf8");
+    process.stdout.write(String(encode(text).length));
+  } catch (e) {
+    // gpt-tokenizer not resolvable from this CWD. Fall back to char/4 estimate.
+    const text = fs.readFileSync(path.join(process.argv[1], "context.txt"), "utf8");
+    process.stdout.write(String(Math.ceil(text.length / 4)));
+  }
+' "$OUT")
+FILE_COUNT=$(jq -r '[.. | objects | .file? // .file_path? // empty] | unique | length' "$OUT/pack.json" 2>/dev/null || echo 0)
+
+printf '{ "strategy": "current-graphify", "duration_ms": %d, "est_tokens": %s, "file_count": %s, "notes": "" }\n' \
+  "$((END - START))" "$EST_TOKENS" "$FILE_COUNT" > "$OUT/meta.json"

--- a/docs/experiments/2026-05-10-current-vs-slicing/strategies/full-context.sh
+++ b/docs/experiments/2026-05-10-current-vs-slicing/strategies/full-context.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Strategy 4: full-context baseline. Concatenate every TS/JS file under the
+# workspace, truncate to a generous character budget. Represents the "what
+# could the agent have known if context were free" upper bound.
+# Adapter contract: see ../README.md "Strategy adapter contract".
+
+set -euo pipefail
+PROMPT="" WORKSPACE="" OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt)    PROMPT="$2"; shift 2 ;;
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    *) echo "[full-context] unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$WORKSPACE" ] && [ -n "$OUT" ] || {
+  echo "[full-context] usage: $0 --prompt <text> --workspace <path> --out <dir>" >&2; exit 1; }
+
+mkdir -p "$OUT"
+CHAR_BUDGET=400000   # ~100K cl100k_base tokens — large but bounded.
+
+START=$(node -e 'process.stdout.write(String(Date.now()))')
+# Walk TS/JS files outside node_modules/dist/build/coverage, prefix each with a
+# header so the model can attribute snippets back to files.
+> "$OUT/context.txt"
+TOTAL_CHARS=0
+COUNT=0
+while IFS= read -r f; do
+  if [ "$TOTAL_CHARS" -ge "$CHAR_BUDGET" ]; then break; fi
+  rel="${f#$WORKSPACE/}"
+  printf '\n// === %s ===\n' "$rel" >> "$OUT/context.txt"
+  remaining=$((CHAR_BUDGET - TOTAL_CHARS))
+  head -c "$remaining" "$f" >> "$OUT/context.txt" || true
+  TOTAL_CHARS=$(wc -c < "$OUT/context.txt" | tr -d ' ')
+  COUNT=$((COUNT + 1))
+done < <(find "$WORKSPACE" \
+  -type f \
+  \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \) \
+  -not -path "*/node_modules/*" \
+  -not -path "*/dist/*" \
+  -not -path "*/build/*" \
+  -not -path "*/.next/*" \
+  -not -path "*/coverage/*" \
+  -not -path "*/.test-artifacts/*" \
+  -not -path "*/graphify-out/*" \
+  | sort)
+END=$(node -e 'process.stdout.write(String(Date.now()))')
+
+EST_TOKENS=$(node -e '
+  const fs = require("fs"), path = require("path");
+  try {
+    const { encode } = require("gpt-tokenizer");
+    const text = fs.readFileSync(path.join(process.argv[1], "context.txt"), "utf8");
+    process.stdout.write(String(encode(text).length));
+  } catch {
+    const text = fs.readFileSync(path.join(process.argv[1], "context.txt"), "utf8");
+    process.stdout.write(String(Math.ceil(text.length / 4)));
+  }
+' "$OUT")
+
+printf '{ "strategy": "full-context", "duration_ms": %d, "est_tokens": %s, "file_count": %d, "notes": "char_budget=%d (truncated)" }\n' \
+  "$((END - START))" "$EST_TOKENS" "$COUNT" "$CHAR_BUDGET" > "$OUT/meta.json"

--- a/docs/experiments/2026-05-10-current-vs-slicing/strategies/lexical-baseline.sh
+++ b/docs/experiments/2026-05-10-current-vs-slicing/strategies/lexical-baseline.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Strategy 2: lexical baseline. ripgrep on prompt-derived terms, expand each
+# match to a context window, concatenate up to a fixed character budget. The
+# dumb-but-fast strawman every smarter retrieval strategy needs to beat.
+# Adapter contract: see ../README.md "Strategy adapter contract".
+
+set -euo pipefail
+PROMPT="" WORKSPACE="" OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt)    PROMPT="$2"; shift 2 ;;
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    *) echo "[lexical-baseline] unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$PROMPT" ] && [ -n "$WORKSPACE" ] && [ -n "$OUT" ] || {
+  echo "[lexical-baseline] usage: $0 --prompt <text> --workspace <path> --out <dir>" >&2; exit 1; }
+command -v rg >/dev/null 2>&1 || { echo "[lexical-baseline] ripgrep (rg) is required (brew install ripgrep)." >&2; exit 2; }
+
+mkdir -p "$OUT"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Pull "significant" tokens from the prompt: words >= 4 chars, alphanumeric,
+# strip a small stopword set. This is intentionally crude — the baseline is
+# meant to be unflattering on purpose.
+STOPWORDS=" the and that this how does what when where which from with into are for has have not but its only also more most other same these those some they them their our your you can will would could should about which list trace identify "
+node -e '
+  const stop = new Set(process.argv[1].split(" ").filter(Boolean));
+  const prompt = process.argv[2].toLowerCase();
+  const terms = (prompt.match(/[a-z][a-z0-9_-]{3,}/g) || [])
+    .filter((t) => !stop.has(t));
+  const uniq = [...new Set(terms)].slice(0, 8);
+  process.stdout.write(uniq.join("\n"));
+' "$STOPWORDS" "$PROMPT" > "$TMP/terms"
+
+START=$(node -e 'process.stdout.write(String(Date.now()))')
+CHAR_BUDGET=20000   # rough proxy for ~5K cl100k_base tokens; pessimistic on purpose
+WINDOW=20           # lines of context around each match
+TOTAL_CHARS=0
+> "$OUT/context.txt"
+FILES_SEEN=()
+
+while IFS= read -r term; do
+  [ -z "$term" ] && continue
+  # 5 best file matches per term, each expanded with WINDOW lines around the hit.
+  rg --no-heading --line-number --max-count 5 --type ts --type js \
+     --context "$WINDOW" --color never -- "$term" "$WORKSPACE" 2>/dev/null \
+    | head -c $((CHAR_BUDGET - TOTAL_CHARS)) >> "$OUT/context.txt" || true
+  TOTAL_CHARS=$(wc -c < "$OUT/context.txt" | tr -d ' ')
+  if [ "$TOTAL_CHARS" -ge "$CHAR_BUDGET" ]; then break; fi
+done < "$TMP/terms"
+END=$(node -e 'process.stdout.write(String(Date.now()))')
+
+EST_TOKENS=$(node -e '
+  const fs = require("fs"), path = require("path");
+  try {
+    const { encode } = require("gpt-tokenizer");
+    const text = fs.readFileSync(path.join(process.argv[1], "context.txt"), "utf8");
+    process.stdout.write(String(encode(text).length));
+  } catch {
+    const text = fs.readFileSync(path.join(process.argv[1], "context.txt"), "utf8");
+    process.stdout.write(String(Math.ceil(text.length / 4)));
+  }
+' "$OUT")
+FILE_COUNT=$(grep -E '^[^[:space:]].*:[0-9]+:' "$OUT/context.txt" | awk -F: '{print $1}' | sort -u | wc -l | tr -d ' ')
+
+printf '{ "strategy": "lexical-baseline", "duration_ms": %d, "est_tokens": %s, "file_count": %s, "notes": "char_budget=%d, window=%d" }\n' \
+  "$((END - START))" "$EST_TOKENS" "$FILE_COUNT" "$CHAR_BUDGET" "$WINDOW" > "$OUT/meta.json"

--- a/docs/experiments/2026-05-10-current-vs-slicing/strategies/slicer-stub.sh
+++ b/docs/experiments/2026-05-10-current-vs-slicing/strategies/slicer-stub.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Strategy 3: task-conditioned program slicing.
+# STUB. Intentionally does not run a real slicer — that lands in #73.
+#
+# This adapter exits with code 78 (EX_CONFIG, "configuration error") and a
+# clear message so run.sh can record the stub state in summary.json without
+# pretending the slicing strategy was measured.
+#
+# Replace this script with the real slicer wrapper once #73 ships.
+
+set -euo pipefail
+PROMPT="" WORKSPACE="" OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt)    PROMPT="$2"; shift 2 ;;
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    *) echo "[slicer-stub] unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+mkdir -p "$OUT"
+cat > "$OUT/context.txt" <<'EOF'
+[slicer-stub] Task-conditioned slicing strategy is not yet implemented.
+
+Tracking issue: https://github.com/mohanagy/graphify-ts/issues/73
+Until #73 ships, this experiment compares strategies 1, 2, and 4 only.
+EOF
+printf '{ "strategy": "slicer-stub", "duration_ms": 0, "est_tokens": 0, "file_count": 0, "notes": "stub; blocked on #73 prototype" }\n' \
+  > "$OUT/meta.json"
+echo "[slicer-stub] not implemented; see https://github.com/mohanagy/graphify-ts/issues/73" >&2
+exit 78

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -156,6 +156,77 @@ describe('public marketing copy honesty', () => {
     })
   })
 
+  describe('docs/experiments/2026-05-10-current-vs-slicing/', () => {
+    const readme = readDoc('docs/experiments/2026-05-10-current-vs-slicing/README.md')
+    const runSh = readDoc('docs/experiments/2026-05-10-current-vs-slicing/run.sh')
+    const aggregateSh = readDoc('docs/experiments/2026-05-10-current-vs-slicing/aggregate.sh')
+    const stubSh = readDoc('docs/experiments/2026-05-10-current-vs-slicing/strategies/slicer-stub.sh')
+    const lexicalSh = readDoc('docs/experiments/2026-05-10-current-vs-slicing/strategies/lexical-baseline.sh')
+    const fullSh = readDoc('docs/experiments/2026-05-10-current-vs-slicing/strategies/full-context.sh')
+    const currentSh = readDoc('docs/experiments/2026-05-10-current-vs-slicing/strategies/current-graphify.sh')
+    const prompts = JSON.parse(readDoc('docs/experiments/2026-05-10-current-vs-slicing/prompts.json')) as {
+      version: number
+      prompts: Array<{ id: string; task: string; text: string }>
+    }
+
+    it('declares the spike scope and links the tracking issue (#71)', () => {
+      expect(readme).toMatch(/#71|issues\/71/)
+      expect(readme).toContain('v0.14-substrate')
+      expect(readme).toContain('Current retrieval vs task-conditioned slicing')
+    })
+
+    it('explicitly marks the slicer as a stub blocked on #73', () => {
+      expect(stubSh).toContain('issues/73')
+      expect(stubSh).toContain('exit 78')
+      expect(readme).toContain('#73')
+    })
+
+    it('ships four strategy adapters with the documented contract', () => {
+      for (const script of [currentSh, lexicalSh, stubSh, fullSh]) {
+        expect(script).toContain('#!/usr/bin/env bash')
+        expect(script).toContain('--prompt')
+        expect(script).toContain('--workspace')
+        expect(script).toContain('--out')
+      }
+    })
+
+    it('uses portable Date.now() millisecond timing (no GNU-only date +%s%3N)', () => {
+      for (const script of [runSh, currentSh, lexicalSh, fullSh]) {
+        expect(script).not.toMatch(/date \+%s%3N/)
+      }
+    })
+
+    it('keeps the prompts.json contract: 8 prompts, all four task modes covered', () => {
+      expect(prompts.version).toBe(1)
+      expect(prompts.prompts).toHaveLength(8)
+      const tasks = new Set(prompts.prompts.map((p) => p.task))
+      for (const expected of ['explain', 'debug', 'review', 'impact']) {
+        expect(tasks.has(expected)).toBe(true)
+      }
+      for (const prompt of prompts.prompts) {
+        expect(prompt.id).toMatch(/^[a-z0-9-]+$/)
+        expect(['explain', 'debug', 'review', 'impact']).toContain(prompt.task)
+        expect(prompt.text.length).toBeGreaterThan(20)
+      }
+    })
+
+    it('ships the orchestrator and aggregator with the documented argument surface', () => {
+      expect(runSh).toContain('--workspace')
+      expect(runSh).toContain('--strategies')
+      expect(runSh).toContain('--exec')
+      expect(runSh).toContain('--prompt-ids')
+      expect(aggregateSh).toContain('summary.json')
+    })
+  })
+
+  describe('docs/benchmarks/2026-05-10-backend-vs-monorepo/ portability', () => {
+    const runSh = readDoc('docs/benchmarks/2026-05-10-backend-vs-monorepo/run.sh')
+
+    it('uses portable Date.now() millisecond timing (no GNU-only date +%s%3N)', () => {
+      expect(runSh).not.toMatch(/date \+%s%3N/)
+    })
+  })
+
   describe('examples/mcp-tool-examples.md', () => {
     const content = readDoc('examples/mcp-tool-examples.md')
     const lower = content.toLowerCase()


### PR DESCRIPTION
Scoped half of #71 (option B from our discussion). Tracking issue: [#71 — Research spike: compare current graph retrieval vs task-conditioned program slicing](https://github.com/mohanagy/graphify-ts/issues/71). Milestone: `v0.14-substrate`.

Also bundles a fix for a latent macOS portability bug in #69's already-merged harness — discovered during this PR's smoke testing, same one-line root cause, didn't want to leave it broken.

## What ships

### `docs/experiments/2026-05-10-current-vs-slicing/`

The runnable half of the spike. Strategies 1, 2, and 4 work today; strategy 3 (slicer) is an explicit stub blocked on #73.

| Strategy | Status | Adapter |
|---|---|---|
| 1. Current `graphify-ts pack` | ✅ runnable | `strategies/current-graphify.sh` |
| 2. Lexical baseline (ripgrep) | ✅ runnable | `strategies/lexical-baseline.sh` |
| 3. Task-conditioned slicer | 🟡 stub (rc=78) | `strategies/slicer-stub.sh` |
| 4. Full-context baseline | ✅ runnable | `strategies/full-context.sh` |

The orchestrator (`run.sh`) runs each enabled strategy for each prompt in `prompts.json`, captures `meta.json` per run, optionally pipes the resulting context through an `--exec` model runner, and writes a side-by-side `summary.json`. The aggregator (`aggregate.sh`) prints a per-prompt comparison table.

### Bundled bug fix: portable millisecond timing

Every `date +%s%3N` invocation across both #69's and #71's harnesses now uses `node -e 'process.stdout.write(String(Date.now()))'`. Symptom on macOS BSD `date` was `value too great for base (error token is "1778399122N")` because BSD `date` doesn't support `%N` and returned the literal string `1778399122N` for `$START`. Caught by smoke-testing #71's harness; same root cause was sitting in #69's already-merged `run.sh` so the next user run on macOS would have hit it too.

## Smoke test (in this PR)

End-to-end run against this repo, no `--exec`:

```
prompt                        full-context              lexical-baseline      slicer-stub
debug-config-env              97,152t / 50f / 4,269ms   4,995t / 3f / 71ms    (stub)
explain-auth-flow             97,152t / 50f / 4,461ms   4,894t / 2f / 56ms    (stub)
```

Confirms strategies execute, produce well-formed `meta.json`, and the aggregator renders the table correctly.

## Honesty constraints I held to

- The slicer adapter does **not** pretend to be a slicer. It exits rc=78 with a clear stub message linking #73, and `summary.json` records the stub state explicitly so anyone reading later can see exactly which strategies were measured.
- README explicitly says: *"the spike answers the narrower question: 'is current retrieval clearly better than dumb lexical at the same budget?'"* — the full pivot recommendation has to wait on #73.
- All token counts are **local `cl100k_base` estimates** (the same `gpt-tokenizer` package the rest of graphify-ts uses), not provider-billed — explicitly labeled as such in the README. Provider-billed numbers only appear if the user passes `--exec` and the runner emits a structured JSON usage block.
- `results/` is gitignored so accidental run outputs never get committed.

## Test plan

- [x] `npm run test:run` — **1395/1395** pass (was 1388 on `main`; +7 new doc-honesty assertions).
- [x] `bash run.sh --help` renders cleanly.
- [x] Smoke test against this repo: 3 strategies × 2 prompts → valid `summary.json` + aggregator table.
- [x] `bash -n` clean for all 6 shell scripts.
- [x] `jq` validates `prompts.json` (8 prompts, all four task modes covered).
- [x] `npm run typecheck` — clean.
- [ ] Reviewer runs `--quick`-style invocation against a real local monorepo and confirms the output bundle.

## Deliverables remaining for #71

After this lands and someone has a real `summary.json` from a monorepo, the user-facing deliverable is `findings.md` next to the README — the recommendation paragraph #71 explicitly asks for. Until #73 ships, that recommendation is bounded to "current retrieval vs lexical baseline (and full-context upper bound)"; the slicing-pivot decision still waits on #73.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new experiment framework comparing retrieval strategies with orchestration and aggregation tooling.
  * Implemented multiple retrieval strategy adapters (current retrieval, lexical baseline, full-context baseline, and slicing stub).

* **Tests**
  * Added documentation verification tests ensuring experiment setup integrity and CLI contract compliance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->