### PR TITLE
feat(#72): SPI v1 slice 3b-ii — NestJS QoL (guards/pipes/injects)

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -23,12 +23,19 @@
 //     and unions/intersections that don't map to a single declaration.
 //   - covered_by edges (heuristic test layer, slice 3c) from source files
 //     to test files that import them.
-//   - NestJS framework edges (slice 3b base): module_imports/provides/exports
-//     and controller_route, plus framework_role tagging on detected
-//     module/controller/provider classes and route methods. The 3b-ii
-//     slice layers @UseGuards/@UsePipes/@UseInterceptors, constructor
-//     injection, @Inject('TOKEN') string tokens, and dynamic
-//     Module.forRoot/forRootAsync resolution on top of this base.
+//   - NestJS framework edges:
+//       * Slice 3b base: module_imports/provides/exports, controller_route,
+//         plus framework_role tagging on detected module/controller/provider
+//         classes and route methods.
+//       * Slice 3b-ii: guards / pipes / intercepts edges from
+//         @UseGuards / @UsePipes / @UseInterceptors at class or method
+//         level; injects edges from constructor parameter types and from
+//         @Inject('TOKEN') decorators (resolved through a workspace-wide
+//         token map built from `useClass` / `useExisting` provider
+//         bindings); low-confidence module_imports edges for dynamic
+//         module shapes (`Module.forRoot(...)` / `forRootAsync(...)` /
+//         register variants) with an info-level diagnostic recording
+//         that the runtime providers list could not be enumerated.
 //
 // This module never touches the existing pipeline; it is pure additive
 // substrate.
@@ -55,7 +62,7 @@ import type {
   SpiSymbolKind,
 } from './types.js'
 import { addTestLayerEdges } from './test-layer.js'
-import { detectNestFramework } from './framework-nestjs.js'
+import { collectNestTokenMap, detectNestFramework } from './framework-nestjs.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -103,7 +110,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
   if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new Error(`SPI build: workspace root not found or not a directory: ${root}`)
   }
-  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3b'
+  const extractorVersion = opts.extractorVersion ?? 'spi-v1.0.0-slice-3b-ii'
   const now = opts.now ?? (() => new Date())
 
   const files: SpiFile[] = []
@@ -603,6 +610,19 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
     else symbolsByFile.set(sym.file_id, [sym])
   }
 
+  // Workspace-level NestJS token-binding pass (slice 3b-ii). Walked once
+  // before the per-file framework detection so @Inject('TOKEN') in any
+  // file can resolve against any module's `useClass` / `useExisting`
+  // bindings regardless of file order.
+  const programSourceFiles = files
+    .map((f) => program.getSourceFile(toPosix(join(root, f.path))))
+    .filter((sf): sf is ts.SourceFile => sf !== undefined)
+  const tokenMap = collectNestTokenMap({
+    sourceFiles: programSourceFiles,
+    pathToFileId,
+    checker,
+  })
+
   for (const file of files) {
     const abs = toPosix(join(root, file.path))
     const sourceFile = program.getSourceFile(abs)
@@ -617,6 +637,7 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       diagnostics,
       pathToFileId,
       checker,
+      tokenMap,
     })
   }
 }

