### PR TITLE
docs(#70): SPI v1 design — Semantic Program Index

### DIFF
--- a/docs/designs/2026-05-10-spi-v1.md
+++ b/docs/designs/2026-05-10-spi-v1.md
@@ -1,0 +1,283 @@
+# SPI v1 — Semantic Program Index design
+
+> **Tracking issue:** [#70](https://github.com/mohanagy/graphify-ts/issues/70) — *Design Semantic Program Index v1 as the internal representation.*
+> **Milestone:** `v0.14-substrate`. Implementation lives in [#72](https://github.com/mohanagy/graphify-ts/issues/72); the slicer that consumes SPI lives in [#73](https://github.com/mohanagy/graphify-ts/issues/73).
+> **Status:** design only — no code in this PR. The implementation contract this document locks down is what #72 will build against.
+
+## Problem
+
+Today's `graph.json` is a flat node/edge map: files, symbols, calls, imports, framework_role nodes for the supported web frameworks. It works for `retrieve` and `pr_impact`, but it has three structural limits that show up the moment we try to build the task-conditioned slicer (#73):
+
+1. **Edge semantics are flat.** A `calls` edge and a `provides` edge are both just `edges[i]`. The slicer needs to walk forward/backward by *kind* (calls only, types only, tests only) without re-deriving semantics from string heuristics every time.
+2. **No confidence dimension.** A statically resolved `ts.Symbol`-backed call edge is much stronger evidence than a regex-matched string call site, but they currently look identical to retrieval. The compiler (#74) needs a confidence signal to score evidence properly.
+3. **No diff layer.** PR-impact derives changed-line → containing-symbol mappings on every call. That's both slow and inconsistent across the rest of the surface (e.g., `impact` and `slicer` would each re-derive it).
+
+SPI v1 is the **internal substrate** that fixes all three. It is *not* a new public CLI surface — it's the data model the existing extractor pipeline produces and the new slicer/selector consume.
+
+## Goals
+
+- One **versioned, typed, deterministic** representation of the workspace's program structure.
+- Edge `kind` + `confidence` + `source` are first-class, not string-encoded.
+- A **diff layer** that maps changed line ranges to symbols once, reused everywhere.
+- **Stable IDs** so the same source produces the same node ID across runs (cache keys, delta computation, agent re-references).
+- Backward compat with today's `graph.json` via a documented projection.
+
+## Non-goals
+
+- Not solving every dynamic JS behavior (metaprogramming, `eval`, runtime route registration). Unresolved cases are recorded as low-confidence diagnostics, not silently dropped.
+- Not replacing all current graph features in one PR — #72 lands SPI alongside today's pipeline; the projection bridges them.
+- Not exposing SPI as a public MCP tool surface yet. Only debug/inspection output until the shape proves useful in #73 + #74.
+- Not adding new language extractors here. SPI v1 = TypeScript / JavaScript only. Other languages keep today's extractor and join SPI in a later milestone.
+
+## Data model
+
+```ts
+type SemanticProgramIndex = {
+  version: 1
+  generated_at: string         // ISO 8601 UTC
+  workspace: SpiWorkspace
+  files:       SpiFile[]
+  symbols:     SpiSymbol[]
+  edges:       SpiEdge[]
+  diagnostics: SpiDiagnostic[]
+}
+
+type SpiWorkspace = {
+  root: string                 // absolute path the index was built against
+  fingerprint: string          // sha256 of (root + tsconfig + extractor version)
+  extractor_version: string
+  graphify_version: string
+}
+
+type SpiFile = {
+  id: string                   // file:<sha256(relative_path)[:16]>
+  path: string                 // relative to workspace.root, POSIX-normalized
+  language: 'typescript' | 'javascript' | 'tsx' | 'jsx' | 'json' | 'unknown'
+  loc: number                  // physical line count
+  hash: string                 // sha256 of file content
+}
+
+type SpiSymbol = {
+  id: string                   // symbol:<file_id>/<kind>/<name>[#<overload>]
+  file_id: string
+  name: string
+  kind: SpiSymbolKind
+  range: SpiRange              // 1-based, inclusive
+  exported: boolean
+  framework_role?: SpiFrameworkRole   // optional layer-7 enrichment
+}
+
+type SpiSymbolKind =
+  | 'function' | 'class' | 'interface' | 'type-alias'
+  | 'enum'     | 'method' | 'constant'  | 'variable'
+  | 'namespace'
+
+type SpiRange = {
+  start: { line: number; column: number }
+  end:   { line: number; column: number }
+}
+
+type SpiEdge = {
+  from: string                 // SpiFile.id | SpiSymbol.id
+  to:   string                 // SpiFile.id | SpiSymbol.id
+  kind: SpiEdgeKind
+  confidence: 'high' | 'medium' | 'low'
+  source: SpiEdgeSource
+  evidence?: { file_id: string; range: SpiRange }
+}
+
+type SpiEdgeKind =
+  // file layer
+  | 'imports' | 'exports'
+  // symbol layer
+  | 'declares' | 'references'
+  // call layer
+  | 'calls'
+  // type layer
+  | 'extends' | 'implements' | 'param_type' | 'return_type'
+  // test layer
+  | 'covered_by'
+  // diff layer (computed on demand, persisted in SpiDiff overlay)
+  | 'changed_in'
+  // framework layer (NestJS v1)
+  | 'module_provides' | 'module_imports' | 'module_exports'
+  | 'controller_route' | 'route_handler'
+  | 'injects' | 'guards' | 'intercepts' | 'pipes'
+
+type SpiEdgeSource =
+  | 'typescript-semantic'      // resolved via ts.TypeChecker
+  | 'typescript-syntactic'     // AST shape only (e.g., barrel re-export)
+  | 'tree-sitter'              // fallback for non-TS
+  | 'framework-decorator'      // resolved via decorator metadata
+  | 'heuristic'                // regex / naming convention; always 'low' confidence
+
+type SpiFrameworkRole =
+  | 'nest_module' | 'nest_controller' | 'nest_route'
+  | 'nest_provider' | 'nest_guard' | 'nest_pipe' | 'nest_interceptor'
+
+type SpiDiagnostic = {
+  id: string                   // stable across reruns for the same source state
+  level: 'info' | 'warn' | 'error'
+  message: string
+  evidence?: { file_id: string; range?: SpiRange }
+}
+
+// Diff overlay — computed on top of SPI when a base ref is supplied; not part
+// of the persisted index because it varies with `git rev-parse`.
+type SpiDiffOverlay = {
+  base_ref: string
+  head_ref: string
+  changed_files: string[]      // SpiFile.id list
+  changed_symbols: string[]    // SpiSymbol.id list
+  edges_added: SpiEdge[]       // kind === 'changed_in'
+}
+```
+
+## Layer-by-layer specification
+
+### File layer
+
+- Source: walks `tsconfig.{json,build.json}` reachability + `.gitignore` — the same set today's extractor uses.
+- Edges: `imports`, `exports` between files.
+- Confidence:
+  - **`high`** when the import target resolves to a concrete `SpiFile.id` via `ts.resolveModuleName`.
+  - **`medium`** when the target is a relative path that resolves to a file but not via the type checker.
+  - **`low`** for type-only imports that the runtime never sees, and for resolution failures that fall back to syntactic match.
+
+### Symbol layer
+
+- Source: TypeScript compiler API (`ts.SyntaxKind` walk).
+- One `SpiSymbol` per declaration. Method overloads use `#0`, `#1` suffixes.
+- Edges: `declares` (file → symbol), `references` (symbol → symbol within the same file scope, with confidence depending on whether the reference resolved through `ts.TypeChecker`).
+
+### Call layer
+
+- Source: `ts.TypeChecker.getResolvedSignature` for callsites where the target is a concrete signature.
+- Edges: `calls` (caller symbol → callee symbol).
+- Confidence:
+  - **`high`** when `getResolvedSignature` returns a single concrete declaration.
+  - **`medium`** when overload resolution returns an ambiguous union.
+  - **`low`** when the callee is dynamically dispatched (computed property, decorator-injected) and we matched by name only.
+- Method calls on injected dependencies (NestJS pattern) get a `medium` baseline that the framework layer can promote to `high` when the DI binding is statically resolvable.
+
+### Type layer
+
+- Edges:
+  - `extends` (class ↔ class, interface ↔ interface)
+  - `implements` (class → interface)
+  - `param_type` and `return_type` (function ↔ type/interface)
+- Confidence: always `high` for type-checker-backed; `low` for type-only references that came from JSDoc.
+
+### Test layer
+
+- Heuristic association (intentionally not type-checker-backed):
+  - `foo.spec.ts` ↔ `foo.ts` if both files exist in the same directory or in a `__tests__/` sibling.
+  - Test files importing a symbol get a `covered_by` edge from that symbol to the test file.
+- Confidence: **`medium`** for filename-pattern matches, **`high`** when the test file actually imports the source symbol (cross-validated via the import layer).
+
+### Diff layer (overlay, not persisted)
+
+- Computed on demand by `SpiDiffOverlay.compute(base_ref, head_ref)`.
+- Maps each changed line range from `git diff` to the smallest containing `SpiSymbol`. If no symbol contains the range (e.g., file-top imports), maps to the file.
+- Adds `changed_in` edges (`SpiSymbol.id → SpiFile.id` for the changed file).
+- Reused by `pr_impact`, `impact --diff`, and the future slicer's PR-review mode (#73).
+
+### Framework layer (NestJS v1)
+
+- Source: `ts.Decorator` metadata + a small NestJS-aware visitor.
+- Edges added beyond what the AST already produces:
+  - `module_provides`, `module_imports`, `module_exports` (Module → Provider/Module/Service).
+  - `controller_route` (Controller class → method with `@Get`/`@Post`/`@Patch`/`@Put`/`@Delete`).
+  - `route_handler` (route → controller method).
+  - `injects` (constructor param → injected provider class).
+  - `guards`, `intercepts`, `pipes` for the matching decorators.
+- All framework edges carry `source: 'framework-decorator'` and `confidence: 'high'` when the decorator + DI binding both resolve.
+- Confidence drops to `medium` when DI uses string tokens (`@Inject('TOKEN')`) and `low` when the binding is configured at module-load time and not statically resolvable.
+
+## Stable ID strategy
+
+```
+file_id   = "file:" + sha256(workspace_relative_path).slice(0, 16)
+symbol_id = "symbol:" + file_id + "/" + kind + "/" + name + ("#" + overload_index if any)
+```
+
+- Path-derived IDs survive re-runs as long as the file path is stable.
+- Renaming a file changes both `file_id` and every `symbol_id` rooted in that file. That's intentional — a rename is a logical identity change for cache and delta purposes; the migration path (renames as moves) is a v2 concern.
+- Method overloads append a deterministic 0-based index in source order.
+- IDs do **not** embed line numbers. Line ranges live on the `range` field; refactors that move a symbol within a file do not change its ID.
+
+## Confidence and source provenance
+
+Every edge carries `(confidence, source)`. The pair drives:
+
+- **Selector scoring** (#74): `high`-confidence evidence outweighs `low`-confidence at equal distance.
+- **Coverage diagnostics** (#78): `low`-confidence-only coverage of a critical evidence class triggers a quality warning.
+- **Honesty surface**: when retrieval emits a snippet whose backing edge is `low`/`heuristic`, the rendered context can label it as "best-effort / not type-checker verified" instead of presenting it as authoritative.
+
+The general rule: when in doubt, **emit at lower confidence rather than dropping the edge**. Missing edges are invisible failures; low-confidence edges are auditable.
+
+## Diagnostics
+
+`SpiDiagnostic` exists to record what the extractor *couldn't* resolve, so failures are visible to the slicer / selector / consumer instead of silent gaps. Examples:
+
+- `info` — "Type-only import of Foo from './bar' — no runtime edge added."
+- `warn` — "Could not resolve callee for `this.client[methodName]()` — dynamic dispatch."
+- `error` — "Failed to parse `apps/api/src/legacy/decorators.ts` (tree-sitter fallback succeeded)."
+
+Diagnostics are stable across runs (same source → same diagnostic ID), so downstream tooling can suppress known-acknowledged warnings.
+
+## Relationship to today's `graph.json`
+
+SPI is the substrate; today's `graph.json` is one of several **projections** that can be derived from it.
+
+| Today | After SPI v1 lands |
+|---|---|
+| Extractor writes `graph.json` directly | Extractor writes `spi.json`; a projector renders the current `graph.json` shape from it |
+| `framework_role` is a node-level enum | SPI symbols carry `framework_role`; framework edges live as their own kinds |
+| PR-impact recomputes diff mapping each call | PR-impact reuses `SpiDiffOverlay` |
+| `impact` walks the flat edge list | `impact` walks SPI edges by kind, with confidence-weighted scoring |
+
+Backward compat:
+
+- `graph.json` keeps its existing shape via the projector. No behavior change for current MCP clients on day one.
+- `spi.json` is additive (new file alongside `graph.json`). Removing `graph.json` is a v2+ decision after consumers migrate.
+
+## Implementation plan (handed to #72)
+
+#72 builds SPI v1 in three slices, in this order:
+
+1. **File + symbol layers**, plus the projection back to today's `graph.json`. Must be byte-equivalent to current output for the existing TS extractor's golden fixtures.
+2. **Call + type layers** with confidence and source provenance.
+3. **Framework layer (NestJS) + diff overlay**. NestJS extractor here is the proving ground; Express/Next.js/Redux/React-Router stay on today's framework-aware path until SPI is proven.
+
+Each slice ships with:
+
+- A small NestJS / TS fixture in `examples/` (or `tests/fixtures/`).
+- Snapshot tests on the resulting `spi.json`.
+- A goldened projection test asserting byte-equivalent `graph.json` for at least the existing `examples/demo-repo/`.
+
+## Open questions
+
+- **Cross-file `references` granularity.** Should we emit `references` edges for every identifier reference, or only the first per (file, target) pair? First-pass design says "first per pair" to keep edge count linear; the slicer will care about *some* signal, not exhaustive enumeration.
+- **Rename detection.** Pure path-derived IDs treat a rename as a delete-plus-create. Worth carrying a `previous_id` field on `SpiSymbol` if and when the cache (#77) needs rename-aware reuse?
+- **Decorator metadata storage.** Decorator arguments (route paths, guard names, etc.) want to live somewhere. Proposed: `SpiSymbol.framework_metadata?: Record<string, unknown>` — open question whether to lock that schema now or leave it `unknown` until specific consumers need it.
+- **Test discovery scope.** The proposed heuristic covers `*.spec.*` and `__tests__/`. Vitest/Jest custom configs may use other patterns. Worth a per-workspace config knob?
+
+These are flagged for resolution during #72, not blockers for landing this design.
+
+## Risks
+
+- **Performance.** Adding a TypeScript compiler API pass on top of today's tree-sitter pass roughly doubles cold-start indexing time on large repos. The incremental cache (#77) is the load-bearing mitigation; #72 should ship together with a cache-key story even if the cache itself lands later.
+- **Edge bloat.** A naive symbol layer could 10× the edge count. The projection back to today's `graph.json` must filter aggressively (no `references` edges in the projection by default; opt-in for impact analysis).
+- **Framework coverage drift.** SPI carrying first-class NestJS edges for v1, but Express / Redux / React Router / Next.js stay on the current path. Risk of two extractors disagreeing on framework role; mitigation: shared `framework_role` enum + shared decorator parser library.
+- **Provenance discipline.** If extractors don't reliably set `source` and `confidence`, the selector and diagnostics layers built on top become useless. #72 needs lint-style assertions: every emitted edge has both fields, never `undefined`.
+
+## References
+
+- #69 — backend-vs-monorepo measurement spike (its findings should refine the layer priorities here before #72 starts implementation)
+- #71 — current-vs-slicing experiment (its findings determine whether SPI's slicing-friendly shape was the right bet)
+- #72 — SPI v1 implementation (consumes this design)
+- #73 — task-conditioned slicer prototype (consumes SPI)
+- #74 — budgeted context selector (consumes SPI confidence)
+- #77 — incremental SPI cache (caches what this design specifies)
+- #78 — quality diagnostics (consumes `SpiDiagnostic` + confidence labels)

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -227,6 +227,59 @@ describe('public marketing copy honesty', () => {
     })
   })
 
+  describe('docs/designs/2026-05-10-spi-v1.md', () => {
+    const content = readDoc('docs/designs/2026-05-10-spi-v1.md')
+
+    it('declares the design scope and links the tracking issue (#70)', () => {
+      expect(content).toMatch(/#70|issues\/70/)
+      expect(content).toContain('v0.14-substrate')
+      expect(content).toContain('design only')
+    })
+
+    it('locks in the SemanticProgramIndex top-level shape', () => {
+      expect(content).toContain('type SemanticProgramIndex')
+      expect(content).toContain('version: 1')
+      expect(content).toContain('files:')
+      expect(content).toContain('symbols:')
+      expect(content).toContain('edges:')
+      expect(content).toContain('diagnostics:')
+    })
+
+    it('documents every layer #70 lists in the issue body', () => {
+      for (const layer of [
+        'File layer',
+        'Symbol layer',
+        'Call layer',
+        'Type layer',
+        'Test layer',
+        'Diff layer',
+        'Framework layer',
+      ]) {
+        expect(content).toContain(layer)
+      }
+    })
+
+    it('locks confidence to {high, medium, low} and source provenance to a closed set', () => {
+      expect(content).toMatch(/confidence:\s*'high'\s*\|\s*'medium'\s*\|\s*'low'/)
+      expect(content).toContain("'typescript-semantic'")
+      expect(content).toContain("'tree-sitter'")
+      expect(content).toContain("'framework-decorator'")
+      expect(content).toContain("'heuristic'")
+    })
+
+    it('cross-links the consuming and adjacent issues so the design is discoverable', () => {
+      for (const ref of ['#69', '#71', '#72', '#73', '#74', '#77', '#78']) {
+        expect(content).toContain(ref)
+      }
+    })
+
+    it('explicitly lists non-goals and open questions to scope the design honestly', () => {
+      expect(content).toContain('## Non-goals')
+      expect(content).toContain('## Open questions')
+      expect(content).toContain('## Risks')
+    })
+  })
+
   describe('examples/mcp-tool-examples.md', () => {
     const content = readDoc('examples/mcp-tool-examples.md')
     const lower = content.toLowerCase()


### PR DESCRIPTION
Phase **C** of our v0.14-substrate sequence. Tracking issue: [#70 — Design Semantic Program Index v1 as the internal representation](https://github.com/mohanagy/graphify-ts/issues/70). Milestone: `v0.14-substrate`.

**Design only.** No code. The contract this document locks down is what [#72](https://github.com/mohanagy/graphify-ts/issues/72) will implement against and what [#73](https://github.com/mohanagy/graphify-ts/issues/73) (slicer) and [#74](https://github.com/mohanagy/graphify-ts/issues/74) (selector) will consume.

## What ships

A single document at `docs/designs/2026-05-10-spi-v1.md` covering:

- **Problem framing** — why today's flat `graph.json` hits limits for the slicer (no kind-aware traversal, no confidence dimension, no diff layer).
- **Goals + non-goals** — scoped to TS/JS for v1; not solving every dynamic JS behavior; not exposing SPI as a public MCP surface yet.
- **Full TypeScript data model** — `SemanticProgramIndex`, `SpiFile`, `SpiSymbol`, `SpiEdge`, `SpiDiagnostic`, `SpiDiffOverlay`. Versioned at `1`.
- **Layer-by-layer specification** — file / symbol / call / type / test / diff / framework (NestJS v1 first; the existing Express / Next.js / Redux / React-Router framework passes stay on today's path until SPI is proven).
- **Stable ID strategy** — path-derived sha256, deterministic across runs, no line numbers in IDs so in-file refactors don't invalidate caches.
- **Confidence + source provenance** — `high / medium / low` × 5 sources (`typescript-semantic`, `typescript-syntactic`, `tree-sitter`, `framework-decorator`, `heuristic`). Rule: emit at lower confidence rather than drop the edge — missing edges are invisible failures, low-confidence edges are auditable.
- **Diagnostics** — `SpiDiagnostic` records what couldn't resolve, with stable IDs across reruns for the same source state.
- **Backward compat** — `graph.json` kept via a documented projection from `spi.json`. Day-one zero behavior change for current MCP clients.
- **Implementation plan for #72** — three slices in order (file+symbol+projection → call+type → framework+diff overlay), each with golden tests.
- **Open questions + risks** — flagged for resolution during #72, not blockers for landing this design (rename detection, references granularity, decorator-metadata schema, performance regression w/o cache).

## Honesty constraints I held to

- The doc is explicit that this is a design, not an implementation, and explicitly scopes SPI v1 to TS/JS — other languages stay on today's extractor.
- Open questions are listed as *open*, not pre-resolved. Risks are listed honestly (perf hit, edge bloat, framework drift).
- Cross-links every dependent issue (#69, #71, #72, #73, #74, #77, #78) so the design is discoverable from the rest of the v0.14 plan.

## Test plan

- [x] `npm run test:run` — **1401/1401** pass (was 1395 on `main`; +6 new doc-honesty assertions).
- [x] New tests pin: tracking issue link, top-level type shape, all seven layers documented, confidence enum closed to `{high, medium, low}`, source enum closed to the documented five values, cross-links to all consuming issues, non-goals + open-questions + risks sections present.
- [x] `npm run typecheck` — clean.
- [ ] Reviewer reads the design end-to-end and either signs off or marks specific layers / IDs / confidence rules for redesign before #72 starts.

## What lands next

After this merges, **#72** (SPI v1 implementation) is unblocked and follows the three-slice plan in the design. **#73** (slicer prototype) is also unblocked design-side, but should still wait until at least slice 1+2 of #72 land so it has a real `spi.json` to walk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a design specification document for the Semantic Program Index (SPI v1), detailing the versioned data model architecture and implementation roadmap.

* **Tests**
  * Added validation tests to ensure the design documentation meets structural and content requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->