### PR TITLE
feat(#72): SPI v1 slice 1c-ii.d — Express middleware detection

### DIFF
--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -172,12 +172,17 @@ function emitMiddlewareForCall(
     if (!ts.isIdentifier(arg)) continue
     const handlerSymbol = resolveHandlerSymbol(arg, ctx)
     if (!handlerSymbol) continue
-    // If a symbol is BOTH used as a route handler and a middleware in the
-    // same file, the route-handler tag wins (it carries more semantic
-    // weight). The express_route role is set first because route
-    // detection runs in the same walk; only set express_middleware when
-    // the symbol isn't already framework-role-tagged.
-    if (handlerSymbol.framework_role === 'express_route') continue
+    // Never overwrite an existing framework_role. A symbol that already
+    // has a role carries more semantic weight than the middleware
+    // fallback:
+    //   * express_route — the symbol was already detected as a route
+    //     handler earlier in the same walk; route wins.
+    //   * express_router — the symbol is a Router instance being mounted
+    //     via `app.use(router)`. The mount call attaches the router to
+    //     the app but the router's own role stays the more specific tag.
+    //   * any future express_* role — same reasoning; middleware is the
+    //     fallback for symbols that have no other Express identity.
+    if (handlerSymbol.framework_role !== undefined) continue
     handlerSymbol.framework_role = 'express_middleware'
   }
 }

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -1,4 +1,5 @@
-// SPI v1 — Express framework layer (slices 1c-ii.b + 1c-ii.c of #72).
+// SPI v1 — Express framework layer (slices 1c-ii.b + 1c-ii.c + 1c-ii.d
+// of #72).
 //
 // Slice 1c-ii.b — substrate: detects Express's `app = express()` and
 // `router = Router()` factory call patterns and tags the resulting
@@ -10,19 +11,26 @@
 // the LAST argument is a named identifier (function or variable symbol
 // in the same file), the handler is tagged framework_role: 'express_route'
 // and a `route_handler` SpiEdge is emitted from the binding's symbol to
-// the handler's symbol with confidence 'high'. Inline arrow handlers
-// (`app.get('/p', (req, res) => {...})`) are intentionally NOT tagged in
-// this slice — they require synthesizing route nodes from anonymous
-// callbacks, which is slice 1c-ii.e territory.
+// the handler's symbol with confidence 'high'.
 //
-// Future slices:
+// Slice 1c-ii.d — middleware detection: walks `<binding>.use(...)` call
+// expressions. Every Identifier argument that resolves to a top-level
+// function/constant/variable in the same file is tagged with
+// framework_role: 'express_middleware'. The optional first string-
+// literal path argument (`app.use('/api', mw1, mw2)`) is skipped. No
+// edge is emitted for middleware — the framework_role tag plus
+// projector layer (slice 1c-ii.a's framework propagation) is enough to
+// surface 'framework: express, framework_role: express_middleware' on
+// the consumer side. Inline arrow middleware is deferred to slice
+// 1c-ii.e (same anonymous-callback synthesis territory as inline route
+// handlers).
 //
-//   * 1c-ii.d — middleware detection: app.use(...) tags handlers with
-//     framework_role: 'express_middleware'.
+// Future slice:
+//
 //   * 1c-ii.e — full byte-equivalence with the legacy
 //     extract/frameworks/express.ts surface (~1,669 lines): synthetic
 //     route nodes with route_path, mounted-router prefix resolution,
-//     dynamic compositions.
+//     dynamic compositions, anonymous-callback handler synthesis.
 
 import ts from 'typescript'
 
@@ -131,16 +139,47 @@ function walkRouteCalls(
       const callee = node.expression
       if (ts.isIdentifier(callee.expression) && ts.isIdentifier(callee.name)) {
         const bindingName = callee.expression.text
-        const httpMethod = callee.name.text
+        const methodName = callee.name.text
         const bindingRecord = expressBindings.get(bindingName)
-        if (bindingRecord && HTTP_ROUTE_METHODS.has(httpMethod) && receiverMatchesBinding(callee.expression, bindingRecord, ctx.checker)) {
-          emitRouteForCall(ctx, bindingRecord.spiSymbol, node, seenEdgeKeys)
+        if (bindingRecord && receiverMatchesBinding(callee.expression, bindingRecord, ctx.checker)) {
+          if (HTTP_ROUTE_METHODS.has(methodName)) {
+            emitRouteForCall(ctx, bindingRecord.spiSymbol, node, seenEdgeKeys)
+          } else if (methodName === 'use') {
+            // Slice 1c-ii.d — middleware detection.
+            emitMiddlewareForCall(ctx, node)
+          }
         }
       }
     }
     ts.forEachChild(node, visit)
   }
   visit(ctx.sourceFile)
