### PR TITLE
feat(#75): run retrieval gate at MCP/CLI entry points + surface in output

### DIFF
--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -4,6 +4,8 @@ import type { KnowledgeGraph } from '../contracts/graph.js'
 import type { TaskContextPlan } from '../contracts/task-context-plan.js'
 import type { PackCliOptions } from '../cli/parser.js'
 import { classifyTaskContract, compileContextPack, estimateContextPackEntryTokens, type ContextPackNodeCandidate } from '../runtime/context-pack.js'
+import type { RetrievalGateDecision } from '../contracts/retrieval-gate.js'
+import { classifyRetrievalLevel } from '../runtime/retrieval-gate.js'
 import { pickImpactTarget } from '../runtime/context-pack-target.js'
 import { analyzeImpact, compactImpactResult, type ImpactResult } from '../runtime/impact.js'
 import { analyzePrImpact, compactPrImpactResult, type PrImpactResult } from '../runtime/pr-impact.js'
@@ -39,6 +41,7 @@ interface ContextPlaneMetadata {
   coverage: ContextPackCoverage
   missing_context: ContextPackEvidenceClass[]
   missing_semantic: ContextPackCoverage['missing_semantic']
+  retrieval_gate?: RetrievalGateDecision
 }
 
 function emptyCoverage(): ContextPackCoverage {
@@ -60,6 +63,7 @@ function contextMetadata(
     claims: ContextPackClaim[]
     expandable: ContextPackExpandableRef[]
     coverage: ContextPackCoverage
+    retrieval_gate: RetrievalGateDecision
   }>,
 ): ContextPlaneMetadata {
   const coverage = payload.coverage ?? emptyCoverage()
@@ -69,6 +73,7 @@ function contextMetadata(
     coverage,
     missing_context: coverage.missing_required,
     missing_semantic: coverage.missing_semantic,
+    ...(payload.retrieval_gate ? { retrieval_gate: payload.retrieval_gate } : {}),
   }
 }
 
@@ -149,6 +154,7 @@ function impactMetadata(
     task_contract: classifyTaskContract('impact', { budget, prompt, task_intent: taskIntent }),
     nodes: candidates,
     community_context: result.affected_communities,
+    retrieval_gate: classifyRetrievalLevel({ prompt }),
   })
 
   return contextMetadata(pack)

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -25,6 +25,8 @@ import {
   estimateContextPackEntryTokens,
   type ContextPackNodeCandidate,
 } from './context-pack.js'
+import type { RetrievalGateDecision } from '../contracts/retrieval-gate.js'
+import { classifyRetrievalLevel } from './retrieval-gate.js'
 import { communitiesFromGraph, estimateQueryTokens } from './serve.js'
 
 const SNIPPET_HALF_WINDOW = 7
@@ -106,6 +108,7 @@ export interface RetrieveResult {
   claims?: ContextPackClaim[]
   expandable?: ContextPackExpandableRef[]
   coverage?: ContextPackCoverage
+  retrieval_gate?: RetrievalGateDecision
 }
 
 export interface CompactRetrieveMatchedNode extends Omit<RetrieveMatchedNode, 'community_label' | 'file_type' | 'framework_boost'> {
@@ -1131,6 +1134,7 @@ function buildRetrieveResultFromOrderedCandidates(
       }))
       .sort((left, right) => right.node_count - left.node_count),
     graph_signals: graphSignalLabels,
+    retrieval_gate: classifyRetrievalLevel({ prompt: options.question }),
   })
 
   return {
@@ -1144,6 +1148,7 @@ function buildRetrieveResultFromOrderedCandidates(
     claims: pack.claims,
     expandable: pack.expandable,
     coverage: pack.coverage,
+    ...(pack.retrieval_gate ? { retrieval_gate: pack.retrieval_gate } : {}),
   }
 }
 
@@ -1163,6 +1168,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       relationships: [],
       community_context: [],
       graph_signals: { god_nodes: [], bridge_nodes: [] },
