### PR TITLE
feat(#72): SPI v1 slice 1c-i — structural projector → ExtractionData

### DIFF
--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -1,6 +1,6 @@
 // SPI v1 — public re-exports.
 //
-// Slices 1a + 1b + 2a + 2b + 3a + 3c + 3b + 3b-ii:
+// Slices 1a + 1b + 2a + 2b + 3a + 3c + 3b + 3b-ii + 1c-i:
 //   * types + file layer + imports/exports edges
 //   * symbol layer + declares edges
 //   * call layer + type layer (extends/implements/param_type/return_type)
@@ -11,8 +11,10 @@
 //   * NestJS framework quality-of-life: guards/pipes/intercepts edges,
 //     injects edges from constructor types and @Inject('TOKEN'),
 //     dynamic Module.forRoot/forRootAsync handling.
-//
-// The projection back to today's graph.json (slice 1c) lands separately.
+//   * Structural projector — projectSpiToExtraction(spi, { root }) bridges
+//     the SPI substrate to the existing graph.json pipeline by producing
+//     ExtractionData of the same shape buildFromJson() consumes. Slice
+//     1c-ii will extend it to byte-equivalence on examples/demo-repo/.
 
 export type {
   SpiVersion,
@@ -59,3 +61,8 @@ export {
   type NestTokenMap,
   type NestTokenBinding,
 } from './framework-nestjs.js'
+
+export {
+  projectSpiToExtraction,
+  type ProjectSpiToExtractionOptions,
+} from './projector.js'

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -1,0 +1,333 @@
+// SPI v1 — projector: SemanticProgramIndex → ExtractionData (slice 1c-i of #72).
+//
+// Bridges the SPI substrate to the existing graph.json pipeline. Slot:
+//
+//     buildSpi(root) → SemanticProgramIndex
+//                          ↓
+//              projectSpiToExtraction(spi, { root })
+//                          ↓
+//                    ExtractionData
+//                          ↓
+//          buildFromJson() → cluster() → analyze() → toJson()
+//                          ↓
+//                       graph.json
+//
+// In other words: replace `extract()` with the SPI build + projector pair and
+// the rest of the pipeline runs unchanged. The projector reuses the exact
+// id/label/provenance helpers from src/pipeline/extract/core.ts so a file the
+// projector emits matches what the legacy extractor would emit for the same
+// path.
+//
+// === Scope of slice 1c-i (this file) ===
+//
+// The projector covers only the structural surface SPI v1 captures:
+//
+//   * File nodes — one per SpiFile, id = `_makeId(basenameWithoutExt(path))`,
+//     label = basename, source_location = "L1", file_type = "code".
+//   * Symbol nodes — one per SpiSymbol of kind in {function, class, interface,
+//     type-alias, enum, method, constant, variable, namespace}. ids and
+//     labels are generated to match the legacy extractor's snake_case
+//     `_makeId(fileBasename, [className,] symbolName)` scheme.
+//   * `contains` edges — file → top-level symbol (every kind except `method`).
+//   * `method`   edges — class → method symbol.
+//   * `imports_from` edges — file → resolved file from SPI's `imports` edges.
+//   * `calls` edges — caller symbol → callee symbol from SPI's `calls` edges.
+//   * `extends` / `implements` edges — symbol → symbol from SPI's type layer.
+//
+// === What's intentionally deferred to slice 1c-ii ===
+//
+// Full byte-equivalence on the checked-in `examples/demo-repo/graphify-out/
+// graph.json` golden fixture requires reproducing every legacy extractor
+// emission decision: framework-specific node kinds (Express/NestJS/Next.js/
+// React Router/Redux), cross-file resolution heuristics, generic call
+// resolution, non-code file extraction, and snippet truncation rules. That's
+// a port of ~3,600 lines of extract.ts and lives in slice 1c-ii.
+//
+// This slice ships the structural projector and a comparison test against a
+// small TS-only sandbox fixture so the contract is exercised; it does NOT
+// trigger the v0.14.0 release (the design doc says the projector landing is
+// the trigger, but only when it covers demo-repo byte-equivalence).
+
+import { basename, extname, resolve } from 'node:path'
+
+import type {
+  ExtractionData,
+  ExtractionEdge,
+  ExtractionNode,
+} from '../../contracts/types.js'
+import {
+  _makeId,
+  addNode,
+  addUniqueEdge,
+  createEdge,
+  createNode,
+} from '../extract/core.js'
+
+import type {
+  SemanticProgramIndex,
+  SpiEdge,
+  SpiFile,
+  SpiSymbol,
+  SpiSymbolKind,
+} from './types.js'
+
+export type ProjectSpiToExtractionOptions = {
+  /** Workspace root the SPI was built against. Used to resolve absolute
+   *  paths so the produced ExtractionNode.source_file matches the legacy
+   *  extractor's path output. */
+  root: string
+}
+
+const PROJECTABLE_SYMBOL_KINDS: ReadonlySet<SpiSymbolKind> = new Set([
+  'function',
+  'class',
+  'interface',
+  'type-alias',
+  'enum',
+  'method',
+  'constant',
+  'variable',
+  'namespace',
+])
+
+const SPI_TO_EXTRACTION_RELATION: Partial<Record<SpiEdge['kind'], string>> = {
+  imports: 'imports_from',
+  calls: 'calls',
+  extends: 'extends',
+  implements: 'implements',
+}
+
+const SPI_TO_EXTRACTION_CONFIDENCE: Record<SpiEdge['confidence'], ExtractionEdge['confidence']> = {
+  high: 'EXTRACTED',
+  medium: 'INFERRED',
+  low: 'AMBIGUOUS',
+}
+
+export function projectSpiToExtraction(
+  spi: SemanticProgramIndex,
+  opts: ProjectSpiToExtractionOptions,
+): ExtractionData {
+  const root = resolve(opts.root)
+
+  // Index SpiFiles for quick (file_id → SpiFile) lookups.
+  const fileById = new Map<string, SpiFile>(spi.files.map((f) => [f.id, f]))
+
+  const nodes: ExtractionNode[] = []
+  const edges: ExtractionEdge[] = []
+  const seenNodeIds = new Set<string>()
+  const seenEdgeKeys = new Set<string>()
+
+  // Mappings from SPI ids to ExtractionNode ids so edges can be rewritten.
+  const fileIdToNodeId = new Map<string, string>()
+  const symbolIdToNodeId = new Map<string, string>()
+  const symbolIdToSourceFile = new Map<string, string>()
+  const symbolIdToLine = new Map<string, number>()
+
+  // 1) File nodes.
+  for (const file of spi.files) {
+    const absPath = resolve(root, file.path)
+    const fileBaseStem = basename(file.path, extname(file.path))
+    const nodeId = _makeId(fileBaseStem)
+    fileIdToNodeId.set(file.id, nodeId)
+    addNode(nodes, seenNodeIds, createNode(nodeId, basename(file.path), absPath, 1, 'code'))
+  }
+
+  // 2) Symbol nodes.
+  for (const symbol of spi.symbols) {
+    if (!PROJECTABLE_SYMBOL_KINDS.has(symbol.kind)) continue
+    const file = fileById.get(symbol.file_id)
+    if (!file) continue
+
+    const absPath = resolve(root, file.path)
+    const fileBaseStem = basename(file.path, extname(file.path))
+    const projection = projectSymbol(symbol, fileBaseStem)
+    if (!projection) continue
+
+    symbolIdToNodeId.set(symbol.id, projection.id)
+    symbolIdToSourceFile.set(symbol.id, absPath)
+    symbolIdToLine.set(symbol.id, symbol.range.start.line)
+
+    addNode(
+      nodes,
+      seenNodeIds,
+      createNode(projection.id, projection.label, absPath, symbol.range.start.line, 'code'),
+    )
+  }
+
+  // 3) Structural edges derived from SPI's `declares` layer:
+  //    - file → top-level symbol (kind ≠ method) becomes `contains`.
+  //    - class → method becomes `method`. SPI emits a file→method `declares`,
+  //      but the legacy extractor models methods as children of their class.
+  //      So we re-link by parsing the SpiSymbol.name (`ClassName.methodName`)
+  //      back to its enclosing class node id.
+  emitContainsAndMethodEdges(
+    spi,
+    fileById,
+    fileIdToNodeId,
+    symbolIdToNodeId,
+    edges,
+    seenEdgeKeys,
+    root,
+  )
+
+  // 4) Cross-symbol edges projected from SPI edge kinds: imports, calls,
+  //    extends, implements.
+  for (const edge of spi.edges) {
+    const relation = SPI_TO_EXTRACTION_RELATION[edge.kind]
+    if (!relation) continue
+
+    const sourceId = resolveEndpoint(edge.from, fileIdToNodeId, symbolIdToNodeId)
+    const targetId = resolveEndpoint(edge.to, fileIdToNodeId, symbolIdToNodeId)
+    if (!sourceId || !targetId) continue
+
+    // Drop self-edges (e.g., file `exports` self-loops in SPI).
+    if (sourceId === targetId) continue
+
+    const evidence = locateEvidence(edge, fileById, fileIdToNodeId, symbolIdToNodeId, symbolIdToSourceFile, symbolIdToLine, root)
+    if (!evidence) continue
+
+    addUniqueEdge(
+      edges,
+      seenEdgeKeys,
+      createEdge(
+        sourceId,
+        targetId,
+        relation,
+        evidence.sourceFile,
+        evidence.line,
+        SPI_TO_EXTRACTION_CONFIDENCE[edge.confidence],
+        1.0,
+      ),
+    )
+  }
+
+  return {
+    schema_version: 1,
+    nodes,
+    edges,
+    hyperedges: [],
+    input_tokens: 0,
+    output_tokens: 0,
+  }
+}
+
+type SymbolProjection = { id: string; label: string }
+
+function projectSymbol(symbol: SpiSymbol, fileBaseStem: string): SymbolProjection | null {
+  if (symbol.kind === 'method') {
+    // SpiSymbol.name for methods is `ClassName.methodName`.
+    const dotAt = symbol.name.lastIndexOf('.')
+    if (dotAt <= 0) return null
+    const className = symbol.name.slice(0, dotAt)
+    const methodName = symbol.name.slice(dotAt + 1)
+    return {
+      id: _makeId(fileBaseStem, className, methodName),
+      label: `.${methodName}()`,
+    }
+  }
+
+  if (symbol.kind === 'function') {
+    return {
+      id: _makeId(fileBaseStem, symbol.name),
+      label: `${symbol.name}()`,
+    }
+  }
+
+  // class / interface / type-alias / enum / constant / variable / namespace
+  return {
+    id: _makeId(fileBaseStem, symbol.name),
+    label: symbol.name,
+  }
+}
+
+function emitContainsAndMethodEdges(
+  spi: SemanticProgramIndex,
+  fileById: Map<string, SpiFile>,
+  fileIdToNodeId: Map<string, string>,
+  symbolIdToNodeId: Map<string, string>,
+  edges: ExtractionEdge[],
+  seenEdgeKeys: Set<string>,
+  root: string,
+): void {
+  for (const symbol of spi.symbols) {
+    if (!PROJECTABLE_SYMBOL_KINDS.has(symbol.kind)) continue
+    const targetId = symbolIdToNodeId.get(symbol.id)
+    if (!targetId) continue
+    const file = fileById.get(symbol.file_id)
+    if (!file) continue
+    const absPath = resolve(root, file.path)
+    const evidenceLine = symbol.range.start.line
+
+    if (symbol.kind === 'method') {
+      // Re-parent: class symbol id is `_makeId(fileBaseStem, ClassName)`.
+      const dotAt = symbol.name.lastIndexOf('.')
+      if (dotAt <= 0) continue
+      const className = symbol.name.slice(0, dotAt)
+      const fileBaseStem = basename(file.path, extname(file.path))
+      const classNodeId = _makeId(fileBaseStem, className)
+      addUniqueEdge(
+        edges,
+        seenEdgeKeys,
+        createEdge(classNodeId, targetId, 'method', absPath, evidenceLine, 'EXTRACTED', 1.0),
+      )
+      continue
+    }
+
+    // file → top-level non-method symbol = `contains`.
+    const fileNodeId = fileIdToNodeId.get(symbol.file_id)
+    if (!fileNodeId) continue
+    addUniqueEdge(
+      edges,
+      seenEdgeKeys,
+      createEdge(fileNodeId, targetId, 'contains', absPath, evidenceLine, 'EXTRACTED', 1.0),
+    )
+  }
+}
+
+function resolveEndpoint(
+  spiId: string,
+  fileIdToNodeId: Map<string, string>,
+  symbolIdToNodeId: Map<string, string>,
+): string | null {
+  if (spiId.startsWith('file:')) return fileIdToNodeId.get(spiId) ?? null
+  if (spiId.startsWith('symbol:')) return symbolIdToNodeId.get(spiId) ?? null
+  return null
+}
+
+type Evidence = { sourceFile: string; line: number }
+
+function locateEvidence(
+  edge: SpiEdge,
+  fileById: Map<string, SpiFile>,
+  fileIdToNodeId: Map<string, string>,
+  symbolIdToNodeId: Map<string, string>,
+  symbolIdToSourceFile: Map<string, string>,
+  symbolIdToLine: Map<string, number>,
+  root: string,
+): Evidence | null {
+  if (edge.evidence) {
+    const file = fileById.get(edge.evidence.file_id)
+    if (file) {
+      return {
+        sourceFile: resolve(root, file.path),
+        line: edge.evidence.range.start.line,
+      }
+    }
+  }
+
+  // Fallback: attribute the edge to the source endpoint's file.
+  if (edge.from.startsWith('symbol:')) {
+    const sf = symbolIdToSourceFile.get(edge.from)
+    const line = symbolIdToLine.get(edge.from)
+    if (sf && line !== undefined) return { sourceFile: sf, line }
+  }
+  if (edge.from.startsWith('file:')) {
+    const file = lookupFileBySpiId(edge.from, fileById)
+    if (file) return { sourceFile: resolve(root, file.path), line: 1 }
+  }
+  return null
+}
+
+function lookupFileBySpiId(spiId: string, fileById: Map<string, SpiFile>): SpiFile | null {
+  return fileById.get(spiId) ?? null
+}

--- a/tests/unit/spi-projector.test.ts
+++ b/tests/unit/spi-projector.test.ts
@@ -1,0 +1,362 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import { projectSpiToExtraction } from '../../src/pipeline/spi/projector.js'
+import { extract } from '../../src/pipeline/extract.js'
+import { buildFromJson } from '../../src/pipeline/build.js'
+import type { ExtractionData, ExtractionEdge, ExtractionNode } from '../../src/contracts/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-10T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-projector-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function project(root: string): ExtractionData {
+  const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+  return projectSpiToExtraction(spi, { root })
+}
+
+function findNode(extraction: ExtractionData, id: string): ExtractionNode | undefined {
+  return extraction.nodes.find((n) => n.id === id)
+}
+
+function findEdges(
+  extraction: ExtractionData,
+  filter: { source?: string; target?: string; relation?: string },
+): ExtractionEdge[] {
+  return extraction.edges.filter((e) =>
+    (filter.source === undefined || e.source === filter.source) &&
+    (filter.target === undefined || e.target === filter.target) &&
+    (filter.relation === undefined || e.relation === filter.relation),
+  )
+}
+
+describe('projectSpiToExtraction (slice 1c-i of #72)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('file nodes', () => {
+    it('emits one file node per SpiFile with snake_case id and basename label', () => {
+      writeFile(sandbox, 'src/audit-log.ts', 'export class AuditLog {}\n')
+      const extraction = project(sandbox)
+
+      const node = findNode(extraction, 'audit_log')
+      expect(node).toBeTruthy()
+      expect(node?.label).toBe('audit-log.ts')
+      expect(node?.file_type).toBe('code')
+      expect(node?.source_location).toBe('L1')
+      expect(node?.layer).toBeDefined()
+      expect(node?.source_file).toBe(resolve(sandbox, 'src/audit-log.ts'))
+    })
+
+    it('attaches typescript-extractor provenance to file nodes', () => {
+      writeFile(sandbox, 'src/svc.ts', 'export const x = 1\n')
+      const extraction = project(sandbox)
+      const node = findNode(extraction, 'svc')
+      expect(node?.provenance).toBeDefined()
+      expect(node?.provenance?.[0]?.capability_id).toBe('builtin:extract:typescript')
+      expect(node?.provenance?.[0]?.stage).toBe('extract')
+    })
+  })
+
+  describe('symbol nodes', () => {
+    it('emits a class node with file-prefixed snake_case id', () => {
+      writeFile(sandbox, 'src/audit-log.ts', 'export class AuditLog {}\n')
+      const extraction = project(sandbox)
+
+      const cls = findNode(extraction, 'audit_log_auditlog')
+      expect(cls).toBeTruthy()
+      expect(cls?.label).toBe('AuditLog')
+      expect(cls?.source_location).toBe('L1')
+    })
+
+    it('emits a function node with `name()` label', () => {
+      writeFile(sandbox, 'src/app.ts', 'export function runDemoScenario(): void {}\n')
+      const extraction = project(sandbox)
+
+      const fn = findNode(extraction, 'app_rundemoscenario')
+      expect(fn).toBeTruthy()
+      expect(fn?.label).toBe('runDemoScenario()')
+    })
+
+    it('emits method nodes with `.name()` label and class-derived id', () => {
+      writeFile(sandbox, 'src/audit-log.ts', [
+        'export class AuditLog {',
+        '  append(): void {}',
+        '  listRecentEntries(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      const append = findNode(extraction, 'audit_log_auditlog_append')
+      const list = findNode(extraction, 'audit_log_auditlog_listrecententries')
+      expect(append?.label).toBe('.append()')
+      expect(list?.label).toBe('.listRecentEntries()')
+    })
+
+    it('emits constructor methods alongside named methods', () => {
+      writeFile(sandbox, 'src/auth-service.ts', [
+        'export class AuthService {',
+        '  constructor() {}',
+        '  loginWithPassword(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      const ctor = findNode(extraction, 'auth_service_authservice_constructor')
+      const login = findNode(extraction, 'auth_service_authservice_loginwithpassword')
+      expect(ctor?.label).toBe('.constructor()')
+      expect(login?.label).toBe('.loginWithPassword()')
+    })
+
+    it('emits interface, type-alias, and enum nodes with the symbol name as label', () => {
+      writeFile(sandbox, 'src/types.ts', [
+        'export interface User { id: string }',
+        'export type UserRole = "admin" | "member"',
+        'export enum Tier { Free, Pro }',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      expect(findNode(extraction, 'types_user')?.label).toBe('User')
+      expect(findNode(extraction, 'types_userrole')?.label).toBe('UserRole')
+      expect(findNode(extraction, 'types_tier')?.label).toBe('Tier')
+    })
+  })
+
+  describe('structural edges (contains / method)', () => {
+    it('emits a `contains` edge from file to top-level class', () => {
+      writeFile(sandbox, 'src/audit-log.ts', 'export class AuditLog {}\n')
+      const extraction = project(sandbox)
+
+      const edges = findEdges(extraction, {
+        source: 'audit_log',
+        target: 'audit_log_auditlog',
+        relation: 'contains',
+      })
+      expect(edges).toHaveLength(1)
+      expect(edges[0]?.confidence).toBe('EXTRACTED')
+    })
+
+    it('emits a `method` edge from class to method, NOT a `contains` edge from file to method', () => {
+      writeFile(sandbox, 'src/audit-log.ts', [
+        'export class AuditLog {',
+        '  append(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      const methodEdge = findEdges(extraction, {
+        source: 'audit_log_auditlog',
+        target: 'audit_log_auditlog_append',
+        relation: 'method',
+      })
+      expect(methodEdge).toHaveLength(1)
+
+      // No file → method `contains` edge.
+      const fileToMethod = findEdges(extraction, {
+        source: 'audit_log',
+        target: 'audit_log_auditlog_append',
+      })
+      expect(fileToMethod).toHaveLength(0)
+    })
+
+    it('emits a `contains` edge for a top-level function', () => {
+      writeFile(sandbox, 'src/app.ts', 'export function runDemoScenario(): void {}\n')
+      const extraction = project(sandbox)
+
+      const edges = findEdges(extraction, {
+        source: 'app',
+        target: 'app_rundemoscenario',
+        relation: 'contains',
+      })
+      expect(edges).toHaveLength(1)
+    })
+  })
+
+  describe('cross-symbol edges (imports_from / calls)', () => {
+    it('projects SPI imports edges to `imports_from` between file nodes', () => {
+      writeFile(sandbox, 'src/tenant-context.ts', 'export const tenant = "x"\n')
+      writeFile(sandbox, 'src/session-store.ts', 'import { tenant } from "./tenant-context.js"\nvoid tenant\n')
+      const extraction = project(sandbox)
+
+      const edges = findEdges(extraction, {
+        source: 'session_store',
+        target: 'tenant_context',
+        relation: 'imports_from',
+      })
+      expect(edges).toHaveLength(1)
+    })
+
+    it('projects SPI calls edges to `calls` between caller and callee symbols', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'export function helper(): number { return 1 }',
+        'export function caller(): number { return helper() }',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      const edges = findEdges(extraction, {
+        source: 'svc_caller',
+        target: 'svc_helper',
+        relation: 'calls',
+      })
+      expect(edges).toHaveLength(1)
+    })
+
+    it('drops self-edges (file `exports` self-loops in SPI are not emitted as extraction edges)', () => {
+      writeFile(sandbox, 'src/svc.ts', 'export const x = 1\n')
+      const extraction = project(sandbox)
+
+      const selfEdges = extraction.edges.filter((e) => e.source === e.target)
+      expect(selfEdges).toHaveLength(0)
+    })
+  })
+
+  describe('extends / implements edges', () => {
+    it('projects SPI extends edges to `extends` between class symbols', () => {
+      writeFile(sandbox, 'src/base.ts', 'export class Base {}\n')
+      writeFile(sandbox, 'src/derived.ts', [
+        'import { Base } from "./base.js"',
+        'export class Derived extends Base {}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      const edges = findEdges(extraction, {
+        source: 'derived_derived',
+        target: 'base_base',
+        relation: 'extends',
+      })
+      expect(edges).toHaveLength(1)
+    })
+
+    it('projects SPI implements edges to `implements` from class to interface', () => {
+      writeFile(sandbox, 'src/contract.ts', 'export interface Contract { id(): string }\n')
+      writeFile(sandbox, 'src/concrete.ts', [
+        'import type { Contract } from "./contract.js"',
+        'export class Concrete implements Contract {',
+        '  id(): string { return "" }',
+        '}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      const edges = findEdges(extraction, {
+        source: 'concrete_concrete',
+        target: 'contract_contract',
+        relation: 'implements',
+      })
+      expect(edges).toHaveLength(1)
+    })
+  })
+
+  describe('shape invariants', () => {
+    it('produces ExtractionData with schema_version: 1 and the standard top-level fields', () => {
+      writeFile(sandbox, 'src/x.ts', 'export const a = 1\n')
+      const extraction = project(sandbox)
+
+      expect(extraction.schema_version).toBe(1)
+      expect(extraction.nodes).toBeInstanceOf(Array)
+      expect(extraction.edges).toBeInstanceOf(Array)
+      expect(extraction.hyperedges).toEqual([])
+      expect(extraction.input_tokens).toBe(0)
+      expect(extraction.output_tokens).toBe(0)
+    })
+
+    it('every emitted node has id/label/file_type/source_file/source_location set', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'export class Svc {',
+        '  do(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+
+      for (const node of extraction.nodes) {
+        expect(typeof node.id).toBe('string')
+        expect(typeof node.label).toBe('string')
+        expect(typeof node.source_file).toBe('string')
+        expect(typeof node.source_location).toBe('string')
+        expect(node.file_type).toBe('code')
+      }
+    })
+
+    it('the projection feeds buildFromJson() without warnings', () => {
+      writeFile(sandbox, 'src/svc.ts', [
+        'export function caller(): number { return helper() }',
+        'export function helper(): number { return 1 }',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const graph = buildFromJson(extraction)
+
+      // Non-zero nodes/edges and the file→function/function→function edges land.
+      expect(graph.numberOfNodes()).toBeGreaterThan(0)
+      expect(graph.numberOfEdges()).toBeGreaterThan(0)
+    })
+  })
+
+  describe('comparison against the legacy extractor', () => {
+    it('produces the same file + class + method node ids as extract() on a small fixture', () => {
+      // Hand-crafted fixture exercising the legacy extractor's "core" surface
+      // (file node, class node, method nodes) which is exactly what slice
+      // 1c-i covers. Frameworks, cross-file resolution, generic call
+      // resolution etc. land in slice 1c-ii.
+      writeFile(sandbox, 'src/audit-log.ts', [
+        'export class AuditLog {',
+        '  append(): void {}',
+        '  listRecentEntries(): void {}',
+        '}',
+      ].join('\n') + '\n')
+
+      const projected = project(sandbox)
+      const legacy = extract([resolve(sandbox, 'src/audit-log.ts')])
+
+      const projectedIds = new Set(projected.nodes.map((n) => n.id))
+      const legacyIds = new Set(legacy.nodes.map((n) => n.id))
+
+      // Every node ID the legacy extractor produces for files/classes/methods
+      // (the slice 1c-i surface) must also appear in the projection. The
+      // projection is allowed to contain additional ids that the legacy
+      // extractor does not emit (e.g., enum-only files where the extractor
+      // takes a different code path).
+      const coreIds = ['audit_log', 'audit_log_auditlog', 'audit_log_auditlog_append', 'audit_log_auditlog_listrecententries']
+      for (const id of coreIds) {
+        expect(projectedIds.has(id)).toBe(true)
+        expect(legacyIds.has(id)).toBe(true)
+      }
+    })
+
+    it('emits the same `contains` and `method` relations as extract() on a small fixture', () => {
+      writeFile(sandbox, 'src/audit-log.ts', [
+        'export class AuditLog {',
+        '  append(): void {}',
+        '}',
+      ].join('\n') + '\n')
+
+      const projected = project(sandbox)
+      const legacy = extract([resolve(sandbox, 'src/audit-log.ts')])
+
+      const projectedRel = (s: string, t: string) =>
+        projected.edges.find((e) => e.source === s && e.target === t)?.relation
+      const legacyRel = (s: string, t: string) =>
+        legacy.edges.find((e) => e.source === s && e.target === t)?.relation
+
+      expect(projectedRel('audit_log', 'audit_log_auditlog')).toBe('contains')
+      expect(legacyRel('audit_log', 'audit_log_auditlog')).toBe('contains')
+      expect(projectedRel('audit_log_auditlog', 'audit_log_auditlog_append')).toBe('method')
+      expect(legacyRel('audit_log_auditlog', 'audit_log_auditlog_append')).toBe('method')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds the **structural** SPI → graph.json projector. Bridges `buildSpi(root) → SemanticProgramIndex` to the existing `buildFromJson() → cluster() → analyze() → toJson()` pipeline by producing `ExtractionData` of the same shape `extract()` produces.
- The projector reuses the exact id/label/provenance helpers from `src/pipeline/extract/core.ts` (`_makeId`, `createNode`, `createEdge`), so a file the projector emits matches what the legacy extractor would emit for the same path.
- Coverage matches what SPI v1 captures: file nodes, symbol nodes for nine SPI symbol kinds, `contains` / `method` structural edges, and cross-symbol `imports_from` / `calls` / `extends` / `implements` edges.

## Why this is **slice 1c-i**, not full slice 1c

Full byte-equivalence on `examples/demo-repo/graphify-out/graph.json` requires reproducing every legacy-extractor emission decision: framework-specific node kinds (Express / NestJS / Next.js / React Router / Redux), cross-file resolution heuristics, generic call resolution, non-code file extraction, snippet truncation rules — i.e. the full ~3,600 lines of `extract.ts`.

That port is its own multi-PR effort. Bundling it into this slice would violate the project's "split if >500 lines or covers >2 distinct concerns" rule. Splitting:

- **Slice 1c-i (this PR)** — Structural projector. Ships the bridge module + a comparison test against the legacy `extract()` on a small fixture. Does **not** trigger v0.14.0.
- **Slice 1c-ii (future)** — Port of the framework extractors and edge-case behaviors needed to achieve byte-equivalence on demo-repo. **This** is the v0.14.0 trigger.

## Edge-kind mapping table

| SPI edge kind | ExtractionEdge relation | Notes |
|---|---|---|
| `imports` | `imports_from` | File → file (resolved). Self-loop file `exports` are dropped. |
| `declares` (file → top-level non-method) | `contains` | Re-derived from SPI symbols, not from edges. |
| `declares` (file → method) | re-parented to `method` (class → method) | Parses `ClassName.methodName` to find the enclosing class node id. |
| `calls` | `calls` | Caller symbol → callee symbol. |
| `extends` | `extends` | |
| `implements` | `implements` | |

SPI confidence projects to extraction confidence: `high → EXTRACTED`, `medium → INFERRED`, `low → AMBIGUOUS`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test:run` — 85 files / **1526** tests pass (20 new for the projector + 1506 pre-existing)
- [x] Tests cover: file-node id/label/provenance format; every symbol-kind label/id pattern (function, class, method, constructor, interface, type-alias, enum); `contains` / `method` structural edges (incl. the negative assertion that file→method `contains` is NOT emitted); `imports_from` / `calls` / `extends` / `implements` projections; shape invariants (every node has id/label/file_type/source_file/source_location set, projection feeds `buildFromJson()` cleanly); a side-by-side comparison test that runs the legacy `extract()` and the new projector on the same small fixture and asserts matching node ids and edge relations.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## What's next

Slice 1c-ii — port the framework-specific extractors and remaining legacy-extractor surface to achieve full byte-equivalence on `examples/demo-repo/graphify-out/graph.json`. That's the v0.14.0 trigger.

Refs #70 (design), #72 (umbrella), #98 + #99 (parent slices 3b / 3b-ii).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a projector that processes semantic program indexes through the extraction pipeline, extracting program structure, symbols, class hierarchies, method relationships, and cross-symbol connections including imports, function calls, inheritance, and interface implementations.

* **Tests**
  * Added comprehensive unit test suite validating symbol and relationship extraction, source location tracking, file provenance, schema compliance, and consistency with the legacy extraction system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/100)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->