+}
+
+function emitMiddlewareForCall(
+  ctx: DetectExpressFrameworkContext,
+  callExpr: ts.CallExpression,
+): void {
+  // Iterate every argument. String-literal path prefixes (e.g.,
+  // `app.use('/api', mw)`) are skipped — they're routing metadata, not
+  // middleware. Every Identifier that resolves to a top-level
+  // function/const/var in the same file is tagged with
+  // framework_role: 'express_middleware'. Inline arrow middleware
+  // (`app.use((req, res, next) => {...})`) is intentionally skipped;
+  // tagging anonymous callbacks requires the symbol-synthesis layer
+  // that lands in slice 1c-ii.e.
+  for (const arg of callExpr.arguments) {
+    if (!ts.isIdentifier(arg)) continue
+    const handlerSymbol = resolveHandlerSymbol(arg, ctx)
+    if (!handlerSymbol) continue
+    // If a symbol is BOTH used as a route handler and a middleware in the
+    // same file, the route-handler tag wins (it carries more semantic
+    // weight). The express_route role is set first because route
+    // detection runs in the same walk; only set express_middleware when
+    // the symbol isn't already framework-role-tagged.
+    if (handlerSymbol.framework_role === 'express_route') continue
+    handlerSymbol.framework_role = 'express_middleware'
+  }
 }
 
 /** Returns true iff the call-site receiver identifier resolves to the

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -361,6 +361,36 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
       expect(allFunctionSymbols).toHaveLength(0)
     })
 
+    it('mounting a Router via app.use(router) does NOT downgrade its express_router role to express_middleware (CodeRabbit fix)', () => {
+      // Real bug: previously the middleware emit only excluded
+      // express_route, so app.use(router) would overwrite the router's
+      // existing express_router framework_role with express_middleware.
+      // The mount call attaches the router to the app, but the router's
+      // own identity remains the more specific role.
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const router = Router()',
+        'app.use(router)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const router = findSymbol(spi, 'src/server.ts', 'router')
+      expect(router?.framework_role).toBe('express_router')
+      expect(router?.framework_role).not.toBe('express_middleware')
+    })
+
+    it('mounting a router with a path prefix preserves express_router too', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'app.use("/api/users", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const router = findSymbol(spi, 'src/server.ts', 'usersRouter')
+      expect(router?.framework_role).toBe('express_router')
+    })
+
     it('does not tag handlers when the receiver is a shadowed local `app`', () => {
       writeFile(sandbox, 'src/server.ts', [
         'import express from "express"',

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -264,6 +264,122 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
     })
   })
 
+  describe('middleware detection (slice 1c-ii.d)', () => {
+    it('tags app.use(middleware) handler with express_middleware', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function logger(_req: unknown, _res: unknown, next: () => void): void { next() }',
+        'app.use(logger)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'logger')
+      expect(handler?.framework_role).toBe('express_middleware')
+    })
+
+    it('skips the optional path-prefix string argument', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function authMiddleware(): void {}',
+        'app.use("/api", authMiddleware)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'authMiddleware')
+      expect(handler?.framework_role).toBe('express_middleware')
+    })
+
+    it('tags every middleware in a chain `app.use(mw1, mw2, mw3)`', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function mw1(): void {}',
+        'export function mw2(): void {}',
+        'export function mw3(): void {}',
+        'app.use(mw1, mw2, mw3)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/server.ts', 'mw1')?.framework_role).toBe('express_middleware')
+      expect(findSymbol(spi, 'src/server.ts', 'mw2')?.framework_role).toBe('express_middleware')
+      expect(findSymbol(spi, 'src/server.ts', 'mw3')?.framework_role).toBe('express_middleware')
+    })
+
+    it('tags `router.use(...)` middleware too', () => {
+      writeFile(sandbox, 'src/routes.ts', [
+        'import { Router } from "express"',
+        'export const router = Router()',
+        'export function middleware(): void {}',
+        'router.use(middleware)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/routes.ts', 'middleware')
+      expect(handler?.framework_role).toBe('express_middleware')
+    })
+
+    it('does not emit a route_handler edge for `use` calls (middleware ≠ route)', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function logger(): void {}',
+        'app.use(logger)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/server.ts', 'app')
+      const logger = findSymbol(spi, 'src/server.ts', 'logger')
+      const edges = spi.edges.filter((e) =>
+        e.from === app?.id && e.to === logger?.id && e.kind === 'route_handler',
+      )
+      expect(edges).toHaveLength(0)
+    })
+
+    it('does not downgrade an express_route tag to express_middleware when a fn is used as both', () => {
+      // A handler used as a route AND as middleware should retain its
+      // route tag — route is the more semantic role. (Convention: route
+      // wins; middleware is the fallback.)
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function dual(): void {}',
+        'app.get("/x", dual)',
+        'app.use(dual)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const dual = findSymbol(spi, 'src/server.ts', 'dual')
+      expect(dual?.framework_role).toBe('express_route')
+    })
+
+    it('does not tag inline arrow middleware (deferred to slice 1c-ii.e)', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.use((_req, _res, next) => next())',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      // No top-level handler symbol exists for the arrow, so nothing to
+      // tag. The detector silently skips. Sanity: no shadow false-tags.
+      const allFunctionSymbols = spi.symbols.filter((s) => s.framework_role === 'express_middleware')
+      expect(allFunctionSymbols).toHaveLength(0)
+    })
+
+    it('does not tag handlers when the receiver is a shadowed local `app`', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function outerMiddleware(): void {}',
+        'function setup(): void {',
+        '  const app = { use: (_h: () => void): void => {} }',
+        '  app.use(outerMiddleware)',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const outer = findSymbol(spi, 'src/server.ts', 'outerMiddleware')
+      // The shadowed inner `app.use(outerMiddleware)` resolves the
+      // receiver to the LOCAL `const app`, not the outer express()
+      // binding. The detector's declaration-identity check rejects it.
+      expect(outer?.framework_role).toBeUndefined()
+    })
+  })
+
   describe('projector — framework propagation through to ExtractionNode', () => {
     it('an express_app variable surfaces with framework=express on the projected ExtractionNode', async () => {
       writeFile(sandbox, 'src/server.ts', [


### PR DESCRIPTION
Builds on slice 1c-ii.c (Express route detection). Adds middleware tagging for \`<binding>.use(...)\` calls.

## Summary

- Extends the Express detector's call-expression walker. When the callee is \`<binding>.use(...)\` and \`<binding>\` resolves to a tagged \`express_app\` / \`express_router\` (verified by declaration identity, not bare name), every \`Identifier\` argument that resolves to a top-level function/const/var symbol in the same file is tagged with \`framework_role: 'express_middleware'\`.
- String-literal first arguments (the optional path prefix in \`app.use('/api', mw)\`) are skipped — they're routing metadata, not middleware.
- No edge is emitted for middleware. The framework_role tag plus slice 1c-ii.a's projector propagation is enough to surface \`framework: 'express'\` / \`framework_role: 'express_middleware'\` / \`node_kind: 'function'\` on the produced ExtractionNode.

## Convention

When a function is used as both a route handler AND middleware (rare but legal — e.g., a body-parser-style fn registered via \`app.use\` in one place and \`app.post\` in another), the route tag wins. Route is the more semantic role; middleware is the fallback. The middleware emit only sets \`framework_role\` when the symbol isn't already framework-role-tagged.

## Out of scope (deferred)

- **Inline arrow middleware** — \`app.use((req, res, next) => ...)\` requires synthesizing a symbol for the anonymous callback. Same blocker as inline arrow routes; both land together in slice 1c-ii.e.
- **\`middleware_attaches\` edges** — currently only the framework_role tag is emitted. If downstream consumers need to query "what middleware does this app use?" via SPI edges, a follow-up slice can add a new edge kind. Today the consumer can do this via the projection layer (filter ExtractionNodes by \`framework: 'express', framework_role: 'express_middleware'\`).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 94 files / **1627** tests pass (8 new for middleware + 1619 pre-existing)
- [x] Tests cover: \`app.use(mw)\` tagging, optional path-prefix skip (\`app.use('/api', mw)\`), middleware chain (\`app.use(mw1, mw2, mw3)\`), \`router.use\` parity, no \`route_handler\` edge emission for middleware, route-tag-wins-over-middleware-tag for dual-use functions, inline-arrow skip, shadowed-receiver regression (outer middleware not tagged when inner \`const app\` shadows).
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## What's next

Slice **1c-ii.e** — full byte-equivalence with the legacy \`extract/frameworks/express.ts\` surface (~1,669 lines). Adds: synthetic route nodes with \`route_path\`, mounted-router prefix resolution (\`app.use('/api', usersRouter)\` → routes mounted at \`/api/users/...\`), dynamic compositions, anonymous-callback handler synthesis. **This is the v0.14.0 trigger** and is the largest remaining piece of the Express port.

Refs #72 (SPI v1 umbrella), #107 (1c-ii.b), #108 (1c-ii.c).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Express middleware detection added to SPI; `app.use()` and `router.use()` are recognized and tagged.
  * Supports middleware chains and optional path prefixes; route handler role keeps priority when both apply.
* **Behavior**
  * Inline arrow middleware passed directly is intentionally ignored.
  * Mounting routers or shadowed receivers won’t be misclassified or downgraded.
* **Tests**
  * New suite validating middleware detection and related edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/109)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->