### PR TITLE
feat(#72): SPI v1 slice 1c-ii.e — inline arrow handler synthesis

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -650,6 +650,7 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       sourceFile,
       fileId: file.id,
       symbolsByFile,
+      symbols,
       edges,
       checker,
     })

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -1,5 +1,5 @@
-// SPI v1 — Express framework layer (slices 1c-ii.b + 1c-ii.c + 1c-ii.d
-// of #72).
+// SPI v1 — Express framework layer (slices 1c-ii.b through 1c-ii.e of
+// #72).
 //
 // Slice 1c-ii.b — substrate: detects Express's `app = express()` and
 // `router = Router()` factory call patterns and tags the resulting
@@ -10,27 +10,32 @@
 // resolves to a previously-tagged express_app/express_router binding and
 // the LAST argument is a named identifier (function or variable symbol
 // in the same file), the handler is tagged framework_role: 'express_route'
-// and a `route_handler` SpiEdge is emitted from the binding's symbol to
-// the handler's symbol with confidence 'high'.
+// and a `route_handler` SpiEdge is emitted with confidence 'high'.
 //
 // Slice 1c-ii.d — middleware detection: walks `<binding>.use(...)` call
 // expressions. Every Identifier argument that resolves to a top-level
 // function/constant/variable in the same file is tagged with
-// framework_role: 'express_middleware'. The optional first string-
-// literal path argument (`app.use('/api', mw1, mw2)`) is skipped. No
-// edge is emitted for middleware — the framework_role tag plus
-// projector layer (slice 1c-ii.a's framework propagation) is enough to
-// surface 'framework: express, framework_role: express_middleware' on
-// the consumer side. Inline arrow middleware is deferred to slice
-// 1c-ii.e (same anonymous-callback synthesis territory as inline route
-// handlers).
+// framework_role: 'express_middleware' (only when no other express_*
+// role already exists; mounted routers keep their express_router tag).
+//
+// Slice 1c-ii.e — anonymous handler synthesis: when the route/middleware
+// argument is an ArrowFunction or FunctionExpression instead of an
+// Identifier (the common `app.get('/p', (req, res) => {...})` pattern),
+// the detector mints a synthetic SpiSymbol with kind 'function' and a
+// deterministic id derived from (file_id, binding name, http method,
+// handler line). The synthetic symbol is tagged with the matching
+// framework_role and pushed into BOTH the flat symbols list and the
+// per-file index so it survives into the projector. For routes, the
+// matching route_handler edge is emitted from the binding to the
+// synthetic symbol.
 //
 // Future slice:
 //
-//   * 1c-ii.e — full byte-equivalence with the legacy
-//     extract/frameworks/express.ts surface (~1,669 lines): synthetic
-//     route nodes with route_path, mounted-router prefix resolution,
-//     dynamic compositions, anonymous-callback handler synthesis.
+//   * 1c-ii.f — full byte-equivalence with the legacy
+//     extract/frameworks/express.ts surface: route_path metadata on the
+//     synthetic symbols (extends SpiSymbol with framework_metadata field),
+//     mounted-router prefix resolution (`app.use('/api', usersRouter)` →
+//     /api/... path prefix), dynamic compositions.
 
 import ts from 'typescript'
 