+      retrieval_gate: classifyRetrievalLevel({ prompt: question }),
     })
 
     return {
@@ -1176,6 +1182,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       claims: emptyPack.claims,
       expandable: emptyPack.expandable,
       coverage: emptyPack.coverage,
+      ...(emptyPack.retrieval_gate ? { retrieval_gate: emptyPack.retrieval_gate } : {}),
     }
   }
 

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -19,6 +19,8 @@ import { validateGraphPath } from '../../shared/security.js'
 import { featureMap } from '../feature-map.js'
 import { implementationChecklist } from '../implementation-checklist.js'
 import { classifyTaskContract, compileContextPack, estimateContextPackEntryTokens, type ContextPackNodeCandidate } from '../context-pack.js'
+import type { RetrievalGateDecision } from '../../contracts/retrieval-gate.js'
+import { classifyRetrievalLevel } from '../retrieval-gate.js'
 import { pickImpactTarget } from '../context-pack-target.js'
 import { analyzeImpact, callChains, compactImpactResult, type ImpactResult } from '../impact.js'
 import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
@@ -83,6 +85,7 @@ interface ContextPlaneMetadata {
   coverage: ContextPackCoverage
   missing_context: ContextPackEvidenceClass[]
   missing_semantic: ContextPackCoverage['missing_semantic']
+  retrieval_gate?: RetrievalGateDecision
 }
 
 interface StoredContextPackHandle {
@@ -138,6 +141,7 @@ function contextMetadata(
     claims: ContextPackClaim[]
     expandable: ContextPackExpandableRef[]
     coverage: ContextPackCoverage
+    retrieval_gate: RetrievalGateDecision
   }>,
 ): ContextPlaneMetadata {
   const coverage = payload.coverage ?? emptyCoverage()
@@ -147,6 +151,7 @@ function contextMetadata(
     coverage,
     missing_context: coverage.missing_required,
     missing_semantic: coverage.missing_semantic,
+    ...(payload.retrieval_gate ? { retrieval_gate: payload.retrieval_gate } : {}),
   }
 }
 
@@ -317,6 +322,7 @@ function impactMetadata(
     task_contract: classifyTaskContract('impact', { budget, prompt, task_intent: taskIntent }),
     nodes: candidates,
     community_context: result.affected_communities,
+    retrieval_gate: classifyRetrievalLevel({ prompt }),
   })
 
   return contextMetadata(pack)
@@ -509,6 +515,7 @@ function buildFocusedExpansionPayload(
         node_count: (communities[communityId] ?? []).length,
       }))
       .sort((left, right) => right.node_count - left.node_count),
