### PR TITLE
feat(#75): expose retrieval-level manual override via CLI/MCP options

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -28,6 +28,10 @@ export interface PackCliOptions {
   budget: number
   task: ContextPackTaskKind
   graphPath: string
+  /** #75 manual override for the retrieval gate. When set (0-5), the gate
+   *  emits a decision with reason 'manual override' at the supplied level
+   *  instead of running its heuristic classifier on the prompt. */
+  retrievalLevel?: 0 | 1 | 2 | 3 | 4 | 5
 }
 
 export type PromptCliProvider = 'claude' | 'gemini'
@@ -394,7 +398,7 @@ export function parseQueryArgs(args: string[]): QueryCliOptions {
 }
 
 export function parsePackArgs(args: string[]): PackCliOptions {
-  const usage = 'Usage: graphify-ts pack "<prompt>" [--budget N] [--task KIND] [--graph path]'
+  const usage = 'Usage: graphify-ts pack "<prompt>" [--budget N] [--task KIND] [--graph path] [--retrieval-level 0-5]'
   const prompt = args[0]?.trim()
   if (!prompt) {
     throw new UsageError(usage)
@@ -403,6 +407,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
   let budget = 3000
   let task: ContextPackTaskKind = 'explain'
   let graphPath = 'graphify-out/graph.json'
+  let retrievalLevel: PackCliOptions['retrievalLevel'] | undefined
 
   const normalizedPrompt = validateCliQuestionText('prompt', prompt)
 
@@ -452,6 +457,18 @@ export function parsePackArgs(args: string[]): PackCliOptions {
       continue
     }
 
+    if (argument === '--retrieval-level') {
+      retrievalLevel = parseRetrievalLevel(requireOptionValue('--retrieval-level', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--retrieval-level=')) {
+      const [, value] = argument.split('=', 2)
+      retrievalLevel = parseRetrievalLevel(requireOptionValue('--retrieval-level', value))
+      continue
+    }
+
     throw new UsageError(`error: unknown option for pack: ${argument}`)
   }
 
@@ -460,7 +477,16 @@ export function parsePackArgs(args: string[]): PackCliOptions {
     budget,
     task,
     graphPath,
+    ...(retrievalLevel !== undefined ? { retrievalLevel } : {}),
   }
+}
+
+function parseRetrievalLevel(value: string): PackCliOptions['retrievalLevel'] {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 5) {
+    throw new UsageError(`error: --retrieval-level must be an integer between 0 and 5 (got ${JSON.stringify(value)})`)
+  }
+  return parsed as PackCliOptions['retrievalLevel']
 }
 
 export function parsePromptArgs(args: string[]): PromptCliOptions {

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -17,7 +17,7 @@ const DEFAULT_IMPACT_DEPTH = 3
 
 export interface ContextPackCommandDependencies {
   loadGraph: (graphPath: string) => KnowledgeGraph
-  retrieveContext: (graph: KnowledgeGraph, options: { question: string; budget: number; taskIntent?: TaskContextPlan['evidence']['recipe_id'] }) => RetrieveResult
+  retrieveContext: (graph: KnowledgeGraph, options: Pick<import('../runtime/retrieve.js').RetrieveOptions, 'question' | 'budget' | 'taskIntent' | 'retrievalLevel'>) => RetrieveResult
   compactRetrieveResult: typeof compactRetrieveResult
   analyzePrImpact: (graph: KnowledgeGraph, projectDir?: string, options?: { baseBranch?: string; depth?: number; budget?: number; taskIntent?: TaskContextPlan['evidence']['recipe_id'] }) => PrImpactResult
   compactPrImpactResult: typeof compactPrImpactResult
@@ -134,6 +134,7 @@ function impactMetadata(
   budget: number,
   prompt: string,
   taskIntent: TaskContextPlan['evidence']['recipe_id'],
+  retrievalLevelOverride?: PackCliOptions['retrievalLevel'],
 ): ContextPlaneMetadata {
   const candidates: ContextPackNodeCandidate<ContextPackNode>[] = []
 
@@ -154,7 +155,10 @@ function impactMetadata(
     task_contract: classifyTaskContract('impact', { budget, prompt, task_intent: taskIntent }),
     nodes: candidates,
     community_context: result.affected_communities,
-    retrieval_gate: classifyRetrievalLevel({ prompt }),
+    retrieval_gate: classifyRetrievalLevel({
+      prompt,
+      ...(retrievalLevelOverride !== undefined ? { manualOverride: retrievalLevelOverride } : {}),
+    }),
   })
 
   return contextMetadata(pack)
@@ -213,6 +217,7 @@ export async function runContextPackCommand(
       question: options.prompt,
       budget: plannerBudget,
       taskIntent: initialPlan.evidence.recipe_id,
+      ...(options.retrievalLevel !== undefined ? { retrievalLevel: options.retrievalLevel } : {}),
     })
     const impactTarget = pickImpactTarget(retrieval)
     const communityLabels = buildCommunityLabels(graph, communitiesFromGraph(graph))
@@ -226,7 +231,7 @@ export async function runContextPackCommand(
       ...baseResponse(options, initialPlan, plannerBudget),
       target: impactTarget,
       pack: impactPack,
-      ...impactMetadata(impactResult, plannerBudget, options.prompt, initialPlan.evidence.recipe_id),
+      ...impactMetadata(impactResult, plannerBudget, options.prompt, initialPlan.evidence.recipe_id, options.retrievalLevel),
     })
   }
 
@@ -234,6 +239,7 @@ export async function runContextPackCommand(
     question: options.prompt,
     budget: plannerBudget,
     taskIntent: initialPlan.evidence.recipe_id,
+    ...(options.retrievalLevel !== undefined ? { retrievalLevel: options.retrievalLevel } : {}),
   })
   const explainPack = dependencies.compactRetrieveResult(retrieval)
 

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -25,7 +25,7 @@ import {
   estimateContextPackEntryTokens,
   type ContextPackNodeCandidate,
 } from './context-pack.js'
