### PR TITLE
feat(#72): SPI v1 slice 3a — diff overlay (computeSpiDiffOverlay)

### DIFF
--- a/src/pipeline/spi/diff-overlay.ts
+++ b/src/pipeline/spi/diff-overlay.ts
@@ -1,0 +1,161 @@
+// SPI v1 — diff overlay (slice 3a of #72).
+//
+// Computed on demand against a base/head ref. Maps each changed line range
+// from `git diff` onto the smallest containing SpiSymbol so PR-impact, the
+// slicer's review mode (#73), and any future delta-only context-pack work
+// (#81) can reason about "what changed" without re-deriving the mapping
+// from scratch every call.
+//
+// Per the SPI v1 design (docs/designs/2026-05-10-spi-v1.md), the diff
+// overlay is intentionally NOT part of the persisted SemanticProgramIndex —
+// it varies with `git rev-parse`. Callers compute it explicitly when they
+// need it.
+//
+// Uses execFileSync from node:child_process to run git, mirroring the same
+// pattern the existing pipeline uses in src/runtime/pr-impact.ts and
+// src/infrastructure/time-travel.ts. execFileSync with args-as-array is
+// safe against shell injection by design.
+
+import { execFileSync } from 'node:child_process'
+
+import type {
+  SemanticProgramIndex,
+  SpiDiffOverlay,
+  SpiEdge,
+  SpiRange,
+} from './types.js'
+
+export type GitDiffRunner = (args: ReadonlyArray<string>, cwd: string) => string
+
+export type ComputeSpiDiffOverlayOptions = {
+  spi: SemanticProgramIndex
+  root: string
+  baseRef: string
+  headRef?: string
+  // Test-only injection point. Production callers pass nothing; the default
+  // runs `git diff --unified=0 --no-color baseRef headRef` via execFileSync.
+  runGitDiff?: GitDiffRunner
+}
+
+export function computeSpiDiffOverlay(opts: ComputeSpiDiffOverlayOptions): SpiDiffOverlay {
+  const baseRef = opts.baseRef
+  const headRef = opts.headRef ?? 'HEAD'
+  const runner = opts.runGitDiff ?? defaultGitDiffRunner
+
+  let diffText = ''
+  try {
+    diffText = runner(
+      ['diff', '--unified=0', '--no-color', '--no-prefix', baseRef, headRef, '--'],
+      opts.root,
+    )
+  } catch {
+    // `git diff` may fail (uninitialized repo, unknown ref, etc.). Honest
+    // empty overlay rather than throwing — callers can detect "nothing
+    // changed" the same way as a clean working tree.
+    return emptyOverlay(baseRef, headRef)
+  }
+
+  const fileChanges = parseUnifiedDiff(diffText)
+
+  const fileById = new Map(opts.spi.files.map((f) => [f.path, f] as const))
+  const symbolsByFileId = new Map<string, SemanticProgramIndex['symbols']>()
+  for (const symbol of opts.spi.symbols) {
+    const list = symbolsByFileId.get(symbol.file_id)
+    if (list) list.push(symbol)
+    else symbolsByFileId.set(symbol.file_id, [symbol])
+  }
+
+  const changedFiles = new Set<string>()
+  const changedSymbols = new Set<string>()
+  const edgesAdded: SpiEdge[] = []
+
+  for (const change of fileChanges) {
+    const file = fileById.get(change.path)
+    if (!file) continue
+    changedFiles.add(file.id)
+    const fileSymbols = symbolsByFileId.get(file.id) ?? []
+    for (const range of change.ranges) {
+      for (const symbol of fileSymbols) {
+        if (!lineOverlaps(symbol.range, range.startLine, range.endLine)) continue
+        if (changedSymbols.has(symbol.id)) continue
+        changedSymbols.add(symbol.id)
+        edgesAdded.push({
+          from: symbol.id,
+          to: file.id,
+          kind: 'changed_in',
+          confidence: 'high',
+          source: 'typescript-syntactic',
+          evidence: { file_id: file.id, range: symbol.range },
+        })
+      }
+    }
+  }
+
+  return {
+    base_ref: baseRef,
+    head_ref: headRef,
+    changed_files: [...changedFiles].sort(),
+    changed_symbols: [...changedSymbols].sort(),
+    edges_added: edgesAdded.sort((a, b) =>
+      `${a.from}|${a.to}|${a.kind}`.localeCompare(`${b.from}|${b.to}|${b.kind}`),
+    ),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+type FileChange = {
+  path: string
+  ranges: Array<{ startLine: number; endLine: number }>
+}
+
+function defaultGitDiffRunner(args: ReadonlyArray<string>, cwd: string): string {
+  return execFileSync('git', [...args], {
+    cwd,
+    encoding: 'utf8',
+    // 64 MB caps the worst-case "diff --unified=0" output size; well above
+    // anything a normal PR produces and below the default Node heap limit.
+    maxBuffer: 64 * 1024 * 1024,
+  })
+}
+
+function emptyOverlay(baseRef: string, headRef: string): SpiDiffOverlay {
+  return { base_ref: baseRef, head_ref: headRef, changed_files: [], changed_symbols: [], edges_added: [] }
+}
+
+function parseUnifiedDiff(diff: string): FileChange[] {
+  const result: FileChange[] = []
+  let current: FileChange | null = null
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      const raw = line.slice(4).trim()
+      if (raw === '/dev/null') {
+        current = null
+        continue
+      }
+      // With --no-prefix git emits paths verbatim; without it we strip the
+      // conventional `b/` prefix. Handle both.
+      const path = raw.startsWith('b/') ? raw.slice(2) : raw
+      current = { path, ranges: [] }
+      result.push(current)
+    } else if (line.startsWith('@@') && current) {
+      // Format: @@ -OLD_START[,OLD_COUNT] +NEW_START[,NEW_COUNT] @@ optional context
+      const match = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line)
+      if (!match) continue
+      const start = Number.parseInt(match[1] ?? '0', 10)
+      const count = match[2] ? Number.parseInt(match[2], 10) : 1
+      // count === 0 means "lines were removed, no new content" — no head-side
+      // range to map; skip.
+      if (count > 0 && start > 0) {
+        current.ranges.push({ startLine: start, endLine: start + count - 1 })
+      }
+    }
+  }
+  return result
+}
+
+function lineOverlaps(range: SpiRange, startLine: number, endLine: number): boolean {
+  return range.start.line <= endLine && range.end.line >= startLine
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -1,7 +1,12 @@
 // SPI v1 — public re-exports.
 //
-// Slices 1a + 1b: types + file layer + symbol layer + declares edges.
-// Call/type/test/diff/framework layers and the projection back to today's
+// Slices 1a + 1b + 2a + 2b + 3a:
+//   * types + file layer + imports/exports edges
+//   * symbol layer + declares edges
+//   * call layer + type layer (extends/implements/param_type/return_type)
+//   * diff overlay (computed on demand against a base/head ref)
+//
+// Test layer, framework (NestJS), and the projection back to today's
 // graph.json land in subsequent slices of #72.
 
 export type {
@@ -32,3 +37,9 @@ export {
   type BuildSpiOptions,
   type BuildSpiFileLayerOptions,
 } from './build.js'
+
+export {
+  computeSpiDiffOverlay,
+  type ComputeSpiDiffOverlayOptions,
+  type GitDiffRunner,
+} from './diff-overlay.js'

--- a/tests/unit/spi-diff-overlay.test.ts
+++ b/tests/unit/spi-diff-overlay.test.ts
@@ -1,0 +1,321 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import { computeSpiDiffOverlay, type GitDiffRunner } from '../../src/pipeline/spi/diff-overlay.js'
+import type { SemanticProgramIndex, SpiSymbol, SpiSymbolKind } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-diff-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function buildIndex(root: string): SemanticProgramIndex {
+  return buildSpi({ root, graphifyVersion: 'test-0.0.0', extractorVersion: 'spi-v1.0.0-slice-3a', now: FROZEN_NOW })
+}
+
+function findSymbol(spi: SemanticProgramIndex, filePath: string, name: string, kind: SpiSymbolKind): SpiSymbol {
+  const file = spi.files.find((f) => f.path === filePath)
+  if (!file) throw new Error(`fixture missing SpiFile: ${filePath}`)
+  const matches = spi.symbols.filter((s) => s.file_id === file.id && s.name === name && s.kind === kind)
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one ${kind} ${name} in ${filePath}; got ${matches.length}`)
+  }
+  return matches[0]!
+}
+
+// Builds a mock git-diff runner that returns the supplied unified-diff text.
+function diffRunner(diff: string): GitDiffRunner {
+  return () => diff
+}
+
+describe('computeSpiDiffOverlay (slice 3a of #72)', () => {
+  let sandbox: string
+
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('basic mapping', () => {
+    it('maps a changed line range to the smallest containing SpiSymbol and emits a changed_in edge', () => {
+      writeFile(sandbox, 'src/a.ts', [
+        'export function alpha() {',  // line 1
+        '  return 1',                  // line 2
+        '}',                            // line 3
+        '',                             // line 4
+        'export function beta() {',    // line 5
+        '  return 2',                   // line 6
+        '}',                            // line 7
+      ].join('\n') + '\n')
+      const spi = buildIndex(sandbox)
+      const alpha = findSymbol(spi, 'src/a.ts', 'alpha', 'function')
+      const beta = findSymbol(spi, 'src/a.ts', 'beta', 'function')
+      const file = spi.files.find((f) => f.path === 'src/a.ts')!
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/a.ts',
+            '+++ src/a.ts',
+            '@@ -2,1 +2,1 @@',
+            '-  return 1',
+            '+  return 42',
+          ].join('\n') + '\n',
+        ),
+      })
+
+      expect(overlay.base_ref).toBe('main')
+      expect(overlay.head_ref).toBe('HEAD')
+      expect(overlay.changed_files).toEqual([file.id])
+      expect(overlay.changed_symbols).toEqual([alpha.id])
+      // beta was not touched; only alpha gets a changed_in edge.
+      expect(overlay.changed_symbols).not.toContain(beta.id)
+      expect(overlay.edges_added).toHaveLength(1)
+      const edge = overlay.edges_added[0]!
+      expect(edge.from).toBe(alpha.id)
+      expect(edge.to).toBe(file.id)
+      expect(edge.kind).toBe('changed_in')
+      expect(edge.confidence).toBe('high')
+      expect(edge.source).toBe('typescript-syntactic')
+    })
+
+    it('attributes a multi-line hunk to every overlapping symbol in the file', () => {
+      writeFile(sandbox, 'src/m.ts', [
+        'export function fst() { return 1 }',  // line 1
+        'export function snd() { return 2 }',  // line 2
+        'export function thd() { return 3 }',  // line 3
+      ].join('\n') + '\n')
+      const spi = buildIndex(sandbox)
+      const fst = findSymbol(spi, 'src/m.ts', 'fst', 'function')
+      const snd = findSymbol(spi, 'src/m.ts', 'snd', 'function')
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/m.ts',
+            '+++ src/m.ts',
+            '@@ -1,2 +1,2 @@',
+            '-export function fst() { return 1 }',
+            '-export function snd() { return 2 }',
+            '+export function fst() { return 11 }',
+            '+export function snd() { return 22 }',
+          ].join('\n') + '\n',
+        ),
+      })
+
+      // fst (line 1) and snd (line 2) are both in the hunk; thd (line 3) is not.
+      expect(overlay.changed_symbols).toEqual([fst.id, snd.id].sort())
+    })
+
+    it('produces no changed_in edge for files not in the SPI', () => {
+      writeFile(sandbox, 'src/in-spi.ts', 'export const x = 1\n')
+      const spi = buildIndex(sandbox)
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/some/unrelated/file.txt',
+            '+++ some/unrelated/file.txt',
+            '@@ -1,1 +1,1 @@',
+            '-old',
+            '+new',
+          ].join('\n') + '\n',
+        ),
+      })
+      expect(overlay.changed_files).toHaveLength(0)
+      expect(overlay.changed_symbols).toHaveLength(0)
+      expect(overlay.edges_added).toHaveLength(0)
+    })
+  })
+
+  describe('git diff parsing edge cases', () => {
+    it('handles deletion-only hunks (count=0) without producing changed_in edges', () => {
+      writeFile(sandbox, 'src/d.ts', 'export function survivor() { return 1 }\n')
+      const spi = buildIndex(sandbox)
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/d.ts',
+            '+++ src/d.ts',
+            '@@ -10,3 +9,0 @@',
+            '-removed line one',
+            '-removed line two',
+            '-removed line three',
+          ].join('\n') + '\n',
+        ),
+      })
+      // The change touched the file but had no head-side range, so no
+      // symbol-level edges. The file itself is still listed as changed.
+      expect(overlay.changed_files).toHaveLength(1)
+      expect(overlay.changed_symbols).toHaveLength(0)
+      expect(overlay.edges_added).toHaveLength(0)
+    })
+
+    it('handles single-line hunks with the implicit count of 1', () => {
+      writeFile(sandbox, 'src/s.ts', 'export const target = 1\n')
+      const spi = buildIndex(sandbox)
+      const target = findSymbol(spi, 'src/s.ts', 'target', 'constant')
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/s.ts',
+            '+++ src/s.ts',
+            // No count = implicit 1
+            '@@ -1 +1 @@',
+            '-export const target = 1',
+            '+export const target = 99',
+          ].join('\n') + '\n',
+        ),
+      })
+      expect(overlay.changed_symbols).toEqual([target.id])
+    })
+
+    it('skips deleted-from-head files (+++ /dev/null)', () => {
+      writeFile(sandbox, 'src/keeper.ts', 'export const k = 1\n')
+      const spi = buildIndex(sandbox)
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/deleted.ts',
+            '+++ /dev/null',
+            '@@ -1,1 +0,0 @@',
+            '-was here',
+          ].join('\n') + '\n',
+        ),
+      })
+      expect(overlay.changed_files).toHaveLength(0)
+    })
+
+    it('strips the conventional b/ prefix when --no-prefix was not used', () => {
+      writeFile(sandbox, 'src/p.ts', 'export const p = 1\n')
+      const spi = buildIndex(sandbox)
+      const target = findSymbol(spi, 'src/p.ts', 'p', 'constant')
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/p.ts',
+            '+++ b/src/p.ts',  // <-- the 'b/' prefix some git configs emit
+            '@@ -1 +1 @@',
+            '-export const p = 1',
+            '+export const p = 2',
+          ].join('\n') + '\n',
+        ),
+      })
+      expect(overlay.changed_symbols).toEqual([target.id])
+    })
+  })
+
+  describe('multiple files in one diff', () => {
+    it('walks every file block and dedupes symbols across hunks', () => {
+      writeFile(sandbox, 'src/a.ts', 'export function fa() { return 1 }\n')
+      writeFile(sandbox, 'src/b.ts', 'export function fb() { return 2 }\n')
+      const spi = buildIndex(sandbox)
+      const fa = findSymbol(spi, 'src/a.ts', 'fa', 'function')
+      const fb = findSymbol(spi, 'src/b.ts', 'fb', 'function')
+
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        headRef: 'feature/foo',
+        runGitDiff: diffRunner(
+          [
+            '--- a/src/a.ts',
+            '+++ src/a.ts',
+            '@@ -1 +1 @@',
+            '-export function fa() { return 1 }',
+            '+export function fa() { return 11 }',
+            '--- a/src/b.ts',
+            '+++ src/b.ts',
+            '@@ -1 +1 @@',
+            '-export function fb() { return 2 }',
+            '+export function fb() { return 22 }',
+          ].join('\n') + '\n',
+        ),
+      })
+      expect(overlay.head_ref).toBe('feature/foo')
+      expect(overlay.changed_symbols.sort()).toEqual([fa.id, fb.id].sort())
+      expect(overlay.edges_added).toHaveLength(2)
+    })
+  })
+
+  describe('graceful failure', () => {
+    it('returns an empty overlay when the git runner throws (uninitialized repo)', () => {
+      writeFile(sandbox, 'src/s.ts', 'export const x = 1\n')
+      const spi = buildIndex(sandbox)
+      const overlay = computeSpiDiffOverlay({
+        spi,
+        root: sandbox,
+        baseRef: 'main',
+        runGitDiff: vi.fn(() => { throw new Error('not a git repo') }),
+      })
+      expect(overlay).toEqual({
+        base_ref: 'main',
+        head_ref: 'HEAD',
+        changed_files: [],
+        changed_symbols: [],
+        edges_added: [],
+      })
+    })
+  })
+
+  describe('determinism', () => {
+    it('produces a stable JSON shape for the same SPI + diff text', () => {
+      writeFile(sandbox, 'src/a.ts', [
+        'export function alpha() { return 1 }',
+        'export function beta() { return 2 }',
+      ].join('\n') + '\n')
+      const spi = buildIndex(sandbox)
+      const diff = [
+        '--- a/src/a.ts',
+        '+++ src/a.ts',
+        '@@ -1,2 +1,2 @@',
+        '-export function alpha() { return 1 }',
+        '-export function beta() { return 2 }',
+        '+export function alpha() { return 11 }',
+        '+export function beta() { return 22 }',
+      ].join('\n') + '\n'
+
+      const first = computeSpiDiffOverlay({ spi, root: sandbox, baseRef: 'main', runGitDiff: diffRunner(diff) })
+      const second = computeSpiDiffOverlay({ spi, root: sandbox, baseRef: 'main', runGitDiff: diffRunner(diff) })
+      expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+    })
+  })
+})


### PR DESCRIPTION
Fifth slice of [#72 — Implement Semantic Program Index v1 for TypeScript/NestJS workspaces](https://github.com/mohanagy/graphify-ts/issues/72). Adds the diff overlay per the SPI v1 [design contract](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md).

**Pure additive** — new module under `src/pipeline/spi/diff-overlay.ts`, new test file. Existing `buildSpi` callers and the rest of the pipeline are untouched.

**Why this slice exists separately:** the design explicitly says the diff overlay is *not* part of the persisted SPI — it varies with `git rev-parse`. So this ships as a standalone `computeSpiDiffOverlay()` function that callers (PR-impact, the slicer's review mode in #73, future delta-only context-pack work in #81) invoke when they need a "what changed" view on top of the static SPI.

## What ships

`src/pipeline/spi/diff-overlay.ts`:

- **`computeSpiDiffOverlay({ spi, root, baseRef, headRef?, runGitDiff? })`** → `SpiDiffOverlay`. Runs `git diff --unified=0 --no-color --no-prefix base head`, parses the unified-diff output, maps each changed line range onto the smallest containing `SpiSymbol` in the head version, and emits a `changed_in` edge (symbol → file) per affected symbol.
- **`runGitDiff`** is a public injection point — production callers pass nothing; tests supply synthetic diff text so they don't need a real git repo. Default invokes `execFileSync('git', ...)` mirroring the same pattern `src/runtime/pr-impact.ts` and `src/infrastructure/time-travel.ts` already use (args-as-array, no shell).
- **Graceful failure**: if the git runner throws (uninitialized repo, unknown ref, etc.) the function returns an empty overlay rather than tanking the caller. Honest "no diff information available" read.

The unified-diff parser handles:

| Case | Behavior |
|---|---|
| Multiple file blocks in one diff | Each parsed independently |
| Single-line `@@ -N +N @@` header | Implicit count of 1 |
| Deletion-only hunks (`@@ -10,3 +9,0 @@`) | File listed as changed; no head-side range, so no symbol-level edges |
| File deleted from head (`+++ /dev/null`) | Skipped — file isn't in SPI anyway |
| `+++ b/path` (conventional prefix) | `b/` stripped automatically |
| File path not in SPI | Silently skipped |

`src/pipeline/spi/index.ts` re-exports `computeSpiDiffOverlay`, `ComputeSpiDiffOverlayOptions`, `GitDiffRunner`.

## Honors the design contract

- Overlay is **not** persisted; computed on demand against the explicit `(baseRef, headRef)` pair.
- `changed_in` edges marked `confidence: 'high'`, `source: 'typescript-syntactic'` — git diff is exact, not heuristic.
- Output is deterministic for the same `(SPI, diff text)` input — `changed_files`, `changed_symbols`, `edges_added` all sorted; asserted by a test.

## Test plan

10 new tests in `tests/unit/spi-diff-overlay.test.ts` covering:

- [x] Single-symbol line-range → one `changed_in` edge with the right shape.
- [x] Multi-line hunk overlapping multiple symbols → all of them flagged.
- [x] Files outside the SPI → empty overlay.
- [x] Deletion-only hunk (count=0) → file flagged, no symbol edges.
- [x] Single-line `@@ -1 +1 @@` header (implicit count of 1).
- [x] `+++ /dev/null` (deleted file) → skipped.
- [x] `b/` prefix on `+++` line stripped.
- [x] Multi-file diff in one invocation.
- [x] Graceful failure when the runner throws → empty overlay (no crash).
- [x] JSON-shape determinism for repeated calls with the same diff.

All 50 prior SPI tests (slices 1a + 1b + 2a + 2b) still pass.

Verified:

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test:run` — **1461/1461** passing (was 1451 on `main`; +10 new)

## Where #72 stands now

| Slice | Scope | Status |
|---|---|---|
| 1a | Types + file layer | ✅ merged (#88) |
| 1b | Symbol layer + `declares` | ✅ merged (#89) |
| 2a | Call edges + checker scaffolding | ✅ merged (#90) |
| 2b | Type edges (extends/implements/param/return) | ✅ merged (#91) |
| **3a (this PR)** | Diff overlay | 🔵 **ready for review** |
| 3b | Framework (NestJS) | next |
| 1c | Projector → `graph.json` (back-compat) | parallel track |

After this lands, **#72 substrate is complete for the slicer (#73)** — file/symbol/import/export/declares/calls/type/diff layers are all in place. NestJS framework awareness (3b) is a quality-of-life enhancement; the back-compat projector (1c) keeps the existing `graph.json` consumers green during the migration but doesn't block #73 either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diff overlay functionality that identifies which code symbols are impacted by changes between git commits, with support for comparing base and head references.

* **Tests**
  * Added comprehensive unit tests covering diff overlay functionality, including edge cases and deterministic output verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->