@@ -52,6 +57,12 @@ export type DetectExpressFrameworkContext = {
   sourceFile: ts.SourceFile
   fileId: string
   symbolsByFile: Map<string, SpiSymbol[]>
+  /** Slice 1c-ii.e pushes synthesized inline-handler SpiSymbols into
+   *  this flat list so they survive into the SPI's symbol set. The
+   *  per-file index (symbolsByFile) is updated in lockstep — both
+   *  references point to the same symbol objects, but only `symbols`
+   *  is what buildSpi sorts/returns. */
+  symbols: SpiSymbol[]
   /** Slice 1c-ii.c writes route_handler SpiEdges into this array when a
    *  named handler is resolved from a `<binding>.<httpMethod>(...)` call. */
   edges: SpiEdge[]
@@ -163,14 +174,16 @@ function emitMiddlewareForCall(
   // Iterate every argument. String-literal path prefixes (e.g.,
   // `app.use('/api', mw)`) are skipped — they're routing metadata, not
   // middleware. Every Identifier that resolves to a top-level
-  // function/const/var in the same file is tagged with
-  // framework_role: 'express_middleware'. Inline arrow middleware
-  // (`app.use((req, res, next) => {...})`) is intentionally skipped;
-  // tagging anonymous callbacks requires the symbol-synthesis layer
-  // that lands in slice 1c-ii.e.
+  // function/const/var is tagged with framework_role:
+  // 'express_middleware'. Inline arrow/function-expression middleware
+  // gets a synthesized SpiSymbol via slice 1c-ii.e.
   for (const arg of callExpr.arguments) {
-    if (!ts.isIdentifier(arg)) continue
-    const handlerSymbol = resolveHandlerSymbol(arg, ctx)
+    let handlerSymbol: SpiSymbol | null = null
+    if (ts.isIdentifier(arg)) {
+      handlerSymbol = resolveHandlerSymbol(arg, ctx)
+    } else if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
+      handlerSymbol = mintSyntheticHandlerSymbol(ctx, callExpr, arg, 'express_middleware')
+    }
     if (!handlerSymbol) continue
     // Never overwrite an existing framework_role. A symbol that already
     // has a role carries more semantic weight than the middleware
@@ -182,7 +195,7 @@ function emitMiddlewareForCall(
     //     the app but the router's own role stays the more specific tag.
     //   * any future express_* role — same reasoning; middleware is the
     //     fallback for symbols that have no other Express identity.
-    if (handlerSymbol.framework_role !== undefined) continue
+    if (handlerSymbol.framework_role !== undefined && handlerSymbol.framework_role !== 'express_middleware') continue
     handlerSymbol.framework_role = 'express_middleware'
   }
 }
@@ -216,13 +229,23 @@ function emitRouteForCall(
   const args = callExpr.arguments
   if (args.length === 0) return
   const handlerArg = args[args.length - 1]
-  if (!handlerArg || !ts.isIdentifier(handlerArg)) return
+  if (!handlerArg) return
 
-  // Resolve the handler. With a checker, prefer declaration-identity
-  // resolution so shadowed inner handlers don't tag the outer symbol.
-  const handlerSymbol = resolveHandlerSymbol(handlerArg, ctx)
+  // Resolve the handler in priority order:
+  //   1. Identifier — existing slice 1c-ii.c path.
+  //   2. ArrowFunction / FunctionExpression — slice 1c-ii.e synthesizes
+  //      a deterministic SpiSymbol for the anonymous callback.
+  let handlerSymbol: SpiSymbol | null = null
+  if (ts.isIdentifier(handlerArg)) {
+    handlerSymbol = resolveHandlerSymbol(handlerArg, ctx)
+  } else if (ts.isArrowFunction(handlerArg) || ts.isFunctionExpression(handlerArg)) {
+    handlerSymbol = mintSyntheticHandlerSymbol(ctx, callExpr, handlerArg, 'express_route')
+  }
   if (!handlerSymbol) return
 
+  // Named-handler path may need framework_role assignment; synthetic
+  // symbols already carry it from the mint helper. The assignment is
+  // idempotent.
   handlerSymbol.framework_role = 'express_route'
   const range = handlerSymbol.range
   const edgeKey = `${bindingSymbol.id}|${handlerSymbol.id}|route_handler`
@@ -236,6 +259,66 @@ function emitRouteForCall(
     source: 'framework-decorator',
     evidence: { file_id: ctx.fileId, range },
   })
+}
+
+/**
+ * Slice 1c-ii.e — synthesize a SpiSymbol for an inline arrow or function
+ * expression used as a route/middleware handler. The symbol's id is
+ * deterministic across builds for the same source: derived from the
+ * file_id, the binding identifier, the HTTP method (or "use" for
+ * middleware), and the handler's starting line number. Two route
+ * registrations at the same line on the same binding/method are rare
+ * but would collide — accept the collision; the second push is a no-op
+ * thanks to the seenEdgeKeys dedupe downstream.
+ */
+function mintSyntheticHandlerSymbol(
+  ctx: DetectExpressFrameworkContext,
+  callExpr: ts.CallExpression,
+  handler: ts.ArrowFunction | ts.FunctionExpression,
+  role: SpiFrameworkRole,
+): SpiSymbol | null {
+  const callee = callExpr.expression
+  if (!ts.isPropertyAccessExpression(callee)) return null
+  if (!ts.isIdentifier(callee.expression) || !ts.isIdentifier(callee.name)) return null
+  const bindingName = callee.expression.text
+  const methodName = callee.name.text
+  const range = rangeOfNode(handler, ctx.sourceFile)
+  const name = `${bindingName}.${methodName}.L${range.start.line}`
+  const id = `symbol:${ctx.fileId}/function/${name}`
+
+  // Don't re-mint if we already minted this one (e.g., on a second walk
+  // over the same source file in a future pipeline change).
+  const fileSymbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (fileSymbols) {
+    const existing = fileSymbols.find((s) => s.id === id)
+    if (existing) {
+      existing.framework_role = role
+      return existing
+    }
+  }
+
+  const synthetic: SpiSymbol = {
+    id,
+    file_id: ctx.fileId,
+    name,
+    kind: 'function',
+    range,
+    exported: false,
+    framework_role: role,
+  }
+  ctx.symbols.push(synthetic)
+  if (fileSymbols) fileSymbols.push(synthetic)
+  else ctx.symbolsByFile.set(ctx.fileId, [synthetic])
+  return synthetic
+}
+
+function rangeOfNode(node: ts.Node, sourceFile: ts.SourceFile): SpiSymbol['range'] {
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd())
+  return {
+    start: { line: start.line + 1, column: start.character + 1 },
+    end: { line: end.line + 1, column: end.character + 1 },
+  }
 }
 
 function resolveHandlerSymbol(

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -202,7 +202,13 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
       expect(handler?.framework_role).toBeUndefined()
     })
 
