### PR TITLE
feat(#72): SPI v1 slice 2a — call edges via TypeScript type checker

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -1,4 +1,4 @@
-// SPI v1 — file + symbol layer builder (slices 1a + 1b of #72).
+// SPI v1 — file + symbol + call layer builder (slices 1a, 1b, 2a of #72).
 //
 // Produces a SemanticProgramIndex containing:
 //   - workspace metadata + fingerprint
@@ -7,10 +7,16 @@
 //   - one SpiSymbol per declared function/class/interface/type/enum/method/
 //     constant/variable/namespace in each file
 //   - declares edges (file -> symbol) for every emitted symbol
+//   - calls edges (caller symbol -> callee symbol), resolved via the
+//     TypeScript type checker. High-confidence when the resolution is
+//     unique and points at a SpiSymbol; medium when the same name has
+//     sibling overload declarations; skipped when the callee resolves
+//     outside the workspace (node_modules / .d.ts) or to a non-SpiSymbol
+//     construct (e.g. an arrow function inside an array literal).
 //
-// Calls, type relationships, tests, framework, and diff overlay land in
-// subsequent slices of #72. This module never touches the existing pipeline;
-// it is pure additive substrate.
+// Type relationships, tests, framework, and diff overlay land in subsequent
+// slices of #72. This module never touches the existing pipeline; it is
+// pure additive substrate.
 
 import { createHash } from 'node:crypto'
 import {
@@ -80,7 +86,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-1b'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-2a'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
@@ -121,6 +127,10 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
     )
     visitFile(sourceFile, file, root, pathToFileId, symbols, edges, diagnostics)
   }
+
+  // Slice 2a: a second pass uses ts.Program + the type checker to resolve
+  // call expressions and emit `calls` edges between SpiSymbols.
+  addCallEdges({ files, root, pathToFileId, symbols, edges, diagnostics })
 
   files.sort((a, b) => a.path.localeCompare(b.path))
   symbols.sort((a, b) => a.id.localeCompare(b.id))
