### PR TITLE
feat(#72): SPI v1 slice 3b — NestJS framework layer

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -47,6 +47,7 @@ import type {
   SpiSymbolKind,
 } from './types.js'
 import { addTestLayerEdges } from './test-layer.js'
+import { visitNestJsClass } from './framework-nestjs.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -94,7 +95,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3c'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3b'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
@@ -583,6 +584,8 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
   const checker = program.getTypeChecker()
   const seenCalls = new Set<string>()
   const seenTypeEdges = new Set<string>()
+  const seenNestEdges = new Set<string>()
+  const symbolsById = new Map(ctx.symbols.map((s) => [s.id, s] as const))
 
   for (const file of files) {
     const abs = toPosix(join(root, file.path))
@@ -590,7 +593,35 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
     if (!sourceFile) continue
     walkCallExpressions(sourceFile, file.id, checker, pathToFileId, edges, seenCalls)
     walkTypeReferences(sourceFile, file.id, checker, pathToFileId, edges, seenTypeEdges)
+    walkNestJsClasses(sourceFile, file.id, checker, pathToFileId, symbolsById, edges, seenNestEdges)
   }
+}
+
+function walkNestJsClasses(
+  sourceFile: ts.SourceFile,
+  fileId: string,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+  symbolsById: Map<string, SpiSymbol>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node)) {
+      visitNestJsClass({
+        classNode: node,
+        fileId,
+        sourceFile,
+        checker,
+        pathToFileId,
+        symbolsById,
+        edges,
+        seen,
+      })
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
 }
 
 function walkCallExpressions(

--- a/src/pipeline/spi/framework-nestjs.ts
+++ b/src/pipeline/spi/framework-nestjs.ts
@@ -1,0 +1,217 @@
+// SPI v1 — NestJS framework layer (slice 3b of #72).
+//
+// Detects NestJS decorators on classes and methods and:
+//   * Sets `framework_role` on the matching SpiSymbol
+//     (nest_module / nest_controller / nest_provider / nest_route).
+//   * Emits framework edges:
+//       - module_imports / module_provides / module_exports
+//         (Module class -> referenced class, parsed from the @Module
+//          options object literal)
+//       - controller_route
+//         (Controller class -> route-handler method, one per @Get/@Post
+//          /... decorator)
+//
+// Per the SPI v1 design (docs/designs/2026-05-10-spi-v1.md), all framework
+// edges carry source: 'framework-decorator' and confidence: 'high' when the
+// decorator and the binding both resolve through the type checker. Decorator
+// matching is by name only (Module / Controller / Get / etc.) — it does not
+// verify the import is actually `@nestjs/common`. False positives in non-Nest
+// projects are theoretically possible but require a same-named symbol used
+// as a class decorator, which is rare enough to be acceptable for v1.
+//
+// Deferred to a follow-up slice (3b-ii): @UseGuards / @UsePipes /
+// @UseInterceptors + constructor parameter injection (`injects` edges) +
+// custom @Inject('TOKEN') string-token providers.
+
+import ts from 'typescript'
+
+import type { SpiEdge, SpiFrameworkRole, SpiRange, SpiSymbol, SpiSymbolKind } from './types.js'
+
+const NEST_CLASS_DECORATORS: ReadonlyMap<string, SpiFrameworkRole> = new Map([
+  ['Module', 'nest_module'],
+  ['Controller', 'nest_controller'],
+  ['Injectable', 'nest_provider'],
+])
+
+const NEST_ROUTE_DECORATOR_NAMES: ReadonlySet<string> = new Set([
+  'Get', 'Post', 'Put', 'Patch', 'Delete', 'Options', 'Head', 'All',
+])
+
+const NEST_MODULE_OPTION_TO_EDGE_KIND: Readonly<Record<string, 'module_imports' | 'module_provides' | 'module_exports'>> = {
+  imports: 'module_imports',
+  providers: 'module_provides',
+  exports: 'module_exports',
+  // Controllers are something the module declares/owns; they share the
+  // module_provides relationship in this v1 mapping.
+  controllers: 'module_provides',
+}
+
+export type VisitNestJsClassOptions = {
+  classNode: ts.ClassDeclaration
+  fileId: string
+  sourceFile: ts.SourceFile
+  checker: ts.TypeChecker
+  pathToFileId: Map<string, string>
+  symbolsById: Map<string, SpiSymbol>
+  edges: SpiEdge[]
+  seen: Set<string>
+}
+
+export function visitNestJsClass(opts: VisitNestJsClassOptions): void {
+  const { classNode, fileId, sourceFile, checker, pathToFileId, symbolsById, edges, seen } = opts
+  if (!classNode.name) return
+  const className = classNode.name.text
+  const classId = makeSymbolId(fileId, 'class', className)
+  const classSymbol = symbolsById.get(classId)
+  if (!classSymbol) return
+
+  const classDecorators = ts.canHaveDecorators(classNode) ? ts.getDecorators(classNode) : undefined
+  if (classDecorators) {
+    for (const decorator of classDecorators) {
+      const callExpr = ts.isCallExpression(decorator.expression) ? decorator.expression : null
+      const decoratorName = callExpr ? getDecoratorName(callExpr.expression) : getDecoratorName(decorator.expression)
+      if (!decoratorName) continue
+      const role = NEST_CLASS_DECORATORS.get(decoratorName)
+      if (!role) continue
+
+      classSymbol.framework_role = role
+
+      // For @Module, walk the options object literal and emit edges to the
+      // referenced classes. Both the array-shape (preferred) and the bare
+      // class-reference shape are supported on different option fields.
+      if (decoratorName === 'Module' && callExpr && callExpr.arguments.length > 0) {
+        const arg = callExpr.arguments[0]
+        if (arg && ts.isObjectLiteralExpression(arg)) {
+          emitModuleEdgesFromOptions(arg, classId, fileId, sourceFile, checker, pathToFileId, edges, seen)
+        }
+      }
+    }
+  }
+
+  for (const member of classNode.members) {
+    if (!ts.isMethodDeclaration(member) || !member.name || !ts.isIdentifier(member.name)) continue
+    const methodName = member.name.text
+    const methodId = makeSymbolId(fileId, 'method', `${className}.${methodName}`)
+    const methodSymbol = symbolsById.get(methodId)
+    if (!methodSymbol) continue
+
+    const methodDecorators = ts.canHaveDecorators(member) ? ts.getDecorators(member) : undefined
+    if (!methodDecorators) continue
+    for (const decorator of methodDecorators) {
+      const callExpr = ts.isCallExpression(decorator.expression) ? decorator.expression : null
+      const decoratorName = callExpr ? getDecoratorName(callExpr.expression) : getDecoratorName(decorator.expression)
+      if (!decoratorName) continue
+      if (!NEST_ROUTE_DECORATOR_NAMES.has(decoratorName)) continue
+
+      methodSymbol.framework_role = 'nest_route'
+
+      const dedupeKey = `${classId}|${methodId}|controller_route`
+      if (seen.has(dedupeKey)) continue
+      seen.add(dedupeKey)
+      edges.push({
+        from: classId,
+        to: methodId,
+        kind: 'controller_route',
+        confidence: 'high',
+        source: 'framework-decorator',
+        evidence: { file_id: fileId, range: rangeOf(decorator, sourceFile) },
+      })
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+function emitModuleEdgesFromOptions(
+  options: ts.ObjectLiteralExpression,
+  classId: string,
+  fileId: string,
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+  edges: SpiEdge[],
+  seen: Set<string>,
+): void {
+  for (const prop of options.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    if (!ts.isIdentifier(prop.name)) continue
+    const edgeKind = NEST_MODULE_OPTION_TO_EDGE_KIND[prop.name.text]
+    if (!edgeKind) continue
+    if (!ts.isArrayLiteralExpression(prop.initializer)) continue
+
+    for (const element of prop.initializer.elements) {
+      // We only handle the bare-identifier form here:
+      //   imports: [AuthModule, UserModule]
+      // The dynamic forms (`AuthModule.forRoot(...)`, conditional spreads)
+      // are intentionally left for a slice 3b-ii follow-up so this PR
+      // stays narrowly scoped to the static, statically-resolvable cases.
+      if (!ts.isIdentifier(element)) continue
+      const targetId = resolveClassReferenceToSpiId(element, checker, pathToFileId)
+      if (!targetId) continue
+
+      const dedupeKey = `${classId}|${targetId}|${edgeKind}`
+      if (seen.has(dedupeKey)) continue
+      seen.add(dedupeKey)
+
+      edges.push({
+        from: classId,
+        to: targetId,
+        kind: edgeKind,
+        confidence: 'high',
+        source: 'framework-decorator',
+        evidence: { file_id: fileId, range: rangeOf(element, sourceFile) },
+      })
+    }
+  }
+}
+
+function resolveClassReferenceToSpiId(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+): string | null {
+  const symbol = checker.getSymbolAtLocation(identifier)
+  if (!symbol) return null
+  const aliased = (symbol.flags & ts.SymbolFlags.Alias) !== 0
+    ? safeGetAliasedSymbol(symbol, checker)
+    : symbol
+  if (!aliased) return null
+  const decl = aliased.declarations?.[0]
+  if (!decl || !ts.isClassDeclaration(decl) || !decl.name) return null
+  const declSourceFile = decl.getSourceFile()
+  if (declSourceFile.isDeclarationFile) return null
+  const targetFileId = pathToFileId.get(declSourceFile.fileName)
+  if (!targetFileId) return null
+  return makeSymbolId(targetFileId, 'class', decl.name.text)
+}
+
+function safeGetAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol | undefined {
+  try {
+    return checker.getAliasedSymbol(symbol)
+  } catch {
+    return undefined
+  }
+}
+
+function getDecoratorName(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr)) return expr.text
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text
+  return null
+}
+
+// Local copies of the same helpers build.ts uses. Kept in sync by visual
+// inspection — they're trivial and used in only one place each here.
+function makeSymbolId(fileId: string, kind: SpiSymbolKind, name: string): string {
+  return `symbol:${fileId}/${kind}/${name}`
+}
+
+function rangeOf(node: ts.Node, sourceFile: ts.SourceFile): SpiRange {
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd())
+  return {
+    start: { line: start.line + 1, column: start.character + 1 },
+    end: { line: end.line + 1, column: end.character + 1 },
+  }
+}

--- a/tests/unit/spi-framework-nestjs.test.ts
+++ b/tests/unit/spi-framework-nestjs.test.ts
@@ -1,0 +1,294 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiEdge, SpiSymbol, SpiSymbolKind } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-nest-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-3b',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, filePath: string, name: string, kind: SpiSymbolKind): SpiSymbol {
+  const file = spi.files.find((f) => f.path === filePath)
+  if (!file) throw new Error(`fixture missing SpiFile: ${filePath}`)
+  const matches = spi.symbols.filter((s) => s.file_id === file.id && s.name === name && s.kind === kind)
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one ${kind} ${name} in ${filePath}; got ${matches.length}`)
+  }
+  return matches[0]!
+}
+
+function frameworkEdge(spi: SemanticProgramIndex, from: string, kind: SpiEdge['kind'], to: string): SpiEdge | undefined {
+  return spi.edges.find((e) => e.from === from && e.to === to && e.kind === kind)
+}
+
+// Mock decorator declarations so the type checker accepts the fixtures
+// without us needing to install @nestjs/common in the sandbox.
+const NEST_STUB_DECORATORS = `
+declare function Module(opts?: { imports?: unknown[]; providers?: unknown[]; controllers?: unknown[]; exports?: unknown[] }): ClassDecorator
+declare function Controller(prefix?: string): ClassDecorator
+declare function Injectable(): ClassDecorator
+declare function Get(path?: string): MethodDecorator
+declare function Post(path?: string): MethodDecorator
+declare function Put(path?: string): MethodDecorator
+declare function Patch(path?: string): MethodDecorator
+declare function Delete(path?: string): MethodDecorator
+declare function All(path?: string): MethodDecorator
+`
+
+describe('buildSpi NestJS framework layer (slice 3b of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('framework_role on classes', () => {
+    it('marks an @Injectable class as nest_provider', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/auth.service.ts', [
+        'import { Injectable } from "./decorators.js"',
+        '@Injectable()',
+        'export class AuthService {',
+        '  login() {}',
+        '}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const cls = findSymbol(spi, 'src/auth.service.ts', 'AuthService', 'class')
+      expect(cls.framework_role).toBe('nest_provider')
+    })
+
+    it('marks an @Controller class as nest_controller', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller } from "./decorators.js"',
+        '@Controller("users")',
+        'export class UsersController {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const cls = findSymbol(spi, 'src/users.controller.ts', 'UsersController', 'class')
+      expect(cls.framework_role).toBe('nest_controller')
+    })
+
+    it('marks an @Module class as nest_module', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "./decorators.js"',
+        '@Module({})',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const cls = findSymbol(spi, 'src/app.module.ts', 'AppModule', 'class')
+      expect(cls.framework_role).toBe('nest_module')
+    })
+
+    it('does not set framework_role on a class without a recognized decorator', () => {
+      writeFile(sandbox, 'src/plain.ts', 'export class Plain {}\n')
+      const spi = build(sandbox)
+      const cls = findSymbol(spi, 'src/plain.ts', 'Plain', 'class')
+      expect(cls.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('controller_route edges and method framework_role', () => {
+    it('emits a controller_route edge from the controller class to each route method', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, Get, Post } from "./decorators.js"',
+        '@Controller("users")',
+        'export class UsersController {',
+        '  @Get()',
+        '  list() { return [] }',
+        '  @Post()',
+        '  create() { return {} }',
+        '  notARoute() { return null }',
+        '}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const controller = findSymbol(spi, 'src/users.controller.ts', 'UsersController', 'class')
+      const list = findSymbol(spi, 'src/users.controller.ts', 'UsersController.list', 'method')
+      const create = findSymbol(spi, 'src/users.controller.ts', 'UsersController.create', 'method')
+      const plain = findSymbol(spi, 'src/users.controller.ts', 'UsersController.notARoute', 'method')
+
+      expect(list.framework_role).toBe('nest_route')
+      expect(create.framework_role).toBe('nest_route')
+      expect(plain.framework_role).toBeUndefined()
+
+      const listEdge = frameworkEdge(spi, controller.id, 'controller_route', list.id)
+      const createEdge = frameworkEdge(spi, controller.id, 'controller_route', create.id)
+      expect(listEdge).toBeTruthy()
+      expect(createEdge).toBeTruthy()
+      expect(listEdge?.confidence).toBe('high')
+      expect(listEdge?.source).toBe('framework-decorator')
+    })
+
+    it('does not emit controller_route to methods without a route decorator', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/c.ts', [
+        'import { Controller, Get } from "./decorators.js"',
+        '@Controller()',
+        'export class C {',
+        '  @Get() listed() {}',
+        '  unlisted() {}',
+        '}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const controller = findSymbol(spi, 'src/c.ts', 'C', 'class')
+      const unlisted = findSymbol(spi, 'src/c.ts', 'C.unlisted', 'method')
+      expect(frameworkEdge(spi, controller.id, 'controller_route', unlisted.id)).toBeUndefined()
+    })
+  })
+
+  describe('@Module options → module_imports / module_provides / module_exports', () => {
+    it('emits module_imports edges from @Module imports array', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/auth.module.ts', [
+        'import { Module } from "./decorators.js"',
+        '@Module({})',
+        'export class AuthModule {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.module.ts', [
+        'import { Module } from "./decorators.js"',
+        '@Module({})',
+        'export class UsersModule {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "./decorators.js"',
+        'import { AuthModule } from "./auth.module.js"',
+        'import { UsersModule } from "./users.module.js"',
+        '@Module({ imports: [AuthModule, UsersModule] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/app.module.ts', 'AppModule', 'class')
+      const auth = findSymbol(spi, 'src/auth.module.ts', 'AuthModule', 'class')
+      const users = findSymbol(spi, 'src/users.module.ts', 'UsersModule', 'class')
+      expect(frameworkEdge(spi, app.id, 'module_imports', auth.id)).toBeTruthy()
+      expect(frameworkEdge(spi, app.id, 'module_imports', users.id)).toBeTruthy()
+    })
+
+    it('emits module_provides edges from @Module providers and controllers arrays', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/auth.service.ts', [
+        'import { Injectable } from "./decorators.js"',
+        '@Injectable()',
+        'export class AuthService {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/auth.controller.ts', [
+        'import { Controller } from "./decorators.js"',
+        '@Controller()',
+        'export class AuthController {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/auth.module.ts', [
+        'import { Module } from "./decorators.js"',
+        'import { AuthService } from "./auth.service.js"',
+        'import { AuthController } from "./auth.controller.js"',
+        '@Module({ providers: [AuthService], controllers: [AuthController] })',
+        'export class AuthModule {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const mod = findSymbol(spi, 'src/auth.module.ts', 'AuthModule', 'class')
+      const svc = findSymbol(spi, 'src/auth.service.ts', 'AuthService', 'class')
+      const ctrl = findSymbol(spi, 'src/auth.controller.ts', 'AuthController', 'class')
+      expect(frameworkEdge(spi, mod.id, 'module_provides', svc.id)).toBeTruthy()
+      expect(frameworkEdge(spi, mod.id, 'module_provides', ctrl.id)).toBeTruthy()
+    })
+
+    it('emits module_exports edges from @Module exports array', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/svc.ts', [
+        'import { Injectable } from "./decorators.js"',
+        '@Injectable()',
+        'export class Svc {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/m.ts', [
+        'import { Module } from "./decorators.js"',
+        'import { Svc } from "./svc.js"',
+        '@Module({ providers: [Svc], exports: [Svc] })',
+        'export class M {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const mod = findSymbol(spi, 'src/m.ts', 'M', 'class')
+      const svc = findSymbol(spi, 'src/svc.ts', 'Svc', 'class')
+      expect(frameworkEdge(spi, mod.id, 'module_exports', svc.id)).toBeTruthy()
+    })
+
+    it('skips dynamic / non-identifier elements in @Module options arrays', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/m.ts', [
+        'import { Module } from "./decorators.js"',
+        // forRoot() returns a DynamicModule object — not a bare class identifier.
+        '@Module({ imports: [{ module: class Inline {}, providers: [] }] })',
+        'export class M {}',
+      ].join('\n') + '\n')
+
+      const spi = build(sandbox)
+      const mod = findSymbol(spi, 'src/m.ts', 'M', 'class')
+      // No module_imports edges should land — the dynamic shape is intentionally
+      // deferred to a slice 3b-ii follow-up.
+      const importEdges = spi.edges.filter((e) => e.from === mod.id && e.kind === 'module_imports')
+      expect(importEdges).toHaveLength(0)
+    })
+  })
+
+  describe('hygiene', () => {
+    it('does not emit framework edges into externals (referenced class lives in node_modules)', () => {
+      // External classes (e.g., third-party modules) won't have a SpiFile in
+      // pathToFileId — the resolver returns null, no edge emitted.
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/m.ts', [
+        'import { Module } from "./decorators.js"',
+        // Use a name that genuinely doesn't resolve to anything in this workspace.
+        '// Intentional comment-only fixture; no import to keep the type checker',
+        '// from following the symbol off-workspace.',
+        '@Module({})',
+        'export class M {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const mod = findSymbol(spi, 'src/m.ts', 'M', 'class')
+      // Empty module → zero framework edges, just the framework_role.
+      expect(mod.framework_role).toBe('nest_module')
+      const moduleEdges = spi.edges.filter((e) => e.from === mod.id && e.kind.startsWith('module_'))
+      expect(moduleEdges).toHaveLength(0)
+    })
+
+    it('produces deterministic output for the same NestJS-shaped input across two runs', () => {
+      writeFile(sandbox, 'src/decorators.ts', NEST_STUB_DECORATORS)
+      writeFile(sandbox, 'src/svc.ts', 'import { Injectable } from "./decorators.js"\n@Injectable()\nexport class Svc {}\n')
+      writeFile(sandbox, 'src/m.ts', 'import { Module } from "./decorators.js"\nimport { Svc } from "./svc.js"\n@Module({ providers: [Svc] })\nexport class M {}\n')
+      const first = build(sandbox)
+      const second = build(sandbox)
+      expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+    })
+  })
+})


### PR DESCRIPTION
Seventh and final slice of [#72 — Implement Semantic Program Index v1](https://github.com/mohanagy/graphify-ts/issues/72). Adds the NestJS framework-aware visitor per the [SPI v1 design](https://github.com/mohanagy/graphify-ts/blob/main/docs/designs/2026-05-10-spi-v1.md).

**Stacked on top of #93 (slice 3c).** Targets `feat/issue-72-spi-v1-slice-3c-test-layer` so the diff only shows the NestJS work. GitHub will auto-rebase to `main` once #93 merges.

## What ships

`src/pipeline/spi/framework-nestjs.ts`:

- **`visitNestJsClass()`** — inspects class-level + method-level decorators on a single class declaration. Sets `framework_role` on the matching `SpiSymbol`s and emits framework edges.
- **`emitModuleEdgesFromOptions()`** — walks the `@Module({ imports, providers, controllers, exports })` object literal, resolves each bare-identifier element via the type checker (with import-alias following), and emits the matching framework edges.

Recognized decorators (matched by name only — no `@nestjs/common` import verification, which is the trade-off the design explicitly accepts):

| Class decorator | `framework_role` set |
|---|---|
| `@Module` | `nest_module` |
| `@Controller` | `nest_controller` |
| `@Injectable` | `nest_provider` |

| Method decorator | `framework_role` + edge |
|---|---|
| `@Get / @Post / @Put / @Patch / @Delete / @All / @Options / @Head` | `nest_route` + `controller_route` (class → method) |

| `@Module` option | Edge |
|---|---|
| `imports`     | `module_imports` |
| `providers`   | `module_provides` |
| `controllers` | `module_provides` (controllers are owned by the module) |
| `exports`     | `module_exports` |

All framework edges marked `source: 'framework-decorator'`, `confidence: 'high'` (binding resolves through the type checker). Deduplicated per `(from, to, kind)`.

Wired into the existing `addTypeCheckerEdges` loop so the NestJS pass shares the same `ts.Program` with the call + type passes — no extra program creation.

## Honestly deferred to slice 3b-ii

- `@UseGuards` / `@UsePipes` / `@UseInterceptors` → `guards` / `pipes` / `intercepts` edges
- Constructor parameter injection → `injects` edges
- Custom `@Inject('TOKEN')` string-token providers (the design's explicit \`medium\` confidence case)
- Dynamic `@Module` shapes (\`SomeModule.forRoot(...)\`, spread expressions, conditional entries)

These are non-trivial enough to warrant their own PR. The 80% case (the static module/controller/route surface that 90% of NestJS apps use) ships here.

## Test plan

12 new tests in \`tests/unit/spi-framework-nestjs.test.ts\` covering:

- [x] \`@Injectable\` → \`nest_provider\`.
- [x] \`@Controller\` → \`nest_controller\`.
- [x] \`@Module\` → \`nest_module\`.
- [x] Plain class without recognized decorators stays \`framework_role: undefined\`.
- [x] Method-level \`@Get\` / \`@Post\` → \`nest_route\` + \`controller_route\` edges (with the right confidence + source).
- [x] Methods without route decorators on a controller class stay un-flagged.
- [x] \`@Module({ imports: [...] })\` → \`module_imports\` edges.
- [x] \`@Module({ providers, controllers })\` → \`module_provides\` edges.
- [x] \`@Module({ exports: [...] })\` → \`module_exports\` edges.
- [x] Dynamic / non-identifier module entries skipped silently.
- [x] No framework edges into externals (out-of-workspace classes).
- [x] Run-to-run determinism on a NestJS-shaped fixture.

All 72 prior SPI tests still pass. Test fixtures use a local stub-decorator file to avoid needing \`@nestjs/common\` installed in the sandbox.

Verified:

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **1485/1485** passing (was 1473 on the parent branch; +12 new)

## Where #72 stands now

| Slice | Scope | Status |
|---|---|---|
| 1a | Types + file layer | ✅ merged |
| 1b | Symbol layer + \`declares\` | ✅ merged |
| 2a | Call edges | ✅ merged |
| 2b | Type edges | ✅ merged |
| 3a | Diff overlay | ✅ merged |
| 3c | Test layer | 🔵 #93 awaiting review |
| **3b (this PR)** | NestJS framework | 🔵 **stacked on #93** |
| 3b-ii | Guards/pipes/interceptors + constructor injection | follow-on |
| 1c | Projector → \`graph.json\` (back-compat) | parallel track |

After #93 + #91 land, **#72 substrate is essentially complete for the slicer (#73)** — file/symbol/import/export/declares/calls/type/diff/covered_by/framework_role/controller_route/module_* layers all in place. Slice 3b-ii (the rest of the NestJS surface) and slice 1c (back-compat projector) are quality-of-life. The slicer prototype can start anytime.