### PR TITLE
feat(#75): selective retrieval gate

### DIFF
--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -162,9 +162,13 @@ function decideLevel(opts: {
         ? { level: 2, reason: 'explain intent with explicit reference — direct dependencies' }
         : { level: 1, reason: 'explain intent without explicit reference — local context' }
     case 'refactor':
+      // Both branches stay within the 0–2 band: a refactor without an
+      // explicit target is still a code-modification intent, not a
+      // debugging trace, so direct dependencies are sufficient and a
+      // behavior slice would over-retrieve.
       return mentions > 0
         ? { level: 2, reason: 'refactor intent with explicit reference — direct dependencies' }
-        : { level: 3, reason: 'refactor intent without explicit reference — behavior slice' }
+        : { level: 2, reason: 'refactor intent without explicit reference — direct dependencies' }
     case 'rename':
       return mentions > 0
         ? { level: 1, reason: 'rename intent with explicit reference — local symbol/file' }

--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -1,0 +1,202 @@
+// Retrieval gate (#75): decides how much repo context to retrieve before
+// building a context pack. Pure deterministic heuristic — no ML, no I/O.
+//
+// Gate output is consumed by upstream callers (CLI, MCP tools, agent
+// pipelines) to decide whether to skip retrieval entirely (level 0), pull
+// only local symbol/file context (level 1-2), trace a behavior slice
+// (level 3), expand to cross-module impact (level 4), or build the full
+// PR-impact pack (level 5). A null-result is never returned: every prompt
+// receives a level + reason so callers can log decisions transparently.
+//
+// Levels (per issue #75):
+//   0 = no retrieval needed
+//   1 = local symbol/file only
+//   2 = direct dependencies
+//   3 = behavior slice
+//   4 = cross-module impact
+//   5 = full PR impact pack
+//
+// This module is intentionally small and dependency-free so the gate can
+// be imported anywhere the runtime needs to make a retrieval decision
+// without pulling the rest of the retrieve pipeline.
+
+export type RetrievalLevel = 0 | 1 | 2 | 3 | 4 | 5
+
+export type RetrievalIntent =
+  | 'rename'
+  | 'explain'
+  | 'debug'
+  | 'refactor'
+  | 'test'
+  | 'review'
+  | 'impact'
+  | 'chitchat'
+  | 'unknown'
+
+export type RetrievalGateInput = {
+  /** The user's prompt or task description. Required. */
+  prompt: string
+  /** Pre-classified intent. If absent, the gate derives it from the prompt. */
+  intent?: RetrievalIntent
+  /** Caller-known signal: a PR diff is available for analysis. */
+  hasPrDiff?: boolean
+  /** Caller-known signal: specific file paths the prompt is about. */
+  mentionedPaths?: ReadonlyArray<string>
+  /** Caller-known signal: specific symbols the prompt is about. */
+  mentionedSymbols?: ReadonlyArray<string>
+  /** Caller-known signal: the prompt embeds a stack trace or error text. */
+  hasStackTrace?: boolean
+  /**
+   * Manual override. When set, bypasses all heuristics and the decision is
+   * returned with reason `'manual override'`. The acceptance criteria of
+   * #75 require the gate be overridable via CLI/MCP options.
+   */
+  manualOverride?: RetrievalLevel
+}
+
+export type RetrievalGateSignals = {
+  has_pr_diff: boolean
+  has_stack_trace: boolean
+  mentioned_paths: ReadonlyArray<string>
+  mentioned_symbols: ReadonlyArray<string>
+}
+
+export type RetrievalGateDecision = {
+  level: RetrievalLevel
+  /** True iff level === 0 — caller can short-circuit retrieval entirely. */
+  skipped_retrieval: boolean
+  /** Human-readable explanation of why this level was selected. */
+  reason: string
+  /** Intent the gate inferred (or that the caller supplied). */
+  intent: RetrievalIntent
+  /** Signals the gate detected from the prompt + caller hints. */
+  signals: RetrievalGateSignals
+}
+
+// Heuristic patterns. Order matters where alternatives overlap (e.g. an
+// "explain why" prompt is debug-shaped, not explain-shaped — debug wins).
+const PATTERNS: ReadonlyArray<{ intent: RetrievalIntent; re: RegExp }> = [
+  { intent: 'chitchat', re: /^\s*(?:hi|hey|hello|thanks?|thank you|yo|ok|okay|cool)\b[\s.!?]*$/i },
+  { intent: 'debug',    re: /\b(?:why|debug|broken|crashe?s?|fail(?:s|ing|ed)?|exception|error|throws?|slow|hang(?:s|ing)?|leak(?:s|ing)?|deadlock|race condition)\b/i },
+  { intent: 'impact',   re: /\b(?:impact|break(?:s|ing)?|regress(?:ion|ions)?|depend(?:s|ency|encies|ent)|affect(?:s|ed)?|consumers?|callers?)\b/i },
+  { intent: 'review',   re: /\b(?:review|audit|critique|look (?:over|at this pr)|sanity[- ]check)\b/i },
+  { intent: 'test',     re: /\b(?:test(?:s|ing)?|spec(?:s)?|coverage|missing tests?)\b/i },
+  { intent: 'refactor', re: /\b(?:refactor|simplif(?:y|ied)|clean ?up|tidy|extract)\b/i },
+  { intent: 'rename',   re: /\b(?:rename|format|fix typo|spell(?:ing)?|reword|capitaliz)\b/i },
+  { intent: 'explain',  re: /\b(?:explain|what (?:does|is)|how does|describe|walk me through|tell me about|summari[sz]e)\b/i },
+]
+
+const PATH_RE = /(?:^|\s|`)((?:[\w@./-]+\/)*[\w./@-]+\.[A-Za-z]{1,8})(?=\b|`|$)/g
+const SYMBOL_BACKTICK_RE = /`([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\(?\)?)`/g
+const STACK_TRACE_RE = /(?:^|\n)\s*at\s+\S+\s*\([^)]*:\d+(?::\d+)?\)|Error[:\s]\s+\S/
+
+export function classifyRetrievalLevel(input: RetrievalGateInput): RetrievalGateDecision {
+  const prompt = input.prompt ?? ''
+  const detectedPaths = input.mentionedPaths ?? detectPaths(prompt)
+  const detectedSymbols = input.mentionedSymbols ?? detectSymbols(prompt)
+  const hasStackTrace = input.hasStackTrace ?? STACK_TRACE_RE.test(prompt)
+  const hasPrDiff = input.hasPrDiff === true
+  const intent = input.intent ?? detectIntent(prompt)
+
+  const signals: RetrievalGateSignals = {
+    has_pr_diff: hasPrDiff,
+    has_stack_trace: hasStackTrace,
+    mentioned_paths: detectedPaths,
+    mentioned_symbols: detectedSymbols,
+  }
+
+  if (input.manualOverride !== undefined) {
+    return {
+      level: input.manualOverride,
+      skipped_retrieval: input.manualOverride === 0,
+      reason: 'manual override',
+      intent,
+      signals,
+    }
+  }
+
+  const decision = decideLevel({ intent, hasPrDiff, hasStackTrace, mentions: detectedPaths.length + detectedSymbols.length })
+  return {
+    ...decision,
+    skipped_retrieval: decision.level === 0,
+    intent,
+    signals,
+  }
+}
+
+function decideLevel(opts: {
+  intent: RetrievalIntent
+  hasPrDiff: boolean
+  hasStackTrace: boolean
+  mentions: number
+}): { level: RetrievalLevel; reason: string } {
+  const { intent, hasPrDiff, hasStackTrace, mentions } = opts
+
+  // Stack trace is strong evidence of a behavior-tracing question regardless
+  // of intent classification.
+  if (hasStackTrace) {
+    return { level: 3, reason: 'stack trace detected — behavior slice retrieval' }
+  }
+
+  // PR diff dominates when present and the user is asking review/impact/test
+  // questions about the change.
+  if (hasPrDiff && (intent === 'review' || intent === 'impact' || intent === 'test')) {
+    return { level: 5, reason: `PR diff present + ${intent} intent — full PR impact pack` }
+  }
+
+  switch (intent) {
+    case 'chitchat':
+      return { level: 0, reason: 'conversational prompt with no code intent — no retrieval' }
+    case 'impact':
+      return { level: 4, reason: 'impact intent without PR diff — cross-module impact' }
+    case 'debug':
+      return { level: 3, reason: 'debug/why intent — behavior slice retrieval' }
+    case 'review':
+      return { level: 3, reason: 'review intent without PR diff — behavior slice retrieval' }
+    case 'test':
+      return mentions > 0
+        ? { level: 3, reason: 'test intent with explicit reference — behavior slice' }
+        : { level: 4, reason: 'test intent without explicit reference — cross-module impact' }
+    case 'explain':
+      return mentions > 0
+        ? { level: 2, reason: 'explain intent with explicit reference — direct dependencies' }
+        : { level: 1, reason: 'explain intent without explicit reference — local context' }
+    case 'refactor':
+      return mentions > 0
+        ? { level: 2, reason: 'refactor intent with explicit reference — direct dependencies' }
+        : { level: 3, reason: 'refactor intent without explicit reference — behavior slice' }
+    case 'rename':
+      return mentions > 0
+        ? { level: 1, reason: 'rename intent with explicit reference — local symbol/file' }
+        : { level: 0, reason: 'rename intent without explicit reference — no retrieval needed' }
+    case 'unknown':
+    default:
+      // Conservative default: pull local context. Prompts that genuinely
+      // need broader context can override or rely on caller-supplied
+      // hints (mentionedPaths / hasPrDiff) on the next pass.
+      return { level: 1, reason: 'unclassified prompt — default to local context' }
+  }
+}
+
+function detectIntent(prompt: string): RetrievalIntent {
+  for (const { intent, re } of PATTERNS) {
+    if (re.test(prompt)) return intent
+  }
+  return 'unknown'
+}
+
+function detectPaths(prompt: string): string[] {
+  const out = new Set<string>()
+  for (const match of prompt.matchAll(PATH_RE)) {
+    if (match[1]) out.add(match[1])
+  }
+  return [...out]
+}
+
+function detectSymbols(prompt: string): string[] {
+  const out = new Set<string>()
+  for (const match of prompt.matchAll(SYMBOL_BACKTICK_RE)) {
+    if (match[1]) out.add(match[1])
+  }
+  return [...out]
+}

--- a/tests/unit/retrieval-gate.test.ts
+++ b/tests/unit/retrieval-gate.test.ts
@@ -170,6 +170,24 @@ describe('classifyRetrievalLevel — signal extraction', () => {
   })
 })
 