+    retrieval_gate: classifyRetrievalLevel({ prompt: stored.prompt }),
   })
   const retrieval: RetrieveResult = {
     question: stored.prompt,

--- a/tests/unit/retrieval-gate-entry-points.test.ts
+++ b/tests/unit/retrieval-gate-entry-points.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { build } from '../../src/pipeline/build.js'
+import { retrieveContext } from '../../src/runtime/retrieve.js'
+
+function buildSmallGraph(): KnowledgeGraph {
+  return build([
+    {
+      schema_version: 1,
+      nodes: [
+        {
+          id: 'auth_service',
+          label: 'AuthService',
+          file_type: 'code',
+          source_file: 'src/auth.ts',
+          source_location: 'L1',
+        },
+      ],
+      edges: [],
+    },
+  ])
+}
+
+describe('retrieveContext attaches retrieval_gate metadata (#75 entry-point hook)', () => {
+  it('attaches a retrieval_gate decision when the question is matched', () => {
+    const graph = buildSmallGraph()
+    const result = retrieveContext(graph, { question: 'explain `AuthService`', budget: 1000 })
+
+    expect(result.retrieval_gate).toBeDefined()
+    expect(result.retrieval_gate?.intent).toBe('explain')
+    expect(result.retrieval_gate?.level).toBeGreaterThanOrEqual(1)
+    expect(result.retrieval_gate?.signals.mentioned_symbols).toContain('AuthService')
+    expect(result.retrieval_gate?.signals.has_pr_diff).toBe(false)
+  })
+
+  it('attaches a retrieval_gate decision on the empty-question branch (no tokens after stop-word filter)', () => {
+    const graph = buildSmallGraph()
+    // 'how does the' is all stop words → tokenizeQuestion returns [] → empty branch.
+    const result = retrieveContext(graph, { question: 'how does the', budget: 1000 })
+
+    expect(result.token_count).toBe(0)
+    expect(result.matched_nodes).toEqual([])
+    expect(result.retrieval_gate).toBeDefined()
+    expect(result.retrieval_gate?.signals).toBeDefined()
+  })
+
+  it('classifies a debug-shaped question as debug intent at level 3', () => {
+    const graph = buildSmallGraph()
+    const result = retrieveContext(graph, { question: 'why does `AuthService` crash on login?', budget: 1000 })
+
+    expect(result.retrieval_gate?.intent).toBe('debug')
+    expect(result.retrieval_gate?.level).toBe(3)
+  })
+
+  it('classifies a chitchat question as chitchat (level 0, skipped_retrieval=true) — even though we still build a result shape', () => {
+    const graph = buildSmallGraph()
+    // Chitchat goes through the empty-question branch because tokenizeQuestion
+    // strips all words.
+    const result = retrieveContext(graph, { question: 'thanks', budget: 1000 })
+
+    expect(result.retrieval_gate?.intent).toBe('chitchat')
+    expect(result.retrieval_gate?.level).toBe(0)
+    expect(result.retrieval_gate?.skipped_retrieval).toBe(true)
+  })
+
+  it('preserves the gate decision across both retrieve paths so callers can rely on it always being present', () => {
+    const graph = buildSmallGraph()
+    const matched = retrieveContext(graph, { question: 'auth', budget: 1000 })
+    const empty = retrieveContext(graph, { question: 'a b c', budget: 1000 })
+
+    // Both results carry the field, regardless of whether retrieval matched.
+    expect(matched.retrieval_gate).toBeDefined()
+    expect(empty.retrieval_gate).toBeDefined()
+  })
+})


### PR DESCRIPTION
Closes the entry-point loop on #75. Builds on #101 (gate module) and #102 (context-pack metadata).

## Summary

- The gate now runs on every prompt-receiving entry point: \`retrieveContext()\`, the two stdio MCP context-pack tools, and the CLI's impact context-pack path. The gate's \`RetrievalGateDecision\` is attached to the produced pack and surfaced to clients via the response shape.
- \`RetrieveResult\` grows an optional \`retrieval_gate\` field. \`ContextPlaneMetadata\` (in both stdio/tools.ts and context-pack-command.ts) grows the same field, and \`contextMetadata()\` picks it up from the supplied pack so any tool already merging metadata into its response inherits the gate decision automatically.
- 20 src-line diff across 3 entry-point files. The wiring is intentionally one-line per call site:

```ts
const pack = compileContextPack({
  task_contract: classifyTaskContract(...),
  nodes: ...,
  retrieval_gate: classifyRetrievalLevel({ prompt }),
})
```

## Behavior on edge cases

- Empty/whitespace-only prompts go through \`tokenizeQuestion\` which returns \`[]\`. The empty-question branch in \`retrieveContext()\` now also attaches a \`retrieval_gate\` so callers can rely on the field being present regardless of which path was taken.
- Chitchat prompts (\`"hi"\`, \`"thanks"\`) classify as \`level: 0\` / \`skipped_retrieval: true\` so MCP clients can skip downstream context construction without re-running the classifier.
- \`"why does X crash?"\` style prompts classify as \`debug\` intent / \`level: 3\`, telling clients a behavior slice is appropriate.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 88 files / **1565** tests pass (5 new for entry-point hook + 1560 pre-existing)
- [x] Tests cover: matched-question branch attaches the gate decision (intent + level + signals); empty-question branch (all-stop-words / token list empty) still attaches; debug-shaped questions classify as debug → level 3; chitchat → level 0 with skipped_retrieval=true; both paths consistently expose the field so callers don't need conditional handling.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## What's left

This was the last load-bearing piece of issue #75. After merge, the gate is wired end-to-end: module → context-pack metadata → entry points → output. Future enhancements (CLI flag for manual override, MCP option to override per-call) are small follow-ups but not blocking.

Refs #101 (gate module), #102 (metadata wiring).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal context retrieval system with improved classification mechanisms across multiple components.
  * Expanded metadata handling to include retrieval categorization throughout the system pipeline.

* **Tests**
  * Added comprehensive test coverage for retrieval classification across various query types and scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/103)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->