-import type { RetrievalGateDecision } from '../contracts/retrieval-gate.js'
+import type { RetrievalGateDecision, RetrievalLevel } from '../contracts/retrieval-gate.js'
 import { classifyRetrievalLevel } from './retrieval-gate.js'
 import { communitiesFromGraph, estimateQueryTokens } from './serve.js'
 
@@ -60,6 +60,11 @@ export interface RetrieveOptions {
   semanticModel?: string
   rerank?: boolean
   rerankerModel?: string
+  /** #75 manual override for the retrieval gate. When set (0-5), the gate
+   *  bypasses heuristic classification and emits a decision with reason
+   *  'manual override' at the supplied level. Caller-side surface for the
+   *  acceptance criterion that the gate be overridable via CLI/MCP. */
+  retrievalLevel?: RetrievalLevel
 }
 
 export interface RetrieveMatchedNode {
@@ -1134,7 +1139,10 @@ function buildRetrieveResultFromOrderedCandidates(
       }))
       .sort((left, right) => right.node_count - left.node_count),
     graph_signals: graphSignalLabels,
-    retrieval_gate: classifyRetrievalLevel({ prompt: options.question }),
+    retrieval_gate: classifyRetrievalLevel({
+      prompt: options.question,
+      ...(options.retrievalLevel !== undefined ? { manualOverride: options.retrievalLevel } : {}),
+    }),
   })
 
   return {
@@ -1168,7 +1176,10 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       relationships: [],
       community_context: [],
       graph_signals: { god_nodes: [], bridge_nodes: [] },
-      retrieval_gate: classifyRetrievalLevel({ prompt: question }),
+      retrieval_gate: classifyRetrievalLevel({
+        prompt: question,
+        ...(options.retrievalLevel !== undefined ? { manualOverride: options.retrievalLevel } : {}),
+      }),
     })
 
     return {

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -756,7 +756,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       // already enforces the range and returns null for absent/out-of-range
       // values, so we only forward when the argument is present.
       const retrieveLevelOverride = helpers.numberParamAlias(toolArguments, ['retrieval_level', 'retrievalLevel'], { min: 0, max: 5 })
-      if (Object.hasOwn(toolArguments, 'retrieval_level') && retrieveLevelOverride === null) {
+      if ((Object.hasOwn(toolArguments, 'retrieval_level') || Object.hasOwn(toolArguments, 'retrievalLevel')) && retrieveLevelOverride === null) {
         return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_level must be an integer between 0 and 5')
       }
       const retrieveLevelTyped = retrieveLevelOverride === null ? null : (retrieveLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)
@@ -835,7 +835,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       }
 
       const contextPackLevelOverride = helpers.numberParamAlias(toolArguments, ['retrieval_level', 'retrievalLevel'], { min: 0, max: 5 })
-      if (Object.hasOwn(toolArguments, 'retrieval_level') && contextPackLevelOverride === null) {
+      if ((Object.hasOwn(toolArguments, 'retrieval_level') || Object.hasOwn(toolArguments, 'retrievalLevel')) && contextPackLevelOverride === null) {
         return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_level must be an integer between 0 and 5')
       }
       const contextPackLevelTyped = contextPackLevelOverride === null ? null : (contextPackLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -302,6 +302,7 @@ function impactMetadata(
   budget: number,
   prompt: string,
   taskIntent: TaskContextPlan['evidence']['recipe_id'],
+  retrievalLevelOverride?: 0 | 1 | 2 | 3 | 4 | 5,
 ): ContextPlaneMetadata {
   const candidates: ContextPackNodeCandidate<ContextPackNode>[] = []
 
@@ -322,7 +323,10 @@ function impactMetadata(
     task_contract: classifyTaskContract('impact', { budget, prompt, task_intent: taskIntent }),
     nodes: candidates,
     community_context: result.affected_communities,
-    retrieval_gate: classifyRetrievalLevel({ prompt }),
+    retrieval_gate: classifyRetrievalLevel({
+      prompt,
+      ...(retrievalLevelOverride !== undefined ? { manualOverride: retrievalLevelOverride } : {}),
+    }),
   })
 
   return contextMetadata(pack)
@@ -747,6 +751,15 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const retrieveRerank = toolArguments.rerank === true
       const retrieveSemanticModel = helpers.stringParamAlias(toolArguments, ['semantic_model', 'semanticModel'])
       const retrieveRerankModel = helpers.stringParamAlias(toolArguments, ['rerank_model', 'rerankModel'])
+      // #75 manual override: numeric retrieval_level argument (0-5) bypasses
+      // the gate's heuristics and forces the supplied level. numberParamAlias
+      // already enforces the range and returns null for absent/out-of-range
+      // values, so we only forward when the argument is present.
+      const retrieveLevelOverride = helpers.numberParamAlias(toolArguments, ['retrieval_level', 'retrievalLevel'], { min: 0, max: 5 })
+      if (Object.hasOwn(toolArguments, 'retrieval_level') && retrieveLevelOverride === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_level must be an integer between 0 and 5')
+      }
+      const retrieveLevelTyped = retrieveLevelOverride === null ? null : (retrieveLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)
       const retrieval = retrieveSemantic || retrieveRerank ? retrieveContextAsync(graph, {
         question,
         budget: retrieveBudget,
@@ -756,11 +769,13 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         ...(retrieveSemanticModel ? { semanticModel: retrieveSemanticModel } : {}),
         ...(retrieveRerank ? { rerank: true } : {}),
         ...(retrieveRerankModel ? { rerankerModel: retrieveRerankModel } : {}),
+        ...(retrieveLevelTyped !== null ? { retrievalLevel: retrieveLevelTyped } : {}),
       }) : Promise.resolve(retrieveContext(graph, {
         question,
         budget: retrieveBudget,
         ...(retrieveCommunity !== null ? { community: retrieveCommunity } : {}),
           ...(retrieveFileType ? { fileType: retrieveFileType } : {}),
+          ...(retrieveLevelTyped !== null ? { retrievalLevel: retrieveLevelTyped } : {}),
         }))
       const useVerboseRetrieve = toolArguments.verbose === true || toolArguments.compact === false
       return retrieval.then((result) => helpers.ok(id, helpers.textToolResult(JSON.stringify(
@@ -819,10 +834,16 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         })))
       }
 
+      const contextPackLevelOverride = helpers.numberParamAlias(toolArguments, ['retrieval_level', 'retrievalLevel'], { min: 0, max: 5 })
+      if (Object.hasOwn(toolArguments, 'retrieval_level') && contextPackLevelOverride === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_level must be an integer between 0 and 5')
+      }
+      const contextPackLevelTyped = contextPackLevelOverride === null ? null : (contextPackLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)
       const retrieval = retrieveContext(graph, {
         question: prompt,
         budget: resolvedBudget,
         taskIntent: initialPlan.evidence.recipe_id,
+        ...(contextPackLevelTyped !== null ? { retrievalLevel: contextPackLevelTyped } : {}),
       })
 
       if (task === 'impact') {
@@ -836,7 +857,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           depth: 3,
         })
         const impactPack = compactImpactResult(impactResult)
-        const metadata = impactMetadata(impactResult, resolvedBudget, prompt, initialPlan.evidence.recipe_id)
+        const metadata = impactMetadata(impactResult, resolvedBudget, prompt, initialPlan.evidence.recipe_id, contextPackLevelTyped ?? undefined)
         storeExpandableHandles(prompt, task, initialPlan.evidence.recipe_id, metadata.expandable, helpers)
         return helpers.ok(id, helpers.textToolResult(JSON.stringify({
           ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),

--- a/tests/unit/retrieval-gate-override-surface.test.ts
+++ b/tests/unit/retrieval-gate-override-surface.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { parsePackArgs } from '../../src/cli/parser.js'
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { build } from '../../src/pipeline/build.js'
+import { retrieveContext } from '../../src/runtime/retrieve.js'
+
+function buildSmallGraph(): KnowledgeGraph {
+  return build([
+    {
+      schema_version: 1,
+      nodes: [
+        {
+          id: 'auth_service',
+          label: 'AuthService',
+          file_type: 'code',
+          source_file: 'src/auth.ts',
+          source_location: 'L1',
+        },
+      ],
+      edges: [],
+    },
+  ])
+}
+
+describe('parsePackArgs --retrieval-level (#75 manual override CLI surface)', () => {
+  it('accepts --retrieval-level <N> with a separate value', () => {
+    const opts = parsePackArgs(['"explain auth"', '--retrieval-level', '0'])
+    expect(opts.retrievalLevel).toBe(0)
+  })
+
+  it('accepts --retrieval-level=N with an inline value', () => {
+    const opts = parsePackArgs(['"explain auth"', '--retrieval-level=5'])
+    expect(opts.retrievalLevel).toBe(5)
+  })
+
+  it('omits retrievalLevel when the flag is not provided', () => {
+    const opts = parsePackArgs(['"explain auth"'])
+    expect(opts.retrievalLevel).toBeUndefined()
+  })
+
+  it('rejects out-of-range levels', () => {
+    expect(() => parsePackArgs(['"explain auth"', '--retrieval-level', '6'])).toThrow(/between 0 and 5/)
+    expect(() => parsePackArgs(['"explain auth"', '--retrieval-level', '-1'])).toThrow(/between 0 and 5/)
+  })
+
+  it('rejects non-integer levels', () => {
+    expect(() => parsePackArgs(['"explain auth"', '--retrieval-level', '1.5'])).toThrow(/integer/)
+    expect(() => parsePackArgs(['"explain auth"', '--retrieval-level', 'foo'])).toThrow(/integer/)
+  })
+
+  it('rejects --retrieval-level without a value', () => {
+    expect(() => parsePackArgs(['"explain auth"', '--retrieval-level'])).toThrow()
+  })
+})
+
+describe('retrieveContext honors options.retrievalLevel (#75 manual override runtime surface)', () => {
+  it('forces level 0 (skipped_retrieval=true) regardless of prompt', () => {
+    const graph = buildSmallGraph()
+    const result = retrieveContext(graph, {
+      question: 'why does AuthService crash on login?', // would normally classify as debug → level 3
+      budget: 1000,
+      retrievalLevel: 0,
+    })
+
+    expect(result.retrieval_gate?.level).toBe(0)
+    expect(result.retrieval_gate?.skipped_retrieval).toBe(true)
+    expect(result.retrieval_gate?.reason).toBe('manual override')
+    // Intent is still detected for transparency.
+    expect(result.retrieval_gate?.intent).toBe('debug')
+  })
+
+  it('forces level 5 even on a chitchat prompt', () => {
+    const graph = buildSmallGraph()
+    const result = retrieveContext(graph, {
+      question: 'thanks',
+      budget: 1000,
+      retrievalLevel: 5,
+    })
+
+    expect(result.retrieval_gate?.level).toBe(5)
+    expect(result.retrieval_gate?.reason).toBe('manual override')
+    expect(result.retrieval_gate?.intent).toBe('chitchat')
+  })
+
+  it('the empty-question branch also honors the override', () => {
+    const graph = buildSmallGraph()
+    const result = retrieveContext(graph, {
+      question: 'how does the', // all-stop-words → empty branch
+      budget: 1000,
+      retrievalLevel: 4,
+    })
+
+    expect(result.token_count).toBe(0)
+    expect(result.retrieval_gate?.level).toBe(4)
+    expect(result.retrieval_gate?.reason).toBe('manual override')
+  })
+
+  it('without the override, the gate runs heuristic classification as before', () => {
+    const graph = buildSmallGraph()
+    const result = retrieveContext(graph, {
+      question: 'explain `AuthService`',
+      budget: 1000,
+    })
+
+    expect(result.retrieval_gate?.intent).toBe('explain')
+    expect(result.retrieval_gate?.level).toBe(2)
+    expect(result.retrieval_gate?.reason).not.toBe('manual override')
+  })
+})


### PR DESCRIPTION
Closes the last load-bearing acceptance criterion of #75: *"the gate can be overridden manually via CLI/MCP options."* Builds on #101 (gate module), #102 (context-pack metadata), #103 (entry-point hook).

## Summary

- **CLI** — \`graphify-ts pack "<prompt>" --retrieval-level <0-5>\` (and the \`--retrieval-level=N\` form). Range-validated; rejects non-integers, out-of-range values, and missing values with clear UsageError messages. \`PackCliOptions\` grows an optional \`retrievalLevel\` field of the typed \`RetrievalLevel\` union.
- **MCP** — both \`retrieve\` and \`context_pack\` tools accept a \`retrieval_level\` argument (with \`retrievalLevel\` alias) parsed via \`numberParamAlias\` with \`{ min: 0, max: 5 }\`. Out-of-range values return \`jsonrpcInvalidParams\` with a precise message.
- **Runtime** — \`RetrieveOptions\` grows \`retrievalLevel?: RetrievalLevel\`. Both \`retrieveContext\` paths (matched and empty-question) forward it to \`classifyRetrievalLevel\` as \`manualOverride\`. The CLI command's \`impactMetadata\` and the MCP \`impactMetadata\` helpers now both accept and thread the override so the impact-task path also honors it.

When the override is supplied, the resulting \`RetrievalGateDecision\` carries \`reason: 'manual override'\` and the supplied level. Intent detection still runs for transparency in the \`intent\` field — only the level is overridden.

## Behavior

| Without override | \`--retrieval-level 0\` | \`--retrieval-level 5\` |
|---|---|---|
| \`"why does X crash?"\` → debug → 3 | \`level: 0\` (skipped_retrieval=true) | \`level: 5\` |
| \`"thanks"\` → chitchat → 0 | \`level: 0\` | \`level: 5\` |
| \`"explain foo"\` → explain → 1 or 2 | \`level: 0\` | \`level: 5\` |

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 89 files / **1575** tests pass (10 new for override + 1565 pre-existing)
- [x] Tests cover: CLI parser accepts both \`--retrieval-level N\` and \`--retrieval-level=N\` forms; rejects out-of-range (\`6\`, \`-1\`); rejects non-integers (\`1.5\`, \`foo\`); rejects missing values; retrieveContext honors the override on the matched-question and empty-question branches; override of \`5\` forces level 5 even on chitchat (\`"thanks"\`); without override, heuristic classification still runs (\`"explain foo"\` → \`level: 2\`).
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## Issue closure

After this PR lands, **issue #75 is wired end-to-end**: gate module → context-pack metadata → MCP/CLI entry points → output, with manual override available at every entry point.

Refs #101 (gate module), #102 (context-pack metadata), #103 (entry-point hook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional --retrieval-level CLI flag for the pack command (values 0–5) to manually override retrieval gating.
  * Supports both --retrieval-level <N> and --retrieval-level=N syntax.
  * Manual retrieval-level override is respected across retrieval and context-pack operations for consistent results.

* **Tests**
  * Added unit tests validating CLI parsing, validation, and runtime behavior of the retrieval-level override.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/104)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->