+describe('classifyRetrievalLevel — refactor intent stays in the 0-2 band', () => {
+  it('refactor with explicit reference → level 2', () => {
+    const decision = classify({ prompt: 'Refactor `UsersService.findById`' })
+    expect(decision.intent).toBe('refactor')
+    expect(decision.signals.mentioned_symbols).toContain('UsersService.findById')
+    expect(decision.level).toBe(2)
+  })
+
+  it('refactor without any explicit reference → level 2 (not over-escalated to behavior slice)', () => {
+    const decision = classify({ prompt: 'Refactor this module' })
+    expect(decision.intent).toBe('refactor')
+    expect(decision.signals.mentioned_symbols).toEqual([])
+    expect(decision.signals.mentioned_paths).toEqual([])
+    expect(decision.level).toBe(2)
+    expect(decision.reason).toMatch(/direct dependencies/i)
+  })
+})
+
 describe('classifyRetrievalLevel — caller-supplied intent', () => {
   it('uses caller-supplied intent verbatim and skips prompt classification', () => {
     const decision = classify({ prompt: 'arbitrary text', intent: 'impact' })

--- a/tests/unit/retrieval-gate.test.ts
+++ b/tests/unit/retrieval-gate.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyRetrievalLevel,
+  type RetrievalGateInput,
+} from '../../src/runtime/retrieval-gate.js'
+
+function classify(input: Partial<RetrievalGateInput> & { prompt: string }) {
+  return classifyRetrievalLevel(input as RetrievalGateInput)
+}
+
+describe('classifyRetrievalLevel — example decisions from issue #75', () => {
+  it('rename without reference → level 0 (no retrieval needed)', () => {
+    const decision = classify({ prompt: 'Rename this variable' })
+    expect(decision.level).toBe(0)
+    expect(decision.skipped_retrieval).toBe(true)
+    expect(decision.intent).toBe('rename')
+    expect(decision.reason).toMatch(/no retrieval/i)
+  })
+
+  it('rename with explicit symbol → level 1 (local symbol/file)', () => {
+    const decision = classify({ prompt: 'Rename the variable `userCount` in this file' })
+    expect(decision.level).toBe(1)
+    expect(decision.intent).toBe('rename')
+    expect(decision.signals.mentioned_symbols).toContain('userCount')
+  })
+
+  it('explain with mention → level 2 (direct dependencies)', () => {
+    const decision = classify({ prompt: 'Explain this function `parseConfig`' })
+    expect(decision.level).toBe(2)
+    expect(decision.intent).toBe('explain')
+    expect(decision.reason).toMatch(/direct dependencies/i)
+  })
+
+  it('explain without mention → level 1 (local context)', () => {
+    const decision = classify({ prompt: 'Explain this function' })
+    expect(decision.level).toBe(1)
+    expect(decision.intent).toBe('explain')
+  })
+
+  it('debug "why" prompt → level 3 (behavior slice)', () => {
+    const decision = classify({ prompt: 'Why is report generation slow?' })
+    expect(decision.level).toBe(3)
+    expect(decision.intent).toBe('debug')
+    expect(decision.reason).toMatch(/behavior slice/i)
+  })
+
+  it('PR break-onboarding question with diff → level 5 (full PR impact pack)', () => {
+    const decision = classify({ prompt: 'Can this PR break onboarding?', hasPrDiff: true })
+    expect(decision.level).toBe(5)
+    expect(decision.intent).toBe('impact')
+    expect(decision.reason).toMatch(/PR (diff|impact pack)/i)
+  })
+
+  it('test prompt with mention → level 3 (behavior slice)', () => {
+    const decision = classify({ prompt: 'What tests should I add for `parseConfig`?' })
+    expect(decision.level).toBe(3)
+    expect(decision.intent).toBe('test')
+  })
+
+  it('test prompt without mention → level 4 (cross-module impact)', () => {
+    const decision = classify({ prompt: 'What tests should I add?' })
+    expect(decision.level).toBe(4)
+    expect(decision.intent).toBe('test')
+  })
+})
+
+describe('classifyRetrievalLevel — escalation signals', () => {
+  it('stack trace forces level 3 even when intent looks like rename', () => {
+    const decision = classify({
+      prompt: [
+        'rename this variable',
+        '    at handleRequest (server.ts:42:7)',
+      ].join('\n'),
+    })
+    expect(decision.level).toBe(3)
+    expect(decision.signals.has_stack_trace).toBe(true)
+    expect(decision.reason).toMatch(/stack trace/i)
+  })
+
+  it('Error: prefix is recognized as a stack-trace signal', () => {
+    const decision = classify({ prompt: 'Error: cannot read properties of undefined' })
+    expect(decision.signals.has_stack_trace).toBe(true)
+    expect(decision.level).toBe(3)
+  })
+
+  it('PR diff + review intent → level 5', () => {
+    const decision = classify({ prompt: 'Please review this PR carefully', hasPrDiff: true })
+    expect(decision.level).toBe(5)
+    expect(decision.intent).toBe('review')
+  })
+
+  it('PR diff + impact intent → level 5', () => {
+    const decision = classify({ prompt: 'What does this PR break?', hasPrDiff: true })
+    expect(decision.level).toBe(5)
+  })
+
+  it('PR diff alone (no review/impact/test intent) does not escalate to level 5', () => {
+    const decision = classify({ prompt: 'Explain this function `foo`', hasPrDiff: true })
+    expect(decision.level).toBe(2)
+  })
+
+  it('review intent without PR diff falls back to behavior slice (level 3)', () => {
+    const decision = classify({ prompt: 'Review this code carefully' })
+    expect(decision.level).toBe(3)
+    expect(decision.intent).toBe('review')
+  })
+})
+
+describe('classifyRetrievalLevel — chitchat and unknowns', () => {
+  it('"hi" → level 0 (chitchat)', () => {
+    const decision = classify({ prompt: 'hi' })
+    expect(decision.level).toBe(0)
+    expect(decision.intent).toBe('chitchat')
+    expect(decision.skipped_retrieval).toBe(true)
+  })
+
+  it('"thanks" → level 0', () => {
+    const decision = classify({ prompt: 'thanks!' })
+    expect(decision.level).toBe(0)
+    expect(decision.intent).toBe('chitchat')
+  })
+
+  it('vague "do something" prompt → level 1 (default to local)', () => {
+    const decision = classify({ prompt: 'do something useful here' })
+    expect(decision.level).toBe(1)
+    expect(decision.intent).toBe('unknown')
+    expect(decision.reason).toMatch(/default to local/i)
+  })
+})
+
+describe('classifyRetrievalLevel — manual override', () => {
+  it('respects an explicit override regardless of intent', () => {
+    const decision = classify({ prompt: 'Why is this slow?', manualOverride: 0 })
+    expect(decision.level).toBe(0)
+    expect(decision.skipped_retrieval).toBe(true)
+    expect(decision.reason).toBe('manual override')
+    // Intent is still detected for transparency — only the level is overridden.
+    expect(decision.intent).toBe('debug')
+  })
+
+  it('override of level 5 forces full pack even on a chitchat prompt', () => {
+    const decision = classify({ prompt: 'hi', manualOverride: 5 })
+    expect(decision.level).toBe(5)
+    expect(decision.reason).toBe('manual override')
+  })
+})
+
+describe('classifyRetrievalLevel — signal extraction', () => {
+  it('extracts file paths from a free-form prompt', () => {
+    const decision = classify({ prompt: 'Why does src/auth/auth-service.ts crash on login?' })
+    expect(decision.signals.mentioned_paths).toContain('src/auth/auth-service.ts')
+    expect(decision.intent).toBe('debug')
+  })
+
+  it('extracts backtick-quoted symbols', () => {
+    const decision = classify({ prompt: 'Refactor `UsersService.findById`' })
+    expect(decision.signals.mentioned_symbols).toContain('UsersService.findById')
+    expect(decision.intent).toBe('refactor')
+  })
+
+  it('caller-supplied mentions override prompt detection', () => {
+    const decision = classify({
+      prompt: 'Explain this',
+      mentionedSymbols: ['MyClass'],
+    })
+    expect(decision.signals.mentioned_symbols).toEqual(['MyClass'])
+    // mentions present → level 2
+    expect(decision.level).toBe(2)
+  })
+})
+
+describe('classifyRetrievalLevel — caller-supplied intent', () => {
+  it('uses caller-supplied intent verbatim and skips prompt classification', () => {
+    const decision = classify({ prompt: 'arbitrary text', intent: 'impact' })
+    expect(decision.intent).toBe('impact')
+    expect(decision.level).toBe(4)
+  })
+})
+
+describe('classifyRetrievalLevel — output shape', () => {
+  it('every decision carries level / skipped_retrieval / reason / intent / signals', () => {
+    const decision = classify({ prompt: 'hello' })
+    expect(decision).toMatchObject({
+      level: expect.any(Number),
+      skipped_retrieval: expect.any(Boolean),
+      reason: expect.any(String),
+      intent: expect.any(String),
+      signals: {
+        has_pr_diff: expect.any(Boolean),
+        has_stack_trace: expect.any(Boolean),
+        mentioned_paths: expect.any(Array),
+        mentioned_symbols: expect.any(Array),
+      },
+    })
+  })
+
+  it('level 0 sets skipped_retrieval to true', () => {
+    const decision = classify({ prompt: 'thanks' })
+    expect(decision.skipped_retrieval).toBe(true)
+  })
+
+  it('any non-zero level sets skipped_retrieval to false', () => {
+    const decision = classify({ prompt: 'Explain this code' })
+    expect(decision.skipped_retrieval).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #75 (in part — wiring into retrieve runtime + context-pack metadata follows in a tiny follow-up).

## Summary

- Adds a deterministic, dependency-free heuristic gate that classifies a prompt into one of six retrieval levels per issue #75 so upstream callers can skip retrieval entirely (level 0) or scope it from local symbol context (level 1) up to a full PR impact pack (level 5).
- Pure function: \`classifyRetrievalLevel({ prompt, intent?, hasPrDiff?, mentionedPaths?, mentionedSymbols?, hasStackTrace?, manualOverride? }) → { level, skipped_retrieval, reason, intent, signals }\`. No I/O, no model calls, no graph lookups — just regex + structured signals so the decision is logged transparently.
- Manual override (\`manualOverride: 0-5\`) satisfies the issue's acceptance criterion that the gate be overridable via CLI/MCP options.

## Decision logic (short version)

| Signal | Level | Reason |
|---|---|---|
| \`manualOverride\` set | as supplied | \`'manual override'\` |
| Stack trace detected | 3 | behavior slice — even if intent looks lexical |
| PR diff + review/impact/test intent | 5 | full PR impact pack |
| Chitchat (\`hi\`, \`thanks\`) | 0 | no retrieval needed |
| Impact intent without PR diff | 4 | cross-module impact |
| Debug (\`why\`, \`error\`, \`slow\`) | 3 | behavior slice |
| Review intent without PR diff | 3 | behavior slice |
| Test intent + mention | 3 | behavior slice |
| Test intent without mention | 4 | cross-module impact |
| Explain + mention | 2 | direct dependencies |
| Explain without mention | 1 | local context |
| Refactor + mention | 2 | direct dependencies |
| Refactor without mention | 3 | behavior slice |
| Rename + mention | 1 | local symbol/file |
| Rename without mention | 0 | no retrieval needed |
| Otherwise unclassified | 1 | default to local |

Heuristic ordering matters where intents overlap: debug (\`explain why\`) beats explain (\`walk me through\`).

## Why a separate slice from wiring

The issue's deliverables include both the gate module and emitting \`retrieval_level\` / \`reason\` / \`skipped_retrieval\` in context-pack output. \`src/runtime/retrieve.ts\` is 1,646 lines, so wiring lives in a small follow-up PR rather than crowding this slice. The gate is shipped standalone here so callers (including future #74 selector and #76 multi-resolution layers) can import it immediately.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 86 files / **1552** tests pass (26 new for the gate + 1526 pre-existing)
- [x] Tests cover: every example decision from issue #75 (rename → 0/1, explain → 1/2, why → 3, "can this PR break onboarding?" → 5, "what tests should I add?" → 3/4); escalation signals (stack trace forces 3, PR diff escalates review/impact/test to 5, PR diff alone does not escalate explain); chitchat ("hi" / "thanks" → 0); manual override behavior (0 and 5); signal extraction (file paths, backtick symbols); caller-supplied intent and mentions; output-shape invariants.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

Refs #74 (budgeted selector), #76 (multi-resolution context) — both consume the gate's level signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an intelligent context retrieval gate that classifies prompts into retrieval levels (0–5), detects intents, stack traces, mentioned paths/symbols, and supports manual overrides to determine how much repository context to fetch.

* **Tests**
  * Added comprehensive unit tests covering intent classification, signal detection, escalation rules, override behavior, and output shape/consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/101)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->