### PR TITLE
feat: bundle — v0.16 finishers + 1c-ii.a framework propagation (#79, #80, #81, #72)

### DIFF
--- a/src/infrastructure/context-prompt.ts
+++ b/src/infrastructure/context-prompt.ts
@@ -2,6 +2,23 @@ import type { ContextSessionDelta, ContextSessionState } from '../contracts/cont
 import { buildContextSession } from '../runtime/context-session.js'
 import { estimateQueryTokens } from '../runtime/serve.js'
 
+/**
+ * #80 — cache-aware prompt layout: order stable_sections so the most stable
+ * content (workspace manifest, language summary) sits first and the most
+ * task-volatile content (current question, recent changes) sits last. The
+ * compiler sorts on `sort_key ?? ref`; recommended sort_key prefixes:
+ *
+ *   "01_workspace_*"   — repository manifest, language summary (most stable)
+ *   "10_communities_*" — community / structure overview (semi-stable)
+ *   "20_evidence_*"    — task-relevant evidence (semi-stable; rebuilds when
+ *                        anchor changes but stays stable across follow-ups
+ *                        in the same session)
+ *   "90_anchor_*"      — current task anchor (least stable; emits last)
+ *
+ * The stable_prefix is byte-stable when the underlying graph + anchor are
+ * unchanged across follow-ups, so Anthropic's automatic prompt cache can
+ * reuse the entire prefix.
+ */
 export interface ContextPromptStableSection {
   ref: string
   title?: string

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -147,11 +147,26 @@ export function projectSpiToExtraction(
     symbolIdToSourceFile.set(symbol.id, absPath)
     symbolIdToLine.set(symbol.id, symbol.range.start.line)
 
-    addNode(
-      nodes,
-      seenNodeIds,
-      createNode(projection.id, projection.label, absPath, symbol.range.start.line, 'code'),
-    )
+    const node = createNode(projection.id, projection.label, absPath, symbol.range.start.line, 'code')
+
+    // Slice 1c-ii (projector framework propagation): if SPI tagged this
+    // symbol with a framework_role (e.g. NestJS slice 3b set
+    // 'nest_module'), surface that on the projected node so downstream
+    // consumers can route framework-aware UX without re-classifying. Maps
+    // SPI roles back onto the legacy extractor's `framework` + `node_kind`
+    // shape for the role types we cover today; full byte-equivalence on
+    // demo-repo's framework-specific synthetic nodes (e.g. NestJS route
+    // nodes with `node_kind: 'route'`) remains in slice 1c-iii.
+    if (symbol.framework_role) {
+      node.framework = frameworkForRole(symbol.framework_role)
+      node.framework_role = symbol.framework_role
+      const inferredKind = nodeKindForRole(symbol.framework_role)
+      if (inferredKind) {
+        node.node_kind = inferredKind
+      }
+    }
+
+    addNode(nodes, seenNodeIds, node)
   }
 
   // 3) Structural edges derived from SPI's `declares` layer:
@@ -208,6 +223,29 @@ export function projectSpiToExtraction(
     hyperedges: [],
     input_tokens: 0,
     output_tokens: 0,
+  }
+}
+
+function frameworkForRole(role: NonNullable<SpiSymbol['framework_role']>): string {
+  // Every SpiFrameworkRole today is a NestJS role (nest_*); future SPI
+  // additions for other frameworks will branch here.
+  if (role.startsWith('nest_')) return 'nestjs'
+  return 'unknown'
+}
+
+function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNullable<ExtractionNode['node_kind']> | null {
+  switch (role) {
+    case 'nest_route':
+      return 'route'
+    case 'nest_controller':
+    case 'nest_module':
+    case 'nest_provider':
+    case 'nest_guard':
+    case 'nest_pipe':
+    case 'nest_interceptor':
+      return 'class'
+    default:
+      return null
   }
 }
 

--- a/src/runtime/context-pack-delta.ts
+++ b/src/runtime/context-pack-delta.ts
@@ -73,17 +73,22 @@ export function computeDeltaContextPack<
     return true
   })
 
-  // Filter relationships: drop edges where either endpoint is now a
-  // referenced id (the receiver already has it). The relationship's
-  // semantic meaning is preserved on the receiver side via the explicit
-  // referenced_ids list, so the agent can still reconstruct the edge if
-  // it needs to.
+  // Filter relationships: drop edges only when BOTH endpoints are already
+  // in the receiver's session. Mixed edges (one new endpoint, one
+  // referenced) carry novel information about how the new node connects
+  // to the known one, so they're kept. Edges between two new nodes are
+  // also kept. Only edges where the receiver already has both ends and
+  // the relation between them are redundant.
   const referencedSet = new Set(referencedIds)
   const keptRelationships = pack.relationships.filter((rel) => {
     const fromId = typeof rel.from_id === 'string' ? rel.from_id : null
     const toId = typeof rel.to_id === 'string' ? rel.to_id : null
-    if (fromId !== null && referencedSet.has(fromId)) return false
-    if (toId !== null && referencedSet.has(toId)) return false
+    if (
+      fromId !== null && toId !== null &&
+      referencedSet.has(fromId) && referencedSet.has(toId)
+    ) {
+      return false
+    }
     return true
   })
 

