### PR TITLE
feat(#75): carry retrieval-gate decision in context-pack output

### DIFF
--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -1,3 +1,4 @@
+import type { RetrievalGateDecision } from './retrieval-gate.js'
 import type { TaskIntentKind } from './task-intent.js'
 
 export type ContextPackTaskKind = 'explain' | 'review' | 'impact'
@@ -148,4 +149,11 @@ export interface CompiledContextPack<
   coverage: ContextPackCoverage
   graph_signals?: ContextPackGraphSignals
   shared_file_type?: string
+  /**
+   * Retrieval-gate decision (#75) attached when the caller invoked the
+   * gate before building the pack. Carries `level`, `reason`, `intent`,
+   * `skipped_retrieval`, and the underlying signals so consumers can
+   * audit why a retrieval depth was chosen.
+   */
+  retrieval_gate?: RetrievalGateDecision
 }

--- a/src/contracts/retrieval-gate.ts
+++ b/src/contracts/retrieval-gate.ts
@@ -1,0 +1,39 @@
+// Retrieval gate (#75) — contract types.
+//
+// These types describe the *output* of the retrieval gate: the classification
+// surface that callers and downstream consumers (e.g., context-pack output)
+// rely on. The gate's runtime function plus its `RetrievalGateInput` shape
+// live in src/runtime/retrieval-gate.ts; only the types that cross the
+// runtime↔contract boundary belong here.
+
+export type RetrievalLevel = 0 | 1 | 2 | 3 | 4 | 5
+
+export type RetrievalIntent =
+  | 'rename'
+  | 'explain'
+  | 'debug'
+  | 'refactor'
+  | 'test'
+  | 'review'
+  | 'impact'
+  | 'chitchat'
+  | 'unknown'
+
+export interface RetrievalGateSignals {
+  has_pr_diff: boolean
+  has_stack_trace: boolean
+  mentioned_paths: ReadonlyArray<string>
+  mentioned_symbols: ReadonlyArray<string>
+}
+
+export interface RetrievalGateDecision {
+  level: RetrievalLevel
+  /** True iff level === 0 — caller can short-circuit retrieval entirely. */
+  skipped_retrieval: boolean
+  /** Human-readable explanation of why this level was selected. */
+  reason: string
+  /** Intent the gate inferred (or that the caller supplied). */
+  intent: RetrievalIntent
+  /** Signals the gate detected from the prompt + caller hints. */
+  signals: RetrievalGateSignals
+}

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -20,6 +20,7 @@ import type {
   ContextPackTaskContract,
   ContextPackTaskKind,
 } from '../contracts/context-pack.js'
+import type { RetrievalGateDecision } from '../contracts/retrieval-gate.js'
 import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { estimateQueryTokens } from './serve.js'
 import { resolveTaskEvidenceRecipe } from './task-evidence-recipes.js'
@@ -56,6 +57,13 @@ export interface CompileContextPackInput<
   relationships?: readonly TRelationship[]
   community_context?: readonly TCommunity[]
   graph_signals?: ContextPackGraphSignals
+  /**
+   * Retrieval-gate decision (#75). When supplied, the resulting
+   * CompiledContextPack carries it through unchanged so consumers can
+   * audit retrieval scope. The gate is *not* re-classified here — callers
+   * compute it once and pass the result down.
+   */
+  retrieval_gate?: RetrievalGateDecision
 }
 
 export type CompactContextPackMode =
@@ -668,6 +676,7 @@ export function compileContextPack<
           },
         }
       : {}),
+    ...(input.retrieval_gate ? { retrieval_gate: input.retrieval_gate } : {}),
   }
 }
 

--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -16,22 +16,23 @@
 //   4 = cross-module impact
 //   5 = full PR impact pack
 //
-// This module is intentionally small and dependency-free so the gate can
-// be imported anywhere the runtime needs to make a retrieval decision
-// without pulling the rest of the retrieve pipeline.
+// The output type lives in src/contracts/retrieval-gate.ts so callers
+// (e.g. CompiledContextPack) can carry the decision without depending on
+// the runtime classifier itself.
 
-export type RetrievalLevel = 0 | 1 | 2 | 3 | 4 | 5
+import type {
+  RetrievalGateDecision,
+  RetrievalGateSignals,
+  RetrievalIntent,
+  RetrievalLevel,
+} from '../contracts/retrieval-gate.js'
 
