### PR TITLE
feat(#72): SPI v1 slice 3b — base NestJS framework layer

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -1,5 +1,6 @@
-// SPI v1 — file + symbol + call + type layer builder
-// (slices 1a, 1b, 2a, 2b of #72).
+// SPI v1 — file + symbol + call + type + test + framework layer builder
+// (slices 1a + 1b + 2a + 2b + 3a + 3c + 3b of #72; the diff overlay is
+// surfaced separately via diff-overlay.ts).
 //
 // Produces a SemanticProgramIndex containing:
 //   - workspace metadata + fingerprint
@@ -20,8 +21,15 @@
 //     All emitted at high confidence; skipped silently for builtins
 //     (string, number, etc.), inline object types, generic parameters,
 //     and unions/intersections that don't map to a single declaration.
+//   - covered_by edges (heuristic test layer, slice 3c) from source files
+//     to test files that import them.
+//   - NestJS framework edges (slice 3b base): module_imports/provides/exports
+//     and controller_route, plus framework_role tagging on detected
+//     module/controller/provider classes and route methods. The 3b-ii
+//     slice layers @UseGuards/@UsePipes/@UseInterceptors, constructor
+//     injection, @Inject('TOKEN') string tokens, and dynamic
+//     Module.forRoot/forRootAsync resolution on top of this base.
 //
-// Tests, framework, and diff overlay land in subsequent slices of #72.
 // This module never touches the existing pipeline; it is pure additive
 // substrate.
 
@@ -47,6 +55,7 @@ import type {
   SpiSymbolKind,
 } from './types.js'
 import { addTestLayerEdges } from './test-layer.js'
+import { detectNestFramework } from './framework-nestjs.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -94,7 +103,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3c'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3b'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
@@ -561,7 +570,7 @@ type TypeCheckerEdgeContext = {
 }
 
 function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
-  const { files, root, pathToFileId, edges, diagnostics } = ctx
+  const { files, root, pathToFileId, symbols, edges, diagnostics } = ctx
   const rootNames = files.map((f) => toPosix(join(root, f.path)))
   if (rootNames.length === 0) return
 
@@ -584,12 +593,31 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
   const seenCalls = new Set<string>()
   const seenTypeEdges = new Set<string>()
 
+  // Pre-index symbols by file so the framework pass can tag framework_role
+  // in O(symbols-in-this-file) instead of scanning the whole symbol list per
+  // class.
+  const symbolsByFile = new Map<string, SpiSymbol[]>()
+  for (const sym of symbols) {
+    const list = symbolsByFile.get(sym.file_id)
+    if (list) list.push(sym)
+    else symbolsByFile.set(sym.file_id, [sym])
+  }
+
   for (const file of files) {
     const abs = toPosix(join(root, file.path))
     const sourceFile = program.getSourceFile(abs)
     if (!sourceFile) continue
     walkCallExpressions(sourceFile, file.id, checker, pathToFileId, edges, seenCalls)
     walkTypeReferences(sourceFile, file.id, checker, pathToFileId, edges, seenTypeEdges)
+    detectNestFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
+      edges,
+      diagnostics,
+      pathToFileId,
+      checker,
+    })
   }
 }
 

