### PR TITLE
feat(#82): cut MCP core-profile schema overhead by 30%

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ PR-review proof on a real diff:
 
 Receipts: [`docs/benchmarks/2026-05-02-govalidate-pr-review/`](docs/benchmarks/2026-05-02-govalidate-pr-review/).
 
-> **The honest summary**: graphify-ts adds a one-time MCP/tool overhead at session start (~13% on cold starts). Multi-question sessions amortize this and end up cheaper. Cost trade-offs depend on session length; see **Honest disclosure** below.
+> **The honest summary**: graphify-ts adds a one-time MCP/tool overhead at session start (now ~750 tokens of tool schema for the core profile, down from ~1,070 after [#82](https://github.com/mohanagy/graphify-ts/pull/?q=is%3Apr+82) — a 30% drop). Multi-question sessions amortize this and end up cheaper. Cost trade-offs depend on session length; see **Honest disclosure** below.
 
 ---
 
@@ -239,7 +239,7 @@ The only command that hits an external service is the optional `compare` / `revi
 
 We measure and publish honest numbers, including the trade-offs. Smaller context is not automatically better unless the selected context is relevant — which is why graphify-ts ships coverage contracts (`benchmark`, `eval`, `review-compare`) that prove the smaller pack still contains the required evidence.
 
-1. **Cold-start sessions cost about 13% more than no-graph baseline** because the MCP server adds ~5K of tool-schema overhead at session init. Multi-question sessions amortize this and end up cheaper. We're tightening it further; watch the changelog.
+1. **Cold-start sessions add a one-time MCP/tool-schema cost at session init.** As of #82 the core (6-tool) profile emits **~3,000 bytes / ~750 tokens** on `tools/list` (down from ~4,270 bytes / ~1,070 tokens, a 30% reduction). The cold-start premium against the no-graph baseline scales with that number; the previously documented "~13%" figure was measured against the older 5K overhead and will be re-benchmarked in the next release. Multi-question sessions amortize this overhead and end up cheaper. A regression test (`tests/unit/mcp-schema-budget.test.ts`) pins the byte ceiling so future tool additions can't silently re-inflate it.
 2. **Deep extraction is best on JS/TS** with framework-aware passes for Express, Redux Toolkit, React Router, NestJS, and Next.js. Python / Ruby / Go / Java / Rust use tree-sitter AST. C / Kotlin / C# / Scala / PHP / Swift / Zig use a generic structural extractor.
 3. **Static analysis cannot resolve every dynamic runtime behavior.** Runtime-generated routes, heavy meta-programmed decorators, and string-built imports fall back to the base AST graph rather than pretending to be first-class semantics.
 4. **Token reduction depends on project structure and task type.** "How does auth work?" benefits more than "fix this typo." Always validate important code changes with tests and review.
@@ -266,7 +266,7 @@ Planned:
 - 🔜 Better PR-impact coverage scoring on diff hotspots
 - 🔜 Cache-aware prompt layout that minimizes Claude session-cache invalidation
 - 🔜 Delta-only context packs between runs (only ship what the agent doesn't already have)
-- 🔜 Tighter cold-start MCP overhead (currently ~5K of tool schema)
+- ✅ Tighter cold-start MCP overhead (core profile ~3,000 bytes, down from ~4,270 — 30% drop, see #82)
 - 🔜 More framework-aware passes (Prisma, tRPC, Hono, Fastify)
 - 🔜 Deeper Python / Go semantic passes beyond tree-sitter AST
 

--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -151,8 +151,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     name: 'community_overview',
-    description:
-      'Get a micro-level overview of all communities — names, sizes, and top nodes. Use this first to understand the codebase structure before diving into specific communities.',
+    description: 'Overview of all communities: names, sizes, top nodes. Call first to map the codebase before zooming in.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -160,76 +159,70 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   },
   {
     name: 'impact',
-    description:
-      'Analyze the blast radius of changing a node. Returns direct dependents, transitive dependents, affected files, and affected communities. Use this before making changes to understand what could break.',
+    description: 'Blast-radius for a node: direct + transitive dependents, affected files and communities.',
     inputSchema: {
       type: 'object',
       required: ['label'],
       properties: {
-        label: { type: 'string', description: 'Label of the node to analyze impact for' },
-        depth: { type: 'number', description: 'Maximum traversal depth (default 3, max 5)' },
+        label: { type: 'string', description: 'Node label' },
+        depth: { type: 'number', description: 'Max traversal depth (default 3, max 5)' },
         edge_types: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Optional: limit to specific edge types (e.g. ["calls", "imports_from"])',
+          description: 'Limit to edge types (e.g. ["calls","imports_from"])',
         },
-        verbose: { type: 'boolean', description: 'Optional: return the legacy verbose impact payload instead of the default compact response.' },
-        compact: { type: 'boolean', description: 'Deprecated alias: use verbose=false or omit both flags for the default compact response.' },
+        verbose: { type: 'boolean', description: 'Return verbose payload (default: compact)' },
       },
     },
   },
   {
     name: 'call_chain',
-    description:
-      'Find all execution paths between two nodes filtered by call/import edges. Returns ordered chains showing how execution flows from source to target.',
+    description: 'Ordered execution paths between two nodes via call/import edges.',
     inputSchema: {
       type: 'object',
       required: ['source', 'target'],
       properties: {
         source: { type: 'string', description: 'Starting node label' },
         target: { type: 'string', description: 'Target node label' },
-        max_hops: { type: 'number', description: 'Maximum chain length (default 8)' },
+        max_hops: { type: 'number', description: 'Max chain length (default 8)' },
         edge_types: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Edge types to follow (default: ["calls", "imports_from"])',
+          description: 'Edge types to follow (default: ["calls","imports_from"])',
         },
       },
     },
   },
   {
     name: 'pr_impact',
-    description:
-      'Analyze the impact of current git changes against the knowledge graph. Parses git diff, finds affected nodes, and computes blast radius across the codebase. Use before creating a PR to understand risk.',
+    description: 'Blast-radius of current git changes: parses diff, finds affected nodes, computes review bundle.',
     inputSchema: {
       type: 'object',
       properties: {
-        base_branch: { type: 'string', description: 'Base branch to diff against (default: auto-detect main/master)' },
-        depth: { type: 'number', description: 'Blast radius depth (default 3)' },
+        base_branch: { type: 'string', description: 'Base branch (default: auto-detect main/master)' },
+        depth: { type: 'number', description: 'Blast-radius depth (default 3)' },
         budget: { type: 'number', description: 'Review bundle token budget (default 2000)' },
-        verbose: { type: 'boolean', description: 'Optional: return the legacy verbose pr_impact payload instead of the default compact response.' },
-        compact: { type: 'boolean', description: 'Deprecated alias: use verbose=false or omit both flags for the default compact response.' },
+        verbose: { type: 'boolean', description: 'Return verbose payload (default: compact)' },
       },
     },
   },
   {
     name: 'retrieve',
-    description:
-      'Retrieve relevant context from the knowledge graph for a natural language question. Returns matched nodes with code snippets, relationships, community context, and structural signals (god nodes, bridges). Use this as the primary tool for answering codebase questions.',
+    description: 'Graph-relevant context for a natural-language question: matched nodes + snippets, relationships, community context, structural signals.',
     inputSchema: {
       type: 'object',
       required: ['question', 'budget'],
       properties: {
-        question: { type: 'string', description: 'Natural language question about the codebase' },
-        budget: { type: 'number', description: 'Maximum tokens to return in the context bundle' },
-        community: { type: 'number', description: 'Optional: limit retrieval to one community id' },
-        file_type: { type: 'string', description: 'Optional: limit retrieval to one file type (e.g. code, document)' },
-        semantic: { type: 'boolean', description: 'Optional: enable local embedding-based semantic fallback for conceptual queries.' },
-        semantic_model: { type: 'string', description: 'Optional: override the local embedding model or local model path used when semantic=true.' },
-        rerank: { type: 'boolean', description: 'Optional: enable local cross-encoder reranking for the candidate pool.' },
-        rerank_model: { type: 'string', description: 'Optional: override the local reranker model or local model path used when rerank=true.' },
-        verbose: { type: 'boolean', description: 'Optional: return the legacy verbose retrieve payload instead of the default compact response.' },
-        compact: { type: 'boolean', description: 'Deprecated alias: use verbose=false or omit both flags for the default compact response.' },
+        question: { type: 'string', description: 'Natural-language question' },
+        budget: { type: 'number', description: 'Max tokens in the context bundle' },
+        community: { type: 'number', description: 'Filter to one community id' },
+        file_type: { type: 'string', description: 'Filter to one file type (e.g. code, document)' },
+        semantic: { type: 'boolean', description: 'Enable embedding-based semantic fallback' },
+        semantic_model: { type: 'string', description: 'Override semantic model or local path' },
+        rerank: { type: 'boolean', description: 'Enable cross-encoder reranking' },
+        rerank_model: { type: 'string', description: 'Override reranker model or local path' },
+        verbose: { type: 'boolean', description: 'Return verbose payload (default: compact)' },
+        retrieval_level: { type: 'number', description: 'Override retrieval-gate level 0-5 (#75)' },
       },
     },
   },

--- a/tests/unit/mcp-schema-budget.test.ts
+++ b/tests/unit/mcp-schema-budget.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { activeMcpTools, MCP_TOOLS } from '../../src/runtime/stdio/definitions.js'
+
+// #82 — pin the JSON byte size of the MCP tool list emitted on tools/list so a
+// future tool addition or description regression can't silently re-inflate the
+// cold-start cache_creation_input_tokens cost. Keep these numbers tight; if a
+// new tool genuinely needs more bytes, raise the ceiling here in the same PR
+// with a note in the commit message and the README.
+//
+// Post-#82 measurements (taken from `node -e "JSON.stringify({tools: ...})"`):
+//   * Core profile (6 tools, the default):  ≈ 2,982 bytes  ≈ ~746 tokens
+//   * Full profile (25 tools, opt-in):      ≈ 11,540 bytes ≈ ~2,885 tokens
+//
+// Pre-#82 core was 4,271 bytes / ~1,068 tokens — i.e. #82 cut the core profile
+// by 30%. The ceilings below sit just above today's measurements to leave a
+// small growth buffer without permitting a silent regression.
+
+const CORE_PROFILE_BYTE_CEILING = 3_100
+const FULL_PROFILE_BYTE_CEILING = 12_000
+
+function payloadBytes(tools: ReadonlyArray<unknown>): number {
+  return JSON.stringify({ tools }).length
+}
+
+describe('MCP tool-schema byte budget (#82)', () => {
+  it('the core profile JSON payload stays under the byte ceiling', () => {
+    const bytes = payloadBytes(activeMcpTools('core'))
+    expect(bytes, `core profile is ${bytes} bytes; ceiling is ${CORE_PROFILE_BYTE_CEILING}`).toBeLessThanOrEqual(CORE_PROFILE_BYTE_CEILING)
+  })
+
+  it('the full profile JSON payload stays under its byte ceiling', () => {
+    const bytes = payloadBytes(activeMcpTools('full'))
+    expect(bytes, `full profile is ${bytes} bytes; ceiling is ${FULL_PROFILE_BYTE_CEILING}`).toBeLessThanOrEqual(FULL_PROFILE_BYTE_CEILING)
+  })
+
+  it('the core profile contains exactly the documented 6 tools', () => {
+    const core = activeMcpTools('core')
+    expect(core.map((t) => t.name).sort()).toEqual([
+      'call_chain',
+      'community_overview',
+      'graph_stats',
+      'impact',
+      'pr_impact',
+      'retrieve',
+    ])
+  })
+
+  it('every core tool has a non-empty description (discoverability sanity check)', () => {
+    for (const tool of activeMcpTools('core')) {
+      expect(tool.description.length, `${tool.name} has empty description`).toBeGreaterThan(0)
+    }
+  })
+
+  it('every full-profile tool has a non-empty description', () => {
+    for (const tool of MCP_TOOLS) {
+      expect(tool.description.length, `${tool.name} has empty description`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/tests/unit/stdio-pr-impact.test.ts
+++ b/tests/unit/stdio-pr-impact.test.ts
@@ -332,7 +332,11 @@ describe('stdio pr impact', () => {
 
     expect(tool?.inputSchema.properties.budget).toEqual(expect.objectContaining({ type: 'number' }))
     expect(tool?.inputSchema.properties.verbose).toEqual(expect.objectContaining({ type: 'boolean' }))
-    expect(tool?.inputSchema.properties.compact).toEqual(expect.objectContaining({ type: 'boolean' }))
+    // The `compact` flag was de-advertised in #82 to shrink cold-start
+    // schema overhead. The runtime still tolerates it for backward compat
+    // (the handler validates it on receipt) but it is no longer surfaced
+    // in tools/list. The runtime tolerance is exercised below.
+    expect(tool?.inputSchema.properties.compact).toBeUndefined()
 
     const response = await Promise.resolve(handleStdioRequest(graphPath, {
       id: 2,

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -76,6 +76,17 @@ describe('public marketing copy honesty', () => {
       expect(content).toContain('`get_neighbors`')
     })
 
+    it('pins the measured post-#82 core-profile schema overhead numbers in the Honest disclosure section', () => {
+      // Per the project's doc-honesty rule, a README claim about a measured
+      // number must be backed by a test that asserts the README contains the
+      // current measurement. If a future PR reduces it further, update both
+      // the README number and the regex below in the same PR. The matched
+      // numbers come straight from tests/unit/mcp-schema-budget.test.ts.
+      expect(lower).toMatch(/~\s*750\s*tokens/)
+      expect(lower).toMatch(/~?\s*3[,.]?000\s*bytes/)
+      expect(lower).toMatch(/30%/)
+    })
+
     it('pins the 2026-05-09 demo-video caption headline reductions', () => {
       expect(content).toMatch(/2[,]?811[,]?682/)
       expect(content).toMatch(/532[,]?021/)


### PR DESCRIPTION
Closes #82.

## Summary

Tightens the 6-tool core profile that ships by default with the graphify-ts MCP server, dropping the JSON payload emitted on \`tools/list\` from **4,271 bytes / ~1,068 tokens** to **2,982 bytes / ~746 tokens** — exactly the **30%** reduction target in the issue.

| Tool | Bytes pre-#82 | Bytes post-#82 | Δ |
|---|---:|---:|---:|
| \`retrieve\`            | 1,558 | 1,080 | −31% |
| \`impact\`              |   887 |   539 | −39% |
| \`pr_impact\`           |   828 |   519 | −37% |
| \`call_chain\`          |   599 |   511 | −15% |
| \`community_overview\`  |   263 |   197 | −25% |
| \`graph_stats\`         |   119 |   119 |   0% |
| **TOTAL** (incl. wrapper) | **4,271** | **2,982** | **−30%** |

## Where the savings came from

- **Tightened every tool description.** Dropped trailing "Use this..." marketing sentences. Replaced "Analyze the blast radius of changing a node" with "Blast-radius for a node:", etc. Discoverability is preserved — each tool still says what it does and what it returns; only the editorializing is gone.
- **De-advertised the deprecated \`compact\` flag** on \`impact\`, \`pr_impact\`, and \`retrieve\`. The handler still validates and accepts \`compact\` on receipt for backward compat (existing clients keep working), but it no longer counts against the cold-start \`cache_creation_input_tokens\` budget. Each occurrence was ~150 bytes of pure deprecated noise.
- **Dropped the redundant \`"Optional:"\` prefix** on parameter descriptions — parameters not in \`required\` are optional by JSON Schema definition.
- **Tightened verbose-flag descriptions** from \`"Optional: return the legacy verbose X payload instead of the default compact response."\` to \`"Return verbose payload (default: compact)."\`
- **Surfaced the \`retrieval_level\` argument** that \`retrieve\` already accepted (#75) so the override is now discoverable in \`tools/list\`. Cost: ~50 bytes; benefit: closes the discoverability gap in #75-iv.

## CI hardening (the issue's third deliverable)

\`tests/unit/mcp-schema-budget.test.ts\` pins the JSON payload size of both profiles:
- Core ceiling: **3,100 bytes** (current: 2,982 → 118-byte growth budget)
- Full ceiling: **12,000 bytes** (current: 11,540 → 460-byte growth budget)

A future tool addition or description regression that pushes either profile over the ceiling fails CI with a clear message identifying which profile and by how much. Test also asserts the core profile contains exactly the 6 documented tools and that every tool has a non-empty description.

\`tests/unit/stdio-pr-impact.test.ts\` updated to assert \`compact\` is NOT advertised in the schema, locking in the intentional removal.

## Doc-honesty pins (the issue's fourth deliverable)

\`tests/unit/why-graphify-doc.test.ts\` gains a regex pin requiring the README's "Honest disclosure" section to contain:
- \`~750 tokens\`
- \`~3,000 bytes\`
- \`30%\`

A future PR that changes any of these numbers must update both the README and the regex in the same commit.

## README updates

- **"Honest disclosure" section** (line 242): rewrites the cold-start premium paragraph with the post-#82 measured numbers and an explicit pointer to the new regression test.
- **"Honest summary" callout** (line 125): replaces the stale ~13% premium phrase with the measured token-overhead figure and a reference to this PR.
- **Roadmap** (line 269): flips \`🔜 Tighter cold-start MCP overhead\` to \`✅\` with the measured 30% drop.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 90 files / **1581** tests pass (6 new for the byte budget + 1575 pre-existing). Two pre-existing tests updated: stdio-pr-impact.test.ts (assert \`compact\` is no longer advertised) and why-graphify-doc.test.ts (pin the new measured numbers).
- [x] Manual measurement via \`node -e "JSON.stringify({ tools: activeMcpTools('core') })"\` confirms 2,982 bytes.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## What's deferred

The shared \`$ref\` schema-fragment idea from the issue body is intentionally NOT implemented here — Claude's MCP client doesn't expand \`\$ref\` in tool input schemas at this time, so the trade-off (less readable definitions, no token savings) didn't pencil. If MCP transport-level dedup ever lands client-side, that's a follow-up.

Refs the issue's "Honest disclosure" link in the README. The README's old "~13%" cold-start premium claim was tied to the pre-#82 5K overhead; the next benchmark refresh will re-measure the new percentage against the no-graph baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated performance metrics: core profile now ~3,000 bytes and ~750 tokens overhead.

* **Improvements**
  * Refined tool descriptions and JSON-schema parameters for graph-related tools.
  * Removed deprecated `compact` flag from impact and pr_impact tools.

* **Tests**
  * Added regression tests for tool-schema byte ceilings and documentation validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->