### PR TITLE
feat(#72): SPI v1 slice 1b — symbol layer + declares edges

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -1,13 +1,16 @@
-// SPI v1 — file-layer builder (slice 1a of #72).
+// SPI v1 — file + symbol layer builder (slices 1a + 1b of #72).
 //
 // Produces a SemanticProgramIndex containing:
 //   - workspace metadata + fingerprint
 //   - one SpiFile per supported source file under the workspace root
 //   - imports / exports edges between files (syntactic only — no type checker)
+//   - one SpiSymbol per declared function/class/interface/type/enum/method/
+//     constant/variable/namespace in each file
+//   - declares edges (file -> symbol) for every emitted symbol
 //
-// Symbols, calls, types, framework, and diff overlay land in subsequent
-// slices of #72. This module never touches the existing pipeline; it is
-// pure additive substrate.
+// Calls, type relationships, tests, framework, and diff overlay land in
+// subsequent slices of #72. This module never touches the existing pipeline;
+// it is pure additive substrate.
 
 import { createHash } from 'node:crypto'
 import {
@@ -27,9 +30,11 @@ import type {
   SpiFile,
   SpiLanguage,
   SpiRange,
+  SpiSymbol,
+  SpiSymbolKind,
 } from './types.js'
 
-export type BuildSpiFileLayerOptions = {
+export type BuildSpiOptions = {
   root: string
   graphifyVersion: string
   extractorVersion?: string
@@ -37,6 +42,10 @@ export type BuildSpiFileLayerOptions = {
   // so snapshot tests can assert deterministic output.
   now?: () => Date
 }
+
+// Backward-compat alias for the slice-1a name. New callers should use
+// BuildSpiOptions / buildSpi directly.
+export type BuildSpiFileLayerOptions = BuildSpiOptions
 
 const SKIP_DIRS = new Set<string>([
   'node_modules',
@@ -66,15 +75,16 @@ const INDEX_RESOLUTION_CANDIDATES = [
   '/index.jsx',
 ] as const
 
-export function buildSpiFileLayer(opts: BuildSpiFileLayerOptions): SemanticProgramIndex {
+export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   const root = resolve(opts.root)
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-1a'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-1b'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
+  const symbols: SpiSymbol[] = []
   const edges: SpiEdge[] = []
   const diagnostics: SpiDiagnostic[] = []
 
@@ -109,10 +119,11 @@ export function buildSpiFileLayer(opts: BuildSpiFileLayerOptions): SemanticProgr
       true,
       scriptKindFor(file.language),
     )
-    visitFile(sourceFile, file, root, pathToFileId, edges, diagnostics)
+    visitFile(sourceFile, file, root, pathToFileId, symbols, edges, diagnostics)
   }
 
   files.sort((a, b) => a.path.localeCompare(b.path))
+  symbols.sort((a, b) => a.id.localeCompare(b.id))
   edges.sort((a, b) =>
     `${a.from}|${a.to}|${a.kind}`.localeCompare(`${b.from}|${b.to}|${b.kind}`),
   )
@@ -128,11 +139,15 @@ export function buildSpiFileLayer(opts: BuildSpiFileLayerOptions): SemanticProgr
       graphify_version: opts.graphifyVersion,
     },
     files,
-    symbols: [],
+    symbols,
     edges,
     diagnostics,
   }
 }
+
+// Backward-compat alias for the slice-1a entry point. New callers should use
+// buildSpi directly.
+export const buildSpiFileLayer = buildSpi
 
 function collectFiles(dir: string, out: string[]): void {
   let entries: import('node:fs').Dirent<string>[]
@@ -158,9 +173,53 @@ function visitFile(
   file: SpiFile,
   root: string,
   pathToFileId: Map<string, string>,
+  symbols: SpiSymbol[],
   edges: SpiEdge[],
   diagnostics: SpiDiagnostic[],
 ): void {
+  // Per-(class+method-name) overload counters so duplicate method names in the
+  // same class get deterministic #0/#1/... suffixes in source order.
+  const methodOverloadCounts = new Map<string, number>()
+
+  const emitTopLevelDeclarations = (parent: ts.Node): void => {
+    ts.forEachChild(parent, (node) => {
+      const exported = hasExportModifier(node) || hasDefaultModifier(node)
+
+      if (ts.isFunctionDeclaration(node) && node.name) {
+        emitSymbol({ name: node.name.text, kind: 'function', node, exported, sourceFile, file, symbols, edges })
+      } else if (ts.isClassDeclaration(node) && node.name) {
+        emitSymbol({ name: node.name.text, kind: 'class', node, exported, sourceFile, file, symbols, edges })
+        emitClassMethods(node, file, symbols, edges, sourceFile, methodOverloadCounts)
+      } else if (ts.isInterfaceDeclaration(node)) {
+        emitSymbol({ name: node.name.text, kind: 'interface', node, exported, sourceFile, file, symbols, edges })
+      } else if (ts.isTypeAliasDeclaration(node)) {
+        emitSymbol({ name: node.name.text, kind: 'type-alias', node, exported, sourceFile, file, symbols, edges })
+      } else if (ts.isEnumDeclaration(node)) {
+        emitSymbol({ name: node.name.text, kind: 'enum', node, exported, sourceFile, file, symbols, edges })
+      } else if (ts.isVariableStatement(node)) {
+        const isConst = (node.declarationList.flags & ts.NodeFlags.Const) !== 0
+        const kind: SpiSymbolKind = isConst ? 'constant' : 'variable'
+        for (const decl of node.declarationList.declarations) {
+          if (ts.isIdentifier(decl.name)) {
+            emitSymbol({ name: decl.name.text, kind, node: decl, exported, sourceFile, file, symbols, edges })
+          }
+          // Destructured declarations (`const { a, b } = ...`) are intentionally
+          // skipped in slice 1b: there's no single-source-name to mint a stable
+          // ID from. They re-enter when the symbol layer ships destructure
+          // tracking in slice 2.
+        }
+      } else if (ts.isModuleDeclaration(node) && node.name && ts.isIdentifier(node.name)) {
+        // Namespace declaration (`namespace Foo { ... }` or
+        // `module Foo { ... }`). External module augmentations
+        // (`declare module 'foo'`) use a string-literal name and are skipped.
+        emitSymbol({ name: node.name.text, kind: 'namespace', node, exported, sourceFile, file, symbols, edges })
+        // Members of namespaces are deferred: SPI v1 represents the namespace
+        // itself but does not enumerate its inner declarations. Slice 2 can
+        // expand this once cross-namespace references matter.
+      }
+    })
+  }
+
   const visit = (node: ts.Node): void => {
     if (ts.isImportDeclaration(node)) {
       const moduleSpec = node.moduleSpecifier
@@ -192,6 +251,94 @@ function visitFile(
     ts.forEachChild(node, visit)
   }
   visit(sourceFile)
+  emitTopLevelDeclarations(sourceFile)
+}
+
+type EmitSymbolArgs = {
+  name: string
+  kind: SpiSymbolKind
+  node: ts.Node
+  exported: boolean
+  sourceFile: ts.SourceFile
+  file: SpiFile
+  symbols: SpiSymbol[]
+  edges: SpiEdge[]
+}
+
+function emitSymbol(args: EmitSymbolArgs): SpiSymbol {
+  const { name, kind, node, exported, sourceFile, file, symbols, edges } = args
+  const symbol: SpiSymbol = {
+    id: makeSymbolId(file.id, kind, name),
+    file_id: file.id,
+    name,
+    kind,
+    range: rangeOf(node, sourceFile),
+    exported,
+  }
+  symbols.push(symbol)
+  edges.push({
+    from: file.id,
+    to: symbol.id,
+    kind: 'declares',
+    confidence: 'high',
+    source: 'typescript-syntactic',
+    evidence: { file_id: file.id, range: symbol.range },
+  })
+  return symbol
+}
+
+function emitClassMethods(
+  classNode: ts.ClassDeclaration,
+  file: SpiFile,
+  symbols: SpiSymbol[],
+  edges: SpiEdge[],
+  sourceFile: ts.SourceFile,
+  methodOverloadCounts: Map<string, number>,
+): void {
+  if (!classNode.name) return
+  const className = classNode.name.text
+  for (const member of classNode.members) {
+    let methodName: string | null = null
+    if (ts.isMethodDeclaration(member) && member.name && ts.isIdentifier(member.name)) {
+      methodName = member.name.text
+    } else if (ts.isConstructorDeclaration(member)) {
+      methodName = 'constructor'
+    } else if (
+      (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) &&
+      member.name &&
+      ts.isIdentifier(member.name)
+    ) {
+      methodName = member.name.text
+    }
+    if (methodName === null) continue
+
+    const overloadKey = `${file.id}/${className}/${methodName}`
+    const overloadIndex = methodOverloadCounts.get(overloadKey) ?? 0
+    methodOverloadCounts.set(overloadKey, overloadIndex + 1)
+    const qualifiedName = `${className}.${methodName}`
+    const baseId = makeSymbolId(file.id, 'method', qualifiedName)
+    const id = overloadIndex === 0 ? baseId : `${baseId}#${overloadIndex}`
+
+    const symbol: SpiSymbol = {
+      id,
+      file_id: file.id,
+      name: qualifiedName,
+      kind: 'method',
+      range: rangeOf(member, sourceFile),
+      // Methods inherit their containing class's export status for v1; SPI's
+      // selector layer can refine this when public-API surface scoring lands.
+      exported: hasExportModifier(classNode) || hasDefaultModifier(classNode),
+    }
+    symbols.push(symbol)
+    edges.push({
+      from: file.id,
+      to: symbol.id,
+      kind: 'declares',
+      confidence: 'high',
+      source: 'typescript-syntactic',
+      evidence: { file_id: file.id, range: symbol.range },
+    })
+  }
 }
 
 function addImportEdge(
@@ -265,6 +412,15 @@ function hasExportModifier(node: ts.Node): boolean {
   return false
 }
 
+function hasDefaultModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined
+  if (!modifiers) return false
+  for (const mod of modifiers) {
+    if (mod.kind === ts.SyntaxKind.DefaultKeyword) return true
+  }
+  return false
+}
+
 function resolveRelativeImport(
   spec: string,
   fromPath: string,
@@ -314,6 +470,10 @@ function rangeOf(node: ts.Node, sourceFile: ts.SourceFile): SpiRange {
 
 function makeFileId(relPath: string): string {
   return 'file:' + sha256(relPath).slice(0, 16)
+}
+
+function makeSymbolId(fileId: string, kind: SpiSymbolKind, name: string): string {
+  return `symbol:${fileId}/${kind}/${name}`
 }
 
 function sha256(text: string): string {

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -1,8 +1,8 @@
 // SPI v1 — public re-exports.
 //
-// Slice 1a: types + file-layer builder. Symbol/call/type/test/diff/framework
-// layers and the projection back to today's graph.json land in subsequent
-// slices of #72.
+// Slices 1a + 1b: types + file layer + symbol layer + declares edges.
+// Call/type/test/diff/framework layers and the projection back to today's
+// graph.json land in subsequent slices of #72.
 
 export type {
   SpiVersion,
@@ -26,4 +26,9 @@ export type {
   SpiDiffOverlay,
 } from './types.js'
 
-export { buildSpiFileLayer, type BuildSpiFileLayerOptions } from './build.js'
+export {
+  buildSpi,
+  buildSpiFileLayer,
+  type BuildSpiOptions,
+  type BuildSpiFileLayerOptions,
+} from './build.js'

--- a/tests/unit/spi-symbols.test.ts
+++ b/tests/unit/spi-symbols.test.ts
@@ -1,0 +1,299 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve as pathResolve } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type {
+  SemanticProgramIndex,
+  SpiSymbol,
+  SpiSymbolKind,
+} from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-symbols-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1b',
+    now: FROZEN_NOW,
+  })
+}
+
+function symbolsIn(spi: SemanticProgramIndex, filePath: string): SpiSymbol[] {
+  const file = spi.files.find((f) => f.path === filePath)
+  if (!file) throw new Error(`fixture missing SpiFile: ${filePath}`)
+  return spi.symbols.filter((s) => s.file_id === file.id)
+}
+
+function findSymbol(spi: SemanticProgramIndex, filePath: string, name: string, kind: SpiSymbolKind): SpiSymbol {
+  const matches = symbolsIn(spi, filePath).filter((s) => s.name === name && s.kind === kind)
+  if (matches.length === 0) {
+    const inFile = symbolsIn(spi, filePath).map((s) => `${s.kind} ${s.name}`).join(', ')
+    throw new Error(`fixture missing SpiSymbol ${kind} ${name} in ${filePath}\nhad: ${inFile}`)
+  }
+  if (matches.length > 1) {
+    throw new Error(`expected exactly one ${kind} ${name} in ${filePath}; got ${matches.length}`)
+  }
+  return matches[0]!
+}
+
+describe('buildSpi symbol layer (slice 1b of #72)', () => {
+  let sandbox: string
+
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('symbol kinds', () => {
+    it('emits one SpiSymbol per top-level declaration form', () => {
+      writeFile(sandbox, 'src/all-kinds.ts', [
+        'export function fn() {}',
+        'export class Cls {}',
+        'export interface Iface { x: number }',
+        'export type Alias = number',
+        'export enum Enm { Z }',
+        'export const constant = 1',
+        'export let variable = 1',
+        'export namespace Ns {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const all = symbolsIn(spi, 'src/all-kinds.ts')
+      const byKind = new Map<SpiSymbolKind, SpiSymbol>()
+      for (const s of all) byKind.set(s.kind, s)
+
+      expect(byKind.get('function')?.name).toBe('fn')
+      expect(byKind.get('class')?.name).toBe('Cls')
+      expect(byKind.get('interface')?.name).toBe('Iface')
+      expect(byKind.get('type-alias')?.name).toBe('Alias')
+      expect(byKind.get('enum')?.name).toBe('Enm')
+      expect(byKind.get('constant')?.name).toBe('constant')
+      expect(byKind.get('variable')?.name).toBe('variable')
+      expect(byKind.get('namespace')?.name).toBe('Ns')
+      // Every top-level declaration was exported in the fixture.
+      for (const symbol of all) {
+        expect(symbol.exported).toBe(true)
+      }
+    })
+
+    it('marks unexported declarations with exported: false', () => {
+      writeFile(sandbox, 'src/private.ts', [
+        'function notExported() {}',
+        'class AlsoNot {}',
+        'export const yes = 1',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/private.ts', 'notExported', 'function').exported).toBe(false)
+      expect(findSymbol(spi, 'src/private.ts', 'AlsoNot', 'class').exported).toBe(false)
+      expect(findSymbol(spi, 'src/private.ts', 'yes', 'constant').exported).toBe(true)
+    })
+
+    it('distinguishes const from let/var on variable statements', () => {
+      writeFile(sandbox, 'src/vars.ts', [
+        'const a = 1',
+        'let b = 2',
+        'var c = 3',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/vars.ts', 'a', 'constant')).toBeTruthy()
+      expect(findSymbol(spi, 'src/vars.ts', 'b', 'variable')).toBeTruthy()
+      expect(findSymbol(spi, 'src/vars.ts', 'c', 'variable')).toBeTruthy()
+    })
+
+    it('emits one SpiSymbol per declarator in a multi-name variable statement', () => {
+      writeFile(sandbox, 'src/multi.ts', 'export const a = 1, b = 2, c = 3\n')
+      const spi = build(sandbox)
+      const constants = symbolsIn(spi, 'src/multi.ts').filter((s) => s.kind === 'constant')
+      expect(constants.map((s) => s.name).sort()).toEqual(['a', 'b', 'c'])
+      for (const c of constants) expect(c.exported).toBe(true)
+    })
+
+    it('skips destructured variable declarations (deferred to slice 2)', () => {
+      writeFile(sandbox, 'src/destructure.ts', [
+        'const { a, b } = { a: 1, b: 2 }',
+        'export const visible = 1',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const constants = symbolsIn(spi, 'src/destructure.ts').filter((s) => s.kind === 'constant')
+      expect(constants.map((s) => s.name)).toEqual(['visible'])
+    })
+
+    it('skips external module augmentations (declare module "string-name")', () => {
+      writeFile(sandbox, 'src/aug.ts', [
+        'declare module "external-pkg" { interface Foo {} }',
+        'export namespace Real {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const namespaces = symbolsIn(spi, 'src/aug.ts').filter((s) => s.kind === 'namespace')
+      expect(namespaces.map((s) => s.name)).toEqual(['Real'])
+    })
+
+    it('does not enumerate namespace members in v1 (slice 2 expansion)', () => {
+      writeFile(sandbox, 'src/ns.ts', [
+        'export namespace Outer {',
+        '  export function inside() {}',
+        '  export class Inner {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const all = symbolsIn(spi, 'src/ns.ts').map((s) => `${s.kind} ${s.name}`)
+      expect(all).toEqual(['namespace Outer'])
+    })
+  })
+
+  describe('class methods', () => {
+    it('emits a method symbol per class member with qualified Class.method names', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'export class AuthService {',
+        '  constructor() {}',
+        '  login(user: string) { return user }',
+        '  logout() {}',
+        '  get current() { return null }',
+        '  set current(_v: unknown) {}',
+        '}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const methods = symbolsIn(spi, 'src/svc.ts').filter((s) => s.kind === 'method')
+      // Note: the getter and setter for `current` collide on name and produce
+      // method-overload IDs; both should still be emitted.
+      const names = methods.map((m) => m.name).sort()
+      expect(names).toEqual([
+        'AuthService.constructor',
+        'AuthService.current',
+        'AuthService.current',
+        'AuthService.login',
+        'AuthService.logout',
+      ])
+    })
+
+    it('appends #1, #2 suffixes to overloaded method IDs in source order', () => {
+      writeFile(sandbox, 'src/overloads.ts', [
+        'export class Foo {',
+        '  bar(a: number): number',
+        '  bar(a: string): string',
+        '  bar(a: number | string): number | string { return a }',
+        '}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const ids = symbolsIn(spi, 'src/overloads.ts')
+        .filter((s) => s.kind === 'method' && s.name === 'Foo.bar')
+        .map((s) => s.id)
+        .sort()
+      expect(ids).toHaveLength(3)
+      // First overload has the bare base id; subsequent get #1, #2 suffixes.
+      const base = ids.find((id) => !id.includes('#'))
+      expect(base).toBeTruthy()
+      expect(ids.some((id) => id.endsWith('#1'))).toBe(true)
+      expect(ids.some((id) => id.endsWith('#2'))).toBe(true)
+    })
+  })
+
+  describe('declares edges', () => {
+    it('emits a high-confidence declares edge from file -> every emitted symbol', () => {
+      writeFile(sandbox, 'src/d.ts', [
+        'export function alpha() {}',
+        'export class Beta {',
+        '  gamma() {}',
+        '}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const file = spi.files.find((f) => f.path === 'src/d.ts')!
+      const fileSymbols = symbolsIn(spi, 'src/d.ts')
+      const declares = spi.edges.filter((e) => e.from === file.id && e.kind === 'declares')
+
+      // One declares edge per symbol in this file, no extras.
+      expect(declares).toHaveLength(fileSymbols.length)
+      for (const edge of declares) {
+        expect(edge.confidence).toBe('high')
+        expect(edge.source).toBe('typescript-syntactic')
+        expect(edge.evidence?.file_id).toBe(file.id)
+        // Edge target must point at a real SpiSymbol id.
+        expect(fileSymbols.some((s) => s.id === edge.to)).toBe(true)
+      }
+    })
+  })
+
+  describe('range and ID stability', () => {
+    it('mints stable IDs that survive in-file reordering as long as path/kind/name are stable', () => {
+      writeFile(sandbox, 'src/order.ts', [
+        'export function a() {}',
+        'export function b() {}',
+      ].join('\n') + '\n')
+      const first = build(sandbox)
+      const idA1 = findSymbol(first, 'src/order.ts', 'a', 'function').id
+      const idB1 = findSymbol(first, 'src/order.ts', 'b', 'function').id
+
+      // Reorder the declarations; same names + same file path => same IDs.
+      writeFile(sandbox, 'src/order.ts', [
+        'export function b() {}',
+        'export function a() {}',
+      ].join('\n') + '\n')
+      const second = build(sandbox)
+      expect(findSymbol(second, 'src/order.ts', 'a', 'function').id).toBe(idA1)
+      expect(findSymbol(second, 'src/order.ts', 'b', 'function').id).toBe(idB1)
+    })
+
+    it('captures one-based line/column ranges for every symbol', () => {
+      writeFile(sandbox, 'src/r.ts', 'export function fn() {\n  return 1\n}\n')
+      const spi = build(sandbox)
+      const fn = findSymbol(spi, 'src/r.ts', 'fn', 'function')
+      expect(fn.range.start.line).toBe(1)
+      expect(fn.range.start.column).toBe(1)
+      expect(fn.range.end.line).toBeGreaterThanOrEqual(3)
+    })
+
+    it('produces a stable, sorted symbol list across two runs of the same workspace', () => {
+      writeFile(sandbox, 'src/a.ts', 'export const a = 1\n')
+      writeFile(sandbox, 'src/b.ts', 'export class B {\n  one() {}\n  two() {}\n}\n')
+      const first = build(sandbox)
+      const second = build(sandbox)
+      expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+    })
+  })
+
+  describe('against the checked-in demo repo', () => {
+    it('emits multiple symbols per source file with declares edges and no error diagnostics', () => {
+      const root = pathResolve(__dirname, '../../examples/demo-repo')
+      const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+
+      // Demo repo has classes/functions across several modules; expect at
+      // least one symbol per source file.
+      expect(spi.symbols.length).toBeGreaterThan(spi.files.length)
+
+      // Spot-check a known class in the auth module.
+      const auth = symbolsIn(spi, 'src/auth/auth-service.ts')
+      const authClass = auth.find((s) => s.kind === 'class')
+      expect(authClass?.name).toBe('AuthService')
+      // It should have at least one declared method.
+      expect(auth.some((s) => s.kind === 'method' && s.name.startsWith('AuthService.'))).toBe(true)
+
+      // Every symbol must have a matching declares edge.
+      for (const symbol of spi.symbols) {
+        expect(spi.edges.some((e) => e.from === symbol.file_id && e.to === symbol.id && e.kind === 'declares')).toBe(true)
+      }
+
+      expect(spi.diagnostics.filter((d) => d.level === 'error')).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Second slice of [#72 — Implement Semantic Program Index v1 for TypeScript/NestJS workspaces](https://github.com/mohanagy/graphify-ts/issues/72). Builds on slice 1a (#88, merged) by adding the symbol layer + \`declares\` edges. Honors the design contract from [docs/designs/2026-05-10-spi-v1.md](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md).

**Pure additive** — touches nothing in the existing pipeline. Slice 1a's API is preserved via a back-compat alias (\`buildSpiFileLayer = buildSpi\`) so any caller that landed against slice 1a keeps working.

## Why this isn't full slice 1

Per our scope discussion at the start of slice 1a, the design's "slice 1" includes the projector back to today's \`graph.json\` with byte-equivalence golden tests on \`examples/demo-repo/\`. That projector is its own substantial effort (needs deep familiarity with the existing extractor's quirks). Splitting it out keeps each PR reviewable and lets SPI shape evolve before back-compat is locked in.

| Slice | Scope | Status |
|---|---|---|
| 1a | Types + file layer | ✅ merged (#88) |
| **1b (this PR)** | Symbol layer + \`declares\` edges | 🔵 **ready for review** |
| 1c | Projector back to \`graph.json\` (byte-equivalent on demo-repo) | next |
| 2 | Call + type layers (TS \`getResolvedSignature\`, confidence promotion) | follow-on |
| 3 | Framework (NestJS) + diff overlay | follow-on |

## What ships

\`src/pipeline/spi/build.ts\`:

- **\`buildSpi(opts)\`** — new public entry point. Same signature as the slice-1a builder, now produces both \`files\` and \`symbols\`. \`buildSpiFileLayer\` and \`BuildSpiFileLayerOptions\` are kept as back-compat aliases.
- **\`emitSymbol\` / \`emitClassMethods\`** — TypeScript AST walk per source file, producing one \`SpiSymbol\` per top-level declaration:

| Source form | \`kind\` |
|---|---|
| \`function foo() {}\` | \`function\` |
| \`class Foo {}\` | \`class\` |
| \`interface Foo {}\` | \`interface\` |
| \`type Foo = ...\` | \`type-alias\` |
| \`enum Foo {}\` | \`enum\` |
| \`const x = 1\` | \`constant\` (per declarator) |
| \`let / var x = 1\` | \`variable\` (per declarator) |
| \`namespace Foo {}\` | \`namespace\` |
| Class methods incl. constructor / getter / setter | \`method\` (named \`Class.method\`) |

- **\`declares\` edges** — every emitted symbol gets a \`high\`-confidence edge from its file → its symbol id, source: \`typescript-syntactic\`.
- **Method overload indexing** — first overload uses the bare base id (e.g. \`symbol:file:.../method/Foo.bar\`); subsequent overloads append \`#1\`, \`#2\`, ... in source order. Per the design's "method overloads append a deterministic 0-based index" rule.

## Honest skip list (deferred to slice 2)

- **Destructured variable statements** (\`const { a, b } = ...\`) — no single-source-name to mint a stable ID from; these need destructure tracking which is best done with the type checker.
- **Namespace members** — \`SpiSymbol\` is emitted for the namespace itself; members are not enumerated yet. Slice 2 can expand once cross-namespace references matter.
- **External module augmentations** (\`declare module 'string-name'\`) — explicitly skipped; not a project-internal symbol.

Each skip is commented in code so the next slice's author sees exactly what to revisit.

## Test plan

14 new tests in \`tests/unit/spi-symbols.test.ts\` covering:

- [x] Every symbol kind from the design (8 forms).
- [x] \`exported\` flag (top-level export modifier).
- [x] \`const\` vs \`let / var\` discrimination on variable statements.
- [x] Multi-declarator variable statement → one symbol per name.
- [x] Destructure / namespace-member / module-augmentation skips (with explicit assertions on what's *not* there).
- [x] Class methods: constructor, instance method, getter/setter all emit; \`Class.method\` qualified name.
- [x] Method overloads → bare-id + \`#1\` + \`#2\`.
- [x] \`declares\` edges: one per symbol, high-confidence, points at a real \`SpiSymbol\` id.
- [x] **ID stability**: in-file reordering does not change symbol IDs.
- [x] Range capture (1-based line/column).
- [x] Run-to-run determinism (byte-equal SPI on identical input).
- [x] Real run against \`examples/demo-repo/\` — known classes/methods present, every symbol has a \`declares\` edge, no error-level diagnostics.

All 13 slice-1a tests still pass against the renamed \`buildSpi\` function.

Verified:

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **1428/1428** passing (was 1414 on \`main\`; +14 new)

## What lands next

**Slice 1c**: projector that renders today's \`graph.json\` shape from \`spi.json\`, with byte-equivalence asserted on \`examples/demo-repo/\`. That's the back-compat layer the design calls out — and the riskiest piece of slice 1, because it has to conform to every quirk of the existing extractor's output. Best done as its own PR with a tight diff against committed golden fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced code analysis to detect and track symbols including functions, classes, interfaces, type aliases, enums, variables, and namespaces.
  * Added file-to-symbol relationship tracking with improved code understanding capabilities.
  * Class method symbols now include overload support with deterministic naming.

* **Tests**
  * Added comprehensive test coverage for new symbol detection functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->