-    it('skips inline arrow handlers (deferred to slice 1c-ii.e)', () => {
+    it('after slice 1c-ii.e, inline arrow handlers ARE tagged via synthesis (covered in detail in the inline-handler-synthesis suite)', () => {
+      // This test was originally a slice 1c-ii.c "skip" assertion. Now
+      // that 1c-ii.e mints synthetic symbols for arrow handlers, the
+      // behavior is the inverse: there IS a route_handler edge to a
+      // synthetic symbol. Detailed assertions live in the synthesis
+      // suite below; this just preserves the original test's coverage
+      // intent with the updated expectation.
       writeFile(sandbox, 'src/server.ts', [
         'import express from "express"',
         'export const app = express()',
@@ -211,8 +217,7 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
       const spi = build(sandbox)
       const app = findSymbol(spi, 'src/server.ts', 'app')
       const routeEdges = spi.edges.filter((edge) => edge.from === app?.id && edge.kind === 'route_handler')
-      // No named handler symbol → no edge emitted in this slice.
-      expect(routeEdges).toHaveLength(0)
+      expect(routeEdges).toHaveLength(1)
     })
 
     it('does NOT tag the outer handler when a lexical shadow uses the same identifier (CodeRabbit fix)', () => {
@@ -348,17 +353,18 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
       expect(dual?.framework_role).toBe('express_route')
     })
 
-    it('does not tag inline arrow middleware (deferred to slice 1c-ii.e)', () => {
+    it('after slice 1c-ii.e, inline arrow middleware IS tagged via synthesis (covered in detail in the synthesis suite)', () => {
+      // Originally a 1c-ii.d "skip" assertion. 1c-ii.e now synthesizes
+      // a symbol for the anonymous middleware callback. Detailed
+      // expectations live in the synthesis suite below.
       writeFile(sandbox, 'src/server.ts', [
         'import express from "express"',
         'export const app = express()',
         'app.use((_req, _res, next) => next())',
       ].join('\n') + '\n')
       const spi = build(sandbox)
-      // No top-level handler symbol exists for the arrow, so nothing to
-      // tag. The detector silently skips. Sanity: no shadow false-tags.
-      const allFunctionSymbols = spi.symbols.filter((s) => s.framework_role === 'express_middleware')
-      expect(allFunctionSymbols).toHaveLength(0)
+      const tagged = spi.symbols.filter((s) => s.framework_role === 'express_middleware')
+      expect(tagged).toHaveLength(1)
     })
 
     it('mounting a Router via app.use(router) does NOT downgrade its express_router role to express_middleware (CodeRabbit fix)', () => {
@@ -407,6 +413,111 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
       // receiver to the LOCAL `const app`, not the outer express()
       // binding. The detector's declaration-identity check rejects it.
       expect(outer?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('inline-handler synthesis (slice 1c-ii.e)', () => {
+    it('mints a synthetic SpiSymbol for an inline arrow route handler', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.get("/users", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetic = spi.symbols.find((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      expect(synthetic).toBeTruthy()
+      // Deterministic name pattern: <binding>.<method>.L<line>
+      expect(synthetic?.name).toMatch(/^app\.get\.L\d+$/)
+      expect(synthetic?.file_id).toBe(spi.files.find((f) => f.path === 'src/server.ts')?.id)
+      expect(synthetic?.exported).toBe(false)
+    })
+
+    it('emits a route_handler edge from the binding to the synthetic handler', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.post("/users", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const app = findSymbol(spi, 'src/server.ts', 'app')
+      const synthetic = spi.symbols.find((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      const edge = spi.edges.find((e) =>
+        e.from === app?.id && e.to === synthetic?.id && e.kind === 'route_handler',
+      )
+      expect(edge).toBeTruthy()
+      expect(edge?.confidence).toBe('high')
+    })
+
+    it('synthesizes distinct symbols for multiple inline handlers in the same file', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.get("/a", (_req, _res) => { void 0 })',
+        'app.post("/b", (_req, _res) => { void 0 })',
+        'app.delete("/c", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetics = spi.symbols.filter((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      expect(synthetics).toHaveLength(3)
+      const names = synthetics.map((s) => s.name).sort()
+      expect(names[0]).toMatch(/^app\.delete\.L\d+$/)
+      expect(names[1]).toMatch(/^app\.get\.L\d+$/)
+      expect(names[2]).toMatch(/^app\.post\.L\d+$/)
+    })
+
+    it('synthesizes for plain function expressions too (function (req, res) { ... })', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.get("/x", function (_req, _res): void { void 0 })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetic = spi.symbols.find((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      expect(synthetic).toBeTruthy()
+      expect(synthetic?.name).toMatch(/^app\.get\.L\d+$/)
+    })
+
+    it('mints synthetic symbols for inline middleware too (slice 1c-ii.d + 1c-ii.e)', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.use((_req, _res, next) => next())',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetic = spi.symbols.find((s) => s.framework_role === 'express_middleware' && s.kind === 'function')
+      expect(synthetic).toBeTruthy()
+      expect(synthetic?.name).toMatch(/^app\.use\.L\d+$/)
+    })
+
+    it('still skips inline handlers when the receiver is a shadowed local binding', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'function setup(): void {',
+        '  const app = { get: (_p: string, _h: () => void): void => {} }',
+        '  app.get("/x", (_req, _res) => { void 0 })',
+        '}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetics = spi.symbols.filter((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      // Receiver doesn't resolve to the outer express() binding so no
+      // synthesis happens. (Slice 1c-ii.c's declaration-identity check
+      // protects us.)
+      expect(synthetics).toHaveLength(0)
+    })
+
+    it('synthesized symbols project to ExtractionNodes with framework=express and node_kind=function', async () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.get("/x", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const projected = extraction.nodes.find((n) => n.framework === 'express' && n.framework_role === 'express_route')
+      expect(projected).toBeTruthy()
+      expect(projected?.node_kind).toBe('route') // nodeKindForRole maps express_route → 'route'
     })
   })
 


### PR DESCRIPTION
Builds on slices 1c-ii.b/c/d (Express factory/route/middleware). Closes the synthesis gap left open by 1c-ii.c and 1c-ii.d.

## Summary

When the route/middleware argument is an \`ArrowFunction\` or \`FunctionExpression\` instead of an \`Identifier\` — the canonical Express idiom \`app.get('/p', (req, res) => {...})\` — the detector now mints a synthetic \`SpiSymbol\` for the anonymous callback.

| Synthesis property | Value |
|---|---|
| \`kind\` | \`'function'\` (closest \`SpiSymbolKind\` for a callable) |
| \`id\` | \`symbol:<file_id>/function/<binding>.<method>.L<line>\` — deterministic across builds |
| \`range\` | the handler node's own source range |
| \`framework_role\` | \`'express_route'\` for HTTP methods, \`'express_middleware'\` for \`.use(...)\` |
| \`exported\` | \`false\` (anonymous callbacks are never exported) |

## Implementation notes

- \`DetectExpressFrameworkContext\` grows a \`symbols: SpiSymbol[]\` field — the flat list buildSpi sorts and returns. Without this, synthesized symbols would live only in the per-file map and never make it back into the final SemanticProgramIndex. \`build.ts\` passes the parent \`symbols\` array through.
- Route synthesis emits a \`route_handler\` edge from binding to synthetic symbol (parity with named-handler routes). Middleware synthesis emits no edge (parity with named-handler middleware's tag-only design).
- The receiver-identity check from slice 1c-ii.c still gates synthesis: an inner-scope shadowed local won't trigger synthesis even if its inline argument is an arrow.

## What's deferred to slice 1c-ii.f (v0.14.0 trigger)

- **\`route_path\` metadata** on synthetic symbols. Requires extending \`SpiSymbol\` with a \`framework_metadata?: Record<string, unknown>\` field (open question 3 in the SPI v1 design doc).
- **Mounted-router prefix resolution**: \`app.use('/api', usersRouter)\` should propagate the \`/api\` prefix down to every route registered on \`usersRouter\`.
- **Full byte-equivalent port** of the remaining surface in \`extract/frameworks/express.ts\` for demo-repo parity.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 94 files / **1636** tests pass (7 new for synthesis + 1629 pre-existing)
- [x] Tests cover: arrow synthesis with deterministic name pattern, \`route_handler\` edge emission, multiple inline handlers in the same file (distinct symbols), plain function-expression handlers, inline middleware synthesis, shadowed-receiver-still-skips, end-to-end projection (synthetic symbol → ExtractionNode with \`framework: 'express'\`, \`node_kind: 'route'\`).
- [x] Two pre-existing 1c-ii.c/d "deferred to 1c-ii.e" skip-assertions are flipped to assert the now-delivered behavior. Same prompts, inverted expectations.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.
- [ ] Note: Windows-Node-20 timeout flakiness from PR #109 may recur; not caused by this change.

Refs #72, #107, #108, #109.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of inline route handlers and middleware callbacks in Express applications. Inline arrow functions and function expressions are now properly recognized and indexed, providing more complete framework mapping.

* **Tests**
  * Updated test suite to validate synthetic symbol generation for inline Express handlers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->