### PR TITLE
feat(#72): SPI v1 slice 1c-ii.c — Express route detection

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -640,13 +640,15 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       checker,
       tokenMap,
     })
-    // Slice 1c-ii.b: substrate-only Express detector. Tags app/router
-    // factory variables with framework_role; route + middleware detection
-    // lands in 1c-ii.c and 1c-ii.d.
+    // Slice 1c-ii.b + 1c-ii.c: Express detector. Tags app/router factory
+    // variables (1c-ii.b) and named-handler route registrations (1c-ii.c)
+    // emitting route_handler edges from binding→handler. Middleware and
+    // synthetic route nodes land in 1c-ii.d and 1c-ii.e respectively.
     detectExpressFramework({
       sourceFile,
       fileId: file.id,
       symbolsByFile,
+      edges,
     })
   }
 }

--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -644,11 +644,14 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
     // variables (1c-ii.b) and named-handler route registrations (1c-ii.c)
     // emitting route_handler edges from binding→handler. Middleware and
     // synthetic route nodes land in 1c-ii.d and 1c-ii.e respectively.
+    // The checker is passed through for declaration-identity resolution
+    // so lexical shadows don't produce false-positive route tags.
     detectExpressFramework({
       sourceFile,
       fileId: file.id,
       symbolsByFile,
       edges,
+      checker,
     })
   }
 }

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -1,32 +1,32 @@
-// SPI v1 — Express framework layer (slice 1c-ii.b of #72).
+// SPI v1 — Express framework layer (slices 1c-ii.b + 1c-ii.c of #72).
 //
-// Detects Express's `app = express()` and `router = Router()` factory call
-// patterns and tags the resulting variable symbols with framework_role.
-// Slice 1c-ii.b is the SUBSTRATE layer of the Express port: it adds the
-// minimum SPI tagging the projector needs to surface 'framework: express'
-// on the produced ExtractionNode (via slice 1c-ii.a's framework_role
-// propagation).
+// Slice 1c-ii.b — substrate: detects Express's `app = express()` and
+// `router = Router()` factory call patterns and tags the resulting
+// variable symbols with framework_role.
 //
-// Future slices extend this:
+// Slice 1c-ii.c — route detection: walks `<binding>.get/post/put/patch/
+// delete/all/options/head(...)` call expressions. When the receiver
+// resolves to a previously-tagged express_app/express_router binding and
+// the LAST argument is a named identifier (function or variable symbol
+// in the same file), the handler is tagged framework_role: 'express_route'
+// and a `route_handler` SpiEdge is emitted from the binding's symbol to
+// the handler's symbol with confidence 'high'. Inline arrow handlers
+// (`app.get('/p', (req, res) => {...})`) are intentionally NOT tagged in
+// this slice — they require synthesizing route nodes from anonymous
+// callbacks, which is slice 1c-ii.e territory.
 //
-//   * 1c-ii.c — call-site route detection: walk app.get / app.post / etc.
-//     emit `controller_route`-equivalent edges from app/router symbols
-//     to the route handler.
-//   * 1c-ii.d — middleware detection: app.use(...) tags middleware
-//     functions with framework_role: 'express_middleware'.
+// Future slices:
+//
+//   * 1c-ii.d — middleware detection: app.use(...) tags handlers with
+//     framework_role: 'express_middleware'.
 //   * 1c-ii.e — full byte-equivalence with the legacy
 //     extract/frameworks/express.ts surface (~1,669 lines): synthetic
-//     route nodes with route_path, framework metadata, mounted-router
-//     resolution.
-//
-// Confidence rules: high when the factory binding resolves to the
-// 'express' module specifier; otherwise the tagging is skipped (no
-// best-effort low-confidence tags here, since Express's runtime patterns
-// are too dynamic for cheap heuristics to reliably distinguish).
+//     route nodes with route_path, mounted-router prefix resolution,
+//     dynamic compositions.
 
 import ts from 'typescript'
 
