### PR TITLE
feat(#72): SPI v1 slice 3c — test layer (covered_by edges)

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -46,6 +46,7 @@ import type {
   SpiSymbol,
   SpiSymbolKind,
 } from './types.js'
+import { addTestLayerEdges } from './test-layer.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -93,7 +94,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-2b'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3c'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
@@ -141,6 +142,11 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   // Slices 2a + 2b: a second pass uses ts.Program + the type checker to
   // emit calls / extends / implements / param_type / return_type edges.
   addTypeCheckerEdges({ files, root, pathToFileId, symbols, edges, diagnostics })
+
+  // Slice 3c: heuristic test layer. Walks the imports edges produced above
+  // to emit covered_by edges from source files to the test files that
+  // import them. No type-checker dependency.
+  addTestLayerEdges({ files, edges })
 
   files.sort((a, b) => a.path.localeCompare(b.path))
   symbols.sort((a, b) => a.id.localeCompare(b.id))

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -43,3 +43,5 @@ export {
   type ComputeSpiDiffOverlayOptions,
   type GitDiffRunner,
 } from './diff-overlay.js'
+
+export { isTestFilePath } from './test-layer.js'

--- a/src/pipeline/spi/test-layer.ts
+++ b/src/pipeline/spi/test-layer.ts
@@ -1,0 +1,93 @@
+// SPI v1 — test layer (slice 3c of #72).
+//
+// Emits `covered_by` edges between source files and the test files that
+// import them. Per the design, this layer is intentionally heuristic
+// (not type-checker-backed) — its job is to make "what tests cover X?"
+// answerable from the SPI without re-scanning, and to provide the
+// cross-validated test-coverage signal the selector (#74) and quality
+// diagnostics (#78) want.
+//
+// Confidence rules (from docs/designs/2026-05-10-spi-v1.md):
+//   * `high`   — name pattern match (foo.ts ↔ foo.spec.ts) AND the test
+//                file imports the source. Cross-validated coverage.
+//   * `medium` — test file imports source but no name-pattern match.
+//                Could still be coverage (helper test, broad spec) but
+//                less confident than a paired *.spec.ts.
+
+import type { SpiEdge, SpiFile } from './types.js'
+
+const TEST_FILE_PATTERNS: ReadonlyArray<RegExp> = [
+  /\.spec\.[mc]?[tj]sx?$/i,
+  /\.test\.[mc]?[tj]sx?$/i,
+  /(^|\/)__tests__\//,
+]
+
+const SOURCE_EXT_RE = /\.[mc]?[tj]sx?$/i
+
+export function isTestFilePath(path: string): boolean {
+  return TEST_FILE_PATTERNS.some((re) => re.test(path))
+}
+
+export type AddTestLayerOptions = {
+  files: SpiFile[]
+  edges: SpiEdge[]
+}
+
+export function addTestLayerEdges(opts: AddTestLayerOptions): void {
+  const { files, edges } = opts
+  const fileById = new Map(files.map((f) => [f.id, f] as const))
+  const testFiles = files.filter((f) => isTestFilePath(f.path))
+  if (testFiles.length === 0) return
+
+  // Walk existing imports edges per test file and emit covered_by edges from
+  // each imported source file back to the test file. Dedupe by (source,
+  // test) pair so a test that imports the same module twice still produces
+  // a single edge.
+  const seen = new Set<string>()
+  for (const testFile of testFiles) {
+    const importEdges = edges.filter((e) => e.from === testFile.id && e.kind === 'imports')
+    for (const importEdge of importEdges) {
+      const target = fileById.get(importEdge.to)
+      if (!target) continue
+      // Skip test-importing-test (e.g., shared spec helpers); only emit
+      // covered_by from a source file to a test that imports it.
+      if (isTestFilePath(target.path)) continue
+
+      const dedupeKey = `${target.id}|${testFile.id}`
+      if (seen.has(dedupeKey)) continue
+      seen.add(dedupeKey)
+
+      const confidence: 'high' | 'medium' =
+        sourceMatchesTestName(target.path, testFile.path) ? 'high' : 'medium'
+
+      const edge: SpiEdge = {
+        from: target.id,
+        to: testFile.id,
+        kind: 'covered_by',
+        confidence,
+        source: 'heuristic',
+      }
+      if (importEdge.evidence) {
+        edge.evidence = { file_id: testFile.id, range: importEdge.evidence.range }
+      }
+      edges.push(edge)
+    }
+  }
+}
+
+// Returns true when the test path is the canonical sibling spec for the
+// source path. Recognizes:
+//   foo.ts            ↔ foo.spec.ts   (and .test.ts variants)
+//   pkg/foo.ts        ↔ pkg/foo.test.ts
+//   pkg/foo.ts        ↔ pkg/__tests__/foo.spec.ts
+function sourceMatchesTestName(sourcePath: string, testPath: string): boolean {
+  const sourceBase = sourcePath.replace(SOURCE_EXT_RE, '')
+  // Strip the test extension layer (.spec / .test) before stripping the file
+  // extension to get the underlying base.
+  const testWithoutFileExt = testPath.replace(SOURCE_EXT_RE, '')
+  const testBase = testWithoutFileExt.replace(/\.spec$|\.test$/i, '')
+  // Drop the __tests__ directory segment if present so a __tests__ sibling
+  // canonicalizes to the same base as the source file next door.
+  const testBaseFlat = testBase.replace(/(^|\/)__tests__\//, '$1')
+  return sourceBase === testBaseFlat
+}

--- a/tests/unit/spi-test-layer.test.ts
+++ b/tests/unit/spi-test-layer.test.ts
@@ -1,0 +1,184 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import { isTestFilePath } from '../../src/pipeline/spi/test-layer.js'
+import type { SemanticProgramIndex, SpiEdge } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-3c',
+    now: FROZEN_NOW,
+  })
+}
+
+function fileIdFor(spi: SemanticProgramIndex, path: string): string {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) throw new Error(`fixture missing SpiFile: ${path}\nhad: ${spi.files.map((f) => f.path).join(', ')}`)
+  return file.id
+}
+
+function coveredBy(spi: SemanticProgramIndex, sourcePath: string, testPath: string): SpiEdge | undefined {
+  const sourceId = fileIdFor(spi, sourcePath)
+  const testId = fileIdFor(spi, testPath)
+  return spi.edges.find((e) => e.from === sourceId && e.to === testId && e.kind === 'covered_by')
+}
+
+describe('isTestFilePath', () => {
+  it('recognizes the standard spec/test naming patterns', () => {
+    expect(isTestFilePath('src/foo.spec.ts')).toBe(true)
+    expect(isTestFilePath('src/foo.test.ts')).toBe(true)
+    expect(isTestFilePath('src/foo.spec.tsx')).toBe(true)
+    expect(isTestFilePath('src/foo.spec.js')).toBe(true)
+    expect(isTestFilePath('src/foo.test.mjs')).toBe(true)
+  })
+
+  it('recognizes files inside a __tests__ directory', () => {
+    expect(isTestFilePath('src/__tests__/foo.ts')).toBe(true)
+    expect(isTestFilePath('packages/auth/__tests__/login.ts')).toBe(true)
+  })
+
+  it('does not flag plain source files as tests', () => {
+    expect(isTestFilePath('src/foo.ts')).toBe(false)
+    expect(isTestFilePath('src/specifications.ts')).toBe(false) // contains "spec" but not as suffix
+    expect(isTestFilePath('src/test-utils.ts')).toBe(false) // "test-" is not the suffix
+  })
+})
+
+describe('buildSpi test layer (slice 3c of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('confidence rules', () => {
+    it('emits a high-confidence covered_by edge when the test file name matches the source file', () => {
+      writeFile(sandbox, 'src/auth.ts', 'export function login() {}\n')
+      writeFile(sandbox, 'src/auth.spec.ts', 'import { login } from "./auth.js"\nlogin()\n')
+      const spi = build(sandbox)
+
+      const edge = coveredBy(spi, 'src/auth.ts', 'src/auth.spec.ts')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('heuristic')
+    })
+
+    it('emits a medium-confidence edge when the test imports the source but the names do not match', () => {
+      writeFile(sandbox, 'src/util.ts', 'export const helper = 1\n')
+      writeFile(sandbox, 'src/integration.spec.ts', 'import { helper } from "./util.js"\nhelper\n')
+      const spi = build(sandbox)
+
+      const edge = coveredBy(spi, 'src/util.ts', 'src/integration.spec.ts')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('medium')
+    })
+
+    it('promotes confidence to high for __tests__ siblings (foo.ts ↔ __tests__/foo.spec.ts)', () => {
+      writeFile(sandbox, 'src/auth/auth.ts', 'export function login() {}\n')
+      writeFile(sandbox, 'src/auth/__tests__/auth.spec.ts', 'import { login } from "../auth.js"\nlogin()\n')
+      const spi = build(sandbox)
+
+      const edge = coveredBy(spi, 'src/auth/auth.ts', 'src/auth/__tests__/auth.spec.ts')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+    })
+
+    it('handles .test.ts naming alongside .spec.ts', () => {
+      writeFile(sandbox, 'src/utils.ts', 'export const u = 1\n')
+      writeFile(sandbox, 'src/utils.test.ts', 'import { u } from "./utils.js"\nu\n')
+      const spi = build(sandbox)
+
+      const edge = coveredBy(spi, 'src/utils.ts', 'src/utils.test.ts')
+      expect(edge?.confidence).toBe('high')
+    })
+  })
+
+  describe('what does NOT get a covered_by edge', () => {
+    it('does not emit an edge from a test file to itself (test importing test)', () => {
+      writeFile(sandbox, 'src/helpers.spec.ts', 'export function makeMock() {}\n')
+      writeFile(sandbox, 'src/auth.spec.ts', 'import { makeMock } from "./helpers.spec.js"\nmakeMock()\n')
+      const spi = build(sandbox)
+
+      const helpers = fileIdFor(spi, 'src/helpers.spec.ts')
+      const edges = spi.edges.filter((e) => e.from === helpers && e.kind === 'covered_by')
+      expect(edges).toHaveLength(0)
+    })
+
+    it('does not emit covered_by for source files that no test imports', () => {
+      writeFile(sandbox, 'src/lonely.ts', 'export const lonely = 1\n')
+      writeFile(sandbox, 'src/other.spec.ts', 'export const t = 1\n') // imports nothing
+      const spi = build(sandbox)
+
+      const lonely = fileIdFor(spi, 'src/lonely.ts')
+      const edges = spi.edges.filter((e) => e.from === lonely && e.kind === 'covered_by')
+      expect(edges).toHaveLength(0)
+    })
+
+    it('does not double-emit when a test imports the same source twice', () => {
+      writeFile(sandbox, 'src/svc.ts', 'export const a = 1\nexport const b = 2\n')
+      writeFile(sandbox, 'src/svc.spec.ts', [
+        'import { a } from "./svc.js"',
+        'import { b } from "./svc.js"',  // different specifier, same module
+        'a; b;',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const svc = fileIdFor(spi, 'src/svc.ts')
+      const test = fileIdFor(spi, 'src/svc.spec.ts')
+      const edges = spi.edges.filter((e) => e.from === svc && e.to === test && e.kind === 'covered_by')
+      expect(edges).toHaveLength(1)
+    })
+  })
+
+  describe('integration with the type checker pass', () => {
+    it('does not produce a spurious calls edge from test imports interfering with the type checker', () => {
+      // Sanity check: adding the test layer must not break the call-edge
+      // resolution we already verified in slice 2a's tests.
+      writeFile(sandbox, 'src/svc.ts', [
+        'export function helper() { return 1 }',
+        'export function caller() { return helper() }',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/svc.spec.ts', 'import { caller } from "./svc.js"\ncaller()\n')
+      const spi = build(sandbox)
+
+      // Both layers' edges should coexist on the same SPI.
+      const callEdges = spi.edges.filter((e) => e.kind === 'calls')
+      const coveredEdges = spi.edges.filter((e) => e.kind === 'covered_by')
+      expect(callEdges.length).toBeGreaterThan(0)
+      expect(coveredEdges.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('against the checked-in demo repo', () => {
+    it('does not crash on a workspace with no test files (demo-repo currently has none)', () => {
+      // This is regression protection: addTestLayerEdges must early-return
+      // gracefully when there are no test files in the index.
+      const root = join(__dirname, '../../examples/demo-repo')
+      const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+      const coveredEdges = spi.edges.filter((e) => e.kind === 'covered_by')
+      // Demo repo currently has no spec/test files; expect zero covered_by.
+      // If/when fixtures gain tests, this should be relaxed to >= 0.
+      expect(coveredEdges).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Sixth slice of [#72 — Implement Semantic Program Index v1](https://github.com/mohanagy/graphify-ts/issues/72). Adds the heuristic test-coverage layer per the [SPI v1 design](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md).

Pure additive — new module + extractor wiring + new test file. No existing edge kinds touched.

## What ships

`src/pipeline/spi/test-layer.ts`:

- **`isTestFilePath(path)`** — public predicate. Matches `*.spec.{ts,tsx,js,jsx,mjs,cjs}`, `*.test.{...}`, and any file under a `__tests__/` directory.
- **`addTestLayerEdges({ files, edges })`** — walks existing `imports` edges per test file, emits one `covered_by` edge from each imported source file → the test file. Deduplicates within a single test file.

Confidence rules per the design:

| Case | Confidence |
|---|---|
| Test imports source AND name pattern matches (`foo.ts` ↔ `foo.spec.ts`) | `high` |
| Test imports source but names don't match (broad integration spec, helper) | `medium` |

All edges marked `source: 'heuristic'` since this layer is intentionally not type-checker-backed.

Wired into `buildSpi` after the type-checker pass so the imports edges from slice 1a are already in place. Public re-export of `isTestFilePath` from `src/pipeline/spi/index.ts`.

## Test plan

12 new tests in `tests/unit/spi-test-layer.test.ts`:

- [x] `isTestFilePath` recognizes `.spec` / `.test` / `__tests__/` patterns; rejects plain source files including the false-positive cases (\`specifications.ts\`, \`test-utils.ts\`).
- [x] High-confidence sibling spec (\`foo.ts\` ↔ \`foo.spec.ts\`).
- [x] Medium-confidence integration spec importing unrelated source.
- [x] \`__tests__/\` subdirectory still promoted to high (\`auth.ts\` ↔ \`__tests__/auth.spec.ts\`).
- [x] \`.test.ts\` vs \`.spec.ts\` variants.
- [x] Test-importing-test → no covered_by edge from the helper test.
- [x] No edge for source files no test imports.
- [x] Multi-import dedup (same source imported under multiple specifiers).
- [x] Integration sanity: calls edges from slice 2a still emitted on the same SPI.
- [x] Graceful zero-edges on the demo repo (currently has no test files).

All 60 prior SPI tests still pass.

Verified:

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **1473/1473** passing (was 1461 on \`main\`; +12 new)

## Where #72 stands now

| Slice | Scope | Status |
|---|---|---|
| 1a | Types + file layer | ✅ merged |
| 1b | Symbol layer + \`declares\` | ✅ merged |
| 2a | Call edges | ✅ merged |
| 2b | Type edges | ✅ merged |
| 3a | Diff overlay | ✅ merged |
| **3c (this PR)** | Test layer | 🔵 **ready** |
| 3b | NestJS framework | next (separate branch in flight) |
| 1c | Projector → \`graph.json\` | parallel track |

Slice 3b (NestJS framework) is being built on a separate branch off this one and will follow as PR shortly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic test file detection and heuristic-based coverage tracking that creates relationships between source files and their corresponding test files based on import patterns.
  * Added test file path identification helper for broader system use.

* **Tests**
  * Added comprehensive unit test suite validating test file recognition and coverage relationship generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/93)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->