@@ -519,4 +529,231 @@ function workspaceFingerprint(root: string, extractorVersion: string): string {
 
 function toPosix(p: string): string {
   return p.split('\\').join('/')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Call layer (slice 2a)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type CallEdgeContext = {
+  files: SpiFile[]
+  root: string
+  pathToFileId: Map<string, string>
+  symbols: SpiSymbol[]
+  edges: SpiEdge[]
+  diagnostics: SpiDiagnostic[]
+}
+
+function addCallEdges(ctx: CallEdgeContext): void {
+  const { files, root, pathToFileId, edges, diagnostics } = ctx
+  const rootNames = files.map((f) => join(root, f.path))
+  if (rootNames.length === 0) return
+
+  const compilerOptions = loadCompilerOptions(root)
+  let program: ts.Program
+  try {
+    program = ts.createProgram({ rootNames, options: compilerOptions })
+  } catch (err) {
+    // ts.createProgram can throw on misconfigured workspaces (e.g., circular
+    // path mappings). Record a diagnostic so the failure is visible without
+    // tanking the rest of the index.
+    diagnostics.push({
+      id: 'spi.call.program-create-failed',
+      level: 'warn',
+      message: `SPI call layer skipped: ts.createProgram threw (${(err as Error).message})`,
+    })
+    return
+  }
+  const checker = program.getTypeChecker()
+  const seen = new Set<string>()
+
+  for (const file of files) {
+    const abs = join(root, file.path)
+    const sourceFile = program.getSourceFile(abs)
+    if (!sourceFile) continue
+    walkCallExpressions(sourceFile, file.id, checker, pathToFileId, edges, seen)
+  }
+}
+
+function walkCallExpressions(
+  sourceFile: ts.SourceFile,
+  fileId: string,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callerId = findEnclosingSpiSymbolId(node, fileId)
+      if (callerId) {
+        const callee = resolveCallee(node, checker, pathToFileId)
+        if (callee && callee.id !== callerId) {
+          const dedupeKey = `${callerId}|${callee.id}`
+          if (!seen.has(dedupeKey)) {
+            seen.add(dedupeKey)
+            edges.push({
+              from: callerId,
+              to: callee.id,
+              kind: 'calls',
+              confidence: callee.confidence,
+              source: 'typescript-semantic',
+              evidence: { file_id: fileId, range: rangeOf(node, sourceFile) },
+            })
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+function findEnclosingSpiSymbolId(callExpr: ts.CallExpression, fileId: string): string | null {
+  let current: ts.Node | undefined = callExpr.parent
+  while (current) {
+    if (ts.isFunctionDeclaration(current) && current.name) {
+      return makeSymbolId(fileId, 'function', current.name.text)
+    }
+    if (ts.isMethodDeclaration(current) && current.name && ts.isIdentifier(current.name)) {
+      const cls = current.parent
+      if (ts.isClassDeclaration(cls) && cls.name) {
+        return makeSymbolId(fileId, 'method', `${cls.name.text}.${current.name.text}`)
+      }
+    }
+    if (ts.isConstructorDeclaration(current)) {
+      const cls = current.parent
+      if (ts.isClassDeclaration(cls) && cls.name) {
+        return makeSymbolId(fileId, 'method', `${cls.name.text}.constructor`)
+      }
+    }
+    if (
+      (ts.isGetAccessorDeclaration(current) || ts.isSetAccessorDeclaration(current)) &&
+      current.name &&
+      ts.isIdentifier(current.name)
+    ) {
+      const cls = current.parent
+      if (ts.isClassDeclaration(cls) && cls.name) {
+        return makeSymbolId(fileId, 'method', `${cls.name.text}.${current.name.text}`)
+      }
+    }
+    if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) {
+      const list = current.parent
+      const stmt = list.parent
+      // Only top-level variable statements have a SpiSymbol in v1 — local
+      // variables inside another function aren't emitted, so keep walking up
+      // past them until we find an enclosing function/method/class.
+      if (ts.isVariableStatement(stmt) && ts.isSourceFile(stmt.parent)) {
+        const isConst = (stmt.declarationList.flags & ts.NodeFlags.Const) !== 0
+        const kind: SpiSymbolKind = isConst ? 'constant' : 'variable'
+        return makeSymbolId(fileId, kind, current.name.text)
+      }
+    }
+    current = current.parent
+  }
+  return null
+}
+
+function resolveCallee(
+  callExpr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+): { id: string; confidence: 'high' | 'medium' | 'low' } | null {
+  const signature = checker.getResolvedSignature(callExpr)
+  if (!signature) return null
+  const decl = signature.getDeclaration() as ts.Declaration | undefined
+  if (!decl) return null
+
+  const sourceFile = decl.getSourceFile()
+  if (sourceFile.isDeclarationFile) return null
+  const targetFileId = pathToFileId.get(sourceFile.fileName)
+  if (!targetFileId) return null
+
+  const id = lookupSpiSymbolForDeclaration(decl, targetFileId)
+  if (!id) return null
+
+  // Confidence: medium when the callee identifier has multiple declarations
+  // (overloads, ambient + impl), high otherwise.
+  const exprSymbol = checker.getSymbolAtLocation(callExpr.expression)
+    ?? (callExpr.expression.kind === ts.SyntaxKind.PropertyAccessExpression
+      ? checker.getSymbolAtLocation((callExpr.expression as ts.PropertyAccessExpression).name)
+      : undefined)
+  const overloadCount = exprSymbol?.declarations?.length ?? 1
+  const confidence: 'high' | 'medium' = overloadCount > 1 ? 'medium' : 'high'
+  return { id, confidence }
+}
+
+function lookupSpiSymbolForDeclaration(decl: ts.Declaration, fileId: string): string | null {
+  if (ts.isFunctionDeclaration(decl) && decl.name) {
+    return makeSymbolId(fileId, 'function', decl.name.text)
+  }
+  if (ts.isMethodDeclaration(decl) && decl.name && ts.isIdentifier(decl.name)) {
+    const cls = decl.parent
+    if (ts.isClassDeclaration(cls) && cls.name) {
+      return makeSymbolId(fileId, 'method', `${cls.name.text}.${decl.name.text}`)
+    }
+  }
+  if (ts.isConstructorDeclaration(decl)) {
+    const cls = decl.parent
+    if (ts.isClassDeclaration(cls) && cls.name) {
+      return makeSymbolId(fileId, 'method', `${cls.name.text}.constructor`)
+    }
+  }
+  if (
+    (ts.isGetAccessorDeclaration(decl) || ts.isSetAccessorDeclaration(decl)) &&
+    decl.name &&
+    ts.isIdentifier(decl.name)
+  ) {
+    const cls = decl.parent
+    if (ts.isClassDeclaration(cls) && cls.name) {
+      return makeSymbolId(fileId, 'method', `${cls.name.text}.${decl.name.text}`)
+    }
+  }
+  if (ts.isFunctionExpression(decl) || ts.isArrowFunction(decl)) {
+    const vd = decl.parent
+    if (ts.isVariableDeclaration(vd) && ts.isIdentifier(vd.name)) {
+      const stmt = vd.parent.parent
+      if (ts.isVariableStatement(stmt)) {
+        const isConst = (stmt.declarationList.flags & ts.NodeFlags.Const) !== 0
+        const kind: SpiSymbolKind = isConst ? 'constant' : 'variable'
+        return makeSymbolId(fileId, kind, vd.name.text)
+      }
+    }
+  }
+  return null
+}
+
+function loadCompilerOptions(root: string): ts.CompilerOptions {
+  const tsConfigPath = join(root, 'tsconfig.json')
+  if (existsSync(tsConfigPath)) {
+    try {
+      const content = readFileSync(tsConfigPath, 'utf8')
+      const parsed = ts.parseConfigFileTextToJson(tsConfigPath, content)
+      if (parsed.config) {
+        const config = ts.parseJsonConfigFileContent(parsed.config, ts.sys, root)
+        // Always keep type-check side effects suppressed; we only want the
+        // checker for resolution, not diagnostics.
+        return { ...config.options, noEmit: true, skipLibCheck: true }
+      }
+    } catch {
+      // Fall through to defaults if the user's tsconfig is malformed; the call
+      // layer is best-effort, not a blocker.
+    }
+  }
+  return defaultCompilerOptions()
+}
+
+function defaultCompilerOptions(): ts.CompilerOptions {
+  return {
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    allowJs: true,
+    jsx: ts.JsxEmit.Preserve,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: false,
+    esModuleInterop: true,
+    isolatedModules: true,
+  }
 }

--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -105,7 +105,10 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
     const rel = toPosix(relative(root, abs))
     const content = readFileSync(abs, 'utf8')
     const fileId = makeFileId(rel)
-    pathToFileId.set(abs, fileId)
+    // Always store keys as forward-slash absolute paths. TypeScript normalizes
+    // sourceFile.fileName to forward slashes on every OS, and so does the
+    // program.getSourceFile() lookup, so the map must match that convention.
+    pathToFileId.set(toPosix(abs), fileId)
     files.push({
       id: fileId,
       path: rel,
@@ -443,11 +446,11 @@ function resolveRelativeImport(
 
   for (const variant of variants) {
     for (const ext of RESOLUTION_CANDIDATE_EXTS) {
-      const id = pathToFileId.get(resolve(fromDir, variant + ext))
+      const id = pathToFileId.get(toPosix(resolve(fromDir, variant + ext)))
       if (id) return id
     }
     for (const tail of INDEX_RESOLUTION_CANDIDATES) {
-      const id = pathToFileId.get(resolve(fromDir, variant + tail))
+      const id = pathToFileId.get(toPosix(resolve(fromDir, variant + tail)))
       if (id) return id
     }
   }
@@ -546,7 +549,7 @@ type CallEdgeContext = {
 
 function addCallEdges(ctx: CallEdgeContext): void {
   const { files, root, pathToFileId, edges, diagnostics } = ctx
-  const rootNames = files.map((f) => join(root, f.path))
+  const rootNames = files.map((f) => toPosix(join(root, f.path)))
   if (rootNames.length === 0) return
 
   const compilerOptions = loadCompilerOptions(root)
@@ -568,7 +571,7 @@ function addCallEdges(ctx: CallEdgeContext): void {
   const seen = new Set<string>()
 
   for (const file of files) {
-    const abs = join(root, file.path)
+    const abs = toPosix(join(root, file.path))
     const sourceFile = program.getSourceFile(abs)
     if (!sourceFile) continue
     walkCallExpressions(sourceFile, file.id, checker, pathToFileId, edges, seen)

--- a/tests/unit/spi-build.test.ts
+++ b/tests/unit/spi-build.test.ts
@@ -99,7 +99,7 @@ describe('buildSpiFileLayer (slice 1a of #72)', () => {
       expect(spi.files.map((f) => f.path)).toEqual(['src/keep.ts'])
     })
 
-    it('produces deterministic output between two runs of the same workspace', () => {
+    it('produces deterministic output between two runs of the same workspace', { timeout: 30_000 }, () => {
       writeFile(sandbox, 'src/a.ts', 'export const a = 1\n')
       writeFile(sandbox, 'src/b.ts', 'import { a } from "./a.js"\nexport const b = a\n')
       const first = build(sandbox)

--- a/tests/unit/spi-calls.test.ts
+++ b/tests/unit/spi-calls.test.ts
@@ -1,0 +1,239 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve as pathResolve } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiEdge, SpiSymbol, SpiSymbolKind } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-calls-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-2a',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, filePath: string, name: string, kind: SpiSymbolKind): SpiSymbol {
+  const file = spi.files.find((f) => f.path === filePath)
+  if (!file) throw new Error(`fixture missing SpiFile: ${filePath}`)
+  const matches = spi.symbols.filter((s) => s.file_id === file.id && s.name === name && s.kind === kind)
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one ${kind} ${name} in ${filePath}; got ${matches.length}`)
+  }
+  return matches[0]!
+}
+
+function callsEdge(spi: SemanticProgramIndex, fromId: string, toId: string): SpiEdge | undefined {
+  return spi.edges.find((e) => e.kind === 'calls' && e.from === fromId && e.to === toId)
+}
+
+describe('buildSpi call layer (slice 2a of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('basic call resolution', () => {
+    it('emits a high-confidence calls edge between two functions in the same file', () => {
+      writeFile(sandbox, 'src/a.ts', [
+        'function helper() { return 1 }',
+        'export function caller() { return helper() }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const caller = findSymbol(spi, 'src/a.ts', 'caller', 'function')
+      const helper = findSymbol(spi, 'src/a.ts', 'helper', 'function')
+      const edge = callsEdge(spi, caller.id, helper.id)
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('typescript-semantic')
+    })
+
+    it('attributes calls inside class methods to the Class.method symbol', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'function helper() { return 1 }',
+        'export class Svc {',
+        '  doWork() { return helper() }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const method = findSymbol(spi, 'src/svc.ts', 'Svc.doWork', 'method')
+      const helper = findSymbol(spi, 'src/svc.ts', 'helper', 'function')
+      expect(callsEdge(spi, method.id, helper.id)).toBeTruthy()
+    })
+
+    it('attributes calls inside constructors to the Class.constructor symbol', () => {
+      writeFile(sandbox, 'src/init.ts', [
+        'function setup() {}',
+        'export class Bootstrapper {',
+        '  constructor() { setup() }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const ctor = findSymbol(spi, 'src/init.ts', 'Bootstrapper.constructor', 'method')
+      const setup = findSymbol(spi, 'src/init.ts', 'setup', 'function')
+      expect(callsEdge(spi, ctor.id, setup.id)).toBeTruthy()
+    })
+
+    it('attributes calls inside arrow-function constants to the constant symbol', () => {
+      writeFile(sandbox, 'src/arrow.ts', [
+        'function inner() { return 1 }',
+        'export const wrapper = () => inner()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const wrapper = findSymbol(spi, 'src/arrow.ts', 'wrapper', 'constant')
+      const inner = findSymbol(spi, 'src/arrow.ts', 'inner', 'function')
+      expect(callsEdge(spi, wrapper.id, inner.id)).toBeTruthy()
+    })
+
+    it('does not emit self-recursive calls edges', () => {
+      writeFile(sandbox, 'src/r.ts', [
+        'export function recursive(n: number): number {',
+        '  return n <= 0 ? 0 : recursive(n - 1)',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const fn = findSymbol(spi, 'src/r.ts', 'recursive', 'function')
+      expect(callsEdge(spi, fn.id, fn.id)).toBeUndefined()
+    })
+
+    it('does not duplicate calls edges when the same caller calls the same callee twice', () => {
+      writeFile(sandbox, 'src/dup.ts', [
+        'function f() { return 1 }',
+        'export function caller() {',
+        '  f()',
+        '  f()',
+        '  return f()',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const caller = findSymbol(spi, 'src/dup.ts', 'caller', 'function')
+      const f = findSymbol(spi, 'src/dup.ts', 'f', 'function')
+      const matches = spi.edges.filter((e) => e.kind === 'calls' && e.from === caller.id && e.to === f.id)
+      expect(matches).toHaveLength(1)
+    })
+  })
+
+  describe('cross-file resolution', () => {
+    it('resolves a call across files via the type checker (no SCC needed)', () => {
+      writeFile(sandbox, 'src/util.ts', 'export function shared() { return 1 }\n')
+      writeFile(sandbox, 'src/feature/index.ts', [
+        'import { shared } from "../util.js"',
+        'export function caller() { return shared() }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const caller = findSymbol(spi, 'src/feature/index.ts', 'caller', 'function')
+      const shared = findSymbol(spi, 'src/util.ts', 'shared', 'function')
+      expect(callsEdge(spi, caller.id, shared.id)).toBeTruthy()
+    })
+  })
+
+  describe('what NOT to emit', () => {
+    it('does not emit calls into node_modules / external packages', () => {
+      writeFile(sandbox, 'src/x.ts', [
+        'import { readFileSync } from "node:fs"',
+        'export function uses() { return readFileSync("a.txt") }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      // No call edge should land on a target outside our SpiSymbol set.
+      const fileId = spi.files.find((f) => f.path === 'src/x.ts')!.id
+      const ourIds = new Set(spi.symbols.map((s) => s.id))
+      for (const e of spi.edges.filter((e) => e.kind === 'calls')) {
+        // Caller must be in our SPI; callee must too. node:fs declarations live
+        // in .d.ts files outside the workspace and never produce SpiSymbol.
+        expect(ourIds.has(e.to)).toBe(true)
+        // sanity: caller must be in this file or another SPI file
+        expect(typeof e.from).toBe('string')
+        // Make linter/coverage happy with fileId reference.
+        expect(typeof fileId).toBe('string')
+      }
+    })
+
+    it('does not emit a calls edge when the callsite is at module top level (no enclosing SpiSymbol)', () => {
+      writeFile(sandbox, 'src/top.ts', [
+        'function init() {}',
+        'init()', // top-level call, no caller symbol
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const init = findSymbol(spi, 'src/top.ts', 'init', 'function')
+      // No edge with this init as the target should exist (no caller).
+      const incoming = spi.edges.filter((e) => e.kind === 'calls' && e.to === init.id)
+      expect(incoming).toHaveLength(0)
+    })
+  })
+
+  describe('confidence', () => {
+    it('marks a call to an overloaded function as medium confidence', () => {
+      writeFile(sandbox, 'src/ov.ts', [
+        'export function shape(a: number): number',
+        'export function shape(a: string): string',
+        'export function shape(a: number | string): number | string { return a }',
+        'export function caller() { return shape(1) }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const caller = findSymbol(spi, 'src/ov.ts', 'caller', 'function')
+      const target = spi.symbols.find((s) => s.kind === 'function' && s.name === 'shape')!
+      const edge = callsEdge(spi, caller.id, target.id)
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('medium')
+    })
+  })
+
+  describe('graceful degradation', () => {
+    it('survives a workspace with a malformed tsconfig.json by falling back to defaults', () => {
+      writeFile(sandbox, 'tsconfig.json', '{ "compilerOptions": { "module": "thisIsNotAValidModule" }, ')
+      writeFile(sandbox, 'src/a.ts', [
+        'function helper() {}',
+        'export function caller() { helper() }',
+      ].join('\n') + '\n')
+      // Should not throw; the call layer is best-effort.
+      const spi = build(sandbox)
+      const caller = findSymbol(spi, 'src/a.ts', 'caller', 'function')
+      const helper = findSymbol(spi, 'src/a.ts', 'helper', 'function')
+      // Even on malformed config, simple in-file resolution should still work.
+      expect(callsEdge(spi, caller.id, helper.id)).toBeTruthy()
+    })
+  })
+
+  describe('against the checked-in demo repo', () => {
+    it('emits at least one cross-file calls edge between known symbols', () => {
+      const root = pathResolve(__dirname, '../../examples/demo-repo')
+      const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+
+      const allCalls = spi.edges.filter((e) => e.kind === 'calls')
+      expect(allCalls.length).toBeGreaterThan(0)
+
+      // Every emitted call points at a symbol that exists in this SPI.
+      const ourSymbolIds = new Set(spi.symbols.map((s) => s.id))
+      for (const edge of allCalls) {
+        expect(ourSymbolIds.has(edge.to)).toBe(true)
+        expect(ourSymbolIds.has(edge.from)).toBe(true)
+        expect(edge.source).toBe('typescript-semantic')
+      }
+
+      // Cross-file call: at least one edge whose caller and callee live in
+      // different files.
+      const symbolToFile = new Map<string, string>()
+      for (const s of spi.symbols) symbolToFile.set(s.id, s.file_id)
+      const crossFileCalls = allCalls.filter((e) => symbolToFile.get(e.from) !== symbolToFile.get(e.to))
+      expect(crossFileCalls.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/unit/spi-symbols.test.ts
+++ b/tests/unit/spi-symbols.test.ts
@@ -235,7 +235,7 @@ describe('buildSpi symbol layer (slice 1b of #72)', () => {
   })
 
   describe('range and ID stability', () => {
-    it('mints stable IDs that survive in-file reordering as long as path/kind/name are stable', () => {
+    it('mints stable IDs that survive in-file reordering as long as path/kind/name are stable', { timeout: 30_000 }, () => {
       writeFile(sandbox, 'src/order.ts', [
         'export function a() {}',
         'export function b() {}',
@@ -263,7 +263,7 @@ describe('buildSpi symbol layer (slice 1b of #72)', () => {
       expect(fn.range.end.line).toBeGreaterThanOrEqual(3)
     })
 
-    it('produces a stable, sorted symbol list across two runs of the same workspace', () => {
+    it('produces a stable, sorted symbol list across two runs of the same workspace', { timeout: 30_000 }, () => {
       writeFile(sandbox, 'src/a.ts', 'export const a = 1\n')
       writeFile(sandbox, 'src/b.ts', 'export class B {\n  one() {}\n  two() {}\n}\n')
       const first = build(sandbox)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     maxWorkers: 4,
+    // SPI v1 builders run a ts.Program per call, which is materially slower
+    // under v8 coverage on shared CI runners (Windows + Linux) than the
+    // 5s vitest default. 15s comfortably covers any single buildSpi call;
+    // tests that build twice carry their own per-test overrides.
+    testTimeout: 15_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
Third slice of [#72 — Implement Semantic Program Index v1 for TypeScript/NestJS workspaces](https://github.com/mohanagy/graphify-ts/issues/72). Builds on slices 1a (#88) + 1b (#89). Honors the design contract from [docs/designs/2026-05-10-spi-v1.md](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md).

**Pure additive** — touches nothing in the existing pipeline. Existing `buildSpi` callers from slices 1a/1b keep working unchanged; this just adds a second pass that emits `calls` edges.

## Why slice 2 is split into 2a + 2b

Per our scope discussion, the design's "slice 2" covers both the call layer AND the type layer (extends/implements/param_type/return_type). To keep each PR reviewable:

- **2a (this PR)** — call edges + the `ts.Program` / type-checker scaffolding that slice 2b will reuse.
- 2b — type relationship edges (extends, implements, param_type, return_type).

Slice 2a is also where the substrate first uses the type checker, so most of the new infrastructure (program creation, declaration → SpiSymbol lookup, tsconfig-aware compiler options) lands here.

| Slice | Scope | Status |
|---|---|---|
| 1a | Types + file layer | ✅ merged (#88) |
| 1b | Symbol layer + `declares` edges | ✅ merged (#89) |
| **2a (this PR)** | Call edges + type-checker scaffolding | 🔵 **ready for review** |
| 2b | Type edges (extends / implements / param_type / return_type) | next |
| 1c | Projector → `graph.json` (back-compat layer) | parallel track |
| 3 | Framework (NestJS) + diff overlay | follow-on |

## What ships

**`src/pipeline/spi/build.ts`** gets a second-pass call layer:

- **`addCallEdges()`** — builds a `ts.Program` from collected source files (respecting workspace `tsconfig.json` if present) and uses the type checker to resolve every call expression. Runs after the syntactic pass so it has the full `SpiSymbol` set to map declarations onto.
- **`findEnclosingSpiSymbolId()`** — walks up the AST to attribute a callsite to its enclosing SpiSymbol: top-level function, class method, constructor, getter/setter, or top-level constant/variable. Local variables inside other functions are skipped (no SpiSymbol in v1) — the walk continues up through them.
- **`resolveCallee()`** — uses `checker.getResolvedSignature()` to map the call target back to a SpiSymbol id. Returns `high` confidence for unique resolutions, `medium` when the callee identifier has multiple declarations (overloads, ambient + impl). Skips externals (`.d.ts`, anything outside our SPI).
- **`loadCompilerOptions()`** — respects the workspace's `tsconfig.json` when present (so module resolution + path mappings work as the user expects). Falls back to sensible NodeNext defaults when missing or malformed; parse failures are best-effort, never blocking.

Edge hygiene:

- Self-recursive call edges suppressed (\`if (callee.id !== callerId)\`).
- Duplicate `(caller, callee)` pairs deduplicated via a seen-set, so a function calling another N times emits a single edge.
- Every emitted call edge has \`source: 'typescript-semantic'\`.

## Honesty constraints I held to

- The call layer is **best-effort**, not blocking: if `ts.createProgram` throws on a misconfigured workspace, a `warn`-level diagnostic is recorded and the rest of the SPI still ships.
- Calls into `node_modules` / `.d.ts` are never emitted — they have no SpiSymbol to point at.
- Calls at module top level (no enclosing SpiSymbol) are not emitted — no fabricated "file calls function" edges.
- Local variables inside functions stay invisible in v1; calls inside them are attributed to the enclosing top-level symbol, not the local var.
- Confidence promotion to `medium` for overloaded callees is honest about ambiguity rather than picking the wrong overload silently.

## Test plan

12 new tests in `tests/unit/spi-calls.test.ts` covering:

- [x] Function calls function (same file) → `high` confidence.
- [x] Method calls function (same class).
- [x] Constructor calls function.
- [x] Calls inside arrow-function constants attribute to the constant symbol.
- [x] Self-recursive calls suppressed.
- [x] Duplicate calls deduplicated.
- [x] Cross-file resolution via the type checker.
- [x] **No edges into externals** (`node:fs`, etc.) — verified by asserting every \`calls\` edge target is in \`ourSymbolIds\`.
- [x] Module-top-level callsites produce no edge.
- [x] Overloaded callee → `medium` confidence.
- [x] **Graceful degradation**: malformed tsconfig.json doesn't crash; in-file resolution still works.
- [x] Real run against \`examples/demo-repo/\`: at least one cross-file call edge exists; every caller/callee maps to a real SpiSymbol id.

All prior 27 SPI tests (slices 1a + 1b) still pass against the expanded \`buildSpi\`.

Verified:

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **1440/1440** passing (was 1428 on \`main\`; +12 new)

## What lands next

**Slice 2b**: type relationship edges. \`extends\` / \`implements\` for class hierarchies, \`param_type\` / \`return_type\` for function signatures. Uses the same \`ts.Program\` scaffolding this PR introduces, so the marginal cost is just the new visit + tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type-aware call-edge detection that records call relationships with source-location evidence, deduplicates edges, and supports cross-file resolution.

* **Bug Fixes**
  * Graceful handling when TypeScript program creation fails: emits a warning and continues analysis for other workspaces.
  * Normalized path handling for reliable import resolution across platforms.

* **Tests**
  * Added comprehensive tests for call-edge behavior (duplicates, external symbols, overload confidence, malformed configs, cross-file cases) and adjusted test timeouts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/90)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->