-import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+import type { SpiEdge, SpiFrameworkRole, SpiSymbol } from './types.js'
 
 const EXPRESS_MODULE_SPECIFIER = 'express'
 
@@ -44,15 +44,30 @@ export type DetectExpressFrameworkContext = {
   sourceFile: ts.SourceFile
   fileId: string
   symbolsByFile: Map<string, SpiSymbol[]>
+  /** Slice 1c-ii.c writes route_handler SpiEdges into this array when a
+   *  named handler is resolved from a `<binding>.<httpMethod>(...)` call. */
+  edges: SpiEdge[]
 }
+
+const HTTP_ROUTE_METHODS: ReadonlySet<string> = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'all',
+  'options',
+  'head',
+])
 
 export function detectExpressFramework(ctx: DetectExpressFrameworkContext): void {
   const bindings = collectExpressBindings(ctx.sourceFile)
   if (!hasAnyBinding(bindings)) return
 
-  // Walk top-level variable statements looking for `const name = express()`
-  // or `const name = Router()` patterns. Tag the variable symbol with the
-  // matching framework_role.
+  // Slice 1c-ii.b — substrate: tag app/router factory variables.
+  // Track the (variable name → symbol) map for slice 1c-ii.c's route
+  // walker so we can resolve `app.get(...)` against the tagged binding.
+  const expressBindingSymbols = new Map<string, SpiSymbol>()
   for (const stmt of ctx.sourceFile.statements) {
     if (!ts.isVariableStatement(stmt)) continue
     const isConst = (stmt.declarationList.flags & ts.NodeFlags.Const) !== 0
@@ -61,9 +76,86 @@ export function detectExpressFramework(ctx: DetectExpressFrameworkContext): void
       if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
       const role = factoryCallRole(decl.initializer, bindings)
       if (!role) continue
-      tagSymbol(ctx.symbolsByFile, ctx.fileId, symbolKind, decl.name.text, role)
+      const tagged = tagSymbol(ctx.symbolsByFile, ctx.fileId, symbolKind, decl.name.text, role)
+      if (tagged && (role === 'express_app' || role === 'express_router')) {
+        expressBindingSymbols.set(decl.name.text, tagged)
+      }
     }
   }