--- a/src/pipeline/spi/framework-nestjs.ts
+++ b/src/pipeline/spi/framework-nestjs.ts
@@ -399,18 +399,16 @@ function emitControllerRoutes(
 
   // Per-method overload counters mirror build.ts emitClassMethods so the
   // method symbol id we link to here matches the one the symbol layer emits.
+  // Increment for every named method declaration (including non-route ones)
+  // so the index of a route method on, say, the third overload of `foo`
+  // resolves to `foo#2` — the same id the symbol layer minted.
   const overloadCounts = new Map<string, number>()
 
   for (const member of classDecl.members) {
     if (!ts.isMethodDeclaration(member) || !member.name || !ts.isIdentifier(member.name)) {
-      if (
-        ts.isMethodDeclaration(member) &&
-        member.name &&
-        ts.isIdentifier(member.name)
-      ) {
-        const k = `${className}.${member.name.text}`
-        overloadCounts.set(k, (overloadCounts.get(k) ?? 0) + 1)
-      }
+      // Constructors, accessors, and properties keep their own counters in
+      // build.ts emitClassMethods (different name keys), so skipping them
+      // here does not desync indices for method declarations.
       continue
     }
 

--- a/src/pipeline/spi/framework-nestjs.ts
+++ b/src/pipeline/spi/framework-nestjs.ts
@@ -1,41 +1,47 @@
-// SPI v1 — NestJS framework layer (slice 3b base of #72).
+// SPI v1 — NestJS framework layer.
 //
-// Detects classes decorated with @Module / @Controller / @Injectable from
-// '@nestjs/common' and emits the design's framework-layer edges:
+// Slice 3b base: detects classes decorated with @Module / @Controller /
+// @Injectable from '@nestjs/common', tags SpiSymbols with framework_role
+// (nest_module / nest_controller / nest_provider / nest_route), and emits
+// `module_imports` / `module_provides` / `module_exports` /
+// `controller_route` framework edges.
 //
-//   * `framework_role` tagging on the SpiSymbol of each detected class
-//     (nest_module / nest_controller / nest_provider). Methods of a
-//     controller that carry an HTTP route decorator additionally inherit
-//     `framework_role: 'nest_route'`.
-//   * `module_imports`   — module class → other module class (resolved via
-//                          the type checker through `imports: [...]`).
-//   * `module_provides`  — module class → provider OR controller class
-//                          listed in `providers: [...]` / `controllers: [...]`.
-//                          The design's edge enum has no dedicated
-//                          `module_controllers` kind; both lists project
-//                          onto `module_provides` here, and the
-//                          provider-vs-controller distinction lives on the
-//                          target's `framework_role` once that file is
-//                          visited.
-//   * `module_exports`   — module class → re-exported provider OR module.
-//   * `controller_route` — controller class → method that carries an HTTP
-//                          route decorator (@Get/@Post/@Put/@Patch/@Delete/
-//                          @Options/@Head/@All).
+// Slice 3b-ii (this file's current shape) layers on top of that base:
 //
-// Slice 3b-ii layers @UseGuards / @UsePipes / @UseInterceptors,
-// constructor injection, @Inject('TOKEN') string tokens, and dynamic
-// Module.forRoot/forRootAsync shapes on top of this base.
+//   * `injects`     — class symbol → injected provider class symbol.
+//                     Constructor parameters typed as a class resolve
+//                     through ts.TypeChecker (high confidence). Parameters
+//                     decorated `@Inject('TOKEN')` resolve through a
+//                     workspace-wide token map built from `useClass` /
+//                     `useExisting` provider entries (medium confidence).
+//                     Unresolvable @Inject tokens emit a low-confidence
+//                     diagnostic; no edge is created.
+//   * `guards`      — class or method symbol → guard class symbol, sourced
+//                     from `@UseGuards(...)` at class level (applies to all
+//                     routes on that controller, edge emitted from class
+//                     symbol) or method level (edge emitted from method
+//                     symbol).
+//   * `intercepts`  — same as guards, sourced from `@UseInterceptors(...)`.
+//   * `pipes`       — same as guards, sourced from `@UsePipes(...)`.
+//   * Dynamic Module shapes — `@Module({ imports: [SomeModule.forRoot()] })`
+//                     and `forRootAsync` resolve to a low-confidence
+//                     `module_imports` edge to the receiver Module class
+//                     plus an info-level diagnostic recording that the
+//                     runtime providers list could not be enumerated.
 //
-// Confidence rules:
-//   * `high`   — decorator binding resolves AND target identifier resolves
+// Confidence rules (per docs/designs/2026-05-10-spi-v1.md):
+//   * `high`   — both decorator binding and target identifier resolve
 //                through ts.TypeChecker to a class declaration in a file
 //                we have indexed.
-//   * `low`    — element of a metadata array that we cannot statically
-//                resolve to a class (call expression, spread, conditional,
-//                or unresolved identifier). Emitted with a diagnostic so
-//                the gap is auditable rather than silent.
+//   * `medium` — `@Inject('TOKEN')` whose token resolves through the
+//                workspace token map (useClass / useExisting providers).
+//   * `low`    — dynamic module shape (`forRoot` / `forRootAsync`) where
+//                we can resolve the receiver module class but not its
+//                runtime contribution.
 //
-// All emitted edges carry `source: 'framework-decorator'`.
+// All emitted edges carry `source: 'framework-decorator'`. Every gap that
+// cannot be resolved produces an info-level SpiDiagnostic so the failure
+// is auditable rather than silent.
 
 import { createHash } from 'node:crypto'
 import ts from 'typescript'
@@ -43,6 +49,7 @@ import ts from 'typescript'
 import type {
   SpiDiagnostic,
   SpiEdge,
+  SpiEdgeConfidence,
   SpiFrameworkRole,
   SpiRange,
   SpiSymbol,
@@ -62,12 +69,37 @@ const ROUTE_DECORATOR_NAMES: ReadonlySet<string> = new Set([
   'All',
 ])
 
+const DYNAMIC_MODULE_FACTORY_METHODS: ReadonlySet<string> = new Set([
+  'forRoot',
+  'forRootAsync',
+  'forFeature',
+  'forFeatureAsync',
+  'register',
+  'registerAsync',
+])
+
 type NestBindings = {
   module: Set<string>
   controller: Set<string>
   injectable: Set<string>
   routeDecorators: Set<string>
+  useGuards: Set<string>
+  useInterceptors: Set<string>
+  usePipes: Set<string>
+  inject: Set<string>
 }
+
+// Workspace-wide map from a NestJS provider token (string literal) to the
+// class that backs it (via `useClass` or `useExisting`). Token uniqueness
+// is the user's responsibility; if two modules bind the same token, the
+// last one wins. Tokens whose binding is `useValue` or `useFactory` are
+// intentionally absent — those are not class references and have no
+// well-defined `injects` target.
+export type NestTokenBinding = {
+  classSymbolId: string
+  confidence: SpiEdgeConfidence
+}
+export type NestTokenMap = Map<string, NestTokenBinding>
 
 export type DetectNestFrameworkContext = {
   sourceFile: ts.SourceFile
@@ -77,6 +109,60 @@ export type DetectNestFrameworkContext = {
   diagnostics: SpiDiagnostic[]
   pathToFileId: Map<string, string>
   checker: ts.TypeChecker
+  tokenMap: NestTokenMap
+}
+
+// Workspace-level token-binding collector. Walks every source file's
+// @Module decorator and registers `{ provide: 'TOKEN', useClass: X }` /
+// `{ provide: 'TOKEN', useExisting: X }` bindings into a global map so
+// downstream @Inject('TOKEN') resolution can find them. Run once before
+// the per-file detectNestFramework pass.
+export type CollectNestTokenMapOptions = {
+  sourceFiles: readonly ts.SourceFile[]
+  pathToFileId: Map<string, string>
+  checker: ts.TypeChecker
+}
+
+export function collectNestTokenMap(opts: CollectNestTokenMapOptions): NestTokenMap {
+  const tokens: NestTokenMap = new Map()
+  for (const sourceFile of opts.sourceFiles) {
+    const bindings = collectNestBindings(sourceFile)
+    if (bindings.module.size === 0) continue
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isClassDeclaration(stmt) || !stmt.name) continue
+      for (const decorator of decoratorsOf(stmt)) {
+        const name = decoratorIdentifierName(decorator)
+        if (!name || !bindings.module.has(name)) continue
+        registerProviderTokens(decorator, opts, tokens)
+      }
+    }
+  }
+  return tokens
+}
+
+function registerProviderTokens(
+  decorator: ts.Decorator,
+  opts: CollectNestTokenMapOptions,
+  tokens: NestTokenMap,
+): void {
+  if (!ts.isCallExpression(decorator.expression)) return
+  const arg = decorator.expression.arguments[0]
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return
+  const providers = providerArrayFor(arg, 'providers')
+  if (!providers) return
+
+  for (const element of providers.elements) {
+    if (!ts.isObjectLiteralExpression(element)) continue
+    const tokenLiteral = stringPropertyValue(element, 'provide')
+    if (!tokenLiteral) continue
+    const useClass = identifierPropertyValue(element, 'useClass')
+    const useExisting = identifierPropertyValue(element, 'useExisting')
+    const target = useClass ?? useExisting
+    if (!target) continue
+    const classId = resolveStaticClassFromIdentifier(target, opts.checker, opts.pathToFileId)
+    if (!classId) continue
+    tokens.set(tokenLiteral, { classSymbolId: classId, confidence: 'medium' })
+  }
 }
 
 export function detectNestFramework(ctx: DetectNestFrameworkContext): void {
@@ -95,11 +181,17 @@ export function detectNestFramework(ctx: DetectNestFrameworkContext): void {
 
     if (decoratorRole.role === 'nest_module' && decoratorRole.decorator) {
       emitModuleEdges(ctx, classId, decoratorRole.decorator)
+      // A module class can itself have constructor injection (rare but legal).
+      emitConstructorInjects(ctx, classId, stmt, bindings)
     } else if (decoratorRole.role === 'nest_controller') {
+      emitClassUseEdges(ctx, classId, classDecorators, bindings)
+      emitConstructorInjects(ctx, classId, stmt, bindings)
       emitControllerRoutes(ctx, classId, stmt, bindings)
+    } else if (decoratorRole.role === 'nest_provider') {
+      // Providers (services, guards, pipes, interceptors marked @Injectable)
+      // don't have routes but absolutely have constructor injection.
+      emitConstructorInjects(ctx, classId, stmt, bindings)
     }
-    // nest_provider currently emits role only; provider-side edges
-    // (injects/uses_*) are slice 3b-ii's domain.
   }
 }
 
@@ -109,6 +201,10 @@ function collectNestBindings(sourceFile: ts.SourceFile): NestBindings {
     controller: new Set<string>(),
     injectable: new Set<string>(),
     routeDecorators: new Set<string>(),
+    useGuards: new Set<string>(),
+    useInterceptors: new Set<string>(),
+    usePipes: new Set<string>(),
+    inject: new Set<string>(),
   }
   for (const stmt of sourceFile.statements) {
     if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
@@ -124,6 +220,10 @@ function collectNestBindings(sourceFile: ts.SourceFile): NestBindings {
       if (importedName === 'Module') bindings.module.add(localName)
       else if (importedName === 'Controller') bindings.controller.add(localName)
       else if (importedName === 'Injectable') bindings.injectable.add(localName)
+      else if (importedName === 'UseGuards') bindings.useGuards.add(localName)
+      else if (importedName === 'UseInterceptors') bindings.useInterceptors.add(localName)
+      else if (importedName === 'UsePipes') bindings.usePipes.add(localName)
+      else if (importedName === 'Inject') bindings.inject.add(localName)
       else if (ROUTE_DECORATOR_NAMES.has(importedName)) bindings.routeDecorators.add(localName)
     }
   }
@@ -131,12 +231,16 @@ function collectNestBindings(sourceFile: ts.SourceFile): NestBindings {
 }
 
 function hasAnyBinding(b: NestBindings): boolean {
-  return b.module.size > 0 || b.controller.size > 0 || b.injectable.size > 0 || b.routeDecorators.size > 0
-}
-
-type DetectedClassDecorator = {
-  role: SpiFrameworkRole
-  decorator: ts.Decorator
+  return (
+    b.module.size > 0 ||
+    b.controller.size > 0 ||
+    b.injectable.size > 0 ||
+    b.routeDecorators.size > 0 ||
+    b.useGuards.size > 0 ||
+    b.useInterceptors.size > 0 ||
+    b.usePipes.size > 0 ||
+    b.inject.size > 0
+  )
 }
 
 function classDecoratorRole(
@@ -189,9 +293,14 @@ function emitModuleEdges(
 
     const initializer = property.initializer
     if (!ts.isArrayLiteralExpression(initializer)) {
-      // e.g. `imports: someComputedArray` — not statically inspectable in
-      // slice 3b base. Record so the gap is visible to downstream layers.
-      pushDiagnostic(ctx, 'spi.nest.module-metadata.non-array', 'info', `NestJS @Module ${key}: non-array initializer cannot be enumerated statically`, ctx.sourceFile, initializer)
+      pushDiagnostic(
+        ctx,
+        'spi.nest.module-metadata.non-array',
+        'info',
+        `NestJS @Module ${key}: non-array initializer cannot be enumerated statically`,
+        ctx.sourceFile,
+        initializer,
+      )
       continue
     }
 
@@ -214,19 +323,69 @@ function emitModuleMetadataEdge(
   edgeKind: 'module_imports' | 'module_provides' | 'module_exports',
   element: ts.Expression,
 ): void {
-  const targetId = resolveStaticClassReference(element, ctx)
-  if (!targetId) {
-    pushDiagnostic(ctx, 'spi.nest.module-metadata.unresolved', 'info', `NestJS @Module ${edgeKind}: unresolved entry (likely dynamic — Module.forRoot, spread, or conditional)`, ctx.sourceFile, element)
+  // Static class reference (`UsersModule`, `users.UsersModule`).
+  const staticTarget = resolveStaticClassReference(element, ctx)
+  if (staticTarget) {
+    ctx.edges.push({
+      from: moduleClassId,
+      to: staticTarget,
+      kind: edgeKind,
+      confidence: 'high',
+      source: 'framework-decorator',
+      evidence: { file_id: ctx.fileId, range: rangeOf(element, ctx.sourceFile) },
+    })
     return
   }
-  ctx.edges.push({
-    from: moduleClassId,
-    to: targetId,
-    kind: edgeKind,
-    confidence: 'high',
-    source: 'framework-decorator',
-    evidence: { file_id: ctx.fileId, range: rangeOf(element, ctx.sourceFile) },
-  })
+
+  // Dynamic module shape: `SomeModule.forRoot(...)` /
+  // `SomeModule.forRootAsync(...)` etc. Resolve the receiver to a Module
+  // class and emit a low-confidence edge so the dependency is not
+  // invisible — the runtime contribution is what we cannot enumerate.
+  const dynamicTarget = resolveDynamicModuleReceiver(element, ctx)
+  if (dynamicTarget) {
+    ctx.edges.push({
+      from: moduleClassId,
+      to: dynamicTarget.classSymbolId,
+      kind: edgeKind,
+      confidence: 'low',
+      source: 'framework-decorator',
+      evidence: { file_id: ctx.fileId, range: rangeOf(element, ctx.sourceFile) },
+    })
+    pushDiagnostic(
+      ctx,
+      'spi.nest.module-metadata.dynamic',
+      'info',
+      `NestJS @Module ${edgeKind}: dynamic module shape via .${dynamicTarget.factoryName}() — runtime providers not resolved`,
+      ctx.sourceFile,
+      element,
+    )
+    return
+  }
+
+  pushDiagnostic(
+    ctx,
+    'spi.nest.module-metadata.unresolved',
+    'info',
+    `NestJS @Module ${edgeKind}: unresolved entry (likely spread, conditional, or computed)`,
+    ctx.sourceFile,
+    element,
+  )
+}
+
+function resolveDynamicModuleReceiver(
+  expr: ts.Expression,
+  ctx: DetectNestFrameworkContext,
+): { classSymbolId: string; factoryName: string } | null {
+  if (!ts.isCallExpression(expr)) return null
+  const callee = expr.expression
+  if (!ts.isPropertyAccessExpression(callee) || !ts.isIdentifier(callee.name)) return null
+  const factoryName = callee.name.text
+  if (!DYNAMIC_MODULE_FACTORY_METHODS.has(factoryName)) return null
+  const receiver = callee.expression
+  if (!ts.isIdentifier(receiver)) return null
+  const id = resolveStaticClassFromIdentifier(receiver, ctx.checker, ctx.pathToFileId)
+  if (!id) return null
+  return { classSymbolId: id, factoryName }
 }
 
 function emitControllerRoutes(
@@ -240,16 +399,18 @@ function emitControllerRoutes(
 
   // Per-method overload counters mirror build.ts emitClassMethods so the
   // method symbol id we link to here matches the one the symbol layer emits.
-  // Increment for every named method declaration (including non-route ones)
-  // so the index of a route method on, say, the third overload of `foo`
-  // resolves to `foo#2` — the same id the symbol layer minted.
   const overloadCounts = new Map<string, number>()
 
   for (const member of classDecl.members) {
     if (!ts.isMethodDeclaration(member) || !member.name || !ts.isIdentifier(member.name)) {
-      // Constructors, accessors, and properties keep their own counters in
-      // build.ts emitClassMethods (different name keys), so skipping them
-      // here does not desync indices for method declarations.
+      if (
+        ts.isMethodDeclaration(member) &&
+        member.name &&
+        ts.isIdentifier(member.name)
+      ) {
+        const k = `${className}.${member.name.text}`
+        overloadCounts.set(k, (overloadCounts.get(k) ?? 0) + 1)
+      }
       continue
     }
 
@@ -258,8 +419,13 @@ function emitControllerRoutes(
     const overloadIndex = overloadCounts.get(overloadKey) ?? 0
     overloadCounts.set(overloadKey, overloadIndex + 1)
 
-    const routeDecorator = findRouteDecorator(member, bindings)
-    if (!routeDecorator) continue
+    const memberDecorators = decoratorsOf(member)
+    const routeDecorator = findRouteDecorator(memberDecorators, bindings)
+    if (!routeDecorator) {
+      // Method-level @Use* on a non-route method is rare but not invalid.
+      // Skip silently — guard/pipe edges only matter for route methods.
+      continue
+    }
 
     const baseId = symbolIdFor(ctx.fileId, 'method', `${className}.${methodName}`)
     const methodId = overloadIndex === 0 ? baseId : `${baseId}#${overloadIndex}`
@@ -274,21 +440,183 @@ function emitControllerRoutes(
       source: 'framework-decorator',
       evidence: { file_id: ctx.fileId, range: rangeOf(member.name, ctx.sourceFile) },
     })
+
+    emitMethodUseEdges(ctx, methodId, memberDecorators, bindings)
   }
 }
 
-function findRouteDecorator(member: ts.MethodDeclaration, bindings: NestBindings): ts.Decorator | null {
-  for (const decorator of decoratorsOf(member)) {
+function findRouteDecorator(decorators: readonly ts.Decorator[], bindings: NestBindings): ts.Decorator | null {
+  for (const decorator of decorators) {
     const name = decoratorIdentifierName(decorator)
     if (name && bindings.routeDecorators.has(name)) return decorator
   }
   return null
 }
 
+function emitClassUseEdges(
+  ctx: DetectNestFrameworkContext,
+  classId: string,
+  decorators: readonly ts.Decorator[],
+  bindings: NestBindings,
+): void {
+  emitUseEdgesFor(ctx, classId, decorators, bindings.useGuards, 'guards')
+  emitUseEdgesFor(ctx, classId, decorators, bindings.useInterceptors, 'intercepts')
+  emitUseEdgesFor(ctx, classId, decorators, bindings.usePipes, 'pipes')
+}
+
+function emitMethodUseEdges(
+  ctx: DetectNestFrameworkContext,
+  methodId: string,
+  decorators: readonly ts.Decorator[],
+  bindings: NestBindings,
+): void {
+  emitUseEdgesFor(ctx, methodId, decorators, bindings.useGuards, 'guards')
+  emitUseEdgesFor(ctx, methodId, decorators, bindings.useInterceptors, 'intercepts')
+  emitUseEdgesFor(ctx, methodId, decorators, bindings.usePipes, 'pipes')
+}
+
+function emitUseEdgesFor(
+  ctx: DetectNestFrameworkContext,
+  fromId: string,
+  decorators: readonly ts.Decorator[],
+  bindingNames: ReadonlySet<string>,
+  edgeKind: 'guards' | 'intercepts' | 'pipes',
+): void {
+  if (bindingNames.size === 0) return
+  for (const decorator of decorators) {
+    const name = decoratorIdentifierName(decorator)
+    if (!name || !bindingNames.has(name)) continue
+    if (!ts.isCallExpression(decorator.expression)) continue
+    for (const arg of decorator.expression.arguments) {
+      const targets = flattenUseDecoratorArg(arg)
+      for (const target of targets) {
+        const targetId = resolveStaticClassReference(target, ctx)
+        if (!targetId) {
+          pushDiagnostic(
+            ctx,
+            'spi.nest.use-decorator.unresolved',
+            'info',
+            `NestJS @Use* ${edgeKind}: unresolved target (instance literal, computed expression, or untyped)`,
+            ctx.sourceFile,
+            target,
+          )
+          continue
+        }
+        ctx.edges.push({
+          from: fromId,
+          to: targetId,
+          kind: edgeKind,
+          confidence: 'high',
+          source: 'framework-decorator',
+          evidence: { file_id: ctx.fileId, range: rangeOf(target, ctx.sourceFile) },
+        })
+      }
+    }
+  }
+}
+
+// `@UseGuards(A, B)` and `@UseGuards([A, B])` are both legal. Flatten
+// arrays inline so callers can iterate over a flat list of class refs.
+function flattenUseDecoratorArg(arg: ts.Expression): ts.Expression[] {
+  if (ts.isArrayLiteralExpression(arg)) {
+    const out: ts.Expression[] = []
+    for (const element of arg.elements) {
+      if (ts.isExpression(element)) {
+        out.push(...flattenUseDecoratorArg(element))
+      }
+    }
+    return out
+  }
+  return [arg]
+}
+
+function emitConstructorInjects(
+  ctx: DetectNestFrameworkContext,
+  classId: string,
+  classDecl: ts.ClassDeclaration,
+  bindings: NestBindings,
+): void {
+  const ctor = classDecl.members.find((m): m is ts.ConstructorDeclaration => ts.isConstructorDeclaration(m))
+  if (!ctor) return
+
+  const seen = new Set<string>()
+  for (const param of ctor.parameters) {
+    const tokenName = injectTokenFromParameter(param, bindings)
+    if (tokenName !== null) {
+      const binding = ctx.tokenMap.get(tokenName)
+      if (!binding) {
+        pushDiagnostic(
+          ctx,
+          'spi.nest.inject-token.unresolved',
+          'info',
+          `NestJS @Inject('${tokenName}'): no useClass / useExisting binding found in any module`,
+          ctx.sourceFile,
+          param,
+        )
+        continue
+      }
+      const dedupeKey = `${classId}|${binding.classSymbolId}`
+      if (seen.has(dedupeKey)) continue
+      seen.add(dedupeKey)
+      ctx.edges.push({
+        from: classId,
+        to: binding.classSymbolId,
+        kind: 'injects',
+        confidence: binding.confidence,
+        source: 'framework-decorator',
+        evidence: { file_id: ctx.fileId, range: rangeOf(param, ctx.sourceFile) },
+      })
+      continue
+    }
+
+    // No @Inject on the parameter — fall through to type-based resolution.
+    if (!param.type) continue
+    const targetId = resolveTypeNodeToClass(param.type, ctx)
+    if (!targetId) continue
+    if (targetId === classId) continue // self-reference — skip
+    const dedupeKey = `${classId}|${targetId}`
+    if (seen.has(dedupeKey)) continue
+    seen.add(dedupeKey)
+    ctx.edges.push({
+      from: classId,
+      to: targetId,
+      kind: 'injects',
+      confidence: 'high',
+      source: 'framework-decorator',
+      evidence: { file_id: ctx.fileId, range: rangeOf(param, ctx.sourceFile) },
+    })
+  }
+}
+
+// Returns the string token of an `@Inject('TOKEN')` decorator on this
+// parameter, or null if the parameter has no @Inject decorator. A
+// non-string @Inject argument (e.g. `@Inject(SomeSymbol)`) returns null
+// too — those bypass the token map and rely on type-based resolution.
+function injectTokenFromParameter(param: ts.ParameterDeclaration, bindings: NestBindings): string | null {
+  if (bindings.inject.size === 0) return null
+  for (const decorator of decoratorsOf(param)) {
+    const name = decoratorIdentifierName(decorator)
+    if (!name || !bindings.inject.has(name)) continue
+    if (!ts.isCallExpression(decorator.expression)) continue
+    const arg = decorator.expression.arguments[0]
+    if (!arg) continue
+    if (ts.isStringLiteralLike(arg)) return arg.text
+  }
+  return null
+}
+
+function resolveTypeNodeToClass(typeNode: ts.TypeNode, ctx: DetectNestFrameworkContext): string | null {
+  if (!ts.isTypeReferenceNode(typeNode)) return null
+  let target: ts.Identifier | null = null
+  if (ts.isIdentifier(typeNode.typeName)) target = typeNode.typeName
+  else if (ts.isQualifiedName(typeNode.typeName)) target = typeNode.typeName.right
+  if (!target) return null
+  return resolveStaticClassFromIdentifier(target, ctx.checker, ctx.pathToFileId)
+}
+
 // Resolves an expression that names a class (e.g. `UsersModule`,
 // `users.UsersModule`) to its SPI class symbol id. Returns null for any
-// expression we cannot statically resolve (call expressions, spread,
-// conditional, etc.) — those are slice 3b-ii's responsibility.
+// expression we cannot statically resolve to a class declaration.
 function resolveStaticClassReference(
   expr: ts.Expression,
   ctx: DetectNestFrameworkContext,
@@ -301,17 +629,22 @@ function resolveStaticClassReference(
   } else {
     return null
   }
+  return resolveStaticClassFromIdentifier(target, ctx.checker, ctx.pathToFileId)
+}
 
-  const symbol = followAlias(ctx.checker.getSymbolAtLocation(target), ctx.checker)
+function resolveStaticClassFromIdentifier(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker,
+  pathToFileId: Map<string, string>,
+): string | null {
+  const symbol = followAlias(checker.getSymbolAtLocation(identifier), checker)
   const decl = symbol?.declarations?.[0]
   if (!decl) return null
   if (!ts.isClassDeclaration(decl) || !decl.name) return null
-
   const declSourceFile = decl.getSourceFile()
   if (declSourceFile.isDeclarationFile) return null
-  const targetFileId = ctx.pathToFileId.get(declSourceFile.fileName)
+  const targetFileId = pathToFileId.get(declSourceFile.fileName)
   if (!targetFileId) return null
-
   return symbolIdFor(targetFileId, 'class', decl.name.text)
 }
 
@@ -348,6 +681,37 @@ function symbolIdFor(fileId: string, kind: SpiSymbolKind, name: string): string 
 function propertyKeyText(name: ts.PropertyName): string | null {
   if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) {
     return name.text
+  }
+  return null
+}
+
+function providerArrayFor(
+  metadataObject: ts.ObjectLiteralExpression,
+  key: string,
+): ts.ArrayLiteralExpression | null {
+  for (const property of metadataObject.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    if (propertyKeyText(property.name) !== key) continue
+    return ts.isArrayLiteralExpression(property.initializer) ? property.initializer : null
+  }
+  return null
+}
+
+function stringPropertyValue(obj: ts.ObjectLiteralExpression, key: string): string | null {
+  for (const property of obj.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    if (propertyKeyText(property.name) !== key) continue
+    if (ts.isStringLiteralLike(property.initializer)) return property.initializer.text
+    return null
+  }
+  return null
+}
+
+function identifierPropertyValue(obj: ts.ObjectLiteralExpression, key: string): ts.Identifier | null {
+  for (const property of obj.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    if (propertyKeyText(property.name) !== key) continue
+    return ts.isIdentifier(property.initializer) ? property.initializer : null
   }
   return null
 }

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -1,6 +1,6 @@
 // SPI v1 — public re-exports.
 //
-// Slices 1a + 1b + 2a + 2b + 3a + 3c + 3b:
+// Slices 1a + 1b + 2a + 2b + 3a + 3c + 3b + 3b-ii:
 //   * types + file layer + imports/exports edges
 //   * symbol layer + declares edges
 //   * call layer + type layer (extends/implements/param_type/return_type)
@@ -8,11 +8,11 @@
 //   * heuristic test layer (covered_by edges)
 //   * NestJS framework base (framework_role tagging + module_imports/
 //     module_provides/module_exports/controller_route)
+//   * NestJS framework quality-of-life: guards/pipes/intercepts edges,
+//     injects edges from constructor types and @Inject('TOKEN'),
+//     dynamic Module.forRoot/forRootAsync handling.
 //
-// The 3b-ii slice (NestJS quality-of-life: @UseGuards/@UsePipes/
-// @UseInterceptors, constructor injection, @Inject('TOKEN') string
-// tokens, dynamic Module.forRoot/forRootAsync) and the projection back
-// to today's graph.json land in subsequent slices of #72.
+// The projection back to today's graph.json (slice 1c) lands separately.
 
 export type {
   SpiVersion,
@@ -53,5 +53,9 @@ export { isTestFilePath } from './test-layer.js'
 
 export {
   detectNestFramework,
+  collectNestTokenMap,
   type DetectNestFrameworkContext,
+  type CollectNestTokenMapOptions,
+  type NestTokenMap,
+  type NestTokenBinding,
 } from './framework-nestjs.js'

--- a/tests/unit/spi-framework-nestjs.test.ts
+++ b/tests/unit/spi-framework-nestjs.test.ts
@@ -210,7 +210,7 @@ describe('buildSpi NestJS framework layer (slice 3b base of #72)', () => {
       expect(exports_[0]?.confidence).toBe('high')
     })
 
-    it('emits a diagnostic and skips the edge for dynamic Module.forRoot() entries', () => {
+    it('emits a low-confidence edge + diagnostic for dynamic Module.forRoot() entries (3b-ii)', () => {
       writeFile(sandbox, 'src/typeorm.module.ts', [
         'import { Module } from "@nestjs/common"',
         '@Module({})',
@@ -227,12 +227,46 @@ describe('buildSpi NestJS framework layer (slice 3b base of #72)', () => {
       const spi = build(sandbox)
 
       const moduleId = classSymbol(spi, 'src/app.module.ts', 'AppModule').id
-      const importEdges = spi.edges.filter((e) => e.from === moduleId && e.kind === 'module_imports')
-      expect(importEdges).toHaveLength(0)
+      const typeormId = classSymbol(spi, 'src/typeorm.module.ts', 'TypeOrmModule').id
+      const importEdges = spi.edges.filter(
+        (e) => e.from === moduleId && e.to === typeormId && e.kind === 'module_imports',
+      )
+      expect(importEdges).toHaveLength(1)
+      expect(importEdges[0]?.confidence).toBe('low')
+      expect(importEdges[0]?.source).toBe('framework-decorator')
+
       const dynamicDiag = spi.diagnostics.find((d) =>
-        d.id.startsWith('spi.nest.module-metadata.unresolved') && d.message.includes('module_imports'),
+        d.id.startsWith('spi.nest.module-metadata.dynamic') && d.message.includes('forRoot'),
       )
       expect(dynamicDiag).toBeTruthy()
+    })
+
+    it('emits a low-confidence edge + diagnostic for Module.forRootAsync() entries (3b-ii)', () => {
+      writeFile(sandbox, 'src/config.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        '@Module({})',
+        'export class ConfigModule {',
+        '  static forRootAsync(): unknown { return null }',
+        '}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { ConfigModule } from "./config.module.js"',
+        '@Module({ imports: [ConfigModule.forRootAsync()] })',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const moduleId = classSymbol(spi, 'src/app.module.ts', 'AppModule').id
+      const configId = classSymbol(spi, 'src/config.module.ts', 'ConfigModule').id
+      const edge = spi.edges.find(
+        (e) => e.from === moduleId && e.to === configId && e.kind === 'module_imports',
+      )
+      expect(edge?.confidence).toBe('low')
+      const diag = spi.diagnostics.find((d) =>
+        d.id.startsWith('spi.nest.module-metadata.dynamic') && d.message.includes('forRootAsync'),
+      )
+      expect(diag).toBeTruthy()
     })
 
     it('emits a diagnostic for spread metadata entries', () => {
@@ -451,11 +485,359 @@ describe('buildSpi NestJS framework layer (slice 3b base of #72)', () => {
         'module_provides',
         'module_exports',
         'controller_route',
+        'guards',
+        'pipes',
+        'intercepts',
+        'injects',
       ]
       const nestEdges = frameworkEdges(spi, FRAMEWORK_KINDS)
       expect(nestEdges).toHaveLength(0)
       const nestRoles = spi.symbols.filter((s) => s.framework_role !== undefined)
       expect(nestRoles).toHaveLength(0)
+    })
+  })
+})
+
+describe('buildSpi NestJS framework layer (slice 3b-ii of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('injects edges from constructor types', () => {
+    it('emits a high-confidence injects edge for a constructor parameter typed as a class', () => {
+      writeFile(sandbox, 'src/users.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class UsersService {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller } from "@nestjs/common"',
+        'import { UsersService } from "./users.service.js"',
+        '@Controller()',
+        'export class UsersController {',
+        '  constructor(private readonly users: UsersService) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/users.controller.ts', 'UsersController').id
+      const toId = classSymbol(spi, 'src/users.service.ts', 'UsersService').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'injects')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('framework-decorator')
+      expect(edge?.evidence).toBeDefined()
+    })
+
+    it('emits injects edges from provider classes too (not just controllers)', () => {
+      writeFile(sandbox, 'src/logger.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class LoggerService {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.service.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        'import { LoggerService } from "./logger.service.js"',
+        '@Injectable()',
+        'export class UsersService {',
+        '  constructor(private readonly logger: LoggerService) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/users.service.ts', 'UsersService').id
+      const toId = classSymbol(spi, 'src/logger.service.ts', 'LoggerService').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'injects')
+      expect(edge?.confidence).toBe('high')
+    })
+
+    it('dedupes when the same dependency appears as multiple constructor parameters', () => {
+      writeFile(sandbox, 'src/dep.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class Dep {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/svc.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        'import { Dep } from "./dep.js"',
+        '@Injectable()',
+        'export class Svc {',
+        '  constructor(a: Dep, b: Dep) { void a; void b }',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/svc.ts', 'Svc').id
+      const toId = classSymbol(spi, 'src/dep.ts', 'Dep').id
+      const edges = spi.edges.filter((e) => e.from === fromId && e.to === toId && e.kind === 'injects')
+      expect(edges).toHaveLength(1)
+    })
+
+    it('does not emit injects when constructor parameter has no type annotation', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class Svc {',
+        '  constructor(private readonly opts: unknown) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/svc.ts', 'Svc').id
+      const edges = spi.edges.filter((e) => e.from === fromId && e.kind === 'injects')
+      expect(edges).toHaveLength(0)
+    })
+  })
+
+  describe('injects edges from @Inject(\'TOKEN\') string-token resolution', () => {
+    it('resolves @Inject(\'TOKEN\') against a useClass binding (medium confidence)', () => {
+      writeFile(sandbox, 'src/redis-cache.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class RedisCache {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/cache.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { RedisCache } from "./redis-cache.js"',
+        '@Module({ providers: [{ provide: "CACHE_TOKEN", useClass: RedisCache }], exports: ["CACHE_TOKEN"] })',
+        'export class CacheModule {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.service.ts', [
+        'import { Injectable, Inject } from "@nestjs/common"',
+        '@Injectable()',
+        'export class UsersService {',
+        '  constructor(@Inject("CACHE_TOKEN") private readonly cache: unknown) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/users.service.ts', 'UsersService').id
+      const toId = classSymbol(spi, 'src/redis-cache.ts', 'RedisCache').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'injects')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('medium')
+      expect(edge?.source).toBe('framework-decorator')
+    })
+
+    it('resolves @Inject(\'TOKEN\') against a useExisting binding (medium confidence)', () => {
+      writeFile(sandbox, 'src/cache-impl.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class CacheImpl {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/cache.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        'import { CacheImpl } from "./cache-impl.js"',
+        '@Module({ providers: [CacheImpl, { provide: "CACHE_ALIAS", useExisting: CacheImpl }] })',
+        'export class CacheModule {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/foo.service.ts', [
+        'import { Injectable, Inject } from "@nestjs/common"',
+        '@Injectable()',
+        'export class FooService {',
+        '  constructor(@Inject("CACHE_ALIAS") private readonly c: unknown) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/foo.service.ts', 'FooService').id
+      const toId = classSymbol(spi, 'src/cache-impl.ts', 'CacheImpl').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'injects')
+      expect(edge?.confidence).toBe('medium')
+    })
+
+    it('emits a diagnostic when @Inject(\'TOKEN\') has no matching useClass / useExisting binding', () => {
+      writeFile(sandbox, 'src/foo.service.ts', [
+        'import { Injectable, Inject } from "@nestjs/common"',
+        '@Injectable()',
+        'export class FooService {',
+        '  constructor(@Inject("UNBOUND_TOKEN") private readonly x: unknown) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/foo.service.ts', 'FooService').id
+      const injectEdges = spi.edges.filter((e) => e.from === fromId && e.kind === 'injects')
+      expect(injectEdges).toHaveLength(0)
+      const diag = spi.diagnostics.find(
+        (d) => d.id.startsWith('spi.nest.inject-token.unresolved') && d.message.includes('UNBOUND_TOKEN'),
+      )
+      expect(diag).toBeTruthy()
+    })
+
+    it('does not consult the token map for @Inject when no useValue/useFactory entry was registered', () => {
+      // useValue is intentionally absent from the token map (no class to
+      // point at). Verify @Inject for a useValue token cleanly fails over
+      // to a diagnostic rather than producing a spurious edge.
+      writeFile(sandbox, 'src/cache.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        '@Module({ providers: [{ provide: "DB_URL", useValue: "postgres://x" }] })',
+        'export class CacheModule {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/foo.service.ts', [
+        'import { Injectable, Inject } from "@nestjs/common"',
+        '@Injectable()',
+        'export class FooService {',
+        '  constructor(@Inject("DB_URL") private readonly url: unknown) {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/foo.service.ts', 'FooService').id
+      const injectEdges = spi.edges.filter((e) => e.from === fromId && e.kind === 'injects')
+      expect(injectEdges).toHaveLength(0)
+      const diag = spi.diagnostics.find((d) => d.message.includes('DB_URL'))
+      expect(diag).toBeTruthy()
+    })
+  })
+
+  describe('guards / intercepts / pipes edges', () => {
+    it('emits a class-level guards edge from controller class to guard class', () => {
+      writeFile(sandbox, 'src/auth.guard.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class AuthGuard {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, UseGuards, Get } from "@nestjs/common"',
+        'import { AuthGuard } from "./auth.guard.js"',
+        '@Controller("users")',
+        '@UseGuards(AuthGuard)',
+        'export class UsersController {',
+        '  @Get() list(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/users.controller.ts', 'UsersController').id
+      const toId = classSymbol(spi, 'src/auth.guard.ts', 'AuthGuard').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'guards')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('framework-decorator')
+    })
+
+    it('emits a method-level guards edge from route method to guard class', () => {
+      writeFile(sandbox, 'src/auth.guard.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class AuthGuard {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, UseGuards, Get } from "@nestjs/common"',
+        'import { AuthGuard } from "./auth.guard.js"',
+        '@Controller()',
+        'export class UsersController {',
+        '  @UseGuards(AuthGuard)',
+        '  @Get() list(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromMethod = methodSymbol(spi, 'src/users.controller.ts', 'UsersController.list').id
+      const toId = classSymbol(spi, 'src/auth.guard.ts', 'AuthGuard').id
+      const edge = spi.edges.find((e) => e.from === fromMethod && e.to === toId && e.kind === 'guards')
+      expect(edge).toBeTruthy()
+    })
+
+    it('handles multiple guards passed positionally and as an array', () => {
+      writeFile(sandbox, 'src/g1.ts', 'import { Injectable } from "@nestjs/common"\n@Injectable()\nexport class G1 {}\n')
+      writeFile(sandbox, 'src/g2.ts', 'import { Injectable } from "@nestjs/common"\n@Injectable()\nexport class G2 {}\n')
+      writeFile(sandbox, 'src/g3.ts', 'import { Injectable } from "@nestjs/common"\n@Injectable()\nexport class G3 {}\n')
+      writeFile(sandbox, 'src/positional.controller.ts', [
+        'import { Controller, UseGuards } from "@nestjs/common"',
+        'import { G1 } from "./g1.js"',
+        'import { G2 } from "./g2.js"',
+        '@Controller()',
+        '@UseGuards(G1, G2)',
+        'export class PositionalController {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/array.controller.ts', [
+        'import { Controller, UseGuards } from "@nestjs/common"',
+        'import { G1 } from "./g1.js"',
+        'import { G3 } from "./g3.js"',
+        '@Controller()',
+        '@UseGuards([G1, G3])',
+        'export class ArrayController {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const positionalId = classSymbol(spi, 'src/positional.controller.ts', 'PositionalController').id
+      const positionalGuards = spi.edges.filter((e) => e.from === positionalId && e.kind === 'guards')
+      expect(positionalGuards).toHaveLength(2)
+
+      const arrayId = classSymbol(spi, 'src/array.controller.ts', 'ArrayController').id
+      const arrayGuards = spi.edges.filter((e) => e.from === arrayId && e.kind === 'guards')
+      expect(arrayGuards).toHaveLength(2)
+    })
+
+    it('emits intercepts edges from @UseInterceptors', () => {
+      writeFile(sandbox, 'src/log.interceptor.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class LogInterceptor {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, UseInterceptors, Get } from "@nestjs/common"',
+        'import { LogInterceptor } from "./log.interceptor.js"',
+        '@Controller()',
+        '@UseInterceptors(LogInterceptor)',
+        'export class UsersController {',
+        '  @Get() list(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/users.controller.ts', 'UsersController').id
+      const toId = classSymbol(spi, 'src/log.interceptor.ts', 'LogInterceptor').id
+      const edge = spi.edges.find((e) => e.from === fromId && e.to === toId && e.kind === 'intercepts')
+      expect(edge).toBeTruthy()
+    })
+
+    it('emits pipes edges from @UsePipes', () => {
+      writeFile(sandbox, 'src/validate.pipe.ts', [
+        'import { Injectable } from "@nestjs/common"',
+        '@Injectable()',
+        'export class ValidatePipe {}',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, UsePipes, Post } from "@nestjs/common"',
+        'import { ValidatePipe } from "./validate.pipe.js"',
+        '@Controller()',
+        'export class UsersController {',
+        '  @UsePipes(ValidatePipe)',
+        '  @Post() create(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromMethod = methodSymbol(spi, 'src/users.controller.ts', 'UsersController.create').id
+      const toId = classSymbol(spi, 'src/validate.pipe.ts', 'ValidatePipe').id
+      const edge = spi.edges.find((e) => e.from === fromMethod && e.to === toId && e.kind === 'pipes')
+      expect(edge).toBeTruthy()
+    })
+
+    it('emits a diagnostic for unresolvable @UseGuards targets (e.g. instance literal)', () => {
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, UseGuards, Get } from "@nestjs/common"',
+        'class FakeGuard { constructor(_: number) {} }', // not @Injectable, not exported
+        '@Controller()',
+        '@UseGuards(new FakeGuard(1))',
+        'export class UsersController {',
+        '  @Get() list(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+
+      const fromId = classSymbol(spi, 'src/users.controller.ts', 'UsersController').id
+      const guards = spi.edges.filter((e) => e.from === fromId && e.kind === 'guards')
+      expect(guards).toHaveLength(0)
+      const diag = spi.diagnostics.find((d) => d.id.startsWith('spi.nest.use-decorator.unresolved'))
+      expect(diag).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
> **Stacked on #98.** Targets \`feat/spi-v1-slice-3b-nestjs-base\` so reviewers see only the 3b-ii diff. GitHub will auto-rebase against \`main\` on merge once #98 lands.

## Summary

- Layers the NestJS quality-of-life additions on top of #98's slice 3b base, completing the framework-decorator surface called for in the SPI v1 design.
- Emits \`injects\` edges from constructor parameters typed as classes (high confidence) and from \`@Inject('TOKEN')\` parameters resolved through a workspace-wide token map (medium confidence).
- Emits \`guards\` / \`intercepts\` / \`pipes\` edges for both class-level (\`@UseGuards\` on the controller) and method-level (\`@UseGuards\` on a route handler) decorator placements; supports both positional (\`@UseGuards(A, B)\`) and array (\`@UseGuards([A, B])\`) argument forms.
- Resolves dynamic \`Module.forRoot(...)\` / \`forRootAsync(...)\` / \`forFeature(...)\` / \`forFeatureAsync(...)\` / \`register(...)\` / \`registerAsync(...)\` to a low-confidence \`module_imports\` edge to the receiver Module class plus a specific \`spi.nest.module-metadata.dynamic\` diagnostic. (Slice 3b base previously emitted no edge here; the existing test was updated.)

## Token-map design

A workspace-level pre-pass walks every \`@Module\` decorator before per-file framework detection, building a single \`Map<token, { classSymbolId, confidence }>\`. Only \`useClass\` / \`useExisting\` bindings register; \`useValue\` and \`useFactory\` providers are intentionally absent because they have no well-defined class target. \`@Inject('TOKEN')\` against a value-only or factory-only or unknown token produces an info-level \`spi.nest.inject-token.unresolved\` diagnostic instead of a spurious edge.

If two modules bind the same token to different classes, the last one wins (token uniqueness is the user's responsibility).

## Diagnostic surface

Every unresolvable case produces an info-level \`SpiDiagnostic\` so coverage gaps stay auditable:

- \`spi.nest.module-metadata.dynamic\` — \`Module.forRoot\`-style entries
- \`spi.nest.module-metadata.unresolved\` — spread, conditional, computed array entries
- \`spi.nest.module-metadata.non-array\` — \`imports: someComputedArray\`
- \`spi.nest.use-decorator.unresolved\` — \`@UseGuards(new Foo())\` and similar non-class arguments
- \`spi.nest.inject-token.unresolved\` — \`@Inject('TOKEN')\` with no matching binding

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 84 files / **1505** tests pass (15 new for 3b-ii on top of 17 from 3b base)
- [x] New tests cover: constructor type-resolved injects (incl. provider-on-provider injection, dedupe, no-edge for unresolvable types); \`@Inject('TOKEN')\` resolution against \`useClass\` and \`useExisting\` (medium confidence); diagnostics for unbound tokens and \`useValue\`-only bindings; class-level + method-level \`@UseGuards\` / \`@UseInterceptors\` / \`@UsePipes\`; positional and array argument forms; \`@UseGuards(new Foo())\` diagnostic; \`Module.forRoot()\` and \`forRootAsync()\` low-confidence edges + diagnostics; demo-repo regression check now also asserts zero \`guards\` / \`pipes\` / \`intercepts\` / \`injects\` edges
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge

## What's next

- Slice 1c (projector → \`graph.json\` byte-equivalent for existing fixtures) is the highest-risk remaining piece of #72. It will trigger v0.14.0 once it lands.
- The selective retrieval gate (#75) is the cheapest v0.15 win and is independent of remaining SPI work.

Refs #70 (design), #72 (implementation umbrella), #98 (parent slice 3b base).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved NestJS framework analysis with enhanced injection token binding resolution.
  * Added workspace-level detection of provider dependencies and dynamic module patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->