--- a/src/runtime/context-pack-delta.ts
+++ b/src/runtime/context-pack-delta.ts
@@ -1,0 +1,123 @@
+// Context-pack delta helper (#81): given a freshly compiled pack and a set
+// of node ids the agent already received in earlier session turns, return a
+// "delta" pack that contains only NEW nodes and relationships, plus an
+// explicit reference list of the ids that were dropped.
+//
+// This is the standalone, side-effect-free building block of #81. The
+// stdio context_pack tool wires it in on a follow-up by:
+//   1. Reading the per-session handle store to get already-seen ids.
+//   2. Calling computeDeltaContextPack(pack, seenIds) to filter the pack.
+//   3. Returning { mode: 'delta', delta_pack, referenced_ids } to the agent.
+//   4. Updating the session store with the new ids the agent has now
+//      received so the next call's delta is correct.
+//
+// Splitting the pure helper from the session-state plumbing keeps the
+// computation testable in isolation and lets future delta consumers
+// (e.g., the prompt compiler or a future federation surface) reuse the
+// same logic without re-implementing the filtering rules.
+
+import type {
+  CompiledContextPack,
+  ContextPackCommunityContext,
+  ContextPackNode,
+  ContextPackRelationship,
+} from '../contracts/context-pack.js'
+
+export interface DeltaContextPackResult<
+  TNode extends ContextPackNode = ContextPackNode,
+  TRelationship extends ContextPackRelationship = ContextPackRelationship,
+  TCommunity extends ContextPackCommunityContext = ContextPackCommunityContext,
+> {
+  /** True iff the input pack overlapped with previously-sent ids. When
+   *  false, the delta is identical to the input pack. */
+  delta_applied: boolean
+  /** Pack with overlapping nodes + their relationships removed. */
+  delta_pack: CompiledContextPack<TNode, TRelationship, TCommunity>
+  /** Node ids the caller already had — surfaced explicitly so the agent
+   *  can resolve them from session state instead of re-reading content. */
+  referenced_ids: string[]
+  /** Bytes-saved estimate (delta vs original JSON length). */
+  bytes_saved: number
+}
+
+export function computeDeltaContextPack<
+  TNode extends ContextPackNode = ContextPackNode,
+  TRelationship extends ContextPackRelationship = ContextPackRelationship,
+  TCommunity extends ContextPackCommunityContext = ContextPackCommunityContext,
+>(
+  pack: CompiledContextPack<TNode, TRelationship, TCommunity>,
+  previouslySentNodeIds: ReadonlyArray<string>,
+): DeltaContextPackResult<TNode, TRelationship, TCommunity> {
+  const seen = new Set(previouslySentNodeIds)
+  if (seen.size === 0) {
+    // No prior session — the delta is the full pack.
+    return {
+      delta_applied: false,
+      delta_pack: pack,
+      referenced_ids: [],
+      bytes_saved: 0,
+    }
+  }
+
+  const originalBytes = JSON.stringify(pack).length
+  const referencedIds: string[] = []
+
+  // Filter nodes: drop those whose node_id is in `seen`. Nodes without a
+  // node_id can't be deduplicated by handle, so they always pass through.
+  const keptNodes = pack.nodes.filter((node) => {
+    const nodeId = typeof node.node_id === 'string' ? node.node_id : null
+    if (nodeId !== null && seen.has(nodeId)) {
+      referencedIds.push(nodeId)
+      return false
+    }
+    return true
+  })
+
+  // Filter relationships: drop edges where either endpoint is now a
+  // referenced id (the receiver already has it). The relationship's
+  // semantic meaning is preserved on the receiver side via the explicit
+  // referenced_ids list, so the agent can still reconstruct the edge if
+  // it needs to.
+  const referencedSet = new Set(referencedIds)
+  const keptRelationships = pack.relationships.filter((rel) => {
+    const fromId = typeof rel.from_id === 'string' ? rel.from_id : null
+    const toId = typeof rel.to_id === 'string' ? rel.to_id : null
+    if (fromId !== null && referencedSet.has(fromId)) return false
+    if (toId !== null && referencedSet.has(toId)) return false
+    return true
+  })
+
+  const deltaPack: CompiledContextPack<TNode, TRelationship, TCommunity> = {
+    ...pack,
+    nodes: keptNodes,
+    relationships: keptRelationships,
+    // token_count is a snapshot from the original pack; dropping nodes
+    // does not retroactively update upstream token estimates. Consumers
+    // that care about post-delta token cost should re-estimate.
+  }
+
+  const deltaBytes = JSON.stringify(deltaPack).length
+  return {
+    delta_applied: referencedIds.length > 0,
+    delta_pack: deltaPack,
+    referenced_ids: referencedIds,
+    bytes_saved: Math.max(0, originalBytes - deltaBytes),
+  }
+}
+
+/**
+ * Convenience overload: extract every `node_id` from a pack. Use this to
+ * record what the agent received after each call so the next call's
+ * `previouslySentNodeIds` argument is correct.
+ */
+export function collectPackNodeIds<TNode extends ContextPackNode>(
+  pack: CompiledContextPack<TNode>,
+): string[] {
+  const out: string[] = []
+  for (const node of pack.nodes) {
+    if (typeof node.node_id === 'string' && node.node_id.length > 0) {
+      out.push(node.node_id)
+    }
+  }
+  return out
+}

--- a/src/runtime/pr-impact.ts
+++ b/src/runtime/pr-impact.ts
@@ -1179,6 +1179,25 @@ export function compactPrImpactResult(result: PrImpactResult): CompactPrImpactRe
   }
   const compactChangedFileSet = new Set(compactChangedFiles)
 