--- a/src/pipeline/spi/framework-nestjs.ts
+++ b/src/pipeline/spi/framework-nestjs.ts
@@ -1,0 +1,387 @@
+// SPI v1 — NestJS framework layer (slice 3b base of #72).
+//
+// Detects classes decorated with @Module / @Controller / @Injectable from
+// '@nestjs/common' and emits the design's framework-layer edges:
+//
+//   * `framework_role` tagging on the SpiSymbol of each detected class
+//     (nest_module / nest_controller / nest_provider). Methods of a
+//     controller that carry an HTTP route decorator additionally inherit
+//     `framework_role: 'nest_route'`.
+//   * `module_imports`   — module class → other module class (resolved via
+//                          the type checker through `imports: [...]`).
+//   * `module_provides`  — module class → provider OR controller class
+//                          listed in `providers: [...]` / `controllers: [...]`.
+//                          The design's edge enum has no dedicated
+//                          `module_controllers` kind; both lists project
+//                          onto `module_provides` here, and the
+//                          provider-vs-controller distinction lives on the
+//                          target's `framework_role` once that file is
+//                          visited.
+//   * `module_exports`   — module class → re-exported provider OR module.
+//   * `controller_route` — controller class → method that carries an HTTP
+//                          route decorator (@Get/@Post/@Put/@Patch/@Delete/
+//                          @Options/@Head/@All).
+//
+// Slice 3b-ii layers @UseGuards / @UsePipes / @UseInterceptors,
+// constructor injection, @Inject('TOKEN') string tokens, and dynamic
+// Module.forRoot/forRootAsync shapes on top of this base.
+//
+// Confidence rules:
+//   * `high`   — decorator binding resolves AND target identifier resolves
+//                through ts.TypeChecker to a class declaration in a file
+//                we have indexed.
+//   * `low`    — element of a metadata array that we cannot statically
+//                resolve to a class (call expression, spread, conditional,
+//                or unresolved identifier). Emitted with a diagnostic so
+//                the gap is auditable rather than silent.
+//
+// All emitted edges carry `source: 'framework-decorator'`.
+
+import { createHash } from 'node:crypto'
+import ts from 'typescript'
+
+import type {
+  SpiDiagnostic,
+  SpiEdge,
+  SpiFrameworkRole,
+  SpiRange,
+  SpiSymbol,
+  SpiSymbolKind,
+} from './types.js'
+
+const NEST_COMMON_SPECIFIER = '@nestjs/common'
+
+const ROUTE_DECORATOR_NAMES: ReadonlySet<string> = new Set([
+  'Get',
+  'Post',
+  'Put',
+  'Patch',
+  'Delete',
+  'Options',
+  'Head',
+  'All',
+])
+
+type NestBindings = {
+  module: Set<string>
+  controller: Set<string>
+  injectable: Set<string>
+  routeDecorators: Set<string>
+}
+
+export type DetectNestFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+  edges: SpiEdge[]
+  diagnostics: SpiDiagnostic[]
+  pathToFileId: Map<string, string>
+  checker: ts.TypeChecker
+}
+
+export function detectNestFramework(ctx: DetectNestFrameworkContext): void {
+  const bindings = collectNestBindings(ctx.sourceFile)
+  if (!hasAnyBinding(bindings)) return
+
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isClassDeclaration(stmt) || !stmt.name) continue
+
+    const classDecorators = decoratorsOf(stmt)
+    const decoratorRole = classDecoratorRole(classDecorators, bindings)
+    if (decoratorRole.role === null) continue
+
+    const classId = symbolIdFor(ctx.fileId, 'class', stmt.name.text)
+    setFrameworkRole(ctx.symbolsByFile, ctx.fileId, classId, decoratorRole.role)
+
+    if (decoratorRole.role === 'nest_module' && decoratorRole.decorator) {
+      emitModuleEdges(ctx, classId, decoratorRole.decorator)
+    } else if (decoratorRole.role === 'nest_controller') {
+      emitControllerRoutes(ctx, classId, stmt, bindings)
+    }
+    // nest_provider currently emits role only; provider-side edges
+    // (injects/uses_*) are slice 3b-ii's domain.
+  }
+}
+
+function collectNestBindings(sourceFile: ts.SourceFile): NestBindings {
+  const bindings: NestBindings = {
+    module: new Set<string>(),
+    controller: new Set<string>(),
+    injectable: new Set<string>(),
+    routeDecorators: new Set<string>(),
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (stmt.moduleSpecifier.text !== NEST_COMMON_SPECIFIER) continue
+
+    const named = stmt.importClause.namedBindings
+    if (!named || !ts.isNamedImports(named)) continue
+
+    for (const element of named.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      const localName = element.name.text
+      if (importedName === 'Module') bindings.module.add(localName)
+      else if (importedName === 'Controller') bindings.controller.add(localName)
+      else if (importedName === 'Injectable') bindings.injectable.add(localName)
+      else if (ROUTE_DECORATOR_NAMES.has(importedName)) bindings.routeDecorators.add(localName)
+    }
+  }
+  return bindings
+}
+
+function hasAnyBinding(b: NestBindings): boolean {
+  return b.module.size > 0 || b.controller.size > 0 || b.injectable.size > 0 || b.routeDecorators.size > 0
+}
+
+type DetectedClassDecorator = {
+  role: SpiFrameworkRole
+  decorator: ts.Decorator
+}
+
+function classDecoratorRole(
+  decorators: readonly ts.Decorator[],
+  bindings: NestBindings,
+): { role: SpiFrameworkRole | null; decorator: ts.Decorator | null } {
+  for (const decorator of decorators) {
+    const name = decoratorIdentifierName(decorator)
+    if (!name) continue
+    if (bindings.module.has(name)) return { role: 'nest_module', decorator }
+    if (bindings.controller.has(name)) return { role: 'nest_controller', decorator }
+    if (bindings.injectable.has(name)) return { role: 'nest_provider', decorator }
+  }
+  return { role: null, decorator: null }
+}
+
+function decoratorIdentifierName(decorator: ts.Decorator): string | null {
+  const expr = decorator.expression
+  if (ts.isCallExpression(expr)) {
+    const callee = expr.expression
+    if (ts.isIdentifier(callee)) return callee.text
+    if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)) return callee.name.text
+    return null
+  }
+  if (ts.isIdentifier(expr)) return expr.text
+  if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.name)) return expr.name.text
+  return null
+}
+
+function decoratorsOf(node: ts.Node): readonly ts.Decorator[] {
+  return ts.canHaveDecorators(node) ? ts.getDecorators(node) ?? [] : []
+}
+
+function emitModuleEdges(
+  ctx: DetectNestFrameworkContext,
+  moduleClassId: string,
+  decorator: ts.Decorator,
+): void {
+  if (!ts.isCallExpression(decorator.expression)) return
+  const firstArg = decorator.expression.arguments[0]
+  if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) return
+
+  for (const property of firstArg.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    const key = propertyKeyText(property.name)
+    if (!key) continue
+
+    const edgeKind = METADATA_KEY_TO_EDGE_KIND[key]
+    if (!edgeKind) continue
+
+    const initializer = property.initializer
+    if (!ts.isArrayLiteralExpression(initializer)) {
+      // e.g. `imports: someComputedArray` — not statically inspectable in
+      // slice 3b base. Record so the gap is visible to downstream layers.
+      pushDiagnostic(ctx, 'spi.nest.module-metadata.non-array', 'info', `NestJS @Module ${key}: non-array initializer cannot be enumerated statically`, ctx.sourceFile, initializer)
+      continue
+    }
+
+    for (const element of initializer.elements) {
+      emitModuleMetadataEdge(ctx, moduleClassId, edgeKind, element)
+    }
+  }
+}
+
+const METADATA_KEY_TO_EDGE_KIND: Record<string, 'module_imports' | 'module_provides' | 'module_exports'> = {
+  imports: 'module_imports',
+  providers: 'module_provides',
+  controllers: 'module_provides',
+  exports: 'module_exports',
+}
+
+function emitModuleMetadataEdge(
+  ctx: DetectNestFrameworkContext,
+  moduleClassId: string,
+  edgeKind: 'module_imports' | 'module_provides' | 'module_exports',
+  element: ts.Expression,
+): void {
+  const targetId = resolveStaticClassReference(element, ctx)
+  if (!targetId) {
+    pushDiagnostic(ctx, 'spi.nest.module-metadata.unresolved', 'info', `NestJS @Module ${edgeKind}: unresolved entry (likely dynamic — Module.forRoot, spread, or conditional)`, ctx.sourceFile, element)
+    return
+  }
+  ctx.edges.push({
+    from: moduleClassId,
+    to: targetId,
+    kind: edgeKind,
+    confidence: 'high',
+    source: 'framework-decorator',
+    evidence: { file_id: ctx.fileId, range: rangeOf(element, ctx.sourceFile) },
+  })
+}
+
+function emitControllerRoutes(
+  ctx: DetectNestFrameworkContext,
+  controllerClassId: string,
+  classDecl: ts.ClassDeclaration,
+  bindings: NestBindings,
+): void {
+  if (!classDecl.name) return
+  const className = classDecl.name.text
+
+  // Per-method overload counters mirror build.ts emitClassMethods so the
+  // method symbol id we link to here matches the one the symbol layer emits.
+  const overloadCounts = new Map<string, number>()
+
+  for (const member of classDecl.members) {
+    if (!ts.isMethodDeclaration(member) || !member.name || !ts.isIdentifier(member.name)) {
+      // Track overload index for non-route methods too so the indices align
+      // with the symbol-layer pass even if a non-route sits between routes.
+      if (
+        ts.isMethodDeclaration(member) &&
+        member.name &&
+        ts.isIdentifier(member.name)
+      ) {
+        const k = `${className}.${member.name.text}`
+        overloadCounts.set(k, (overloadCounts.get(k) ?? 0) + 1)
+      }
+      continue
+    }
+
+    const methodName = member.name.text
+    const overloadKey = `${className}.${methodName}`
+    const overloadIndex = overloadCounts.get(overloadKey) ?? 0
+    overloadCounts.set(overloadKey, overloadIndex + 1)
+
+    const routeDecorator = findRouteDecorator(member, bindings)
+    if (!routeDecorator) continue
+
+    const baseId = symbolIdFor(ctx.fileId, 'method', `${className}.${methodName}`)
+    const methodId = overloadIndex === 0 ? baseId : `${baseId}#${overloadIndex}`
+
+    setFrameworkRole(ctx.symbolsByFile, ctx.fileId, methodId, 'nest_route')
+
+    ctx.edges.push({
+      from: controllerClassId,
+      to: methodId,
+      kind: 'controller_route',
+      confidence: 'high',
+      source: 'framework-decorator',
+      evidence: { file_id: ctx.fileId, range: rangeOf(member.name, ctx.sourceFile) },
+    })
+  }
+}
+
+function findRouteDecorator(member: ts.MethodDeclaration, bindings: NestBindings): ts.Decorator | null {
+  for (const decorator of decoratorsOf(member)) {
+    const name = decoratorIdentifierName(decorator)
+    if (name && bindings.routeDecorators.has(name)) return decorator
+  }
+  return null
+}
+
+// Resolves an expression that names a class (e.g. `UsersModule`,
+// `users.UsersModule`) to its SPI class symbol id. Returns null for any
+// expression we cannot statically resolve (call expressions, spread,
+// conditional, etc.) — those are slice 3b-ii's responsibility.
+function resolveStaticClassReference(
+  expr: ts.Expression,
+  ctx: DetectNestFrameworkContext,
+): string | null {
+  let target: ts.Identifier | null = null
+  if (ts.isIdentifier(expr)) {
+    target = expr
+  } else if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.name)) {
+    target = expr.name
+  } else {
+    return null
+  }
+
+  const symbol = followAlias(ctx.checker.getSymbolAtLocation(target), ctx.checker)
+  const decl = symbol?.declarations?.[0]
+  if (!decl) return null
+  if (!ts.isClassDeclaration(decl) || !decl.name) return null
+
+  const declSourceFile = decl.getSourceFile()
+  if (declSourceFile.isDeclarationFile) return null
+  const targetFileId = ctx.pathToFileId.get(declSourceFile.fileName)
+  if (!targetFileId) return null
+
+  return symbolIdFor(targetFileId, 'class', decl.name.text)
+}
+
+function followAlias(symbol: ts.Symbol | undefined, checker: ts.TypeChecker): ts.Symbol | undefined {
+  if (!symbol) return undefined
+  if ((symbol.flags & ts.SymbolFlags.Alias) === 0) return symbol
+  try {
+    return checker.getAliasedSymbol(symbol)
+  } catch {
+    return undefined
+  }
+}
+
+function setFrameworkRole(
+  symbolsByFile: Map<string, SpiSymbol[]>,
+  fileId: string,
+  symbolId: string,
+  role: SpiFrameworkRole,
+): void {
+  const symbols = symbolsByFile.get(fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.id === symbolId) {
+      symbol.framework_role = role
+      return
+    }
+  }
+}
+
+function symbolIdFor(fileId: string, kind: SpiSymbolKind, name: string): string {
+  return `symbol:${fileId}/${kind}/${name}`
+}
+
+function propertyKeyText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) {
+    return name.text
+  }
+  return null
+}
+
+function rangeOf(node: ts.Node, sourceFile: ts.SourceFile): SpiRange {
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd())
+  return {
+    start: { line: start.line + 1, column: start.character + 1 },
+    end: { line: end.line + 1, column: end.character + 1 },
+  }
+}
+
+function pushDiagnostic(
+  ctx: DetectNestFrameworkContext,
+  prefix: string,
+  level: SpiDiagnostic['level'],
+  message: string,
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+): void {
+  const range = rangeOf(node, sourceFile)
+  const stableSlug = createHash('sha256')
+    .update(`${ctx.fileId}|${prefix}|${range.start.line}:${range.start.column}|${node.getText(sourceFile)}`)
+    .digest('hex')
+    .slice(0, 12)
+  ctx.diagnostics.push({
+    id: `${prefix}.${stableSlug}`,
+    level,
+    message,
+    evidence: { file_id: ctx.fileId, range },
+  })
+}