+
+  // Slice 1c-ii.c — route detection: walk every call expression in the
+  // file. When the callee is `<binding>.<httpMethod>(...)` and `<binding>`
+  // is a tagged express_app/express_router, resolve the LAST argument to
+  // a named handler symbol in the same file. If found, tag the handler
+  // with framework_role: 'express_route' and emit a route_handler edge.
+  if (expressBindingSymbols.size === 0) return
+  walkRouteCalls(ctx, expressBindingSymbols)
+}
+
+function walkRouteCalls(
+  ctx: DetectExpressFrameworkContext,
+  expressBindingSymbols: Map<string, SpiSymbol>,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const callee = node.expression
+      if (ts.isIdentifier(callee.expression) && ts.isIdentifier(callee.name)) {
+        const bindingName = callee.expression.text
+        const httpMethod = callee.name.text
+        const bindingSymbol = expressBindingSymbols.get(bindingName)
+        if (bindingSymbol && HTTP_ROUTE_METHODS.has(httpMethod)) {
+          emitRouteForCall(ctx, bindingSymbol, node)
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(ctx.sourceFile)
+}
+
+function emitRouteForCall(
+  ctx: DetectExpressFrameworkContext,
+  bindingSymbol: SpiSymbol,
+  callExpr: ts.CallExpression,
+): void {
+  // The route handler is the last argument. Earlier args may be the path
+  // string, parameter regexes, or middleware functions.
+  const args = callExpr.arguments
+  if (args.length === 0) return
+  const handlerArg = args[args.length - 1]
+  if (!handlerArg || !ts.isIdentifier(handlerArg)) return
+
+  // Look up the handler in the file's symbol list. Match function or
+  // constant/variable symbols by exact name; method symbols (with
+  // ClassName.foo) and namespace symbols don't match the bare identifier
+  // pattern callers use here.
+  const handlerName = handlerArg.text
+  const symbols = ctx.symbolsByFile.get(ctx.fileId) ?? []
+  const handlerSymbol = symbols.find((s) =>
+    s.name === handlerName && (s.kind === 'function' || s.kind === 'constant' || s.kind === 'variable'),
+  )
+  if (!handlerSymbol) return
+
+  // Tag and emit edge. Multiple route registrations against the same
+  // handler are common (the same fn registered on / and /alias). The
+  // framework_role assignment is idempotent; the edge dedupe is the
+  // caller's job (build.ts already passes edges through addUniqueEdge-
+  // free push semantics, so we dedupe here).
+  handlerSymbol.framework_role = 'express_route'
+  const range = handlerSymbol.range
+  const edgeKey = `${bindingSymbol.id}|${handlerSymbol.id}|route_handler`
+  if (ctx.edges.some((e) => e.from === bindingSymbol.id && e.to === handlerSymbol.id && e.kind === 'route_handler')) {
+    return
+  }
+  void edgeKey
+  ctx.edges.push({
+    from: bindingSymbol.id,
+    to: handlerSymbol.id,
+    kind: 'route_handler',
+    confidence: 'high',
+    source: 'framework-decorator',
+    evidence: { file_id: ctx.fileId, range },
+  })
 }
 
 function collectExpressBindings(sourceFile: ts.SourceFile): ExpressBindings {
@@ -147,13 +239,14 @@ function tagSymbol(
   kind: SpiSymbol['kind'],
   name: string,
   role: SpiFrameworkRole,
-): void {
+): SpiSymbol | null {
   const symbols = symbolsByFile.get(fileId)
-  if (!symbols) return
+  if (!symbols) return null
   for (const symbol of symbols) {
     if (symbol.kind === kind && symbol.name === name) {
       symbol.framework_role = role
-      return
+      return symbol
     }
   }
+  return null
 }

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -47,6 +47,23 @@ export type DetectExpressFrameworkContext = {
   /** Slice 1c-ii.c writes route_handler SpiEdges into this array when a
    *  named handler is resolved from a `<binding>.<httpMethod>(...)` call. */
   edges: SpiEdge[]
+  /** Type checker for the program — used to resolve callee/handler
+   *  identifiers to their *declarations* so lexical shadows don't
+   *  produce false-positive route tags (CodeRabbit catch on slice
+   *  1c-ii.c). When omitted, the detector falls back to bare-name
+   *  matching, which is correct only when no inner scope shadows the
+   *  receiver or handler identifier. */
+  checker?: ts.TypeChecker
+}
+
+/** Internal record: pairs a tagged Express binding's SpiSymbol with the
+ *  ts.VariableDeclaration that produced it, so call-site resolution can
+ *  verify a `<id>.method(...)` callee resolves back to the SAME
+ *  declaration instead of any other binding that happens to share the
+ *  identifier text. */
+type ExpressBindingRecord = {
+  spiSymbol: SpiSymbol
+  declaration: ts.VariableDeclaration
 }
 
 const HTTP_ROUTE_METHODS: ReadonlySet<string> = new Set([
@@ -65,9 +82,12 @@ export function detectExpressFramework(ctx: DetectExpressFrameworkContext): void
   if (!hasAnyBinding(bindings)) return
 
   // Slice 1c-ii.b — substrate: tag app/router factory variables.
-  // Track the (variable name → symbol) map for slice 1c-ii.c's route
-  // walker so we can resolve `app.get(...)` against the tagged binding.
-  const expressBindingSymbols = new Map<string, SpiSymbol>()
+  // Slice 1c-ii.c — record (name → { spiSymbol, declaration }) so the
+  // route walker can verify call-site receivers resolve back to the
+  // SAME declaration (defends against lexical shadows where an inner
+  // `const app = { get: ... }` would otherwise hijack the outer
+  // express_app binding).
+  const expressBindings = new Map<string, ExpressBindingRecord>()
   for (const stmt of ctx.sourceFile.statements) {
     if (!ts.isVariableStatement(stmt)) continue
     const isConst = (stmt.declarationList.flags & ts.NodeFlags.Const) !== 0
@@ -78,33 +98,43 @@ export function detectExpressFramework(ctx: DetectExpressFrameworkContext): void
       if (!role) continue
       const tagged = tagSymbol(ctx.symbolsByFile, ctx.fileId, symbolKind, decl.name.text, role)
       if (tagged && (role === 'express_app' || role === 'express_router')) {
-        expressBindingSymbols.set(decl.name.text, tagged)
+        expressBindings.set(decl.name.text, { spiSymbol: tagged, declaration: decl })
       }
     }
   }
 
   // Slice 1c-ii.c — route detection: walk every call expression in the
   // file. When the callee is `<binding>.<httpMethod>(...)` and `<binding>`
-  // is a tagged express_app/express_router, resolve the LAST argument to
-  // a named handler symbol in the same file. If found, tag the handler
-  // with framework_role: 'express_route' and emit a route_handler edge.
-  if (expressBindingSymbols.size === 0) return
-  walkRouteCalls(ctx, expressBindingSymbols)
+  // is a tagged express_app/express_router (verified by declaration
+  // identity, not bare name), resolve the LAST argument to a named
+  // handler symbol in the same file. If found, tag the handler with
+  // framework_role: 'express_route' and emit a route_handler edge.
+  if (expressBindings.size === 0) return
+  walkRouteCalls(ctx, expressBindings)
 }
 
 function walkRouteCalls(
   ctx: DetectExpressFrameworkContext,
-  expressBindingSymbols: Map<string, SpiSymbol>,
+  expressBindings: Map<string, ExpressBindingRecord>,
 ): void {
+  // O(1) edge-dedupe set keyed by `${from}|${to}|route_handler`. Replaces
+  // the previous O(n) linear scan over ctx.edges per candidate.
+  const seenEdgeKeys = new Set<string>()
+  for (const edge of ctx.edges) {
+    if (edge.kind === 'route_handler') {
+      seenEdgeKeys.add(`${edge.from}|${edge.to}|route_handler`)
+    }
+  }
+
   const visit = (node: ts.Node): void => {
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
       const callee = node.expression
       if (ts.isIdentifier(callee.expression) && ts.isIdentifier(callee.name)) {
         const bindingName = callee.expression.text
         const httpMethod = callee.name.text
-        const bindingSymbol = expressBindingSymbols.get(bindingName)
-        if (bindingSymbol && HTTP_ROUTE_METHODS.has(httpMethod)) {
-          emitRouteForCall(ctx, bindingSymbol, node)
+        const bindingRecord = expressBindings.get(bindingName)
+        if (bindingRecord && HTTP_ROUTE_METHODS.has(httpMethod) && receiverMatchesBinding(callee.expression, bindingRecord, ctx.checker)) {
+          emitRouteForCall(ctx, bindingRecord.spiSymbol, node, seenEdgeKeys)
         }
       }
     }
@@ -113,10 +143,29 @@ function walkRouteCalls(
   visit(ctx.sourceFile)
 }
 
+/** Returns true iff the call-site receiver identifier resolves to the
+ *  SAME declaration that we tagged earlier. Without a checker we fall
+ *  back to bare-name matching (the legacy behavior), which can produce
+ *  false positives in shadowed inner scopes. With a checker we walk the
+ *  resolved ts.Symbol's declarations and compare against the tagged
+ *  ts.VariableDeclaration node directly. */
+function receiverMatchesBinding(
+  identifier: ts.Identifier,
+  bindingRecord: ExpressBindingRecord,
+  checker: ts.TypeChecker | undefined,
+): boolean {
+  if (!checker) return true
+  const tsSymbol = checker.getSymbolAtLocation(identifier)
+  const declarations = tsSymbol?.declarations
+  if (!declarations || declarations.length === 0) return false
+  return declarations.some((decl) => decl === bindingRecord.declaration)
+}
+
 function emitRouteForCall(
   ctx: DetectExpressFrameworkContext,
   bindingSymbol: SpiSymbol,
   callExpr: ts.CallExpression,
+  seenEdgeKeys: Set<string>,
 ): void {
   // The route handler is the last argument. Earlier args may be the path
   // string, parameter regexes, or middleware functions.
@@ -125,29 +174,16 @@ function emitRouteForCall(
   const handlerArg = args[args.length - 1]
   if (!handlerArg || !ts.isIdentifier(handlerArg)) return
 
-  // Look up the handler in the file's symbol list. Match function or
-  // constant/variable symbols by exact name; method symbols (with
-  // ClassName.foo) and namespace symbols don't match the bare identifier
-  // pattern callers use here.
-  const handlerName = handlerArg.text
-  const symbols = ctx.symbolsByFile.get(ctx.fileId) ?? []
-  const handlerSymbol = symbols.find((s) =>
-    s.name === handlerName && (s.kind === 'function' || s.kind === 'constant' || s.kind === 'variable'),
-  )
+  // Resolve the handler. With a checker, prefer declaration-identity
+  // resolution so shadowed inner handlers don't tag the outer symbol.
+  const handlerSymbol = resolveHandlerSymbol(handlerArg, ctx)
   if (!handlerSymbol) return
 
-  // Tag and emit edge. Multiple route registrations against the same
-  // handler are common (the same fn registered on / and /alias). The
-  // framework_role assignment is idempotent; the edge dedupe is the
-  // caller's job (build.ts already passes edges through addUniqueEdge-
-  // free push semantics, so we dedupe here).
   handlerSymbol.framework_role = 'express_route'
   const range = handlerSymbol.range
   const edgeKey = `${bindingSymbol.id}|${handlerSymbol.id}|route_handler`
-  if (ctx.edges.some((e) => e.from === bindingSymbol.id && e.to === handlerSymbol.id && e.kind === 'route_handler')) {
-    return
-  }
-  void edgeKey
+  if (seenEdgeKeys.has(edgeKey)) return
+  seenEdgeKeys.add(edgeKey)
   ctx.edges.push({
     from: bindingSymbol.id,
     to: handlerSymbol.id,
@@ -156,6 +192,43 @@ function emitRouteForCall(
     source: 'framework-decorator',
     evidence: { file_id: ctx.fileId, range },
   })
+}
+
+function resolveHandlerSymbol(
+  handlerIdentifier: ts.Identifier,
+  ctx: DetectExpressFrameworkContext,
+): SpiSymbol | null {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId) ?? []
+  const handlerName = handlerIdentifier.text
+
+  // With a checker, resolve the identifier to its declaration and only
+  // accept top-level declarations (parent === SourceFile or a
+  // top-level VariableStatement). This rejects shadowed inner scopes.
+  if (ctx.checker) {
+    const tsSymbol = ctx.checker.getSymbolAtLocation(handlerIdentifier)
+    const declarations = tsSymbol?.declarations
+    if (!declarations || declarations.length === 0) return null
+    const isTopLevel = declarations.some((decl) => isTopLevelDeclaration(decl))
+    if (!isTopLevel) return null
+  }
+
+  return symbols.find((s) =>
+    s.name === handlerName && (s.kind === 'function' || s.kind === 'constant' || s.kind === 'variable'),
+  ) ?? null
+}
+
+function isTopLevelDeclaration(decl: ts.Declaration): boolean {
+  // Function declarations: `function foo() {}` directly under a SourceFile.
+  if (ts.isFunctionDeclaration(decl)) return ts.isSourceFile(decl.parent)
+  // Variable declarations: `const foo = ...` — parent chain is
+  // VariableDeclaration → VariableDeclarationList → VariableStatement →
+  // SourceFile.
+  if (ts.isVariableDeclaration(decl)) {
+    const list = decl.parent
+    const stmt = list.parent
+    return ts.isVariableStatement(stmt) && ts.isSourceFile(stmt.parent)
+  }
+  return false
 }
 
 function collectExpressBindings(sourceFile: ts.SourceFile): ExpressBindings {

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -120,6 +120,118 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
     })
   })
 
+  describe('route detection (slice 1c-ii.c)', () => {
+    it('tags a named handler referenced by app.get() with framework_role=express_route', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function listUsers(req: unknown, res: unknown): void { void req; void res }',
+        'app.get("/users", listUsers)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      expect(handler?.framework_role).toBe('express_route')
+    })
+
+    it('emits a route_handler edge from the express binding to the handler', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function listUsers(req: unknown, res: unknown): void { void req; void res }',
+        'app.get("/users", listUsers)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/server.ts', 'app')
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      const edge = spi.edges.find((e) => e.from === app?.id && e.to === handler?.id && e.kind === 'route_handler')
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+      expect(edge?.source).toBe('framework-decorator')
+    })
+
+    it('detects every standard HTTP route method', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function a(): void {}',
+        'export function b(): void {}',
+        'export function c(): void {}',
+        'export function d(): void {}',
+        'export function e(): void {}',
+        'export function f(): void {}',
+        'export function g(): void {}',
+        'export function h(): void {}',
+        'app.get("/a", a)',
+        'app.post("/b", b)',
+        'app.put("/c", c)',
+        'app.patch("/d", d)',
+        'app.delete("/e", e)',
+        'app.all("/f", f)',
+        'app.options("/g", g)',
+        'app.head("/h", h)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/server.ts', 'app')
+      const routeEdges = spi.edges.filter((edge) => edge.from === app?.id && edge.kind === 'route_handler')
+      expect(routeEdges).toHaveLength(8)
+    })
+
+    it('works for router.<method> too (router from express.Router())', () => {
+      writeFile(sandbox, 'src/routes.ts', [
+        'import { Router } from "express"',
+        'export const router = Router()',
+        'export function listUsers(): void {}',
+        'router.get("/users", listUsers)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/routes.ts', 'listUsers')
+      expect(handler?.framework_role).toBe('express_route')
+    })
+
+    it('does not tag handlers when the receiver is not an express binding', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'function notExpress(): { get: (path: string, fn: () => void) => void } {',
+        '  return { get: (_path, _fn) => {} }',
+        '}',
+        'const fakeApp = notExpress()',
+        'export function handler(): void {}',
+        'fakeApp.get("/x", handler)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'handler')
+      expect(handler?.framework_role).toBeUndefined()
+    })
+
+    it('skips inline arrow handlers (deferred to slice 1c-ii.e)', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.get("/x", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/server.ts', 'app')
+      const routeEdges = spi.edges.filter((edge) => edge.from === app?.id && edge.kind === 'route_handler')
+      // No named handler symbol → no edge emitted in this slice.
+      expect(routeEdges).toHaveLength(0)
+    })
+
+    it('dedupes route_handler edges when the same handler is registered on multiple paths', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function handler(): void {}',
+        'app.get("/a", handler)',
+        'app.get("/alias", handler)',
+        'app.post("/a", handler)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/server.ts', 'app')
+      const handler = findSymbol(spi, 'src/server.ts', 'handler')
+      const routeEdges = spi.edges.filter((e) => e.from === app?.id && e.to === handler?.id && e.kind === 'route_handler')
+      expect(routeEdges).toHaveLength(1)
+    })
+  })
+
   describe('projector — framework propagation through to ExtractionNode', () => {
     it('an express_app variable surfaces with framework=express on the projected ExtractionNode', async () => {
       writeFile(sandbox, 'src/server.ts', [

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -215,6 +215,38 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
       expect(routeEdges).toHaveLength(0)
     })
 
+    it('does NOT tag the outer handler when a lexical shadow uses the same identifier (CodeRabbit fix)', () => {
+      // Critical correctness regression: an inner scope that shadows
+      // either the receiver (`const app = { get: ... }`) or the handler
+      // (`const handler = ...`) must not cause the OUTER express_app and
+      // OUTER handler symbols to be treated as a route registration. The
+      // detector compares the receiver's resolved declaration to the
+      // tagged binding declaration, and only accepts top-level handler
+      // declarations.
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function handler(): void {}',
+        'function setup(): void {',
+        '  const app = { get: (_p: string, _h: () => void): void => {} }',
+        '  const handler = (): void => {}',
+        '  app.get("/x", handler)',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const outerApp = findSymbol(spi, 'src/server.ts', 'app')
+      const outerHandler = findSymbol(spi, 'src/server.ts', 'handler')
+      // Neither the outer handler should be tagged express_route, nor
+      // should there be any route_handler edge from the outer app to
+      // the outer handler. The shadowed inner call resolves to the
+      // local `app` and `handler`, neither of which is in the SPI.
+      expect(outerHandler?.framework_role).toBeUndefined()
+      const edges = spi.edges.filter((e) =>
+        e.from === outerApp?.id && e.to === outerHandler?.id && e.kind === 'route_handler',
+      )
+      expect(edges).toHaveLength(0)
+    })
+
     it('dedupes route_handler edges when the same handler is registered on multiple paths', () => {
       writeFile(sandbox, 'src/server.ts', [
         'import express from "express"',


### PR DESCRIPTION
Builds on slice 1c-ii.b (Express factory substrate). Adds named-handler route detection.

## Summary

When the SPI Express detector sees a call expression of the form \`<binding>.<httpMethod>(...)\` where \`<binding>\` resolves to a previously-tagged \`express_app\` / \`express_router\` symbol and the LAST argument is an \`Identifier\` referencing a function/constant/variable symbol in the same file, the handler is tagged with \`framework_role: 'express_route'\` and a \`route_handler\` SpiEdge is emitted from the binding's symbol to the handler's symbol.

Recognised HTTP methods: \`get / post / put / patch / delete / all / options / head\` — the canonical Express route surface.

Edges carry:
- \`confidence: 'high'\` (binding + handler both resolved statically)
- \`source: 'framework-decorator'\` (matches NestJS framework-edge convention)
- \`evidence\`: the handler's source range

## Out of scope (deferred)

- **Inline arrow handlers** — \`app.get('/p', (_req, _res) => {...})\` are not tagged in this slice. The arrow has no top-level symbol to tag; the legacy extractor synthesizes a route node from the anonymous callback. That synthesis lands in slice 1c-ii.e together with \`route_path\` metadata.
- **Middleware** — \`app.use(...)\` patterns are slice 1c-ii.d.
- **Mounted-router prefix resolution** — \`app.use('/api', usersRouter)\` route-prefix propagation lands in 1c-ii.e.

## Edge dedupe

The same handler is often registered on multiple paths (e.g. \`/api/users\` and \`/users\`) or multiple methods. Only one \`route_handler\` edge is emitted per \`(binding, handler)\` pair — multiple registrations carry the same routing claim from the substrate's POV.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 94 files / **1618** tests pass (7 new for routes + 1611 pre-existing)
- [x] Tests cover: named-handler tagging via \`app.get\`; \`route_handler\` edge emission with provenance; all 8 standard HTTP methods; \`router.<method>\` (Express.Router-derived bindings); negative case (non-express receiver → no tagging); inline-arrow skip case (the deferred path); dedupe across multiple registrations of the same handler.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## What slice 1c-ii.d will add

Middleware tagging:
- \`app.use(handlerFn)\` → tags \`handlerFn\` with \`framework_role: 'express_middleware'\`
- \`app.use('/prefix', handlerFn)\` — same tagging, plus prefix metadata for 1c-ii.e
- \`router.use(...)\` — same shape

Refs #72 (SPI v1 umbrella), #107 (1c-ii.b — substrate this builds on).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Express.js detection for app/router bindings and automatic tagging of named route handlers
  * Emits high-confidence route links for detected handlers and deduplicates duplicate registrations
  * Covers all standard HTTP methods for route analysis

* **Tests**
  * Added tests for handler tagging, deduplication, shadowing safety, and method coverage

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/108)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->