-export type RetrievalIntent =
-  | 'rename'
-  | 'explain'
-  | 'debug'
-  | 'refactor'
-  | 'test'
-  | 'review'
-  | 'impact'
-  | 'chitchat'
-  | 'unknown'
+export type {
+  RetrievalGateDecision,
+  RetrievalGateSignals,
+  RetrievalIntent,
+  RetrievalLevel,
+} from '../contracts/retrieval-gate.js'
 
 export type RetrievalGateInput = {
   /** The user's prompt or task description. Required. */
@@ -52,25 +53,6 @@ export type RetrievalGateInput = {
    * #75 require the gate be overridable via CLI/MCP options.
    */
   manualOverride?: RetrievalLevel
-}
-
-export type RetrievalGateSignals = {
-  has_pr_diff: boolean
-  has_stack_trace: boolean
-  mentioned_paths: ReadonlyArray<string>
-  mentioned_symbols: ReadonlyArray<string>
-}
-
-export type RetrievalGateDecision = {
-  level: RetrievalLevel
-  /** True iff level === 0 — caller can short-circuit retrieval entirely. */
-  skipped_retrieval: boolean
-  /** Human-readable explanation of why this level was selected. */
-  reason: string
-  /** Intent the gate inferred (or that the caller supplied). */
-  intent: RetrievalIntent
-  /** Signals the gate detected from the prompt + caller hints. */
-  signals: RetrievalGateSignals
 }
 
 // Heuristic patterns. Order matters where alternatives overlap (e.g. an

--- a/tests/unit/context-pack-retrieval-gate.test.ts
+++ b/tests/unit/context-pack-retrieval-gate.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ContextPackNode } from '../../src/contracts/context-pack.js'
+import type { RetrievalGateDecision } from '../../src/contracts/retrieval-gate.js'
+import {
+  classifyTaskContract,
+  compactContextPack,
+  compileContextPack,
+  type ContextPackNodeCandidate,
+} from '../../src/runtime/context-pack.js'
+import { classifyRetrievalLevel } from '../../src/runtime/retrieval-gate.js'
+
+function nodeCandidate(
+  entry: ContextPackNode,
+  evidenceClass: 'primary' | 'supporting' | 'structural' | 'change' | 'impact',
+  tokenCost: number,
+): ContextPackNodeCandidate<ContextPackNode> {
+  return {
+    label: entry.label,
+    ...(typeof entry.node_id === 'string' ? { node_id: entry.node_id } : {}),
+    community: entry.community ?? null,
+    ...(typeof entry.source_file === 'string' ? { source_file: entry.source_file } : {}),
+    ...(typeof entry.line_number === 'number' ? { line_number: entry.line_number } : {}),
+    ...(typeof entry.file_type === 'string' ? { file_type: entry.file_type } : {}),
+    ...(typeof entry.node_kind === 'string' ? { node_kind: entry.node_kind } : {}),
+    ...(typeof entry.snippet === 'string' ? { snippet: entry.snippet } : {}),
+    evidence_class: evidenceClass,
+    estimate_tokens: () => tokenCost,
+    build_entry: () => ({ ...entry, evidence_class: evidenceClass }),
+  }
+}
+
+function sampleCandidate(): ContextPackNodeCandidate<ContextPackNode> {
+  return nodeCandidate({
+    node_id: 'auth_service',
+    label: 'AuthService',
+    source_file: 'src/auth.ts',
+    line_number: 10,
+    file_type: 'code',
+    snippet: 'export class AuthService {}',
+    match_score: 9,
+    relevance_band: 'direct',
+    community: 0,
+    community_label: 'Auth',
+  }, 'primary', 5)
+}
+
+function sampleContract(prompt: string) {
+  return classifyTaskContract('explain', { budget: 100, prompt })
+}
+
+describe('compileContextPack — retrieval-gate metadata (#75-ii)', () => {
+  it('omits the retrieval_gate field when the caller does not supply one', () => {
+    const pack = compileContextPack({
+      task_contract: sampleContract('explain `AuthService`'),
+      nodes: [sampleCandidate()],
+    })
+    expect(pack.retrieval_gate).toBeUndefined()
+  })
+
+  it('attaches the supplied retrieval_gate decision unchanged', () => {
+    const decision = classifyRetrievalLevel({ prompt: 'explain `AuthService`' })
+    const pack = compileContextPack({
+      task_contract: sampleContract('explain `AuthService`'),
+      nodes: [sampleCandidate()],
+      retrieval_gate: decision,
+    })
+
+    expect(pack.retrieval_gate).toBeDefined()
+    expect(pack.retrieval_gate).toEqual(decision)
+    expect(pack.retrieval_gate?.intent).toBe('explain')
+    expect(pack.retrieval_gate?.level).toBe(2)
+    expect(pack.retrieval_gate?.skipped_retrieval).toBe(false)
+  })
+
+  it('carries the gate decision through compactContextPack (review mode)', () => {
+    const decision: RetrievalGateDecision = {
+      level: 5,
+      skipped_retrieval: false,
+      reason: 'PR diff present + review intent',
+      intent: 'review',
+      signals: { has_pr_diff: true, has_stack_trace: false, mentioned_paths: [], mentioned_symbols: [] },
+    }
+    const pack = compileContextPack({
+      task_contract: classifyTaskContract('review', { budget: 100, prompt: 'review this PR' }),
+      nodes: [sampleCandidate()],
+      retrieval_gate: decision,
+    })
+
+    const compacted = compactContextPack(pack, { kind: 'review', seed_node_ids: ['auth_service'] })
+    expect(compacted.retrieval_gate).toEqual(decision)
+  })
+
+  it('carries the gate decision through compactContextPack (retrieve mode)', () => {
+    const decision: RetrievalGateDecision = {
+      level: 0,
+      skipped_retrieval: true,
+      reason: 'manual override',
+      intent: 'chitchat',
+      signals: { has_pr_diff: false, has_stack_trace: false, mentioned_paths: [], mentioned_symbols: [] },
+    }
+    const pack = compileContextPack({
+      task_contract: sampleContract('hello'),
+      nodes: [sampleCandidate()],
+      retrieval_gate: decision,
+    })
+
+    const compacted = compactContextPack(pack, { kind: 'retrieve' })
+    expect(compacted.retrieval_gate).toEqual(decision)
+    expect(compacted.retrieval_gate?.skipped_retrieval).toBe(true)
+  })
+
+  it('preserves all gate signals (paths, symbols, stack-trace flag, PR-diff flag) on the carried decision', () => {
+    const decision = classifyRetrievalLevel({
+      prompt: 'why does src/auth/auth-service.ts crash on `loginWithPassword`?',
+      hasPrDiff: false,
+    })
+    const pack = compileContextPack({
+      task_contract: sampleContract('why does it crash?'),
+      nodes: [sampleCandidate()],
+      retrieval_gate: decision,
+    })
+
+    expect(pack.retrieval_gate?.signals.mentioned_paths).toContain('src/auth/auth-service.ts')
+    expect(pack.retrieval_gate?.signals.mentioned_symbols).toContain('loginWithPassword')
+    expect(pack.retrieval_gate?.signals.has_pr_diff).toBe(false)
+    expect(pack.retrieval_gate?.signals.has_stack_trace).toBe(false)
+    expect(pack.retrieval_gate?.intent).toBe('debug')
+    expect(pack.retrieval_gate?.level).toBe(3)
+  })
+
+  it('does not affect the rest of the pack when a gate decision is supplied', () => {
+    const decision = classifyRetrievalLevel({ prompt: 'explain `AuthService`' })
+    const withGate = compileContextPack({
+      task_contract: sampleContract('explain `AuthService`'),
+      nodes: [sampleCandidate()],
+      retrieval_gate: decision,
+    })
+    const withoutGate = compileContextPack({
+      task_contract: sampleContract('explain `AuthService`'),
+      nodes: [sampleCandidate()],
+    })
+
+    // Pack contents are identical apart from the new metadata field.
+    expect(withGate.token_count).toBe(withoutGate.token_count)
+    expect(withGate.nodes).toEqual(withoutGate.nodes)
+    expect(withGate.relationships).toEqual(withoutGate.relationships)
+    expect(withGate.coverage).toEqual(withoutGate.coverage)
+  })
+})