--- a/src/pipeline/spi/framework-nestjs.ts
+++ b/src/pipeline/spi/framework-nestjs.ts
@@ -240,20 +240,16 @@ function emitControllerRoutes(
 
   // Per-method overload counters mirror build.ts emitClassMethods so the
   // method symbol id we link to here matches the one the symbol layer emits.
+  // Increment for every named method declaration (including non-route ones)
+  // so the index of a route method on, say, the third overload of `foo`
+  // resolves to `foo#2` — the same id the symbol layer minted.
   const overloadCounts = new Map<string, number>()
 
   for (const member of classDecl.members) {
     if (!ts.isMethodDeclaration(member) || !member.name || !ts.isIdentifier(member.name)) {
-      // Track overload index for non-route methods too so the indices align
-      // with the symbol-layer pass even if a non-route sits between routes.
-      if (
-        ts.isMethodDeclaration(member) &&
-        member.name &&
-        ts.isIdentifier(member.name)
-      ) {
-        const k = `${className}.${member.name.text}`
-        overloadCounts.set(k, (overloadCounts.get(k) ?? 0) + 1)
-      }
+      // Constructors, accessors, and properties keep their own counters in
+      // build.ts emitClassMethods (different name keys), so skipping them
+      // here does not desync indices for method declarations.
       continue
     }
 

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -1,13 +1,18 @@
 // SPI v1 — public re-exports.
 //
-// Slices 1a + 1b + 2a + 2b + 3a:
+// Slices 1a + 1b + 2a + 2b + 3a + 3c + 3b:
 //   * types + file layer + imports/exports edges
 //   * symbol layer + declares edges
 //   * call layer + type layer (extends/implements/param_type/return_type)
 //   * diff overlay (computed on demand against a base/head ref)
+//   * heuristic test layer (covered_by edges)
+//   * NestJS framework base (framework_role tagging + module_imports/
+//     module_provides/module_exports/controller_route)
 //
-// Test layer, framework (NestJS), and the projection back to today's
-// graph.json land in subsequent slices of #72.
+// The 3b-ii slice (NestJS quality-of-life: @UseGuards/@UsePipes/
+// @UseInterceptors, constructor injection, @Inject('TOKEN') string
+// tokens, dynamic Module.forRoot/forRootAsync) and the projection back
+// to today's graph.json land in subsequent slices of #72.
 
 export type {
   SpiVersion,
@@ -45,3 +50,8 @@ export {
 } from './diff-overlay.js'
 
 export { isTestFilePath } from './test-layer.js'
+
+export {
+  detectNestFramework,
+  type DetectNestFrameworkContext,
+} from './framework-nestjs.js'

--- a/tests/unit/spi-framework-nestjs.test.ts
+++ b/tests/unit/spi-framework-nestjs.test.ts
@@ -320,6 +320,40 @@ describe('buildSpi NestJS framework layer (slice 3b base of #72)', () => {
       expect(routeEdges).toHaveLength(8)
     })
 
+    it('aligns the route edge with the symbol-layer overload index when a method is overloaded', () => {
+      // A method with overload signatures + implementation produces three
+      // SpiSymbol entries (`foo`, `foo#1`, `foo#2`); the route decorator
+      // sits on the implementation, so the controller_route edge must
+      // target `foo#2` — proving the overload counter is incremented for
+      // every method declaration, not just routes.
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'import { Controller, Get } from "@nestjs/common"',
+        '@Controller()',
+        'export class AppController {',
+        '  list(name: string): string',
+        '  list(id: number): string',
+        '  @Get() list(arg: string | number): string { return String(arg) }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const controllerId = classSymbol(spi, 'src/app.controller.ts', 'AppController').id
+      const routeEdges = spi.edges.filter((e) => e.from === controllerId && e.kind === 'controller_route')
+      expect(routeEdges).toHaveLength(1)
+
+      const fileId = fileIdFor(spi, 'src/app.controller.ts')
+      const overloadIds = spi.symbols
+        .filter((s) => s.file_id === fileId && s.kind === 'method' && s.name === 'AppController.list')
+        .map((s) => s.id)
+        .sort()
+      // Expect exactly three method symbols for the three declarations.
+      expect(overloadIds).toHaveLength(3)
+      // The route edge must target the last (third) declaration's id, which
+      // carries the `#2` overload suffix.
+      const expectedTarget = overloadIds.find((id) => id.endsWith('#2'))
+      expect(routeEdges[0]?.to).toBe(expectedTarget)
+    })
+
     it('does not emit controller_route for plain classes that happen to use @Get from somewhere else', () => {
       // If @Get is not imported from @nestjs/common, the binding map is empty
       // and we don't emit a route edge.

--- a/tests/unit/spi-framework-nestjs.test.ts
+++ b/tests/unit/spi-framework-nestjs.test.ts
@@ -1,0 +1,427 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type {
+  SemanticProgramIndex,
+  SpiEdge,
+  SpiEdgeKind,
+  SpiSymbol,
+} from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-nest-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-3b',
+    now: FROZEN_NOW,
+  })
+}
+
+function fileIdFor(spi: SemanticProgramIndex, path: string): string {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) {
+    throw new Error(`fixture missing SpiFile: ${path}\nhad: ${spi.files.map((f) => f.path).join(', ')}`)
+  }
+  return file.id
+}
+
+function classSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol {
+  const fileId = fileIdFor(spi, path)
+  const symbol = spi.symbols.find((s) => s.file_id === fileId && s.kind === 'class' && s.name === name)
+  if (!symbol) {
+    throw new Error(`class symbol not found: ${name} in ${path}`)
+  }
+  return symbol
+}
+
+function methodSymbol(spi: SemanticProgramIndex, path: string, qualifiedName: string): SpiSymbol {
+  const fileId = fileIdFor(spi, path)
+  const symbol = spi.symbols.find((s) => s.file_id === fileId && s.kind === 'method' && s.name === qualifiedName)
+  if (!symbol) {
+    throw new Error(`method symbol not found: ${qualifiedName} in ${path}`)
+  }
+  return symbol
+}
+
+function frameworkEdges(spi: SemanticProgramIndex, kinds: ReadonlyArray<SpiEdgeKind>): SpiEdge[] {
+  return spi.edges.filter((e) => kinds.includes(e.kind))
+}
+
+describe('buildSpi NestJS framework layer (slice 3b base of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('framework_role tagging', () => {
+    it('tags @Module classes with framework_role nest_module', () => {
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        '@Module({})',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const symbol = classSymbol(spi, 'src/app.module.ts', 'AppModule')
+      expect(symbol.framework_role).toBe('nest_module')
+    })
+
+    it('tags @Controller classes with framework_role nest_controller', () => {
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'import { Controller } from "@nestjs/common"',
+        '@Controller("app")',
+        'export class AppController {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const symbol = classSymbol(spi, 'src/app.controller.ts', 'AppController')
+      expect(symbol.framework_role).toBe('nest_controller')
+    })
+
+    it('tags @Injectable classes with framework_role nest_provider', () => {
+      writeFile(sandbox, 'src/app.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class AppService {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const symbol = classSymbol(spi, 'src/app.service.ts', 'AppService')
+      expect(symbol.framework_role).toBe('nest_provider')
+    })
+
+    it('honors aliased import bindings (e.g. import { Module as NestModule })', () => {
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module as NestModule } from "@nestjs/common"',
+        '@NestModule({})',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const symbol = classSymbol(spi, 'src/app.module.ts', 'AppModule')
+      expect(symbol.framework_role).toBe('nest_module')
+    })
+
+    it('does not tag plain classes with no Nest decorators', () => {
+      writeFile(sandbox, 'src/plain.ts', 'export class Plain {}\n')
+      const spi = build(sandbox)
+
+      const symbol = classSymbol(spi, 'src/plain.ts', 'Plain')
+      expect(symbol.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('module_* edges', () => {
+    it('emits module_imports edges to other module classes', () => {
+      writeFile(sandbox, 'src/users/users.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        '@Module({})',
+        'export class UsersModule {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { UsersModule } from "./users/users.module.js"',
+        '@Module({ imports: [UsersModule] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/app.module.ts', 'AppModule').id
+      const toId = classSymbol(spi, 'src/users/users.module.ts', 'UsersModule').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'module_imports')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('framework-decorator')
+      expect(edge?.evidence).toBeDefined()
+    })
+
+    it('emits module_provides edges for both providers and controllers lists', () => {
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'import { Controller } from "@nestjs/common"',
+        '@Controller()',
+        'export class AppController {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class AppService {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { AppController } from "./app.controller.js"',
+        'import { AppService } from "./app.service.js"',
+        '@Module({ controllers: [AppController], providers: [AppService] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const moduleId = classSymbol(spi, 'src/app.module.ts', 'AppModule').id
+      const controllerId = classSymbol(spi, 'src/app.controller.ts', 'AppController').id
+      const serviceId = classSymbol(spi, 'src/app.service.ts', 'AppService').id
+
+      const provides = spi.edges.filter((e) => e.from === moduleId && e.kind === 'module_provides')
+      const targets = new Set(provides.map((e) => e.to))
+      expect(targets.has(controllerId)).toBe(true)
+      expect(targets.has(serviceId)).toBe(true)
+      // Both providers and controllers are framework-decorator sourced + high.
+      for (const edge of provides) {
+        expect(edge.source).toBe('framework-decorator')
+        expect(edge.confidence).toBe('high')
+      }
+    })
+
+    it('emits module_exports edges for re-exported providers', () => {
+      writeFile(sandbox, 'src/app.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class AppService {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { AppService } from "./app.service.js"',
+        '@Module({ providers: [AppService], exports: [AppService] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const moduleId = classSymbol(spi, 'src/app.module.ts', 'AppModule').id
+      const serviceId = classSymbol(spi, 'src/app.service.ts', 'AppService').id
+      const exports_ = spi.edges.filter((e) => e.from === moduleId && e.to === serviceId && e.kind === 'module_exports')
+      expect(exports_).toHaveLength(1)
+      expect(exports_[0]?.confidence).toBe('high')
+    })
+
+    it('emits a diagnostic and skips the edge for dynamic Module.forRoot() entries', () => {
+      writeFile(sandbox, 'src/typeorm.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        '@Module({})',
+        'export class TypeOrmModule {',
+        '  static forRoot(): unknown { return null }',
+        '}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { TypeOrmModule } from "./typeorm.module.js"',
+        '@Module({ imports: [TypeOrmModule.forRoot()] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const moduleId = classSymbol(spi, 'src/app.module.ts', 'AppModule').id
+      const importEdges = spi.edges.filter((e) => e.from === moduleId && e.kind === 'module_imports')
+      expect(importEdges).toHaveLength(0)
+      const dynamicDiag = spi.diagnostics.find((d) =>
+        d.id.startsWith('spi.nest.module-metadata.unresolved') && d.message.includes('module_imports'),
+      )
+      expect(dynamicDiag).toBeTruthy()
+    })
+
+    it('emits a diagnostic for spread metadata entries', () => {
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'const SHARED = [] as const',
+        '@Module({ providers: [...SHARED] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const diag = spi.diagnostics.find((d) =>
+        d.id.startsWith('spi.nest.module-metadata.unresolved') && d.message.includes('module_provides'),
+      )
+      expect(diag).toBeTruthy()
+    })
+  })
+
+  describe('controller_route edges', () => {
+    it('emits a controller_route edge from controller class to each route method', () => {
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'import { Controller, Get, Post } from "@nestjs/common"',
+        '@Controller("app")',
+        'export class AppController {',
+        '  @Get()',
+        '  list(): string { return "" }',
+        '  @Post()',
+        '  create(): void {}',
+        '  helper(): void {} // not a route',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const controllerId = classSymbol(spi, 'src/app.controller.ts', 'AppController').id
+      const listId = methodSymbol(spi, 'src/app.controller.ts', 'AppController.list').id
+      const createId = methodSymbol(spi, 'src/app.controller.ts', 'AppController.create').id
+
+      const routeEdges = spi.edges.filter((e) => e.from === controllerId && e.kind === 'controller_route')
+      const targets = new Set(routeEdges.map((e) => e.to))
+      expect(targets.has(listId)).toBe(true)
+      expect(targets.has(createId)).toBe(true)
+      // helper() has no decorator → no edge
+      expect(routeEdges).toHaveLength(2)
+      for (const edge of routeEdges) {
+        expect(edge.source).toBe('framework-decorator')
+        expect(edge.confidence).toBe('high')
+        expect(edge.evidence).toBeDefined()
+      }
+    })
+
+    it('tags route methods with framework_role nest_route', () => {
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'import { Controller, Get } from "@nestjs/common"',
+        '@Controller()',
+        'export class AppController {',
+        '  @Get()',
+        '  list(): string { return "" }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const list = methodSymbol(spi, 'src/app.controller.ts', 'AppController.list')
+      expect(list.framework_role).toBe('nest_route')
+    })
+
+    it('recognizes every standard HTTP route decorator', () => {
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'import { Controller, Get, Post, Put, Patch, Delete, Options, Head, All } from "@nestjs/common"',
+        '@Controller()',
+        'export class AppController {',
+        '  @Get()    a(): void {}',
+        '  @Post()   b(): void {}',
+        '  @Put()    c(): void {}',
+        '  @Patch()  d(): void {}',
+        '  @Delete() e(): void {}',
+        '  @Options() f(): void {}',
+        '  @Head()   g(): void {}',
+        '  @All()    h(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const controllerId = classSymbol(spi, 'src/app.controller.ts', 'AppController').id
+      const routeEdges = spi.edges.filter((e) => e.from === controllerId && e.kind === 'controller_route')
+      expect(routeEdges).toHaveLength(8)
+    })
+
+    it('does not emit controller_route for plain classes that happen to use @Get from somewhere else', () => {
+      // If @Get is not imported from @nestjs/common, the binding map is empty
+      // and we don't emit a route edge.
+      writeFile(sandbox, 'src/app.controller.ts', [
+        'function Get(): MethodDecorator { return () => {} }',
+        'function Controller(): ClassDecorator { return () => {} }',
+        '@Controller()',
+        'export class AppController {',
+        '  @Get()',
+        '  list(): string { return "" }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const controllerId = classSymbol(spi, 'src/app.controller.ts', 'AppController').id
+      const routeEdges = spi.edges.filter((e) => e.from === controllerId && e.kind === 'controller_route')
+      expect(routeEdges).toHaveLength(0)
+      const controller = classSymbol(spi, 'src/app.controller.ts', 'AppController')
+      expect(controller.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('edge invariants', () => {
+    it('every framework edge carries source=framework-decorator and a defined confidence', () => {
+      writeFile(sandbox, 'src/users.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class UsersService {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, Get } from "@nestjs/common"',
+        '@Controller("users")',
+        'export class UsersController {',
+        '  @Get() list(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { UsersController } from "./users.controller.js"',
+        'import { UsersService } from "./users.service.js"',
+        '@Module({ controllers: [UsersController], providers: [UsersService], exports: [UsersService] })',
+        'export class UsersModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const FRAMEWORK_KINDS: ReadonlyArray<SpiEdgeKind> = [
+        'module_imports',
+        'module_provides',
+        'module_exports',
+        'controller_route',
+      ]
+      const edges = frameworkEdges(spi, FRAMEWORK_KINDS)
+      expect(edges.length).toBeGreaterThan(0)
+      for (const edge of edges) {
+        expect(edge.source).toBe('framework-decorator')
+        expect(['high', 'medium', 'low']).toContain(edge.confidence)
+      }
+    })
+
+    it('coexists with calls and type edges from earlier slices', () => {
+      writeFile(sandbox, 'src/users.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class UsersService {',
+        '  list(): string[] { return [] }',
+        '}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, Get } from "@nestjs/common"',
+        'import { UsersService } from "./users.service.js"',
+        '@Controller("users")',
+        'export class UsersController {',
+        '  constructor(private readonly users: UsersService) {}',
+        '  @Get() list(): string[] { return this.users.list() }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      // calls edge from list() to UsersService.list — slice 2a coverage
+      // continues to work alongside the framework layer.
+      const callEdges = spi.edges.filter((e) => e.kind === 'calls')
+      expect(callEdges.length).toBeGreaterThan(0)
+      // controller_route edge — slice 3b base.
+      const routeEdges = spi.edges.filter((e) => e.kind === 'controller_route')
+      expect(routeEdges.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('against the checked-in demo repo', () => {
+    it('does not crash and emits no NestJS edges (demo-repo has no Nest files)', () => {
+      const root = join(__dirname, '../../examples/demo-repo')
+      const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+      const FRAMEWORK_KINDS: ReadonlyArray<SpiEdgeKind> = [
+        'module_imports',
+        'module_provides',
+        'module_exports',
+        'controller_route',
+      ]
+      const nestEdges = frameworkEdges(spi, FRAMEWORK_KINDS)
+      expect(nestEdges).toHaveLength(0)
+      const nestRoles = spi.symbols.filter((s) => s.framework_role !== undefined)
+      expect(nestRoles).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds the **base** NestJS framework layer to SPI v1, completing the static-decorator portion of slice 3b from #72. The 3b-ii slice (guards/pipes/interceptors, constructor injection, `@Inject('TOKEN')`, dynamic `Module.forRoot`/`forRootAsync`) will stack on top of this branch.
- Detects `@Module` / `@Controller` / `@Injectable` from `@nestjs/common` and tags `SpiSymbol.framework_role` accordingly. Methods carrying an HTTP route decorator (`@Get/@Post/@Put/@Patch/@Delete/@Options/@Head/@All`) inherit `framework_role: 'nest_route'`.
- Emits `module_imports` / `module_provides` / `module_exports` from `@Module` metadata and `controller_route` from controller class to each route method. All edges carry `source: 'framework-decorator'` and `confidence: 'high'` when the decorator binding and target identifier both resolve through `ts.TypeChecker`.
- Unresolvable metadata entries (`Module.forRoot()`, spread, conditional, computed-array initializers) emit an info-level `SpiDiagnostic` so the gap is auditable rather than a silent miss. Dynamic shapes get first-class handling in 3b-ii.

## Design notes

- The design's edge enum has no `module_controllers` kind, so controllers in `@Module({ controllers: [...] })` project onto `module_provides`. The controller-vs-provider distinction lives on the target's `framework_role` once that file is visited.
- The framework pass piggybacks on the existing `ts.Program` created for the call/type layers — no second program build, so the cold-start cost is bounded by the per-file decorator walk.
- Default `extractor_version` bumps to `spi-v1.0.0-slice-3b`. Tests that pin a specific version override it explicitly so no existing tests break.

## What's still deferred (3b-ii)

- `@UseGuards` / `@UsePipes` / `@UseInterceptors` → `guards` / `pipes` / `intercepts` edges
- Constructor parameter injection → `injects` edges
- `@Inject('TOKEN')` string-token resolution (medium confidence)
- Dynamic `Module.forRoot(...)` / `Module.forRootAsync(...)` → low-confidence import edge + diagnostic

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test:run` — 84 files / 1490 tests pass (17 new, 1473 pre-existing)
- [x] New tests cover: framework_role tagging, aliased imports, `module_*` edges (imports/provides for both lists/exports), dynamic-entry diagnostics, `controller_route` for all 8 HTTP decorators, edge invariants (every framework edge has `source` + `confidence`), regression check that calls/type edges from earlier slices still emit alongside framework edges, no-crash on `examples/demo-repo` (which has no NestJS files)
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge

Refs #70 (design), #72 (implementation umbrella).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds NestJS framework detection to identify modules, controllers, providers, and HTTP routes, and to emit framework-layer relationships for improved analysis and visualization.

* **Tests**
  * Comprehensive unit tests validating detection across NestJS patterns, decorator aliases, overloads, diagnostics for unresolved metadata, and coexistence with existing call/type edges.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->