### PR TITLE
feat(#72): SPI v1 slice 1c-ii.b — Express framework substrate

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -63,6 +63,7 @@ import type {
 } from './types.js'
 import { addTestLayerEdges } from './test-layer.js'
 import { collectNestTokenMap, detectNestFramework } from './framework-nestjs.js'
+import { detectExpressFramework } from './framework-express.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -638,6 +639,14 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       pathToFileId,
       checker,
       tokenMap,
+    })
+    // Slice 1c-ii.b: substrate-only Express detector. Tags app/router
+    // factory variables with framework_role; route + middleware detection
+    // lands in 1c-ii.c and 1c-ii.d.
+    detectExpressFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
     })
   }
 }

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -1,0 +1,159 @@
+// SPI v1 — Express framework layer (slice 1c-ii.b of #72).
+//
+// Detects Express's `app = express()` and `router = Router()` factory call
+// patterns and tags the resulting variable symbols with framework_role.
+// Slice 1c-ii.b is the SUBSTRATE layer of the Express port: it adds the
+// minimum SPI tagging the projector needs to surface 'framework: express'
+// on the produced ExtractionNode (via slice 1c-ii.a's framework_role
+// propagation).
+//
+// Future slices extend this:
+//
+//   * 1c-ii.c — call-site route detection: walk app.get / app.post / etc.
+//     emit `controller_route`-equivalent edges from app/router symbols
+//     to the route handler.
+//   * 1c-ii.d — middleware detection: app.use(...) tags middleware
+//     functions with framework_role: 'express_middleware'.
+//   * 1c-ii.e — full byte-equivalence with the legacy
+//     extract/frameworks/express.ts surface (~1,669 lines): synthetic
+//     route nodes with route_path, framework metadata, mounted-router
+//     resolution.
+//
+// Confidence rules: high when the factory binding resolves to the
+// 'express' module specifier; otherwise the tagging is skipped (no
+// best-effort low-confidence tags here, since Express's runtime patterns
+// are too dynamic for cheap heuristics to reliably distinguish).
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const EXPRESS_MODULE_SPECIFIER = 'express'
+
+type ExpressBindings = {
+  /** Local name(s) for the default `express` export — i.e., the factory
+   *  callable that produces an app. Typically {'express'}. */
+  appFactory: Set<string>
+  /** Local name(s) for the named `Router` export. Typically {'Router'}. */
+  routerFactory: Set<string>
+  /** Local name(s) for namespace imports: `import * as e from 'express'`. */
+  namespaceAlias: Set<string>
+}
+
+export type DetectExpressFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+export function detectExpressFramework(ctx: DetectExpressFrameworkContext): void {
+  const bindings = collectExpressBindings(ctx.sourceFile)
+  if (!hasAnyBinding(bindings)) return
+
+  // Walk top-level variable statements looking for `const name = express()`
+  // or `const name = Router()` patterns. Tag the variable symbol with the
+  // matching framework_role.
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    const isConst = (stmt.declarationList.flags & ts.NodeFlags.Const) !== 0
+    const symbolKind: SpiSymbol['kind'] = isConst ? 'constant' : 'variable'
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      const role = factoryCallRole(decl.initializer, bindings)
+      if (!role) continue
+      tagSymbol(ctx.symbolsByFile, ctx.fileId, symbolKind, decl.name.text, role)
+    }
+  }
+}
+
+function collectExpressBindings(sourceFile: ts.SourceFile): ExpressBindings {
+  const bindings: ExpressBindings = {
+    appFactory: new Set<string>(),
+    routerFactory: new Set<string>(),
+    namespaceAlias: new Set<string>(),
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (stmt.moduleSpecifier.text !== EXPRESS_MODULE_SPECIFIER) continue
+
+    // Default import: `import express from 'express'` — the local name is
+    // the factory callable that yields an Express app.
+    if (stmt.importClause.name) {
+      bindings.appFactory.add(stmt.importClause.name.text)
+    }
+
+    const namedBindings = stmt.importClause.namedBindings
+    if (!namedBindings) continue
+
+    if (ts.isNamespaceImport(namedBindings)) {
+      // `import * as e from 'express'` — both e() and e.Router() are
+      // factory calls. We track the namespace alias and resolve member
+      // accesses below.
+      bindings.namespaceAlias.add(namedBindings.name.text)
+      continue
+    }
+
+    if (ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        const importedName = element.propertyName?.text ?? element.name.text
+        const localName = element.name.text
+        if (importedName === 'Router') bindings.routerFactory.add(localName)
+        // `import { default as express, Router } from 'express'` is the
+        // explicit form of the default-import pattern above. Treat the
+        // 'default' aliased import as an app factory.
+        if (importedName === 'default') bindings.appFactory.add(localName)
+      }
+    }
+  }
+  return bindings
+}
+
+function hasAnyBinding(b: ExpressBindings): boolean {
+  return b.appFactory.size > 0 || b.routerFactory.size > 0 || b.namespaceAlias.size > 0
+}
+
+function factoryCallRole(initializer: ts.Expression, bindings: ExpressBindings): SpiFrameworkRole | null {
+  if (!ts.isCallExpression(initializer)) return null
+  const callee = initializer.expression
+
+  // `express()` — direct call to the app factory.
+  if (ts.isIdentifier(callee) && bindings.appFactory.has(callee.text)) {
+    return 'express_app'
+  }
+
+  // `e.Router()` or `e()` via a namespace import alias.
+  if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.expression) && ts.isIdentifier(callee.name)) {
+    const namespaceName = callee.expression.text
+    const memberName = callee.name.text
+    if (bindings.namespaceAlias.has(namespaceName)) {
+      if (memberName === 'Router') return 'express_router'
+      // Namespace.default() is unusual but legal; treat as app factory.
+      if (memberName === 'default') return 'express_app'
+    }
+  }
+
+  // `Router()` — named-import call to the Router factory.
+  if (ts.isIdentifier(callee) && bindings.routerFactory.has(callee.text)) {
+    return 'express_router'
+  }
+
+  return null
+}
+
+function tagSymbol(
+  symbolsByFile: Map<string, SpiSymbol[]>,
+  fileId: string,
+  kind: SpiSymbol['kind'],
+  name: string,
+  role: SpiFrameworkRole,
+): void {
+  const symbols = symbolsByFile.get(fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.kind === kind && symbol.name === name) {
+      symbol.framework_role = role
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -66,3 +66,8 @@ export {
   projectSpiToExtraction,
   type ProjectSpiToExtractionOptions,
 } from './projector.js'
+
+export {
+  detectExpressFramework,
+  type DetectExpressFrameworkContext,
+} from './framework-express.js'

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -227,16 +227,18 @@ export function projectSpiToExtraction(
 }
 
 function frameworkForRole(role: NonNullable<SpiSymbol['framework_role']>): string {
-  // Every SpiFrameworkRole today is a NestJS role (nest_*); future SPI
-  // additions for other frameworks will branch here.
   if (role.startsWith('nest_')) return 'nestjs'
+  if (role.startsWith('express_')) return 'express'
   return 'unknown'
 }
 
 function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNullable<ExtractionNode['node_kind']> | null {
   switch (role) {
     case 'nest_route':
+    case 'express_route':
       return 'route'
+    case 'express_router':
+      return 'router'
     case 'nest_controller':
     case 'nest_module':
     case 'nest_provider':
@@ -244,6 +246,9 @@ function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNul
     case 'nest_pipe':
     case 'nest_interceptor':
       return 'class'
+    case 'express_app':
+    case 'express_middleware':
+      return 'function'
     default:
       return null
   }

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -65,6 +65,7 @@ export type SpiRange = {
 }
 
 export type SpiFrameworkRole =
+  // NestJS roles (slice 3b base)
   | 'nest_module'
   | 'nest_controller'
   | 'nest_route'
@@ -72,6 +73,11 @@ export type SpiFrameworkRole =
   | 'nest_guard'
   | 'nest_pipe'
   | 'nest_interceptor'
+  // Express roles (slice 1c-ii.b)
+  | 'express_app'
+  | 'express_router'
+  | 'express_route'
+  | 'express_middleware'
 
 export type SpiSymbol = {
   id: string

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-express-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1c-ii.b',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('SPI Express framework detector (slice 1c-ii.b)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('app factory detection', () => {
+    it('tags `const app = express()` with framework_role express_app via default import', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/server.ts', 'app')
+      expect(sym?.framework_role).toBe('express_app')
+    })
+
+    it('tags `const app = express.default()` via named-default import', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import { default as expressFactory } from "express"',
+        'export const app = expressFactory()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/server.ts', 'app')
+      expect(sym?.framework_role).toBe('express_app')
+    })
+
+    it('tags `const app = e()` via namespace import alias', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import * as e from "express"',
+        'export const app = e.default()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/server.ts', 'app')
+      expect(sym?.framework_role).toBe('express_app')
+    })
+  })
+
+  describe('router factory detection', () => {
+    it('tags `const router = Router()` via named import', () => {
+      writeFile(sandbox, 'src/routes.ts', [
+        'import { Router } from "express"',
+        'export const router = Router()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/routes.ts', 'router')
+      expect(sym?.framework_role).toBe('express_router')
+    })
+
+    it('tags `const router = e.Router()` via namespace alias', () => {
+      writeFile(sandbox, 'src/routes.ts', [
+        'import * as e from "express"',
+        'export const router = e.Router()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/routes.ts', 'router')
+      expect(sym?.framework_role).toBe('express_router')
+    })
+  })
+
+  describe('non-Express files', () => {
+    it('does not tag variables in files that do not import express', () => {
+      writeFile(sandbox, 'src/plain.ts', [
+        'function notExpress(): { use: () => void } { return { use: () => {} } }',
+        'export const app = notExpress()',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/plain.ts', 'app')
+      expect(sym?.framework_role).toBeUndefined()
+    })
+
+    it('does not tag variables when express is imported but not used as a factory', () => {
+      writeFile(sandbox, 'src/types.ts', [
+        'import type { Application } from "express"',
+        'export const app: Application | null = null',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/types.ts', 'app')
+      // Type-only imports skip the bindings collector entirely.
+      expect(sym?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('projector — framework propagation through to ExtractionNode', () => {
+    it('an express_app variable surfaces with framework=express on the projected ExtractionNode', async () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+      ].join('\n') + '\n')
+      // Lazy-import projector to avoid pulling extraction-side deps for
+      // tests that only need the SPI substrate.
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'app')
+      expect(node?.framework).toBe('express')
+      expect(node?.framework_role).toBe('express_app')
+      expect(node?.node_kind).toBe('function')
+    })
+
+    it('an express_router variable projects with node_kind=router', async () => {
+      writeFile(sandbox, 'src/routes.ts', [
+        'import { Router } from "express"',
+        'export const router = Router()',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'router')
+      expect(node?.framework).toBe('express')
+      expect(node?.framework_role).toBe('express_router')
+      expect(node?.node_kind).toBe('router')
+    })
+  })
+})


### PR DESCRIPTION
First slice of the Express port toward 1c-ii's v0.14.0 trigger.

## Summary

Extends the SPI substrate to recognise Express's factory-call-based framework patterns (\`const app = express()\`, \`const router = Router()\`). The legacy \`extract/frameworks/express.ts\` (~1,669 lines) walks call-expressions to discover routes and middleware; SPI slice 1c-ii.b lays the type-system + detector foundation for an SPI-driven equivalent without attempting the full port.

- Adds four new variants to \`SpiFrameworkRole\`: \`express_app\`, \`express_router\`, \`express_route\`, \`express_middleware\`. The latter two are reserved for slices 1c-ii.c and 1c-ii.d (route detection + middleware tagging).
- New module \`src/pipeline/spi/framework-express.ts\`: minimal detector that recognises the four common factory patterns:
  - \`import express from 'express'; const app = express()\`
  - \`import { default as f } from 'express'; const app = f()\`
  - \`import * as e from 'express'; const app = e.default()\`
  - \`import { Router } from 'express'; const router = Router()\` (and \`e.Router()\`)
- Wired into \`build.ts\` immediately after the NestJS detector pass.
- Projector updates: slice 1c-ii.a's \`framework_role\` propagation already routes the new roles through to ExtractionNode. \`frameworkForRole\` now branches on the \`express_*\` prefix returning \`'express'\`; \`nodeKindForRole\` maps \`express_route\` → \`'route'\`, \`express_router\` → \`'router'\`, \`express_app\` / \`express_middleware\` → \`'function'\`.

## Why this is just the substrate, not the full port

The legacy Express extractor inspects call-expressions and merges route-handler scope, middleware chains, and mounted-router resolution. Doing the same on SPI requires:
1. A walker that recognises \`<binding>.get/post/put/patch/delete/all/use(...)\` call expressions (slice 1c-ii.c).
2. Route-handler enclosure detection — find which function symbol owns the inline arrow callback (slice 1c-ii.c).
3. Middleware chain attribution: \`app.use('/api', authMiddleware, router)\` (slice 1c-ii.d).
4. Synthetic route nodes with \`route_path\`, mounted prefix resolution, and dynamic composition (slice 1c-ii.e — v0.14.0 trigger).

Each of these is its own substantial bounded slice. Bundling all four would re-create the bundle-PR review-difficulty problem we hit on #106. This PR limits itself to the substrate so the next four slices can land independently.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 94 files / **1611** tests pass (9 new for Express + 1602 pre-existing)
- [x] Tests cover: default-import factory detection, named-default-import alias, namespace-alias detection (\`e.Router()\`, \`e.default()\`), negative case (no express import → no tagging), type-only-import negative case (\`import type { Application }\`), end-to-end projection through to ExtractionNode (\`framework: 'express'\`, \`framework_role: 'express_*'\`, correct \`node_kind\`).
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## Sequence ahead

- **1c-ii.c** — route detection: \`app.get/post/etc.\` tag handler symbols with \`express_route\`.
- **1c-ii.d** — middleware tagging: \`app.use(...)\` tag handler symbols with \`express_middleware\`.
- **1c-ii.e** — full byte-equivalent extractor port + synthetic route nodes. Triggers v0.14.0.

Refs #72 (SPI v1 umbrella), #106 (1c-ii.a — projector framework_role propagation, where this slice plugs in).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework detection has been extended to support Express, automatically identifying Express application instances and router components within TypeScript code for improved code analysis and architectural understanding.

* **Tests**
  * Added comprehensive unit test coverage for Express framework detection, validating behavior across different import patterns and configuration styles to ensure accurate component classification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/107)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->