### PR TITLE
feat(#72): SPI v1 slice 1c-ii.f — route_path + mount_path framework_metadata

### DIFF
--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -171,13 +171,14 @@ function emitMiddlewareForCall(
   ctx: DetectExpressFrameworkContext,
   callExpr: ts.CallExpression,
 ): void {
-  // Iterate every argument. String-literal path prefixes (e.g.,
-  // `app.use('/api', mw)`) are skipped — they're routing metadata, not
-  // middleware. Every Identifier that resolves to a top-level
-  // function/const/var is tagged with framework_role:
-  // 'express_middleware'. Inline arrow/function-expression middleware
-  // gets a synthesized SpiSymbol via slice 1c-ii.e.
-  for (const arg of callExpr.arguments) {
+  // Slice 1c-ii.f — extract the optional path-prefix from the first arg
+  // if it's a string literal. `app.use('/api', mw1, mw2)` → mount_path:
+  // '/api'. Attached to every middleware symbol in the same call so
+  // downstream consumers can see which prefix triggered the middleware.
+  const args = callExpr.arguments
+  const mountPath = args.length > 0 ? stringLiteralValue(args[0]) : null
+
+  for (const arg of args) {
     let handlerSymbol: SpiSymbol | null = null
     if (ts.isIdentifier(arg)) {
       handlerSymbol = resolveHandlerSymbol(arg, ctx)
@@ -197,6 +198,12 @@ function emitMiddlewareForCall(
     //     fallback for symbols that have no other Express identity.
     if (handlerSymbol.framework_role !== undefined && handlerSymbol.framework_role !== 'express_middleware') continue
     handlerSymbol.framework_role = 'express_middleware'
+    if (mountPath !== null) {
+      handlerSymbol.framework_metadata = {
+        ...(handlerSymbol.framework_metadata ?? {}),
+        mount_path: mountPath,
+      }
+    }
   }
 }
 
@@ -231,6 +238,13 @@ function emitRouteForCall(
   const handlerArg = args[args.length - 1]
   if (!handlerArg) return
 
+  // Slice 1c-ii.f — extract the route path string from the FIRST
+  // argument if it's a string literal. \`app.get('/users/:id', ...)\` →
+  // route_path: '/users/:id'. Dynamic paths (template literals, computed
+  // expressions) are skipped — the metadata only carries statically
+  // known values; consumers shouldn't trust a partial path.
+  const routePath = stringLiteralValue(args[0])
+
   // Resolve the handler in priority order:
   //   1. Identifier — existing slice 1c-ii.c path.
   //   2. ArrowFunction / FunctionExpression — slice 1c-ii.e synthesizes
@@ -243,10 +257,14 @@ function emitRouteForCall(
   }
   if (!handlerSymbol) return
 
-  // Named-handler path may need framework_role assignment; synthetic
-  // symbols already carry it from the mint helper. The assignment is
-  // idempotent.
   handlerSymbol.framework_role = 'express_route'
+  if (routePath !== null) {
+    handlerSymbol.framework_metadata = {
+      ...(handlerSymbol.framework_metadata ?? {}),
+      route_path: routePath,
+    }
+  }
+
   const range = handlerSymbol.range
   const edgeKey = `${bindingSymbol.id}|${handlerSymbol.id}|route_handler`
   if (seenEdgeKeys.has(edgeKey)) return
@@ -259,6 +277,17 @@ function emitRouteForCall(
     source: 'framework-decorator',
     evidence: { file_id: ctx.fileId, range },
   })
+}
+
+/** Extract the value of a string-literal node (single or double-quoted,
+ *  or a no-substitution template literal). Returns null for anything
+ *  more complex — template literals with expressions, computed
+ *  identifiers, etc. */
+function stringLiteralValue(node: ts.Expression | undefined): string | null {
+  if (!node) return null
+  if (ts.isStringLiteral(node)) return node.text
+  if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text
+  return null
 }
 
 /**

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -87,6 +87,26 @@ export type SpiSymbol = {
   range: SpiRange
   exported: boolean
   framework_role?: SpiFrameworkRole
+  /**
+   * #72 slice 1c-ii.f — opt-in framework metadata bag. Populated by
+   * framework detectors when the symbol carries framework-specific data
+   * that doesn't fit the generic SpiSymbol shape:
+   *
+   *   - Express route handler (\`express_route\` role):
+   *       \`route_path: string\`  — the route path string from the first
+   *                                argument of \`<binding>.<method>(path, handler)\`.
+   *                                e.g. \`'/users/:id'\`.
+   *   - Express middleware (\`express_middleware\` role):
+   *       \`mount_path?: string\` — the optional prefix from
+   *                                \`app.use('/api', middleware)\`. Absent
+   *                                when middleware is registered globally.
+   *
+   * Per the SPI v1 design's open questions: the schema is intentionally
+   * \`unknown\` so framework extensions can store framework-specific
+   * fields without rev-ing the SpiSymbol type. A consumer that wants to
+   * type-narrow should do so against the symbol's \`framework_role\`.
+   */
+  framework_metadata?: Record<string, unknown>
 }
 
 export type SpiEdgeKind =

--- a/tests/unit/spi-framework-express.test.ts
+++ b/tests/unit/spi-framework-express.test.ts
@@ -521,6 +521,96 @@ describe('SPI Express framework detector (slice 1c-ii.b)', () => {
     })
   })
 