+  // Compute coverage_score against the POST-compaction review bundle so
+  // the compact result doesn't inherit the full result's coverage_score
+  // verbatim if compactReviewBundle drops a node that was counted as
+  // covered. This is the fix for the CodeRabbit follow-up to #79: claims
+  // about coverage have to match what the consumer actually sees.
+  const compactedReviewBundle = compactReviewBundle(result.review_bundle, result.seed_nodes)
+  const compactedReviewLabels = new Set(compactedReviewBundle.nodes.map((node) => node.label))
+  const compactHighImpactSet = new Set(result.risk_summary.high_impact_nodes)
+  const compactTotalHighImpact = compactHighImpactSet.size
+  let compactCoveredHighImpact = 0
+  for (const label of compactHighImpactSet) {
+    if (compactedReviewLabels.has(label)) compactCoveredHighImpact += 1
+  }
+  const compactCoverageScore = compactTotalHighImpact === 0
+    ? 1
+    : compactCoveredHighImpact / compactTotalHighImpact
+  const compactUncoveredHotspots = result.changed_nodes
+    .filter((node) => compactHighImpactSet.has(node.label) && !compactedReviewLabels.has(node.label))
+
   return {
     base_branch: result.base_branch,
     changed_files: compactChangedFiles,
@@ -1194,12 +1213,17 @@ export function compactPrImpactResult(result: PrImpactResult): CompactPrImpactRe
     total_blast_radius: result.total_blast_radius,
     affected_communities: result.affected_communities.slice(0, MAX_COMPACT_AFFECTED_COMMUNITIES),
     review_context: result.review_context,
-    review_bundle: compactReviewBundle(result.review_bundle, result.seed_nodes),
+    review_bundle: compactedReviewBundle,
     risk_summary: {
       ...result.risk_summary,
       high_impact_nodes: result.risk_summary.high_impact_nodes.slice(0, MAX_COMPACT_HIGH_IMPACT_NODES),
     },
-    coverage_score: result.coverage_score,
-    uncovered_hotspots: result.uncovered_hotspots,
+    // #79 + CodeRabbit follow-up: recompute coverage against the
+    // post-compaction review bundle so the compact result doesn't claim
+    // coverage that compactReviewBundle has dropped. A high-impact node
+    // is "covered" only if it survived into compactedReviewBundle.nodes;
+    // otherwise it shows up in compactUncoveredHotspots.
+    coverage_score: compactCoverageScore,
+    uncovered_hotspots: compactUncoveredHotspots,
   }
 }

--- a/src/runtime/pr-impact.ts
+++ b/src/runtime/pr-impact.ts
@@ -121,6 +121,19 @@ export interface PrImpactResult {
       reason: string
     }>
   }
+  /**
+   * #79 — Coverage score in [0, 1] for the compact review_bundle's coverage
+   * of high-impact nodes. 1.0 = every high-impact node has at least one
+   * representative in the review_bundle. Lower values mean the compact
+   * pack risks silently dropping a hotspot.
+   */
+  coverage_score: number
+  /**
+   * #79 — High-impact changed nodes that are NOT represented in the
+   * review_bundle. Surfaced so reviewers and AI agents can audit the
+   * compact pack before trusting it as the basis for review decisions.
+   */
+  uncovered_hotspots: ChangedNode[]
 }
 
 export interface CompactPrImpactNodeImpact {
@@ -153,6 +166,8 @@ export interface CompactPrImpactResult extends Pick<
   | 'affected_communities'
   | 'review_context'
   | 'risk_summary'
+  | 'coverage_score'
+  | 'uncovered_hotspots'
 > {
   per_node_impact: CompactPrImpactNodeImpact[]
   review_bundle: CompactPrReviewBundle
@@ -1009,6 +1024,8 @@ export function analyzePrImpact(
         coverage: emptyPack.coverage,
       },
       risk_summary: { high_impact_nodes: [], cross_community_changes: 0, top_risks: [] },
+      coverage_score: 1,
+      uncovered_hotspots: [],
     }
   }
 
@@ -1097,6 +1114,24 @@ export function analyzePrImpact(
 
   const changedCommunityIds = new Set(impactTargets.map((node) => node.community).filter((id): id is number => id !== null))
 
+  // #79 — coverage scoring. A high-impact changed node is "covered" when at
+  // least one node with the same label survives into review_bundle.nodes.
+  // Score is the ratio of covered high-impact nodes to total high-impact
+  // nodes, defaulting to 1.0 when there are no high-impact nodes (i.e., no
+  // coverage gap to score). Uncovered hotspots are the ChangedNode entries
+  // whose labels appear in high_impact_nodes but not in the review_bundle.
+  const reviewBundleLabels = new Set(reviewBundle.nodes.map((node) => node.label))
+  const highImpactLabelSet = new Set(highImpactNodes)
+  const totalHighImpact = highImpactLabelSet.size
+  let coveredHighImpact = 0
+  for (const label of highImpactLabelSet) {
+    if (reviewBundleLabels.has(label)) coveredHighImpact += 1
+  }
+  const coverageScore = totalHighImpact === 0 ? 1 : coveredHighImpact / totalHighImpact
+  const uncoveredHotspots = changedNodes
+    .map((node) => node.serialized)
+    .filter((node) => highImpactLabelSet.has(node.label) && !reviewBundleLabels.has(node.label))
+
   return {
     base_branch: baseBranch,
     changed_files: changedFiles.map((changedFile) => changedFile.path),
@@ -1123,6 +1158,8 @@ export function analyzePrImpact(
         .slice(0, MAX_TOP_REVIEW_RISKS)
         .map(({ label, severity, reason }) => ({ label, severity, reason })),
     },
+    coverage_score: coverageScore,
+    uncovered_hotspots: uncoveredHotspots,
   }
 }
 
@@ -1162,5 +1199,7 @@ export function compactPrImpactResult(result: PrImpactResult): CompactPrImpactRe
       ...result.risk_summary,
       high_impact_nodes: result.risk_summary.high_impact_nodes.slice(0, MAX_COMPACT_HIGH_IMPACT_NODES),
     },
+    coverage_score: result.coverage_score,
+    uncovered_hotspots: result.uncovered_hotspots,
   }
 }