### PR DESCRIPTION
Closes the remaining acceptance criterion of #75: explanatory metadata in context-pack output. Builds on #101 (the gate module).

## Summary

- Promotes `RetrievalLevel` / `RetrievalIntent` / `RetrievalGateSignals` / `RetrievalGateDecision` from a runtime-only export to `src/contracts/retrieval-gate.ts` so the contract layer can reference them without depending on the runtime classifier. The runtime module now re-exports the same types from the contract, keeping a single source of truth.
- Adds `retrieval_gate?: RetrievalGateDecision` to `CompiledContextPack` and `CompileContextPackInput`. `compileContextPack` attaches the supplied decision unchanged. `compactContextPack` already preserved the field through its existing `...pack` spread on both review and retrieve modes — no code change needed there, but a regression test pins each mode.
- The decision flows in (caller computes it once with `classifyRetrievalLevel(...)`) and out (it sits on the pack for downstream consumers); the runtime does not re-classify.

## Architecture note

This is the **wiring** slice. The CLI / MCP entry-point hooks — so the gate runs automatically when a context pack is built from a user prompt and the decision shows up in stdio responses — are intentionally a follow-up. The contract is in place so those callers can attach the field without touching the runtime again. Splitting keeps each PR small and reviewable.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test:run` — 87 files / **1560** tests pass (6 new for the wiring + 1554 pre-existing)
- [x] Tests cover: \`retrieval_gate\` omitted when no gate is supplied; attached decision is byte-equal to input; decision flows through both \`compactContextPack\` modes (review + retrieve); all five signal fields (mentioned_paths, mentioned_symbols, has_pr_diff, has_stack_trace, intent) survive round-trip; supplying a gate decision does not change any other field of the resulting pack (token_count, nodes, relationships, coverage all match the no-gate baseline).
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

Refs #101 (gate module), #74 (budgeted selector — will consume the level signal), #76 (multi-resolution context — same).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieval gate decisions are now tracked and propagated through context packs, carrying audit information including retrieval level, intent, reason, and contextual signals.
  * Support for retrieval level classification (0–5) and multiple intent categories to enable fine-grained control over context retrieval behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->