### PR TITLE
feat(#72): SPI v1 slice 2b — type edges (extends/implements/param_type/return_type)

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -1,4 +1,5 @@
-// SPI v1 — file + symbol + call layer builder (slices 1a, 1b, 2a of #72).
+// SPI v1 — file + symbol + call + type layer builder
+// (slices 1a, 1b, 2a, 2b of #72).
 //
 // Produces a SemanticProgramIndex containing:
 //   - workspace metadata + fingerprint
@@ -9,14 +10,20 @@
 //   - declares edges (file -> symbol) for every emitted symbol
 //   - calls edges (caller symbol -> callee symbol), resolved via the
 //     TypeScript type checker. High-confidence when the resolution is
-//     unique and points at a SpiSymbol; medium when the same name has
-//     sibling overload declarations; skipped when the callee resolves
-//     outside the workspace (node_modules / .d.ts) or to a non-SpiSymbol
-//     construct (e.g. an arrow function inside an array literal).
+//     unique; medium when the callee identifier has sibling overload
+//     declarations.
+//   - type edges via the same type checker pass:
+//       * extends   (class -> class, interface -> interface)
+//       * implements (class -> interface)
+//       * param_type  (function/method -> type/interface/class)
+//       * return_type (function/method -> type/interface/class)
+//     All emitted at high confidence; skipped silently for builtins
+//     (string, number, etc.), inline object types, generic parameters,
+//     and unions/intersections that don't map to a single declaration.
 //
-// Type relationships, tests, framework, and diff overlay land in subsequent
-// slices of #72. This module never touches the existing pipeline; it is
-// pure additive substrate.
+// Tests, framework, and diff overlay land in subsequent slices of #72.
+// This module never touches the existing pipeline; it is pure additive
+// substrate.
 
 import { createHash } from 'node:crypto'
 import {
@@ -86,7 +93,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-2a'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-2b'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
@@ -131,9 +138,9 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
     visitFile(sourceFile, file, root, pathToFileId, symbols, edges, diagnostics)
   }
 
-  // Slice 2a: a second pass uses ts.Program + the type checker to resolve
-  // call expressions and emit `calls` edges between SpiSymbols.
-  addCallEdges({ files, root, pathToFileId, symbols, edges, diagnostics })
+  // Slices 2a + 2b: a second pass uses ts.Program + the type checker to
+  // emit calls / extends / implements / param_type / return_type edges.
+  addTypeCheckerEdges({ files, root, pathToFileId, symbols, edges, diagnostics })
 
   files.sort((a, b) => a.path.localeCompare(b.path))
   symbols.sort((a, b) => a.id.localeCompare(b.id))
@@ -535,10 +542,10 @@ function toPosix(p: string): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Call layer (slice 2a)
+// Type-checker pass: call layer (slice 2a) + type layer (slice 2b)
 // ─────────────────────────────────────────────────────────────────────────────
 
-type CallEdgeContext = {
+type TypeCheckerEdgeContext = {
   files: SpiFile[]
   root: string
   pathToFileId: Map<string, string>
@@ -547,7 +554,7 @@ type CallEdgeContext = {
   diagnostics: SpiDiagnostic[]
 }
 
-function addCallEdges(ctx: CallEdgeContext): void {
+function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
   const { files, root, pathToFileId, edges, diagnostics } = ctx
   const rootNames = files.map((f) => toPosix(join(root, f.path)))
   if (rootNames.length === 0) return
@@ -563,18 +570,20 @@ function addCallEdges(ctx: CallEdgeContext): void {
     diagnostics.push({
       id: 'spi.call.program-create-failed',
       level: 'warn',
-      message: `SPI call layer skipped: ts.createProgram threw (${(err as Error).message})`,
+      message: `SPI call+type layer skipped: ts.createProgram threw (${(err as Error).message})`,
     })
     return
   }
   const checker = program.getTypeChecker()
-  const seen = new Set<string>()
+  const seenCalls = new Set<string>()
+  const seenTypeEdges = new Set<string>()
 
   for (const file of files) {
     const abs = toPosix(join(root, file.path))
     const sourceFile = program.getSourceFile(abs)
     if (!sourceFile) continue
-    walkCallExpressions(sourceFile, file.id, checker, pathToFileId, edges, seen)
+    walkCallExpressions(sourceFile, file.id, checker, pathToFileId, edges, seenCalls)
+    walkTypeReferences(sourceFile, file.id, checker, pathToFileId, edges, seenTypeEdges)
   }
 }
 
@@ -759,4 +768,175 @@ function defaultCompilerOptions(): ts.CompilerOptions {
     esModuleInterop: true,
     isolatedModules: true,
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type layer (slice 2b): extends / implements / param_type / return_type edges
+// ─────────────────────────────────────────────────────────────────────────────
+
+type TypeEdgeKind = 'extends' | 'implements' | 'param_type' | 'return_type'
+
+function walkTypeReferences(
+  sourceFile: ts.SourceFile,
+  fileId: string,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) && node.name) {
+      const fromId = makeSymbolId(fileId, 'class', node.name.text)
+      visitHeritageClauses(node.heritageClauses, fromId, sourceFile, fileId, checker, pathToFileId, edges, seen)
+    } else if (ts.isInterfaceDeclaration(node)) {
+      const fromId = makeSymbolId(fileId, 'interface', node.name.text)
+      visitHeritageClauses(node.heritageClauses, fromId, sourceFile, fileId, checker, pathToFileId, edges, seen)
+    }
+
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isConstructorDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
+    ) {
+      const fromId = lookupSpiSymbolForDeclaration(node, fileId)
+      if (fromId) visitSignatureTypes(node, fromId, sourceFile, fileId, checker, pathToFileId, edges, seen)
+    }
+
+    if ((ts.isFunctionExpression(node) || ts.isArrowFunction(node)) && ts.isVariableDeclaration(node.parent)) {
+      // Const/let/var holding an arrow function: param/return types attribute
+      // to the variable's SpiSymbol.
+      const fromId = lookupSpiSymbolForDeclaration(node, fileId)
+      if (fromId) visitSignatureTypes(node, fromId, sourceFile, fileId, checker, pathToFileId, edges, seen)
+    }
+
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+function visitHeritageClauses(
+  clauses: ts.NodeArray<ts.HeritageClause> | undefined,
+  fromId: string,
+  sourceFile: ts.SourceFile,
+  fileId: string,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  if (!clauses) return
+  for (const clause of clauses) {
+    const kind: TypeEdgeKind = clause.token === ts.SyntaxKind.ExtendsKeyword ? 'extends' : 'implements'
+    for (const heritageType of clause.types) {
+      // heritageType is ExpressionWithTypeArguments. Its `.expression` is the
+      // identifier or property access that names the parent type.
+      const symbol = followAlias(checker.getSymbolAtLocation(heritageType.expression), checker)
+      emitTypeEdgeFromSymbol(fromId, kind, symbol, heritageType, sourceFile, fileId, pathToFileId, edges, seen)
+    }
+  }
+}
+
+function visitSignatureTypes(
+  node: ts.SignatureDeclaration,
+  fromId: string,
+  sourceFile: ts.SourceFile,
+  fileId: string,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  for (const param of node.parameters) {
+    if (param.type) {
+      const symbol = symbolForTypeNode(param.type, checker)
+      emitTypeEdgeFromSymbol(fromId, 'param_type', symbol, param.type, sourceFile, fileId, pathToFileId, edges, seen)
+    }
+  }
+  if (node.type) {
+    const symbol = symbolForTypeNode(node.type, checker)
+    emitTypeEdgeFromSymbol(fromId, 'return_type', symbol, node.type, sourceFile, fileId, pathToFileId, edges, seen)
+  }
+}
+
+function symbolForTypeNode(typeNode: ts.TypeNode, checker: ts.TypeChecker): ts.Symbol | undefined {
+  // Direct TypeReference: walk to the typeName for the most reliable lookup.
+  if (ts.isTypeReferenceNode(typeNode)) {
+    return followAlias(checker.getSymbolAtLocation(typeNode.typeName), checker)
+  }
+  // Other type nodes (object literal types, unions, intersections, builtins)
+  // fall back to the resolved type's symbol. Builtins return undefined or a
+  // synthetic intrinsic symbol with no usable declarations — naturally
+  // skipped downstream.
+  return followAlias(checker.getTypeFromTypeNode(typeNode).getSymbol(), checker)
+}
+
+// Imported types come back as alias symbols whose own declaration is the
+// ImportSpecifier, not the underlying interface/class/type-alias/enum. Walk
+// the alias chain so the lookup lands on the real declaration in the
+// originating file.
+function followAlias(symbol: ts.Symbol | undefined, checker: ts.TypeChecker): ts.Symbol | undefined {
+  if (!symbol) return undefined
+  if ((symbol.flags & ts.SymbolFlags.Alias) === 0) return symbol
+  try {
+    return checker.getAliasedSymbol(symbol)
+  } catch {
+    return undefined
+  }
+}
+
+function emitTypeEdgeFromSymbol(
+  fromId: string,
+  kind: TypeEdgeKind,
+  symbol: ts.Symbol | undefined,
+  evidenceNode: ts.Node,
+  sourceFile: ts.SourceFile,
+  fileId: string,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  if (!symbol) return
+  const decl = symbol.declarations?.[0]
+  if (!decl) return
+  const declSourceFile = decl.getSourceFile()
+  if (declSourceFile.isDeclarationFile) return
+  const targetFileId = pathToFileId.get(declSourceFile.fileName)
+  if (!targetFileId) return
+
+  const toId = lookupTypeReferenceSymbolId(decl, targetFileId)
+  if (!toId) return
+  if (toId === fromId) return // skip self-references
+
+  const dedupeKey = `${fromId}|${toId}|${kind}`
+  if (seen.has(dedupeKey)) return
+  seen.add(dedupeKey)
+
+  edges.push({
+    from: fromId,
+    to: toId,
+    kind,
+    confidence: 'high',
+    source: 'typescript-semantic',
+    evidence: { file_id: fileId, range: rangeOf(evidenceNode, sourceFile) },
+  })
+}
+
+// Type-side counterpart to lookupSpiSymbolForDeclaration: maps
+// class/interface/type-alias/enum declarations onto their SpiSymbol id.
+function lookupTypeReferenceSymbolId(decl: ts.Declaration, fileId: string): string | null {
+  if (ts.isClassDeclaration(decl) && decl.name) {
+    return makeSymbolId(fileId, 'class', decl.name.text)
+  }
+  if (ts.isInterfaceDeclaration(decl)) {
+    return makeSymbolId(fileId, 'interface', decl.name.text)
+  }
+  if (ts.isTypeAliasDeclaration(decl)) {
+    return makeSymbolId(fileId, 'type-alias', decl.name.text)
+  }
+  if (ts.isEnumDeclaration(decl)) {
+    return makeSymbolId(fileId, 'enum', decl.name.text)
+  }
+  return null
 }

--- a/tests/unit/spi-types.test.ts
+++ b/tests/unit/spi-types.test.ts
@@ -1,0 +1,228 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve as pathResolve } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type {
+  SemanticProgramIndex,
+  SpiEdge,
+  SpiSymbol,
+  SpiSymbolKind,
+} from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-types-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-2b',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, filePath: string, name: string, kind: SpiSymbolKind): SpiSymbol {
+  const file = spi.files.find((f) => f.path === filePath)
+  if (!file) throw new Error(`fixture missing SpiFile: ${filePath}`)
+  const matches = spi.symbols.filter((s) => s.file_id === file.id && s.name === name && s.kind === kind)
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one ${kind} ${name} in ${filePath}; got ${matches.length}`)
+  }
+  return matches[0]!
+}
+
+function typeEdge(spi: SemanticProgramIndex, fromId: string, kind: SpiEdge['kind'], toId: string): SpiEdge | undefined {
+  return spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === kind)
+}
+
+describe('buildSpi type layer (slice 2b of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('class extends and implements', () => {
+    it('emits an extends edge from a derived class to its parent class', () => {
+      writeFile(sandbox, 'src/h.ts', [
+        'export class Animal {}',
+        'export class Dog extends Animal {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const dog = findSymbol(spi, 'src/h.ts', 'Dog', 'class')
+      const animal = findSymbol(spi, 'src/h.ts', 'Animal', 'class')
+      const edge = typeEdge(spi, dog.id, 'extends', animal.id)
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('typescript-semantic')
+    })
+
+    it('emits an implements edge from a class to each implemented interface', () => {
+      writeFile(sandbox, 'src/i.ts', [
+        'export interface Logger { log(msg: string): void }',
+        'export interface Sink { flush(): void }',
+        'export class ConsoleLogger implements Logger, Sink {',
+        '  log(_msg: string) {}',
+        '  flush() {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const cls = findSymbol(spi, 'src/i.ts', 'ConsoleLogger', 'class')
+      const logger = findSymbol(spi, 'src/i.ts', 'Logger', 'interface')
+      const sink = findSymbol(spi, 'src/i.ts', 'Sink', 'interface')
+      expect(typeEdge(spi, cls.id, 'implements', logger.id)).toBeTruthy()
+      expect(typeEdge(spi, cls.id, 'implements', sink.id)).toBeTruthy()
+    })
+
+    it('does not emit extends/implements edges for external (lib.dom) types', () => {
+      writeFile(sandbox, 'src/x.ts', [
+        'export class MyError extends Error {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const cls = findSymbol(spi, 'src/x.ts', 'MyError', 'class')
+      // Error lives in lib.es5.d.ts → outside our SPI → no edge.
+      const extendsEdges = spi.edges.filter((e) => e.from === cls.id && e.kind === 'extends')
+      expect(extendsEdges).toHaveLength(0)
+    })
+  })
+
+  describe('interface extends interface', () => {
+    it('emits extends edges between interfaces (single and multiple parents)', () => {
+      writeFile(sandbox, 'src/iface.ts', [
+        'export interface Shape { area(): number }',
+        'export interface Drawable { draw(): void }',
+        'export interface Polygon extends Shape, Drawable {',
+        '  sides(): number',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const polygon = findSymbol(spi, 'src/iface.ts', 'Polygon', 'interface')
+      const shape = findSymbol(spi, 'src/iface.ts', 'Shape', 'interface')
+      const drawable = findSymbol(spi, 'src/iface.ts', 'Drawable', 'interface')
+      expect(typeEdge(spi, polygon.id, 'extends', shape.id)).toBeTruthy()
+      expect(typeEdge(spi, polygon.id, 'extends', drawable.id)).toBeTruthy()
+    })
+  })
+
+  describe('function/method param_type and return_type', () => {
+    it('emits param_type and return_type edges for an exported function', () => {
+      writeFile(sandbox, 'src/fn.ts', [
+        'export interface User { id: string }',
+        'export interface Session { token: string }',
+        'export function login(user: User): Session {',
+        '  return { token: user.id }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const login = findSymbol(spi, 'src/fn.ts', 'login', 'function')
+      const user = findSymbol(spi, 'src/fn.ts', 'User', 'interface')
+      const session = findSymbol(spi, 'src/fn.ts', 'Session', 'interface')
+      expect(typeEdge(spi, login.id, 'param_type', user.id)).toBeTruthy()
+      expect(typeEdge(spi, login.id, 'return_type', session.id)).toBeTruthy()
+    })
+
+    it('emits type edges for class methods', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'export interface Request { url: string }',
+        'export interface Response { status: number }',
+        'export class Handler {',
+        '  handle(req: Request): Response { return { status: 200 } }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const method = findSymbol(spi, 'src/svc.ts', 'Handler.handle', 'method')
+      const req = findSymbol(spi, 'src/svc.ts', 'Request', 'interface')
+      const res = findSymbol(spi, 'src/svc.ts', 'Response', 'interface')
+      expect(typeEdge(spi, method.id, 'param_type', req.id)).toBeTruthy()
+      expect(typeEdge(spi, method.id, 'return_type', res.id)).toBeTruthy()
+    })
+
+    it('skips builtin types (string, number, void) and inline object types', () => {
+      writeFile(sandbox, 'src/b.ts', [
+        'export function plain(a: string, b: number): boolean { return a.length > b }',
+        'export function inlineObj(arg: { x: number }): { y: number } { return { y: arg.x } }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const plainFn = findSymbol(spi, 'src/b.ts', 'plain', 'function')
+      const inlineFn = findSymbol(spi, 'src/b.ts', 'inlineObj', 'function')
+      // No type edges should land for either of these — string/number/boolean
+      // are builtins, and inline object literal types don't map to a SpiSymbol.
+      expect(spi.edges.filter((e) => e.from === plainFn.id && (e.kind === 'param_type' || e.kind === 'return_type'))).toHaveLength(0)
+      expect(spi.edges.filter((e) => e.from === inlineFn.id && (e.kind === 'param_type' || e.kind === 'return_type'))).toHaveLength(0)
+    })
+
+    it('resolves a type alias used as a return annotation', () => {
+      writeFile(sandbox, 'src/al.ts', [
+        'export type UserId = string',
+        'export function makeId(): UserId { return "u" }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const fn = findSymbol(spi, 'src/al.ts', 'makeId', 'function')
+      const alias = findSymbol(spi, 'src/al.ts', 'UserId', 'type-alias')
+      expect(typeEdge(spi, fn.id, 'return_type', alias.id)).toBeTruthy()
+    })
+  })
+
+  describe('cross-file resolution', () => {
+    it('resolves param_type / return_type across files', () => {
+      writeFile(sandbox, 'src/types.ts', 'export interface Payload { data: string }\n')
+      writeFile(sandbox, 'src/handler.ts', [
+        'import type { Payload } from "./types.js"',
+        'export function handle(p: Payload): Payload { return p }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handle = findSymbol(spi, 'src/handler.ts', 'handle', 'function')
+      const payload = findSymbol(spi, 'src/types.ts', 'Payload', 'interface')
+      expect(typeEdge(spi, handle.id, 'param_type', payload.id)).toBeTruthy()
+      expect(typeEdge(spi, handle.id, 'return_type', payload.id)).toBeTruthy()
+    })
+  })
+
+  describe('deduplication', () => {
+    it('emits at most one edge per (from, to, kind) tuple even when the type appears multiple times', () => {
+      writeFile(sandbox, 'src/dup.ts', [
+        'export interface T { v: number }',
+        'export function f(a: T, b: T, c: T): T { return a }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const fn = findSymbol(spi, 'src/dup.ts', 'f', 'function')
+      const t = findSymbol(spi, 'src/dup.ts', 'T', 'interface')
+      const params = spi.edges.filter((e) => e.from === fn.id && e.to === t.id && e.kind === 'param_type')
+      expect(params).toHaveLength(1)
+    })
+  })
+
+  describe('against the checked-in demo repo', () => {
+    it('emits at least one type edge that points at a demo-repo SpiSymbol', () => {
+      const root = pathResolve(__dirname, '../../examples/demo-repo')
+      const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+
+      const ourIds = new Set(spi.symbols.map((s) => s.id))
+      const typeKinds = new Set<SpiEdge['kind']>(['extends', 'implements', 'param_type', 'return_type'])
+      const typeEdges = spi.edges.filter((e) => typeKinds.has(e.kind))
+
+      expect(typeEdges.length).toBeGreaterThan(0)
+      // Every emitted type edge must point at a real SpiSymbol in this index.
+      for (const edge of typeEdges) {
+        expect(ourIds.has(edge.to)).toBe(true)
+        expect(ourIds.has(edge.from)).toBe(true)
+        expect(edge.confidence).toBe('high')
+        expect(edge.source).toBe('typescript-semantic')
+      }
+    })
+  })
+})


### PR DESCRIPTION
Fourth slice of [#72 — Implement Semantic Program Index v1 for TypeScript/NestJS workspaces](https://github.com/mohanagy/graphify-ts/issues/72). Builds on slices 1a (#88), 1b (#89), 2a (#90). Honors the design contract from [docs/designs/2026-05-10-spi-v1.md](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md).

**Pure additive** — touches nothing in the existing pipeline. Reuses the `ts.Program` scaffolding from slice 2a so the cost of SPI build only grows by the type-reference walk, not a second program creation.

## What ships

`src/pipeline/spi/build.ts` gets the type-relationship layer in the same type-checker pass as call edges:

- **`addCallEdges` → `addTypeCheckerEdges`** — single `ts.Program` creation now feeds both the call-expression walk and the new type-reference walk.
- **`walkTypeReferences()`** — visits class/interface heritage clauses and function/method/arrow-constant signatures. Emits:

| Edge | Source form |
|---|---|
| `extends` | `class Dog extends Animal {}`, `interface Polygon extends Shape, Drawable {}` |
| `implements` | `class C implements Logger, Sink {}` |
| `param_type` | every annotated parameter on a function/method/arrow |
| `return_type` | the explicit return annotation on a function/method/arrow |

- **`symbolForTypeNode()`** — handles `TypeReferenceNode` directly, falls back to `getTypeFromTypeNode().getSymbol()` for everything else. Builtins (`string`, `number`, `boolean`, `void`) and inline object types fail the SpiSymbol lookup downstream and are silently skipped.
- **`followAlias()`** — when a type comes from \`import type { Foo } …\`, \`getSymbolAtLocation\` returns the import-alias symbol whose own declaration is the \`ImportSpecifier\`. Walking the alias chain via \`checker.getAliasedSymbol\` lets cross-file type references resolve to the actual interface/class/type-alias declaration.
- Edges deduplicated per `(from, to, kind)` — a function with multiple parameters of the same type emits one `param_type` edge.

## Honors the design contract

- All type-checker-backed edges are \`confidence: 'high'\`, \`source: 'typescript-semantic'\`.
- Self-references suppressed.
- Externals (\`lib.dom\`, \`.d.ts\` files outside the workspace) skipped — \`class MyError extends Error {}\` produces zero \`extends\` edges, asserted by a test.
- Generic instantiations resolve to the unparameterized type, so \`Promise<User>\` reads as an edge to \`Promise\` (which falls outside our SPI and is skipped). Type-parameter expansion is a slice 3 concern.

## Test plan

11 new tests in \`tests/unit/spi-types.test.ts\` covering:

- [x] Class \`extends\` (single parent).
- [x] Class \`implements\` multiple interfaces.
- [x] External-type heritage skipped (\`extends Error\` produces no edge).
- [x] Interface multi-parent \`extends\`.
- [x] Function \`param_type\` + \`return_type\`.
- [x] Class method \`param_type\` + \`return_type\`.
- [x] Builtins / inline object types skipped silently.
- [x] Type alias used as return annotation resolves.
- [x] **Cross-file** \`param_type\` / \`return_type\` via \`import type\` (regression-protects the alias-follow logic).
- [x] Deduplication: 3 params of the same type → 1 edge.
- [x] Real run against \`examples/demo-repo/\`: at least one type edge exists; every emitted edge points at a real SpiSymbol; all marked \`high\` / \`typescript-semantic\`.

All prior 39 SPI tests (slices 1a + 1b + 2a) still pass against the renamed pass.

Verified:

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **1451/1451** passing (was 1440 on \`main\`; +11 new)

## Where slice 2 stands now

| Slice | Scope | Status |
|---|---|---|
| 1a | Types + file layer | ✅ merged (#88) |
| 1b | Symbol layer + \`declares\` edges | ✅ merged (#89) |
| 2a | Call edges + type-checker scaffolding | ✅ merged (#90) |
| **2b (this PR)** | Type edges | 🔵 **ready for review** |
| 1c | Projector → \`graph.json\` (back-compat) | parallel track |
| 3 | Framework (NestJS) + diff overlay | follow-on |

After this lands, the SPI substrate's TS/JS coverage is essentially complete for the slicer's needs (#73). Slice 1c (back-compat projector) and slice 3 (framework + diff) are the remaining pieces, and neither blocks #73 from starting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SPI indexing now captures type relationship data including inheritance, interface implementation, and parameter/return type edges in a unified semantic analysis pass.

* **Tests**
  * Added test coverage validating type relationship detection, cross-file type resolution, and symbol deduplication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/91)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->