--- a/tests/unit/context-pack-delta.test.ts
+++ b/tests/unit/context-pack-delta.test.ts
@@ -82,19 +82,20 @@ describe('computeDeltaContextPack (#81)', () => {
     expect(result.bytes_saved).toBeGreaterThan(0)
   })
 
-  it('drops relationships whose endpoints are now referenced (the receiver already has them)', () => {
+  it('drops relationships only when BOTH endpoints are referenced (mixed edges are kept)', () => {
     const original = pack(
-      [node('a', 'A'), node('b', 'B'), node('c', 'C')],
+      [node('a', 'A'), node('b', 'B'), node('c', 'C'), node('d', 'D')],
       [
-        relationship('a', 'b', 'A', 'B'), // both new — keep
-        relationship('a', 'c', 'A', 'C'), // c is referenced — drop
-        relationship('b', 'c', 'B', 'C'), // c is referenced — drop
+        relationship('a', 'b', 'A', 'B'), // both new (a, b not referenced) — keep
+        relationship('a', 'c', 'A', 'C'), // mixed (a new, c referenced) — keep (novel link)
+        relationship('b', 'c', 'B', 'C'), // mixed (b new, c referenced) — keep (novel link)
+        relationship('c', 'd', 'C', 'D'), // both referenced — DROP (receiver already has it)
       ],
     )
-    const result = computeDeltaContextPack(original, ['c'])
-    expect(result.delta_pack.relationships).toHaveLength(1)
-    expect(result.delta_pack.relationships[0]?.from_id).toBe('a')
-    expect(result.delta_pack.relationships[0]?.to_id).toBe('b')
+    const result = computeDeltaContextPack(original, ['c', 'd'])
+    expect(result.delta_pack.relationships).toHaveLength(3)
+    const keptKinds = result.delta_pack.relationships.map((r) => `${r.from_id}->${r.to_id}`)
+    expect(keptKinds).toEqual(['a->b', 'a->c', 'b->c'])
   })
 
   it('passes through nodes that have no node_id (cannot be deduplicated by handle)', () => {

--- a/tests/unit/context-pack-delta.test.ts
+++ b/tests/unit/context-pack-delta.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  CompiledContextPack,
+  ContextPackNode,
+  ContextPackRelationship,
+} from '../../src/contracts/context-pack.js'
+import {
+  collectPackNodeIds,
+  computeDeltaContextPack,
+} from '../../src/runtime/context-pack-delta.js'
+
+function node(id: string, label: string): ContextPackNode {
+  return {
+    node_id: id,
+    label,
+    source_file: `src/${label}.ts`,
+    line_number: 1,
+    snippet: null,
+    file_type: 'code',
+  }
+}
+
+function relationship(
+  fromId: string,
+  toId: string,
+  fromLabel: string,
+  toLabel: string,
+  relation = 'calls',
+): ContextPackRelationship {
+  return { from_id: fromId, to_id: toId, from: fromLabel, to: toLabel, relation }
+}
+
+function pack(nodes: ContextPackNode[], rels: ContextPackRelationship[] = []): CompiledContextPack {
+  return {
+    task_contract: {
+      version: 1,
+      task_kind: 'explain',
+      evidence_recipe_id: 'explain',
+      budget: 1000,
+      required_evidence: [],
+      preferred_evidence: [],
+      semantic_required: [],
+      semantic_optional: [],
+    },
+    token_count: 100,
+    nodes,
+    relationships: rels,
+    community_context: [],
+    claims: [],
+    expandable: [],
+    coverage: {
+      required_evidence: [],
+      semantic_required: [],
+      semantic_optional: [],
+      entries: [],
+      semantic_entries: [],
+      missing_required: [],
+      missing_semantic: [],
+      available_relationships: rels.length,
+      selected_relationships: rels.length,
+    },
+  }
+}
+
+describe('computeDeltaContextPack (#81)', () => {
+  it('returns the input pack unchanged when there are no previously-sent ids', () => {
+    const original = pack([node('a', 'A'), node('b', 'B')])
+    const result = computeDeltaContextPack(original, [])
+    expect(result.delta_applied).toBe(false)
+    expect(result.delta_pack).toBe(original)
+    expect(result.referenced_ids).toEqual([])
+    expect(result.bytes_saved).toBe(0)
+  })
+
+  it('drops nodes whose node_id is in the previously-sent set and surfaces them as references', () => {
+    const original = pack([node('a', 'A'), node('b', 'B'), node('c', 'C')])
+    const result = computeDeltaContextPack(original, ['a', 'c'])
+    expect(result.delta_applied).toBe(true)
+    expect(result.delta_pack.nodes.map((n) => n.node_id)).toEqual(['b'])
+    expect(result.referenced_ids.sort()).toEqual(['a', 'c'])
+    expect(result.bytes_saved).toBeGreaterThan(0)
+  })
+
+  it('drops relationships whose endpoints are now referenced (the receiver already has them)', () => {
+    const original = pack(
+      [node('a', 'A'), node('b', 'B'), node('c', 'C')],
+      [
+        relationship('a', 'b', 'A', 'B'), // both new — keep
+        relationship('a', 'c', 'A', 'C'), // c is referenced — drop
+        relationship('b', 'c', 'B', 'C'), // c is referenced — drop
+      ],
+    )
+    const result = computeDeltaContextPack(original, ['c'])
+    expect(result.delta_pack.relationships).toHaveLength(1)
+    expect(result.delta_pack.relationships[0]?.from_id).toBe('a')
+    expect(result.delta_pack.relationships[0]?.to_id).toBe('b')
+  })
+
+  it('passes through nodes that have no node_id (cannot be deduplicated by handle)', () => {
+    const noIdNode: ContextPackNode = {
+      label: 'NoId',
+      source_file: 'src/x.ts',
+      line_number: 1,
+      snippet: null,
+    }
+    const result = computeDeltaContextPack(pack([noIdNode, node('a', 'A')]), ['a'])
+    expect(result.delta_pack.nodes.map((n) => n.label)).toEqual(['NoId'])
+  })
+
+  it('reports zero bytes_saved when there is no overlap', () => {
+    const original = pack([node('a', 'A'), node('b', 'B')])
+    const result = computeDeltaContextPack(original, ['x', 'y'])
+    expect(result.delta_applied).toBe(false)
+    expect(result.bytes_saved).toBe(0)
+  })
+})
+
+describe('collectPackNodeIds (#81)', () => {
+  it('returns every node_id present on the pack nodes', () => {
+    const ids = collectPackNodeIds(pack([node('a', 'A'), node('b', 'B')]))
+    expect(ids.sort()).toEqual(['a', 'b'])
+  })
+
+  it('skips nodes without a node_id', () => {
+    const noIdNode: ContextPackNode = {
+      label: 'NoId',
+      source_file: 'src/x.ts',
+      line_number: 1,
+      snippet: null,
+    }
+    const ids = collectPackNodeIds(pack([noIdNode, node('a', 'A')]))
+    expect(ids).toEqual(['a'])
+  })
+})

--- a/tests/unit/context-prompt-cache-stability.test.ts
+++ b/tests/unit/context-prompt-cache-stability.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildContextPrompt,
+  type BuildContextPromptInput,
+} from '../../src/infrastructure/context-prompt.js'
+
+// #80 — cache-aware prompt layout regression tests. Two consecutive
+// buildContextPrompt calls with the same anchor and same stable input must
+// produce a byte-identical stable_prefix. If this regresses, Anthropic's
+// automatic prompt cache stops reusing the prefix and effective_prompt_tokens
+// trends UP turn-over-turn instead of down.
+
+function workspacePromptInput(question: string): BuildContextPromptInput {
+  return {
+    instructions: ['Use only graph evidence.'],
+    stable_sections: [
+      // Most stable — workspace manifest. Sort key 01.
+      { ref: 'workspace_manifest', title: 'Workspace', body: 'graphify-ts (TypeScript, 148 files)', sort_key: '01_workspace_manifest' },
+      // Semi-stable — community structure. Sort key 10.
+      { ref: 'communities_overview', title: 'Communities', body: 'Pipeline Extract, Runtime Retrieve, Infrastructure Compare, ...', sort_key: '10_communities_overview' },
+      // Anchor — current task. Sort key 90 (last).
+      { ref: 'task_anchor', title: 'Anchor', body: question, sort_key: '90_anchor' },
+    ],
+    dynamic_sections: [
+      { title: 'Question', body: question },
+    ],
+    stable_prefix_title: 'Stable context',
+  }
+}
+
+describe('cache-aware prompt layout (#80)', () => {
+  it('produces a byte-identical stable_prefix on two consecutive calls with the same anchor', () => {
+    const input = workspacePromptInput('How does authentication work?')
+    const first = buildContextPrompt(input)
+    const second = buildContextPrompt(input)
+    expect(first.stable_prefix).toBe(second.stable_prefix)
+    expect(first.metrics.stable_prefix_tokens).toBe(second.metrics.stable_prefix_tokens)
+  })
+
+  it('reorders stable_sections deterministically by sort_key regardless of input order', () => {
+    const inOrder = workspacePromptInput('Q1')
+    const reordered: BuildContextPromptInput = {
+      ...inOrder,
+      stable_sections: [...inOrder.stable_sections].reverse(),
+    }
+    const a = buildContextPrompt(inOrder)
+    const b = buildContextPrompt(reordered)
+    expect(a.stable_prefix).toBe(b.stable_prefix)
+    expect(a.ordered_stable_refs).toEqual(b.ordered_stable_refs)
+  })
+
+  it('changes the stable_prefix when the anchor body changes (stable for one anchor, NOT shared across anchors)', () => {
+    const a = buildContextPrompt(workspacePromptInput('How does auth work?'))
+    const b = buildContextPrompt(workspacePromptInput('Why is the report slow?'))
+    // Anchor section is part of stable_prefix sorted last, so it does change
+    // across questions. The earlier sort-keyed sections (workspace_manifest,
+    // communities_overview) STAY identical — that's the cache-friendly part.
+    expect(a.stable_prefix).not.toBe(b.stable_prefix)
+    // But the workspace + communities portion is shared. We can't easily
+    // slice the prefix, so we rely on stable_prefix_tokens monotonicity
+    // across changing anchors with the same stable sections being roughly
+    // similar (token deltas come only from the anchor body diff).
+    expect(Math.abs(a.metrics.stable_prefix_tokens - b.metrics.stable_prefix_tokens)).toBeLessThan(20)
+  })
+
+  it('exposes reused_context_tokens on a follow-up call with a passed-in session state', () => {
+    // First call — no session, no reuse.
+    const first = buildContextPrompt(workspacePromptInput('Q1'))
+    expect(first.metrics.reused_context_tokens).toBe(0)
+    // Second call — supply the prior session_state. The compiler should
+    // detect the unchanged refs and report a non-zero reused_context_tokens.
+    const second = buildContextPrompt({
+      ...workspacePromptInput('Q1'),
+      session: first.session_state,
+    })
+    expect(second.metrics.reused_context_tokens).toBeGreaterThan(0)
+    expect(second.metrics.effective_prompt_tokens).toBeLessThanOrEqual(first.metrics.raw_prompt_tokens)
+  })
+
+  it('the stable prefix never embeds an ISO timestamp (prevents accidental cache invalidation)', () => {
+    const built = buildContextPrompt(workspacePromptInput('Q'))
+    expect(built.stable_prefix).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+})

--- a/tests/unit/pr-impact-coverage.test.ts
+++ b/tests/unit/pr-impact-coverage.test.ts
@@ -121,6 +121,51 @@ describe('PR-impact coverage scoring (#79)', () => {
     expect(compact.uncovered_hotspots).toHaveLength(2)
   })
 
+  it('CodeRabbit follow-up: coverage is recomputed against the POST-compaction review bundle, not inherited verbatim', () => {
+    // Construct a fixture where every high-impact node DOES appear in the
+    // full review bundle (full coverage_score = 1.0 in the verbose result),
+    // but where the bundle is large enough that compactReviewBundle drops
+    // some of those same nodes during compaction. The compact result must
+    // honestly report the post-compaction coverage, not the verbose one.
+    // Use 12 high-impact nodes; compactReviewBundle's per-evidence-class
+    // caps will drop most, so the compact coverage_score should be < 1.
+    const labels = Array.from({ length: 12 }, (_, i) => `Hotspot${i + 1}`)
+    const full: PrImpactResult = {
+      base_branch: 'main',
+      changed_files: [],
+      changed_ranges: [],
+      changed_nodes: labels.map((label) => changedNode(label, 'src/x.ts')),
+      seed_nodes: labels.map((label) => ({ ...changedNode(label, 'src/x.ts'), match_kind: 'line' })),
+      per_node_impact: [],
+      total_blast_radius: 0,
+      affected_files: [],
+      affected_communities: [],
+      review_context: { supporting_paths: [], test_paths: [], hotspots: [] },
+      review_bundle: reviewBundleWithLabels(labels),
+      risk_summary: {
+        high_impact_nodes: labels,
+        cross_community_changes: 0,
+        top_risks: [],
+      },
+      // Verbose claims full coverage; compact must NOT inherit this.
+      coverage_score: 1,
+      uncovered_hotspots: [],
+    }
+
+    const compact = compactPrImpactResult(full)
+    // The compact bundle MAY contain all 12 nodes if the budget allows it,
+    // OR fewer if compactReviewBundle dropped some. Either way, the compact
+    // coverage_score must reflect the compact bundle's actual contents —
+    // not be slavishly copied from the verbose 1.0.
+    const compactReviewLabels = new Set(compact.review_bundle.nodes.map((n) => n.label))
+    const expectedCovered = labels.filter((label) => compactReviewLabels.has(label)).length
+    const expectedScore = labels.length === 0 ? 1 : expectedCovered / labels.length
+    expect(compact.coverage_score).toBeCloseTo(expectedScore, 5)
+    // And uncovered_hotspots is the symmetric set.
+    const expectedUncoveredCount = labels.filter((label) => !compactReviewLabels.has(label)).length
+    expect(compact.uncovered_hotspots).toHaveLength(expectedUncoveredCount)
+  })
+
   it('coverage_score is 1.0 by convention when there are no high-impact nodes', () => {
     const full = fixture({
       highImpactNodes: [],

--- a/tests/unit/pr-impact-coverage.test.ts
+++ b/tests/unit/pr-impact-coverage.test.ts
@@ -35,6 +35,8 @@ function reviewBundleWithLabels(labels: ReadonlyArray<string>): PrImpactResult['
       snippet: null,
       match_score: 0,
       relevance_band: 'direct',
+      community: null,
+      community_label: null,
     })),
     relationships: [],
     community_context: [],

--- a/tests/unit/pr-impact-coverage.test.ts
+++ b/tests/unit/pr-impact-coverage.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  compactPrImpactResult,
+  type PrImpactResult,
+} from '../../src/runtime/pr-impact.js'
+
+// #79 — focused coverage_score / uncovered_hotspots tests. Constructs
+// PrImpactResult fixtures directly so the unit under test is the coverage
+// computation in analyzePrImpact's return shape, not git/diff parsing.
+
+function changedNode(label: string, sourceFile: string): PrImpactResult['changed_nodes'][number] {
+  return {
+    node_id: label.toLowerCase(),
+    label,
+    source_file: sourceFile,
+    node_kind: 'function',
+    community: null,
+    community_label: null,
+    line_number: 1,
+    source_location: 'L1',
+  }
+}
+
+function reviewBundleWithLabels(labels: ReadonlyArray<string>): PrImpactResult['review_bundle'] {
+  return {
+    budget: 1000,
+    token_count: 0,
+    nodes: labels.map((label) => ({
+      label,
+      source_file: 'src/x.ts',
+      line_number: 1,
+      node_kind: 'function',
+      file_type: 'code',
+      snippet: null,
+      match_score: 0,
+      relevance_band: 'direct',
+    })),
+    relationships: [],
+    community_context: [],
+  }
+}
+
+function fixture(opts: {
+  highImpactNodes: ReadonlyArray<string>
+  changedNodes: ReadonlyArray<{ label: string; sourceFile: string }>
+  reviewLabels: ReadonlyArray<string>
+  coverageScore: number
+  uncoveredLabels: ReadonlyArray<string>
+}): PrImpactResult {
+  // Smallest valid PrImpactResult that exercises the coverage logic.
+  return {
+    base_branch: 'main',
+    changed_files: [],
+    changed_ranges: [],
+    changed_nodes: opts.changedNodes.map((n) => changedNode(n.label, n.sourceFile)),
+    seed_nodes: [],
+    per_node_impact: [],
+    total_blast_radius: 0,
+    affected_files: [],
+    affected_communities: [],
+    review_context: { supporting_paths: [], test_paths: [], hotspots: [] },
+    review_bundle: reviewBundleWithLabels(opts.reviewLabels),
+    risk_summary: {
+      high_impact_nodes: [...opts.highImpactNodes],
+      cross_community_changes: 0,
+      top_risks: [],
+    },
+    coverage_score: opts.coverageScore,
+    uncovered_hotspots: opts.uncoveredLabels.map((label) => changedNode(label, 'src/x.ts')),
+  }
+}
+
+describe('PR-impact coverage scoring (#79)', () => {
+  it('compactPrImpactResult preserves coverage_score and uncovered_hotspots', () => {
+    const full = fixture({
+      highImpactNodes: ['authService', 'sessionStore'],
+      changedNodes: [
+        { label: 'authService', sourceFile: 'src/auth.ts' },
+        { label: 'sessionStore', sourceFile: 'src/session.ts' },
+      ],
+      reviewLabels: ['authService'],
+      coverageScore: 0.5,
+      uncoveredLabels: ['sessionStore'],
+    })
+
+    const compact = compactPrImpactResult(full)
+    expect(compact.coverage_score).toBe(0.5)
+    expect(compact.uncovered_hotspots).toHaveLength(1)
+    expect(compact.uncovered_hotspots[0]?.label).toBe('sessionStore')
+  })
+
+  it('coverage_score 1.0 with no uncovered hotspots when every high-impact node is in the review bundle', () => {
+    const full = fixture({
+      highImpactNodes: ['authService'],
+      changedNodes: [{ label: 'authService', sourceFile: 'src/auth.ts' }],
+      reviewLabels: ['authService'],
+      coverageScore: 1,
+      uncoveredLabels: [],
+    })
+    const compact = compactPrImpactResult(full)
+    expect(compact.coverage_score).toBe(1)
+    expect(compact.uncovered_hotspots).toHaveLength(0)
+  })
+
+  it('coverage_score 0.0 when no high-impact node survives compaction into the review bundle', () => {
+    const full = fixture({
+      highImpactNodes: ['authService', 'sessionStore'],
+      changedNodes: [
+        { label: 'authService', sourceFile: 'src/auth.ts' },
+        { label: 'sessionStore', sourceFile: 'src/session.ts' },
+      ],
+      reviewLabels: ['somethingElse'],
+      coverageScore: 0,
+      uncoveredLabels: ['authService', 'sessionStore'],
+    })
+    const compact = compactPrImpactResult(full)
+    expect(compact.coverage_score).toBe(0)
+    expect(compact.uncovered_hotspots).toHaveLength(2)
+  })
+
+  it('coverage_score is 1.0 by convention when there are no high-impact nodes', () => {
+    const full = fixture({
+      highImpactNodes: [],
+      changedNodes: [{ label: 'minorChange', sourceFile: 'src/x.ts' }],
+      reviewLabels: [],
+      coverageScore: 1,
+      uncoveredLabels: [],
+    })
+    const compact = compactPrImpactResult(full)
+    expect(compact.coverage_score).toBe(1)
+  })
+})

--- a/tests/unit/pr-impact.test.ts
+++ b/tests/unit/pr-impact.test.ts
@@ -863,6 +863,8 @@ describe('pr impact', () => {
         cross_community_changes: 0,
         top_risks: [],
       },
+      coverage_score: 1,
+      uncovered_hotspots: [],
     }
 
     expect(compactPrImpactResult(full).per_node_impact.map((impact) => impact.node)).toEqual([
@@ -923,6 +925,8 @@ describe('pr impact', () => {
         cross_community_changes: 0,
         top_risks: [],
       },
+      coverage_score: 1,
+      uncovered_hotspots: [],
     }
 
     const compact = compactPrImpactResult(full)
@@ -982,6 +986,8 @@ describe('pr impact', () => {
         cross_community_changes: 0,
         top_risks: [],
       },
+      coverage_score: 1,
+      uncovered_hotspots: [],
     }
 
     const compact = compactPrImpactResult(full)
@@ -1055,6 +1061,8 @@ describe('pr impact', () => {
           },
         ],
       },
+      coverage_score: 1,
+      uncovered_hotspots: [],
     }
 
     const compact = compactPrImpactResult(full)

--- a/tests/unit/spi-projector.test.ts
+++ b/tests/unit/spi-projector.test.ts
@@ -307,6 +307,57 @@ describe('projectSpiToExtraction (slice 1c-i of #72)', () => {
     })
   })
 
+  describe('framework_role propagation (slice 1c-ii)', () => {
+    it('propagates SPI nest_module role onto the projected ExtractionNode', () => {
+      writeFile(sandbox, 'src/app.module.ts', [
+        'import { Module } from "@nestjs/common"',
+        '@Module({})',
+        'export class AppModule {}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const node = findNode(extraction, 'app_module_appmodule')
+      expect(node?.framework).toBe('nestjs')
+      expect(node?.framework_role).toBe('nest_module')
+      expect(node?.node_kind).toBe('class')
+    })
+
+    it('propagates nest_controller role and class node_kind', () => {
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller } from "@nestjs/common"',
+        '@Controller("users")',
+        'export class UsersController {}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const node = findNode(extraction, 'users_controller_userscontroller')
+      expect(node?.framework).toBe('nestjs')
+      expect(node?.framework_role).toBe('nest_controller')
+      expect(node?.node_kind).toBe('class')
+    })
+
+    it('propagates nest_route on route methods with route node_kind', () => {
+      writeFile(sandbox, 'src/users.controller.ts', [
+        'import { Controller, Get } from "@nestjs/common"',
+        '@Controller()',
+        'export class UsersController {',
+        '  @Get() list(): void {}',
+        '}',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const method = extraction.nodes.find((n) => n.source_file.endsWith('users.controller.ts') && n.label === '.list()')
+      expect(method?.framework).toBe('nestjs')
+      expect(method?.framework_role).toBe('nest_route')
+      expect(method?.node_kind).toBe('route')
+    })
+
+    it('does not tag plain (non-nest) classes with framework metadata', () => {
+      writeFile(sandbox, 'src/plain.ts', 'export class Plain {}\n')
+      const extraction = project(sandbox)
+      const node = findNode(extraction, 'plain_plain')
+      expect(node?.framework).toBeUndefined()
+      expect(node?.framework_role).toBeUndefined()
+    })
+  })
+
   describe('comparison against the legacy extractor', () => {
     it('produces the same file + class + method node ids as extract() on a small fixture', () => {
       // Hand-crafted fixture exercising the legacy extractor's "core" surface


### PR DESCRIPTION
> ⚠️ **This is a bundle PR by explicit user request.** It violates the project's standard "one slice per PR" rule. The user signed off on the trade-off explicitly. Each commit on this branch is self-contained, has its own test coverage, and is reviewable in isolation. If this is too much for one review, the cleanest unbundling is to revert this PR and cherry-pick each of the 4 commits onto its own branch.

Closes part of #79, #80, #81. Advances #72 (slice 1c-ii.a). Built on top of #105 (post-merge to main).

## Commits in this PR (each its own logical unit)

### 1. \`adf95ce\` — feat(#72): SPI projector → propagate framework_role (slice 1c-ii.a)
When SPI symbols carry a \`framework_role\` (set by slice 3b's NestJS detector), the projector now surfaces \`framework\`, \`framework_role\`, and \`node_kind\` on the projected ExtractionNode. Maps SPI roles back onto the legacy extractor's shape so downstream consumers can route framework-aware UX without re-classifying. Full byte-equivalence on demo-repo (slice 1c-ii.b through .e — porting Express / Next.js / React Router / Redux extractor logic) remains future work.
- New: \`frameworkForRole\`, \`nodeKindForRole\` helpers in projector.ts
- Tests: 4 new — nest_module / nest_controller / nest_route propagation, no-tagging-of-plain-classes regression

### 2. \`20ad12f\` — feat(#79): PR-impact coverage scoring
Adds \`coverage_score\` (numeric, [0, 1]) and \`uncovered_hotspots\` (\`ChangedNode[]\`) to \`PrImpactResult\` and \`CompactPrImpactResult\`. Coverage score = ratio of high-impact changed nodes whose label appears in the review bundle. Convention: 1.0 when there are no high-impact nodes (no coverage gap to score). The compact result preserves both fields verbatim so MCP and CLI clients can audit pack coverage without round-tripping through the verbose payload.
- Tests: 4 new in pr-impact-coverage.test.ts; existing pr-impact.test.ts fixtures updated to include the new fields.

### 3. \`939c71e\` — feat(#80): document + regression-test cache-aware prompt layout
Most of #80's mechanics already lived in \`buildContextPrompt\` (deterministic sort_key ordering, separate stable_prefix vs dynamic_suffix, \`stable_prefix_tokens\` / \`reused_context_tokens\` / \`effective_prompt_tokens\` metrics, session-aware delta payload). What was missing:
- The convention for sort_key prefixes that maximises Anthropic's automatic prompt-cache reuse (\`01_workspace_*\`, \`10_communities_*\`, \`20_evidence_*\`, \`90_anchor_*\`). Documented in JSDoc.
- Regression tests asserting the prefix is byte-stable across two consecutive calls with the same anchor, deterministic across input order, and never embeds an ISO timestamp (cache-invalidation regression guard).
- Tests: 5 new in context-prompt-cache-stability.test.ts.

### 4. \`273fa64\` — feat(#81): standalone delta-pack helper
Adds \`computeDeltaContextPack(pack, previouslySentNodeIds)\` — pure side-effect-free filter that returns the input pack with overlapping nodes + their relationships removed, plus an explicit \`referenced_ids\` list of dropped handles and a \`bytes_saved\` measurement. Plus \`collectPackNodeIds(pack)\` for callers to record what the agent received after each call.
- New file: src/runtime/context-pack-delta.ts (130 LOC + JSDoc)
- Tests: 7 new in context-pack-delta.test.ts.
- **Out-of-scope here:** wiring into the stdio context_pack tool's session state. The session-state plumbing (per-session handle store, response shape, reset flow) is substantial and bundling it here would push the diff past safe review size. The helper has full coverage so a one-line follow-up wires it in.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — **93 files / 1601 tests pass** (20 new across the bundle: 4 + 4 + 5 + 7)
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## What's intentionally deferred

Per the bundle's "minimum viable per issue" scope, each issue is partially closed by this PR. The remaining work for each:

- **#79** — \`review-compare\` integration (per-hotspot coverage delta in compare reports) and a documented benchmark fixture under \`docs/benchmarks/\`. Fields are now in the payload; consumer wiring is a follow-up.
- **#80** — actual benchmark refresh showing \`effective_token_count\` shrinking turn-over-turn. Mechanics + tests are in place; updating the README's measured numbers needs a multi-turn measurement run.
- **#81** — wire \`delta\` mode into the stdio \`context_pack\` tool (handle-store integration, response shape addition, \`context_session_reset\` invalidation). Helper is shipped; one PR away from end-to-end.
- **#72 slice 1c-ii** — \`.b through .e\`: Express, Next.js, React Router, Redux framework extractor ports for full demo-repo byte-equivalence + v0.14.0 trigger. NestJS portion is now structurally projected via 1c-ii.a.

Refs #79, #80, #81, #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Propagates framework-specific metadata to improve NestJS code detection.
  * Adds PR coverage scoring and uncovered-hotspots reporting.
  * Adds context-pack delta deduplication to reduce multi-turn payloads.

* **Documentation**
  * Added guidance on cache-aware prompt layout to improve prompt-cache reuse.

* **Tests**
  * Added unit tests validating deduplication, prompt-layout stability, PR-coverage behavior, and framework-role propagation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/106)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->