### PR TITLE
feat(#72): SPI v1 slice 1a — types + file-layer builder

### DIFF
--- a/docs/designs/2026-05-10-spi-v1.md
+++ b/docs/designs/2026-05-10-spi-v1.md
@@ -1,0 +1,283 @@
+# SPI v1 — Semantic Program Index design
+
+> **Tracking issue:** [#70](https://github.com/mohanagy/graphify-ts/issues/70) — *Design Semantic Program Index v1 as the internal representation.*
+> **Milestone:** `v0.14-substrate`. Implementation lives in [#72](https://github.com/mohanagy/graphify-ts/issues/72); the slicer that consumes SPI lives in [#73](https://github.com/mohanagy/graphify-ts/issues/73).
+> **Status:** design only — no code in this PR. The implementation contract this document locks down is what #72 will build against.
+
+## Problem
+
+Today's `graph.json` is a flat node/edge map: files, symbols, calls, imports, framework_role nodes for the supported web frameworks. It works for `retrieve` and `pr_impact`, but it has three structural limits that show up the moment we try to build the task-conditioned slicer (#73):
+
+1. **Edge semantics are flat.** A `calls` edge and a `provides` edge are both just `edges[i]`. The slicer needs to walk forward/backward by *kind* (calls only, types only, tests only) without re-deriving semantics from string heuristics every time.
+2. **No confidence dimension.** A statically resolved `ts.Symbol`-backed call edge is much stronger evidence than a regex-matched string call site, but they currently look identical to retrieval. The compiler (#74) needs a confidence signal to score evidence properly.
+3. **No diff layer.** PR-impact derives changed-line → containing-symbol mappings on every call. That's both slow and inconsistent across the rest of the surface (e.g., `impact` and `slicer` would each re-derive it).
+
+SPI v1 is the **internal substrate** that fixes all three. It is *not* a new public CLI surface — it's the data model the existing extractor pipeline produces and the new slicer/selector consume.
+
+## Goals
+
+- One **versioned, typed, deterministic** representation of the workspace's program structure.
+- Edge `kind` + `confidence` + `source` are first-class, not string-encoded.
+- A **diff layer** that maps changed line ranges to symbols once, reused everywhere.
+- **Stable IDs** so the same source produces the same node ID across runs (cache keys, delta computation, agent re-references).
+- Backward compat with today's `graph.json` via a documented projection.
+
+## Non-goals
+
+- Not solving every dynamic JS behavior (metaprogramming, `eval`, runtime route registration). Unresolved cases are recorded as low-confidence diagnostics, not silently dropped.
+- Not replacing all current graph features in one PR — #72 lands SPI alongside today's pipeline; the projection bridges them.
+- Not exposing SPI as a public MCP tool surface yet. Only debug/inspection output until the shape proves useful in #73 + #74.
+- Not adding new language extractors here. SPI v1 = TypeScript / JavaScript only. Other languages keep today's extractor and join SPI in a later milestone.
+
+## Data model
+
+```ts
+type SemanticProgramIndex = {
+  version: 1
+  generated_at: string         // ISO 8601 UTC
+  workspace: SpiWorkspace
+  files:       SpiFile[]
+  symbols:     SpiSymbol[]
+  edges:       SpiEdge[]
+  diagnostics: SpiDiagnostic[]
+}
+
+type SpiWorkspace = {
+  root: string                 // absolute path the index was built against
+  fingerprint: string          // sha256 of (root + tsconfig + extractor version)
+  extractor_version: string
+  graphify_version: string
+}
+
+type SpiFile = {
+  id: string                   // file:<sha256(relative_path)[:16]>
+  path: string                 // relative to workspace.root, POSIX-normalized
+  language: 'typescript' | 'javascript' | 'tsx' | 'jsx' | 'json' | 'unknown'
+  loc: number                  // physical line count
+  hash: string                 // sha256 of file content
+}
+
+type SpiSymbol = {
+  id: string                   // symbol:<file_id>/<kind>/<name>[#<overload>]
+  file_id: string
+  name: string
+  kind: SpiSymbolKind
+  range: SpiRange              // 1-based, inclusive
+  exported: boolean
+  framework_role?: SpiFrameworkRole   // optional layer-7 enrichment
+}
+
+type SpiSymbolKind =
+  | 'function' | 'class' | 'interface' | 'type-alias'
+  | 'enum'     | 'method' | 'constant'  | 'variable'
+  | 'namespace'
+
+type SpiRange = {
+  start: { line: number; column: number }
+  end:   { line: number; column: number }
+}
+
+type SpiEdge = {
+  from: string                 // SpiFile.id | SpiSymbol.id
+  to:   string                 // SpiFile.id | SpiSymbol.id
+  kind: SpiEdgeKind
+  confidence: 'high' | 'medium' | 'low'
+  source: SpiEdgeSource
+  evidence?: { file_id: string; range: SpiRange }
+}
+
+type SpiEdgeKind =
+  // file layer
+  | 'imports' | 'exports'
+  // symbol layer
+  | 'declares' | 'references'
+  // call layer
+  | 'calls'
+  // type layer
+  | 'extends' | 'implements' | 'param_type' | 'return_type'
+  // test layer
+  | 'covered_by'
+  // diff layer (computed on demand, persisted in SpiDiff overlay)
+  | 'changed_in'
+  // framework layer (NestJS v1)
+  | 'module_provides' | 'module_imports' | 'module_exports'
+  | 'controller_route' | 'route_handler'
+  | 'injects' | 'guards' | 'intercepts' | 'pipes'
+
+type SpiEdgeSource =
+  | 'typescript-semantic'      // resolved via ts.TypeChecker
+  | 'typescript-syntactic'     // AST shape only (e.g., barrel re-export)
+  | 'tree-sitter'              // fallback for non-TS
+  | 'framework-decorator'      // resolved via decorator metadata
+  | 'heuristic'                // regex / naming convention; always 'low' confidence
+
+type SpiFrameworkRole =
+  | 'nest_module' | 'nest_controller' | 'nest_route'
+  | 'nest_provider' | 'nest_guard' | 'nest_pipe' | 'nest_interceptor'
+
+type SpiDiagnostic = {
+  id: string                   // stable across reruns for the same source state
+  level: 'info' | 'warn' | 'error'
+  message: string
+  evidence?: { file_id: string; range?: SpiRange }
+}
+
+// Diff overlay — computed on top of SPI when a base ref is supplied; not part
+// of the persisted index because it varies with `git rev-parse`.
+type SpiDiffOverlay = {
+  base_ref: string
+  head_ref: string
+  changed_files: string[]      // SpiFile.id list
+  changed_symbols: string[]    // SpiSymbol.id list
+  edges_added: SpiEdge[]       // kind === 'changed_in'
+}
+```
+
+## Layer-by-layer specification
+
+### File layer
+
+- Source: walks `tsconfig.{json,build.json}` reachability + `.gitignore` — the same set today's extractor uses.
+- Edges: `imports`, `exports` between files.
+- Confidence:
+  - **`high`** when the import target resolves to a concrete `SpiFile.id` via `ts.resolveModuleName`.
+  - **`medium`** when the target is a relative path that resolves to a file but not via the type checker.
+  - **`low`** for type-only imports that the runtime never sees, and for resolution failures that fall back to syntactic match.
+
+### Symbol layer
+
+- Source: TypeScript compiler API (`ts.SyntaxKind` walk).
+- One `SpiSymbol` per declaration. Method overloads use `#0`, `#1` suffixes.
+- Edges: `declares` (file → symbol), `references` (symbol → symbol within the same file scope, with confidence depending on whether the reference resolved through `ts.TypeChecker`).
+
+### Call layer
+
+- Source: `ts.TypeChecker.getResolvedSignature` for callsites where the target is a concrete signature.
+- Edges: `calls` (caller symbol → callee symbol).
+- Confidence:
+  - **`high`** when `getResolvedSignature` returns a single concrete declaration.
+  - **`medium`** when overload resolution returns an ambiguous union.
+  - **`low`** when the callee is dynamically dispatched (computed property, decorator-injected) and we matched by name only.
+- Method calls on injected dependencies (NestJS pattern) get a `medium` baseline that the framework layer can promote to `high` when the DI binding is statically resolvable.
+
+### Type layer
+
+- Edges:
+  - `extends` (class ↔ class, interface ↔ interface)
+  - `implements` (class → interface)
+  - `param_type` and `return_type` (function ↔ type/interface)
+- Confidence: always `high` for type-checker-backed; `low` for type-only references that came from JSDoc.
+
+### Test layer
+
+- Heuristic association (intentionally not type-checker-backed):
+  - `foo.spec.ts` ↔ `foo.ts` if both files exist in the same directory or in a `__tests__/` sibling.
+  - Test files importing a symbol get a `covered_by` edge from that symbol to the test file.
+- Confidence: **`medium`** for filename-pattern matches, **`high`** when the test file actually imports the source symbol (cross-validated via the import layer).
+
+### Diff layer (overlay, not persisted)
+
+- Computed on demand by `SpiDiffOverlay.compute(base_ref, head_ref)`.
+- Maps each changed line range from `git diff` to the smallest containing `SpiSymbol`. If no symbol contains the range (e.g., file-top imports), maps to the file.
+- Adds `changed_in` edges (`SpiSymbol.id → SpiFile.id` for the changed file).
+- Reused by `pr_impact`, `impact --diff`, and the future slicer's PR-review mode (#73).
+
+### Framework layer (NestJS v1)
+
+- Source: `ts.Decorator` metadata + a small NestJS-aware visitor.
+- Edges added beyond what the AST already produces:
+  - `module_provides`, `module_imports`, `module_exports` (Module → Provider/Module/Service).
+  - `controller_route` (Controller class → method with `@Get`/`@Post`/`@Patch`/`@Put`/`@Delete`).
+  - `route_handler` (route → controller method).
+  - `injects` (constructor param → injected provider class).
+  - `guards`, `intercepts`, `pipes` for the matching decorators.
+- All framework edges carry `source: 'framework-decorator'` and `confidence: 'high'` when the decorator + DI binding both resolve.
+- Confidence drops to `medium` when DI uses string tokens (`@Inject('TOKEN')`) and `low` when the binding is configured at module-load time and not statically resolvable.
+
+## Stable ID strategy
+
+```
+file_id   = "file:" + sha256(workspace_relative_path).slice(0, 16)
+symbol_id = "symbol:" + file_id + "/" + kind + "/" + name + ("#" + overload_index if any)
+```
+
+- Path-derived IDs survive re-runs as long as the file path is stable.
+- Renaming a file changes both `file_id` and every `symbol_id` rooted in that file. That's intentional — a rename is a logical identity change for cache and delta purposes; the migration path (renames as moves) is a v2 concern.
+- Method overloads append a deterministic 0-based index in source order.
+- IDs do **not** embed line numbers. Line ranges live on the `range` field; refactors that move a symbol within a file do not change its ID.
+
+## Confidence and source provenance
+
+Every edge carries `(confidence, source)`. The pair drives:
+
+- **Selector scoring** (#74): `high`-confidence evidence outweighs `low`-confidence at equal distance.
+- **Coverage diagnostics** (#78): `low`-confidence-only coverage of a critical evidence class triggers a quality warning.
+- **Honesty surface**: when retrieval emits a snippet whose backing edge is `low`/`heuristic`, the rendered context can label it as "best-effort / not type-checker verified" instead of presenting it as authoritative.
+
+The general rule: when in doubt, **emit at lower confidence rather than dropping the edge**. Missing edges are invisible failures; low-confidence edges are auditable.
+
+## Diagnostics
+
+`SpiDiagnostic` exists to record what the extractor *couldn't* resolve, so failures are visible to the slicer / selector / consumer instead of silent gaps. Examples:
+
+- `info` — "Type-only import of Foo from './bar' — no runtime edge added."
+- `warn` — "Could not resolve callee for `this.client[methodName]()` — dynamic dispatch."
+- `error` — "Failed to parse `apps/api/src/legacy/decorators.ts` (tree-sitter fallback succeeded)."
+
+Diagnostics are stable across runs (same source → same diagnostic ID), so downstream tooling can suppress known-acknowledged warnings.
+
+## Relationship to today's `graph.json`
+
+SPI is the substrate; today's `graph.json` is one of several **projections** that can be derived from it.
+
+| Today | After SPI v1 lands |
+|---|---|
+| Extractor writes `graph.json` directly | Extractor writes `spi.json`; a projector renders the current `graph.json` shape from it |
+| `framework_role` is a node-level enum | SPI symbols carry `framework_role`; framework edges live as their own kinds |
+| PR-impact recomputes diff mapping each call | PR-impact reuses `SpiDiffOverlay` |
+| `impact` walks the flat edge list | `impact` walks SPI edges by kind, with confidence-weighted scoring |
+
+Backward compat:
+
+- `graph.json` keeps its existing shape via the projector. No behavior change for current MCP clients on day one.
+- `spi.json` is additive (new file alongside `graph.json`). Removing `graph.json` is a v2+ decision after consumers migrate.
+
+## Implementation plan (handed to #72)
+
+#72 builds SPI v1 in three slices, in this order:
+
+1. **File + symbol layers**, plus the projection back to today's `graph.json`. Must be byte-equivalent to current output for the existing TS extractor's golden fixtures.
+2. **Call + type layers** with confidence and source provenance.
+3. **Framework layer (NestJS) + diff overlay**. NestJS extractor here is the proving ground; Express/Next.js/Redux/React-Router stay on today's framework-aware path until SPI is proven.
+
+Each slice ships with:
+
+- A small NestJS / TS fixture in `examples/` (or `tests/fixtures/`).
+- Snapshot tests on the resulting `spi.json`.
+- A goldened projection test asserting byte-equivalent `graph.json` for at least the existing `examples/demo-repo/`.
+
+## Open questions
+
+- **Cross-file `references` granularity.** Should we emit `references` edges for every identifier reference, or only the first per (file, target) pair? First-pass design says "first per pair" to keep edge count linear; the slicer will care about *some* signal, not exhaustive enumeration.
+- **Rename detection.** Pure path-derived IDs treat a rename as a delete-plus-create. Worth carrying a `previous_id` field on `SpiSymbol` if and when the cache (#77) needs rename-aware reuse?
+- **Decorator metadata storage.** Decorator arguments (route paths, guard names, etc.) want to live somewhere. Proposed: `SpiSymbol.framework_metadata?: Record<string, unknown>` — open question whether to lock that schema now or leave it `unknown` until specific consumers need it.
+- **Test discovery scope.** The proposed heuristic covers `*.spec.*` and `__tests__/`. Vitest/Jest custom configs may use other patterns. Worth a per-workspace config knob?
+
+These are flagged for resolution during #72, not blockers for landing this design.
+
+## Risks
+
+- **Performance.** Adding a TypeScript compiler API pass on top of today's tree-sitter pass roughly doubles cold-start indexing time on large repos. The incremental cache (#77) is the load-bearing mitigation; #72 should ship together with a cache-key story even if the cache itself lands later.
+- **Edge bloat.** A naive symbol layer could 10× the edge count. The projection back to today's `graph.json` must filter aggressively (no `references` edges in the projection by default; opt-in for impact analysis).
+- **Framework coverage drift.** SPI carrying first-class NestJS edges for v1, but Express / Redux / React Router / Next.js stay on the current path. Risk of two extractors disagreeing on framework role; mitigation: shared `framework_role` enum + shared decorator parser library.
+- **Provenance discipline.** If extractors don't reliably set `source` and `confidence`, the selector and diagnostics layers built on top become useless. #72 needs lint-style assertions: every emitted edge has both fields, never `undefined`.
+
+## References
+
+- #69 — backend-vs-monorepo measurement spike (its findings should refine the layer priorities here before #72 starts implementation)
+- #71 — current-vs-slicing experiment (its findings determine whether SPI's slicing-friendly shape was the right bet)
+- #72 — SPI v1 implementation (consumes this design)
+- #73 — task-conditioned slicer prototype (consumes SPI)
+- #74 — budgeted context selector (consumes SPI confidence)
+- #77 — incremental SPI cache (caches what this design specifies)
+- #78 — quality diagnostics (consumes `SpiDiagnostic` + confidence labels)

--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -1,0 +1,362 @@
+// SPI v1 — file-layer builder (slice 1a of #72).
+//
+// Produces a SemanticProgramIndex containing:
+//   - workspace metadata + fingerprint
+//   - one SpiFile per supported source file under the workspace root
+//   - imports / exports edges between files (syntactic only — no type checker)
+//
+// Symbols, calls, types, framework, and diff overlay land in subsequent
+// slices of #72. This module never touches the existing pipeline; it is
+// pure additive substrate.
+
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs'
+import { dirname, extname, join, relative, resolve } from 'node:path'
+import ts from 'typescript'
+
+import type {
+  SemanticProgramIndex,
+  SpiDiagnostic,
+  SpiEdge,
+  SpiEdgeEvidence,
+  SpiFile,
+  SpiLanguage,
+  SpiRange,
+} from './types.js'
+
+export type BuildSpiFileLayerOptions = {
+  root: string
+  graphifyVersion: string
+  extractorVersion?: string
+  // Override the wall-clock used in `generated_at`. Test-only escape hatch
+  // so snapshot tests can assert deterministic output.
+  now?: () => Date
+}
+
+const SKIP_DIRS = new Set<string>([
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+  '.git',
+  'graphify-out',
+  '.test-artifacts',
+  '.turbo',
+  '.vercel',
+])
+
+const EXT_TO_LANG: Record<string, SpiLanguage> = {
+  '.ts': 'typescript',
+  '.tsx': 'tsx',
+  '.js': 'javascript',
+  '.jsx': 'jsx',
+}
+
+const RESOLUTION_CANDIDATE_EXTS = ['', '.ts', '.tsx', '.js', '.jsx'] as const
+const INDEX_RESOLUTION_CANDIDATES = [
+  '/index.ts',
+  '/index.tsx',
+  '/index.js',
+  '/index.jsx',
+] as const
+
+export function buildSpiFileLayer(opts: BuildSpiFileLayerOptions): SemanticProgramIndex {
+  const root = resolve(opts.root)
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
+    throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
+  }
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-1a'
+  const now = opts.now ?? (() => new Date())
+
+  const files: SpiFile[] = []
+  const edges: SpiEdge[] = []
+  const diagnostics: SpiDiagnostic[] = []
+
+  const absPaths: string[] = []
+  collectFiles(root, absPaths)
+
+  const pathToFileId = new Map<string, string>()
+  for (const abs of absPaths) {
+    const ext = extname(abs).toLowerCase()
+    const language = EXT_TO_LANG[ext]
+    if (!language) continue
+    const rel = toPosix(relative(root, abs))
+    const content = readFileSync(abs, 'utf8')
+    const fileId = makeFileId(rel)
+    pathToFileId.set(abs, fileId)
+    files.push({
+      id: fileId,
+      path: rel,
+      language,
+      loc: countLines(content),
+      hash: sha256(content),
+    })
+  }
+
+  for (const file of files) {
+    const abs = join(root, file.path)
+    const content = readFileSync(abs, 'utf8')
+    const sourceFile = ts.createSourceFile(
+      file.path,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      scriptKindFor(file.language),
+    )
+    visitFile(sourceFile, file, root, pathToFileId, edges, diagnostics)
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path))
+  edges.sort((a, b) =>
+    `${a.from}|${a.to}|${a.kind}`.localeCompare(`${b.from}|${b.to}|${b.kind}`),
+  )
+  diagnostics.sort((a, b) => a.id.localeCompare(b.id))
+
+  return {
+    version: 1,
+    generated_at: now().toISOString(),
+    workspace: {
+      root,
+      fingerprint: workspaceFingerprint(root, extractorVersion),
+      extractor_version: extractorVersion,
+      graphify_version: opts.graphifyVersion,
+    },
+    files,
+    symbols: [],
+    edges,
+    diagnostics,
+  }
+}
+
+function collectFiles(dir: string, out: string[]): void {
+  let entries: import('node:fs').Dirent<string>[]
+  try {
+    entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue
+    if (entry.isSymbolicLink()) continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      collectFiles(full, out)
+    } else if (entry.isFile()) {
+      out.push(full)
+    }
+  }
+}
+
+function visitFile(
+  sourceFile: ts.SourceFile,
+  file: SpiFile,
+  root: string,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  diagnostics: SpiDiagnostic[],
+): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      const moduleSpec = node.moduleSpecifier
+      if (ts.isStringLiteral(moduleSpec)) {
+        const isTypeOnly = node.importClause?.isTypeOnly ?? false
+        addImportEdge(moduleSpec.text, isTypeOnly, node, sourceFile, file, root, pathToFileId, edges, diagnostics)
+      }
+    } else if (ts.isExportDeclaration(node)) {
+      addExportEdge(node, sourceFile, file, edges)
+      const moduleSpec = node.moduleSpecifier
+      if (moduleSpec && ts.isStringLiteral(moduleSpec)) {
+        const isTypeOnly = node.isTypeOnly
+        addImportEdge(moduleSpec.text, isTypeOnly, node, sourceFile, file, root, pathToFileId, edges, diagnostics)
+      }
+    } else if (ts.isExportAssignment(node)) {
+      addExportEdge(node, sourceFile, file, edges)
+    } else if (
+      // export const | export function | export class etc.
+      hasExportModifier(node) &&
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node) ||
+        ts.isVariableStatement(node))
+    ) {
+      addExportEdge(node, sourceFile, file, edges)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+function addImportEdge(
+  spec: string,
+  isTypeOnly: boolean,
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  file: SpiFile,
+  root: string,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  diagnostics: SpiDiagnostic[],
+): void {
+  const evidence: SpiEdgeEvidence = { file_id: file.id, range: rangeOf(node, sourceFile) }
+  // Bare module specifiers are external — skip silently for v1.
+  if (!spec.startsWith('.') && !spec.startsWith('/')) return
+
+  const targetFileId = resolveRelativeImport(spec, file.path, root, pathToFileId)
+  if (targetFileId) {
+    edges.push({
+      from: file.id,
+      to: targetFileId,
+      kind: 'imports',
+      confidence: isTypeOnly ? 'low' : 'high',
+      source: 'typescript-syntactic',
+      evidence,
+    })
+    return
+  }
+  edges.push({
+    from: file.id,
+    to: 'file:unresolved/' + spec,
+    kind: 'imports',
+    confidence: 'medium',
+    source: 'typescript-syntactic',
+    evidence,
+  })
+  diagnostics.push({
+    id: 'spi.import.unresolved.' + sha256(file.id + ':' + spec).slice(0, 12),
+    level: 'info',
+    message: `Unresolved relative import "${spec}" from ${file.path}`,
+    evidence,
+  })
+}
+
+function addExportEdge(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  file: SpiFile,
+  edges: SpiEdge[],
+): void {
+  // File-layer export edge: file -> file (self). Symbol-level exports land in
+  // slice 1b once SpiSymbols exist.
+  edges.push({
+    from: file.id,
+    to: file.id,
+    kind: 'exports',
+    confidence: 'high',
+    source: 'typescript-syntactic',
+    evidence: { file_id: file.id, range: rangeOf(node, sourceFile) },
+  })
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  // ts.canHaveModifiers / ts.getModifiers on the public ts namespace.
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined
+  if (!modifiers) return false
+  for (const mod of modifiers) {
+    if (mod.kind === ts.SyntaxKind.ExportKeyword) return true
+  }
+  return false
+}
+
+function resolveRelativeImport(
+  spec: string,
+  fromPath: string,
+  root: string,
+  pathToFileId: Map<string, string>,
+): string | null {
+  const fromAbs = resolve(root, fromPath)
+  const fromDir = dirname(fromAbs)
+  const variants = expandJsToTsVariants(spec)
+
+  for (const variant of variants) {
+    for (const ext of RESOLUTION_CANDIDATE_EXTS) {
+      const id = pathToFileId.get(resolve(fromDir, variant + ext))
+      if (id) return id
+    }
+    for (const tail of INDEX_RESOLUTION_CANDIDATES) {
+      const id = pathToFileId.get(resolve(fromDir, variant + tail))
+      if (id) return id
+    }
+  }
+  return null
+}
+
+// Node ESM with TypeScript convention: relative imports keep the `.js` suffix
+// at write time but resolve to the matching `.ts`/`.tsx` source. Translate so
+// the file-layer resolver matches what the type checker would.
+function expandJsToTsVariants(spec: string): string[] {
+  if (spec.endsWith('.js')) {
+    const base = spec.slice(0, -3)
+    return [spec, base, base + '.ts', base + '.tsx']
+  }
+  if (spec.endsWith('.jsx')) {
+    const base = spec.slice(0, -4)
+    return [spec, base, base + '.tsx', base + '.ts']
+  }
+  return [spec]
+}
+
+function rangeOf(node: ts.Node, sourceFile: ts.SourceFile): SpiRange {
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd())
+  return {
+    start: { line: start.line + 1, column: start.character + 1 },
+    end: { line: end.line + 1, column: end.character + 1 },
+  }
+}
+
+function makeFileId(relPath: string): string {
+  return 'file:' + sha256(relPath).slice(0, 16)
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex')
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0
+  let count = 1
+  for (let i = 0; i < text.length; i += 1) {
+    if (text.charCodeAt(i) === 10) count += 1
+  }
+  return count
+}
+
+function scriptKindFor(language: SpiLanguage): ts.ScriptKind {
+  switch (language) {
+    case 'typescript':
+      return ts.ScriptKind.TS
+    case 'tsx':
+      return ts.ScriptKind.TSX
+    case 'javascript':
+      return ts.ScriptKind.JS
+    case 'jsx':
+      return ts.ScriptKind.JSX
+    default:
+      return ts.ScriptKind.Unknown
+  }
+}
+
+function workspaceFingerprint(root: string, extractorVersion: string): string {
+  const tsConfigPath = join(root, 'tsconfig.json')
+  let tsConfigContent = ''
+  if (existsSync(tsConfigPath)) {
+    try {
+      tsConfigContent = readFileSync(tsConfigPath, 'utf8')
+    } catch {
+      // Best-effort fingerprint; missing or unreadable tsconfig is acceptable.
+    }
+  }
+  return sha256(`${root}|${tsConfigContent}|${extractorVersion}`).slice(0, 16)
+}
+
+function toPosix(p: string): string {
+  return p.split('\\').join('/')
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -1,0 +1,29 @@
+// SPI v1 — public re-exports.
+//
+// Slice 1a: types + file-layer builder. Symbol/call/type/test/diff/framework
+// layers and the projection back to today's graph.json land in subsequent
+// slices of #72.
+
+export type {
+  SpiVersion,
+  SemanticProgramIndex,
+  SpiWorkspace,
+  SpiLanguage,
+  SpiFile,
+  SpiSymbolKind,
+  SpiPosition,
+  SpiRange,
+  SpiFrameworkRole,
+  SpiSymbol,
+  SpiEdgeKind,
+  SpiEdgeConfidence,
+  SpiEdgeSource,
+  SpiEdgeEvidence,
+  SpiEdge,
+  SpiDiagnosticLevel,
+  SpiDiagnosticEvidence,
+  SpiDiagnostic,
+  SpiDiffOverlay,
+} from './types.js'
+
+export { buildSpiFileLayer, type BuildSpiFileLayerOptions } from './build.js'

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -1,0 +1,160 @@
+// SPI v1 — Semantic Program Index types.
+//
+// These types are the design contract from docs/designs/2026-05-10-spi-v1.md.
+// They are intentionally exhaustive (every layer the design names) so later
+// slices of #72 can fill in symbols / edges / framework / diff overlay
+// without re-shaping the public surface.
+//
+// Slice 1a (this file) lands the type definitions plus the file-layer
+// builder. Other layers ship in subsequent PRs of #72.
+
+export type SpiVersion = 1
+
+export type SemanticProgramIndex = {
+  version: SpiVersion
+  generated_at: string
+  workspace: SpiWorkspace
+  files: SpiFile[]
+  symbols: SpiSymbol[]
+  edges: SpiEdge[]
+  diagnostics: SpiDiagnostic[]
+}
+
+export type SpiWorkspace = {
+  root: string
+  fingerprint: string
+  extractor_version: string
+  graphify_version: string
+}
+
+export type SpiLanguage =
+  | 'typescript'
+  | 'javascript'
+  | 'tsx'
+  | 'jsx'
+  | 'json'
+  | 'unknown'
+
+export type SpiFile = {
+  id: string
+  path: string
+  language: SpiLanguage
+  loc: number
+  hash: string
+}
+
+export type SpiSymbolKind =
+  | 'function'
+  | 'class'
+  | 'interface'
+  | 'type-alias'
+  | 'enum'
+  | 'method'
+  | 'constant'
+  | 'variable'
+  | 'namespace'
+
+export type SpiPosition = {
+  line: number
+  column: number
+}
+
+export type SpiRange = {
+  start: SpiPosition
+  end: SpiPosition
+}
+
+export type SpiFrameworkRole =
+  | 'nest_module'
+  | 'nest_controller'
+  | 'nest_route'
+  | 'nest_provider'
+  | 'nest_guard'
+  | 'nest_pipe'
+  | 'nest_interceptor'
+
+export type SpiSymbol = {
+  id: string
+  file_id: string
+  name: string
+  kind: SpiSymbolKind
+  range: SpiRange
+  exported: boolean
+  framework_role?: SpiFrameworkRole
+}
+
+export type SpiEdgeKind =
+  // file layer
+  | 'imports'
+  | 'exports'
+  // symbol layer
+  | 'declares'
+  | 'references'
+  // call layer
+  | 'calls'
+  // type layer
+  | 'extends'
+  | 'implements'
+  | 'param_type'
+  | 'return_type'
+  // test layer
+  | 'covered_by'
+  // diff overlay
+  | 'changed_in'
+  // framework layer (NestJS v1)
+  | 'module_provides'
+  | 'module_imports'
+  | 'module_exports'
+  | 'controller_route'
+  | 'route_handler'
+  | 'injects'
+  | 'guards'
+  | 'intercepts'
+  | 'pipes'
+
+export type SpiEdgeConfidence = 'high' | 'medium' | 'low'
+
+export type SpiEdgeSource =
+  | 'typescript-semantic'
+  | 'typescript-syntactic'
+  | 'tree-sitter'
+  | 'framework-decorator'
+  | 'heuristic'
+
+export type SpiEdgeEvidence = {
+  file_id: string
+  range: SpiRange
+}
+
+export type SpiEdge = {
+  from: string
+  to: string
+  kind: SpiEdgeKind
+  confidence: SpiEdgeConfidence
+  source: SpiEdgeSource
+  evidence?: SpiEdgeEvidence
+}
+
+export type SpiDiagnosticLevel = 'info' | 'warn' | 'error'
+
+export type SpiDiagnosticEvidence = {
+  file_id: string
+  range?: SpiRange
+}
+
+export type SpiDiagnostic = {
+  id: string
+  level: SpiDiagnosticLevel
+  message: string
+  evidence?: SpiDiagnosticEvidence
+}
+
+// Diff overlay is computed on demand against a base ref and is intentionally
+// not part of the persisted SemanticProgramIndex (it varies with git state).
+export type SpiDiffOverlay = {
+  base_ref: string
+  head_ref: string
+  changed_files: string[]
+  changed_symbols: string[]
+  edges_added: SpiEdge[]
+}

--- a/tests/unit/spi-build.test.ts
+++ b/tests/unit/spi-build.test.ts
@@ -1,0 +1,217 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve as pathResolve } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpiFileLayer } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiEdge, SpiFile } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-test-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpiFileLayer({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1a',
+    now: FROZEN_NOW,
+  })
+}
+
+function edgesBetween(spi: SemanticProgramIndex, fromPath: string, toPath: string, kind: SpiEdge['kind']): SpiEdge[] {
+  const fromId = findFile(spi, fromPath).id
+  const toId = findFile(spi, toPath).id
+  return spi.edges.filter((e) => e.from === fromId && e.to === toId && e.kind === kind)
+}
+
+function findFile(spi: SemanticProgramIndex, path: string): SpiFile {
+  const f = spi.files.find((x) => x.path === path)
+  if (!f) throw new Error(`fixture missing SpiFile: ${path}\nhad: ${spi.files.map((x) => x.path).join(', ')}`)
+  return f
+}
+
+describe('buildSpiFileLayer (slice 1a of #72)', () => {
+  let sandbox: string
+
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('shape and metadata', () => {
+    it('produces a versioned SemanticProgramIndex with workspace metadata', () => {
+      writeFile(sandbox, 'src/a.ts', 'export const a = 1\n')
+      const spi = build(sandbox)
+
+      expect(spi.version).toBe(1)
+      expect(spi.generated_at).toBe('2026-05-10T12:34:56.000Z')
+      expect(spi.workspace.root).toBe(pathResolve(sandbox))
+      expect(spi.workspace.extractor_version).toBe('spi-v1.0.0-slice-1a')
+      expect(spi.workspace.graphify_version).toBe('test-0.0.0')
+      expect(spi.workspace.fingerprint).toMatch(/^[a-f0-9]{16}$/)
+    })
+
+    it('throws when the workspace root is missing', () => {
+      expect(() => build(join(sandbox, 'does-not-exist'))).toThrow(/not found or not a directory/)
+    })
+  })
+
+  describe('file discovery', () => {
+    it('emits one SpiFile per supported source file with stable id, hash, loc, language', () => {
+      writeFile(sandbox, 'src/auth.ts', 'export const x = 1\nexport const y = 2\n')
+      writeFile(sandbox, 'src/ui.tsx', 'export const Button = () => null\n')
+      writeFile(sandbox, 'src/script.js', 'module.exports = 1\n')
+      writeFile(sandbox, 'src/widget.jsx', 'export const Widget = () => null\n')
+      writeFile(sandbox, 'README.md', '# unsupported, must be ignored\n')
+
+      const spi = build(sandbox)
+      const paths = spi.files.map((f) => f.path)
+      expect(paths).toEqual(['src/auth.ts', 'src/script.js', 'src/ui.tsx', 'src/widget.jsx'])
+
+      const auth = findFile(spi, 'src/auth.ts')
+      expect(auth.id).toMatch(/^file:[a-f0-9]{16}$/)
+      expect(auth.language).toBe('typescript')
+      expect(auth.loc).toBe(3) // 2 newlines + trailing
+      expect(auth.hash).toMatch(/^[a-f0-9]{64}$/)
+      expect(findFile(spi, 'src/ui.tsx').language).toBe('tsx')
+      expect(findFile(spi, 'src/widget.jsx').language).toBe('jsx')
+      expect(findFile(spi, 'src/script.js').language).toBe('javascript')
+    })
+
+    it('skips node_modules, dist, build, .next, coverage, .git, graphify-out, .test-artifacts', () => {
+      for (const dir of ['node_modules', 'dist', 'build', '.next', 'coverage', '.git', 'graphify-out', '.test-artifacts']) {
+        writeFile(sandbox, `${dir}/leak.ts`, 'export const x = 1\n')
+      }
+      writeFile(sandbox, 'src/keep.ts', 'export const k = 1\n')
+      const spi = build(sandbox)
+      expect(spi.files.map((f) => f.path)).toEqual(['src/keep.ts'])
+    })
+
+    it('produces deterministic output between two runs of the same workspace', () => {
+      writeFile(sandbox, 'src/a.ts', 'export const a = 1\n')
+      writeFile(sandbox, 'src/b.ts', 'import { a } from "./a.js"\nexport const b = a\n')
+      const first = build(sandbox)
+      const second = build(sandbox)
+      expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+    })
+  })
+
+  describe('imports / exports edges', () => {
+    it('resolves Node-ESM .js-suffixed relative imports to the .ts source', () => {
+      writeFile(sandbox, 'src/shared/util.ts', 'export const util = 1\n')
+      writeFile(sandbox, 'src/feature/index.ts', 'import { util } from "../shared/util.js"\nexport const feature = util\n')
+      const spi = build(sandbox)
+
+      const importEdges = edgesBetween(spi, 'src/feature/index.ts', 'src/shared/util.ts', 'imports')
+      expect(importEdges).toHaveLength(1)
+      expect(importEdges[0]?.confidence).toBe('high')
+      expect(importEdges[0]?.source).toBe('typescript-syntactic')
+      expect(importEdges[0]?.evidence?.file_id).toBe(findFile(spi, 'src/feature/index.ts').id)
+    })
+
+    it('marks `import type` edges as low confidence', () => {
+      writeFile(sandbox, 'src/types.ts', 'export type T = number\n')
+      writeFile(sandbox, 'src/use.ts', 'import type { T } from "./types.js"\nexport const x: T = 1\n')
+      const spi = build(sandbox)
+
+      const importEdges = edgesBetween(spi, 'src/use.ts', 'src/types.ts', 'imports')
+      expect(importEdges).toHaveLength(1)
+      expect(importEdges[0]?.confidence).toBe('low')
+    })
+
+    it('records unresolved relative imports as medium confidence with a diagnostic', () => {
+      writeFile(sandbox, 'src/a.ts', 'import { x } from "./missing.js"\nexport const y = x\n')
+      const spi = build(sandbox)
+
+      const aId = findFile(spi, 'src/a.ts').id
+      const unresolved = spi.edges.filter((e) => e.from === aId && e.kind === 'imports' && e.to.startsWith('file:unresolved/'))
+      expect(unresolved).toHaveLength(1)
+      expect(unresolved[0]?.confidence).toBe('medium')
+      expect(spi.diagnostics.some((d) => d.message.includes('Unresolved relative import "./missing.js"'))).toBe(true)
+    })
+
+    it('skips bare module specifiers without recording diagnostics', () => {
+      writeFile(sandbox, 'src/a.ts', 'import { something } from "external-package"\nexport const x = 1\n')
+      const spi = build(sandbox)
+      expect(spi.edges.filter((e) => e.kind === 'imports')).toHaveLength(0)
+      expect(spi.diagnostics).toHaveLength(0)
+    })
+
+    it('emits an exports edge (file -> self) for every exported declaration form', () => {
+      writeFile(sandbox, 'src/all-export-forms.ts', [
+        'export const a = 1',
+        'export function b() { return 1 }',
+        'export class C {}',
+        'export interface I {}',
+        'export type T = number',
+        'export enum E { Z }',
+        'const d = 1',
+        'export { d }',
+        'export default 1',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const id = findFile(spi, 'src/all-export-forms.ts').id
+      const exportEdges = spi.edges.filter((e) => e.from === id && e.to === id && e.kind === 'exports')
+      // 6 declarations w/ export modifier + 1 export-list + 1 export default = 8.
+      expect(exportEdges.length).toBeGreaterThanOrEqual(8)
+      for (const edge of exportEdges) {
+        expect(edge.confidence).toBe('high')
+        expect(edge.source).toBe('typescript-syntactic')
+      }
+    })
+
+    it('emits an imports edge for re-export from another module', () => {
+      writeFile(sandbox, 'src/inner.ts', 'export const v = 1\n')
+      writeFile(sandbox, 'src/barrel.ts', 'export { v } from "./inner.js"\n')
+      const spi = build(sandbox)
+      expect(edgesBetween(spi, 'src/barrel.ts', 'src/inner.ts', 'imports')).toHaveLength(1)
+    })
+
+    it('resolves `./folder` index imports', () => {
+      writeFile(sandbox, 'src/utils/index.ts', 'export const u = 1\n')
+      writeFile(sandbox, 'src/feature.ts', 'import { u } from "./utils/index.js"\nexport const f = u\n')
+      const spi = build(sandbox)
+      expect(edgesBetween(spi, 'src/feature.ts', 'src/utils/index.ts', 'imports')).toHaveLength(1)
+    })
+  })
+
+  describe('against the checked-in demo repo', () => {
+    it('produces a populated SPI for examples/demo-repo with cross-module imports resolved', () => {
+      const root = pathResolve(__dirname, '../../examples/demo-repo')
+      const spi = buildSpiFileLayer({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+
+      expect(spi.files.length).toBeGreaterThan(5)
+      // Every file path is workspace-relative, no leading slash, POSIX.
+      for (const file of spi.files) {
+        expect(file.path.startsWith('/')).toBe(false)
+        expect(file.path.includes('\\')).toBe(false)
+      }
+      // Two known cross-module links in the demo repo.
+      expect(edgesBetween(spi, 'src/billing/invoice-service.ts', 'src/notifications/email-notifier.ts', 'imports')).toHaveLength(1)
+      expect(edgesBetween(spi, 'src/app.ts', 'src/auth/auth-service.ts', 'imports')).toHaveLength(1)
+      // Type-only import we observed in the fixture is marked low.
+      const tenantImports = spi.edges.filter(
+        (e) => e.kind === 'imports' && e.to === findFile(spi, 'src/shared/tenant-context.ts').id,
+      )
+      expect(tenantImports.length).toBeGreaterThan(0)
+      for (const edge of tenantImports) {
+        expect(['low', 'high']).toContain(edge.confidence)
+      }
+      // No unresolved diagnostics on the curated demo.
+      expect(spi.diagnostics.filter((d) => d.level === 'error')).toHaveLength(0)
+    })
+  })
+})

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -227,6 +227,59 @@ describe('public marketing copy honesty', () => {
     })
   })
 
+  describe('docs/designs/2026-05-10-spi-v1.md', () => {
+    const content = readDoc('docs/designs/2026-05-10-spi-v1.md')
+
+    it('declares the design scope and links the tracking issue (#70)', () => {
+      expect(content).toMatch(/#70|issues\/70/)
+      expect(content).toContain('v0.14-substrate')
+      expect(content).toContain('design only')
+    })
+
+    it('locks in the SemanticProgramIndex top-level shape', () => {
+      expect(content).toContain('type SemanticProgramIndex')
+      expect(content).toContain('version: 1')
+      expect(content).toContain('files:')
+      expect(content).toContain('symbols:')
+      expect(content).toContain('edges:')
+      expect(content).toContain('diagnostics:')
+    })
+
+    it('documents every layer #70 lists in the issue body', () => {
+      for (const layer of [
+        'File layer',
+        'Symbol layer',
+        'Call layer',
+        'Type layer',
+        'Test layer',
+        'Diff layer',
+        'Framework layer',
+      ]) {
+        expect(content).toContain(layer)
+      }
+    })
+
+    it('locks confidence to {high, medium, low} and source provenance to a closed set', () => {
+      expect(content).toMatch(/confidence:\s*'high'\s*\|\s*'medium'\s*\|\s*'low'/)
+      expect(content).toContain("'typescript-semantic'")
+      expect(content).toContain("'tree-sitter'")
+      expect(content).toContain("'framework-decorator'")
+      expect(content).toContain("'heuristic'")
+    })
+
+    it('cross-links the consuming and adjacent issues so the design is discoverable', () => {
+      for (const ref of ['#69', '#71', '#72', '#73', '#74', '#77', '#78']) {
+        expect(content).toContain(ref)
+      }
+    })
+
+    it('explicitly lists non-goals and open questions to scope the design honestly', () => {
+      expect(content).toContain('## Non-goals')
+      expect(content).toContain('## Open questions')
+      expect(content).toContain('## Risks')
+    })
+  })
+
   describe('examples/mcp-tool-examples.md', () => {
     const content = readDoc('examples/mcp-tool-examples.md')
     const lower = content.toLowerCase()


### PR DESCRIPTION
First slice of [#72 — Implement Semantic Program Index v1 for TypeScript/NestJS workspaces](https://github.com/mohanagy/graphify-ts/issues/72). Milestone: \`v0.14-substrate\`. Honors the design contract from [docs/designs/2026-05-10-spi-v1.md](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md) (PR #87).

**Pure additive.** Touches nothing in the existing pipeline. New module under \`src/pipeline/spi/\`, new test file. The current \`graph.json\` extractor and every MCP tool keep behaving identically.

## Why slice it this small

Per our scope discussion, slice 1 of the design ("file + symbol layers + projection back to \`graph.json\`") is too big to land in one PR responsibly — TS compiler API integration plus byte-equivalent projection is the load-bearing constraint. This PR ships **slice 1a**: types + file layer only. Slices land in this order:

| Slice | Scope | Status |
|---|---|---|
| **1a (this PR)** | Types + file layer (\`SpiFile\`, imports/exports edges) | ✅ ready for review |
| 1b | Symbol layer + projection back to \`graph.json\` (byte-equivalence golden tests) | next PR |
| 2 | Call + type layers (TS \`getResolvedSignature\`, confidence promotion) | follow-on |
| 3 | Framework (NestJS) + diff overlay | follow-on |

## What ships

\`src/pipeline/spi/types.ts\` — the **full** \`SemanticProgramIndex\` contract from the design. Every layer's types are in place even though only the file layer is *built* today, so later slices can fill in symbols/calls/framework without re-shaping the public surface.

\`src/pipeline/spi/build.ts\` — \`buildSpiFileLayer({ root, graphifyVersion, extractorVersion?, now? })\` walks the workspace, produces one \`SpiFile\` per supported source file, and emits \`imports\`/\`exports\` edges between files. Honors the design's confidence rules:

| Edge | Confidence | Source |
|---|---|---|
| Resolved relative import | \`high\` | \`typescript-syntactic\` |
| Type-only import (\`import type\`) | \`low\` | \`typescript-syntactic\` |
| Unresolved relative import | \`medium\` (+ \`SpiDiagnostic\`) | \`typescript-syntactic\` |
| Bare module specifier (\`import x from 'react'\`) | not emitted | — |
| Every \`export …\` declaration | \`high\` | \`typescript-syntactic\` |

\`src/pipeline/spi/index.ts\` — public re-exports.

## Honors the design contract

- **Stable IDs**: \`file:<sha256(rel_path)[:16]>\` — deterministic across runs, no line numbers in IDs.
- **Versioned at \`1\`**, \`generated_at\` is ISO-8601 (overridable for tests via the \`now\` injection).
- \`workspace.fingerprint\` = sha256 of (root + tsconfig content + extractor version).
- Skips \`node_modules / dist / build / .next / coverage / .git / graphify-out / .test-artifacts / .turbo / .vercel\`.
- Handles **Node-ESM \`.js → .ts\` rewrite** for relative imports (the convention the demo-repo and most modern TS projects use).
- Output is **deterministic** — same source, same SPI, byte-for-byte (asserted by a test).
- Symbols, call / type / test / diff / framework layers, and the projection back to \`graph.json\` are explicitly deferred to subsequent slices (the design's section "Implementation plan (handed to #72)").

## Test plan

13 new tests in \`tests/unit/spi-build.test.ts\` covering:

- [x] Versioned shape + workspace metadata + frozen \`now\` injection.
- [x] Throws on missing root.
- [x] One \`SpiFile\` per supported source, correct \`language\`/\`loc\`/\`hash\` shape.
- [x] Skip-dir matrix (10 dirs).
- [x] **Determinism**: two runs of the same workspace produce byte-equal SPI.
- [x] Node-ESM \`.js\`-suffixed relative imports resolve to \`.ts\` source.
- [x] \`import type\` edges are \`low\` confidence.
- [x] Unresolved relative imports are \`medium\` confidence + emit a stable \`SpiDiagnostic\`.
- [x] Bare module specifiers skipped silently.
- [x] All export forms (const/function/class/interface/type/enum/list/default) emit edges.
- [x] Re-exports emit both an exports edge and an imports edge.
- [x] Folder/\`index.ts\` resolution.
- [x] Real run against \`examples/demo-repo/\` — known cross-module links resolve, no error-level diagnostics.

Verified:

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **1414/1414** passing (was 1401 on \`main\`; +13 new)

## What lands next

**Slice 1b**: symbol layer (\`SpiSymbol\` extraction via \`ts.SyntaxKind\` walk) + projector that renders today's \`graph.json\` from \`spi.json\` with byte-equivalence asserted on \`examples/demo-repo/\` golden fixture. That's the harder half of slice 1 — TS compiler API integration plus the back-compat constraint — and will be its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Semantic Program Index (SPI) v1, a typed, versioned substrate for workspace analysis with file metadata, import/export tracking, and confidence provenance.

* **Documentation**
  * Added comprehensive SPI v1 design specification covering semantic layers, stable identifiers, and diagnostic emission rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/88)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->