+  describe('route_path metadata (slice 1c-ii.f)', () => {
+    it('attaches route_path to a named route handler', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function listUsers(): void {}',
+        'app.get("/users/:id", listUsers)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      expect(handler?.framework_metadata).toEqual({ route_path: '/users/:id' })
+    })
+
+    it('attaches route_path to a synthesized inline route handler', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.post("/users", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetic = spi.symbols.find((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      expect(synthetic?.framework_metadata).toEqual({ route_path: '/users' })
+    })
+
+    it('extracts route_path from a no-substitution template literal', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function h(): void {}',
+        'app.delete(`/orders/:id`, h)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'h')
+      expect(handler?.framework_metadata?.route_path).toBe('/orders/:id')
+    })
+
+    it('does NOT attach route_path when the path is a dynamic expression (template with substitution)', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function h(): void {}',
+        'const prefix = "/v1"',
+        'app.get(`${prefix}/users`, h)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'h')
+      // Dynamic path → no route_path metadata. Consumers should not
+      // see a partial path; absent is honest.
+      expect(handler?.framework_metadata).toBeUndefined()
+    })
+
+    it('attaches mount_path to middleware registered with a path prefix', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function authMw(): void {}',
+        'app.use("/api", authMw)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'authMw')
+      expect(handler?.framework_metadata).toEqual({ mount_path: '/api' })
+    })
+
+    it('does NOT attach mount_path to middleware registered globally (app.use(mw) with no prefix)', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function globalMw(): void {}',
+        'app.use(globalMw)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'globalMw')
+      expect(handler?.framework_role).toBe('express_middleware')
+      expect(handler?.framework_metadata).toBeUndefined()
+    })
+
+    it('attaches the same mount_path to every middleware in a chained registration', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function mw1(): void {}',
+        'export function mw2(): void {}',
+        'app.use("/admin", mw1, mw2)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/server.ts', 'mw1')?.framework_metadata?.mount_path).toBe('/admin')
+      expect(findSymbol(spi, 'src/server.ts', 'mw2')?.framework_metadata?.mount_path).toBe('/admin')
+    })
+  })
+
   describe('projector — framework propagation through to ExtractionNode', () => {
     it('an express_app variable surfaces with framework=express on the projected ExtractionNode', async () => {
       writeFile(sandbox, 'src/server.ts', [


### PR DESCRIPTION
Resolves the SPI design's open question 3 (\"Decorator metadata storage\") for the Express framework path-metadata case.

## Substrate addition: \`SpiSymbol.framework_metadata\`

Extends \`SpiSymbol\` with an opt-in \`framework_metadata?: Record<string, unknown>\`. Unschematized by design so framework detectors can attach framework-specific data without re-rev'ing the substrate type. Consumers type-narrow against \`framework_role\` to know the metadata shape.

## Express metadata populated by this slice

| Role | Key | Source | Example |
|---|---|---|---|
| \`express_route\` (named or synthetic) | \`route_path\` | first arg of \`<binding>.<method>(path, handler)\` | \`'/users/:id'\` |
| \`express_middleware\` | \`mount_path\` (optional) | first arg of \`app.use(path, mw1, mw2)\` | \`'/api'\` |

Dynamic paths (template literals with substitutions, computed expressions) are intentionally omitted from \`route_path\` — a partial path is more misleading than absent. Globally-registered middleware (no path arg) carries no \`mount_path\`; consumers should treat absent as 'global'.

## What's deferred to slice 1c-ii.g (v0.14.0 trigger)

- **Mounted-router prefix resolution**: when \`app.use('/api', usersRouter)\` is seen, routes registered on \`usersRouter\` should have their \`route_path\` prefixed with \`/api\`. Today the child route's \`route_path\` is the un-prefixed path; full resolution requires cross-call analysis and a second pass.
- **Projector update**: emitting \`framework_metadata.route_path\` onto the produced ExtractionNode (today the metadata lives on the SpiSymbol only). Lands together with the prefix-resolution work in 1c-ii.g.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 94 files / **1643** tests pass (7 new for path metadata + 1636 pre-existing)
- [x] Tests cover: named-handler \`route_path\`, synthetic-handler \`route_path\`, no-substitution-template path extraction, dynamic-template skip case, mount_path on prefixed middleware, no mount_path on global middleware, mount_path propagation across a chained registration.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.
- [ ] Note: Windows-Node-20 timeout flakiness may recur; not caused by this change.

## Sequence

- ✅ 1c-ii.b factory tagging (#107)
- ✅ 1c-ii.c named route detection (#108)
- ✅ 1c-ii.d middleware detection (#109)
- ✅ 1c-ii.e inline arrow synthesis (#110)
- ✅ 1c-ii.f path metadata (this PR)
- 🟡 1c-ii.g mounted-router prefix resolution + projector wiring (v0.14.0 trigger)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Express framework detection with improved metadata enrichment for route handlers and middleware registrations
  * Route paths and middleware mount paths now captured during symbol analysis for more detailed framework-specific code analysis

* **Tests**
  * Added test coverage for Express route and middleware path metadata extraction

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->