### PR TITLE
feat(#72): SPI v1 slice 1c-iv.a — Next.js substrate (file-convention detector)

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -64,6 +64,7 @@ import type {
 import { addTestLayerEdges } from './test-layer.js'
 import { collectNestTokenMap, detectNestFramework } from './framework-nestjs.js'
 import { detectExpressFramework } from './framework-express.js'
+import { detectNextjsFramework } from './framework-nextjs.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -653,6 +654,16 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       symbols,
       edges,
       checker,
+    })
+    // Slice 1c-iv.a: convention-based Next.js detector. Tags exported
+    // symbols in app/.../page.tsx, app/.../route.ts, pages/api/...,
+    // pages/..., and root middleware.ts with the matching nextjs_*
+    // framework_role.
+    detectNextjsFramework({
+      sourceFile,
+      fileId: file.id,
+      filePath: file.path,
+      symbolsByFile,
     })
   }
 }

--- a/src/pipeline/spi/framework-nextjs.ts
+++ b/src/pipeline/spi/framework-nextjs.ts
@@ -1,0 +1,204 @@
+// SPI v1 — Next.js framework layer (slice 1c-iv.a of #72).
+//
+// Next.js is convention-based rather than call-based: routes, layouts,
+// middleware, and API handlers are identified by file path patterns, not
+// by AST shapes. This detector walks each file's path and applies the
+// matching SpiFrameworkRole to the file's exports.
+//
+// Conventions recognized in this slice:
+//
+//   app/<segments>/page.tsx          → nextjs_app_page     (default export)
+//   app/<segments>/route.ts          → nextjs_app_route    (named HTTP-method exports)
+//   app/<segments>/layout.tsx        → nextjs_app_layout   (default export)
+//   app/<segments>/loading.tsx       → nextjs_app_loading  (default export)
+//   app/<segments>/error.tsx         → nextjs_app_error    (default export)
+//   app/<segments>/template.tsx      → nextjs_app_template (default export)
+//   pages/api/<segments>.ts          → nextjs_pages_api    (default export)
+//   pages/<segments>.tsx             → nextjs_pages_page   (default export)
+//   middleware.ts (workspace root)   → nextjs_middleware   (default export)
+//
+// For app-router route.ts files the convention is **named** exports per
+// HTTP method (`export function GET() {}`, `export function POST() {}`),
+// so the detector tags every named export whose name is a recognized
+// HTTP verb. For every other convention the convention's payload lives
+// on the default export.
+//
+// Out of scope for this slice (deferred to follow-ups):
+//
+//   * route_path metadata derived from the file path
+//     (e.g. `app/users/[id]/page.tsx` → route_path: '/users/:id'). Slot
+//     in framework_metadata reserved for slice 1c-iv.b.
+//   * Dynamic segments and route groups: [id], [[...slug]], (group) —
+//     same metadata work above.
+//   * server/client component detection via the 'use client' directive.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const APP_FILE_CONVENTIONS: ReadonlyMap<string, SpiFrameworkRole> = new Map([
+  ['page', 'nextjs_app_page'],
+  ['layout', 'nextjs_app_layout'],
+  ['loading', 'nextjs_app_loading'],
+  ['error', 'nextjs_app_error'],
+  ['template', 'nextjs_app_template'],
+])
+
+const ROUTE_HTTP_NAMES: ReadonlySet<string> = new Set([
+  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD',
+])
+
+type NextjsConventionMatch =
+  | { kind: 'default'; role: SpiFrameworkRole }
+  | { kind: 'http_methods'; role: SpiFrameworkRole }
+
+export type DetectNextjsFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  /** Workspace-relative POSIX-normalized file path (the SpiFile.path). */
+  filePath: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+export function detectNextjsFramework(ctx: DetectNextjsFrameworkContext): void {
+  const match = matchConvention(ctx.filePath)
+  if (!match) return
+
+  if (match.kind === 'default') {
+    tagDefaultExport(ctx, match.role)
+  } else {
+    tagHttpMethodExports(ctx, match.role)
+  }
+}
+
+/** Returns the Next.js convention match for a workspace-relative path, or
+ *  null when the path doesn't match any convention. The detector accepts
+ *  the path with or without a leading `src/` directory (the common Next.js
+ *  configuration). */
+function matchConvention(filePath: string): NextjsConventionMatch | null {
+  const normalized = stripLeadingSrc(filePath)
+
+  // Root middleware: `middleware.ts` or `middleware.tsx`.
+  if (normalized === 'middleware.ts' || normalized === 'middleware.tsx') {
+    return { kind: 'default', role: 'nextjs_middleware' }
+  }
+
+  // App router conventions: `app/.../<basename>.tsx?` for pages/layouts/
+  // etc., `app/.../route.ts` for route handlers.
+  if (normalized.startsWith('app/')) {
+    const basename = stripExtension(getBasename(normalized))
+    if (basename === 'route') {
+      return { kind: 'http_methods', role: 'nextjs_app_route' }
+    }
+    const role = APP_FILE_CONVENTIONS.get(basename)
+    if (role) return { kind: 'default', role }
+    return null
+  }
+
+  // Pages router conventions.
+  if (normalized.startsWith('pages/')) {
+    // `pages/api/...` files are API routes (default export).
+    if (normalized.startsWith('pages/api/')) {
+      return { kind: 'default', role: 'nextjs_pages_api' }
+    }
+    // Other pages/* files are page components, but skip Next.js'
+    // special files (_app, _document, _error, _middleware) and any
+    // co-located non-routable file like `_components`.
+    const basename = stripExtension(getBasename(normalized))
+    if (basename.startsWith('_')) return null
+    return { kind: 'default', role: 'nextjs_pages_page' }
+  }
+
+  return null
+}
+
+function stripLeadingSrc(filePath: string): string {
+  return filePath.startsWith('src/') ? filePath.slice(4) : filePath
+}
+
+function getBasename(filePath: string): string {
+  const slash = filePath.lastIndexOf('/')
+  return slash === -1 ? filePath : filePath.slice(slash + 1)
+}
+
+function stripExtension(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot === -1 ? name : name.slice(0, dot)
+}
+
+function tagDefaultExport(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkRole): void {
+  // A Next.js page/layout/etc. is whatever symbol the file exports as
+  // its default. Two AST shapes produce a default export:
+  //   1. `export default function Foo() {}` — direct on a declaration.
+  //   2. `export default <expr>` — a separate ExportAssignment node.
+  // For (2) the expression is usually an Identifier referencing a
+  // previously-declared function/class/variable; we resolve back to that
+  // name. Anonymous default exports (`export default () => ...`) carry
+  // no SpiSymbol today and are skipped — synthesis for them would land
+  // in a follow-up slice mirroring slice 1c-ii.e's pattern.
+  const defaultExportName = findDefaultExportName(ctx.sourceFile)
+  if (defaultExportName === null) return
+  tagSymbolByName(ctx, defaultExportName, role)
+}
+
+function tagHttpMethodExports(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkRole): void {
+  // App-router route handlers (`app/.../route.ts`) export one function
+  // per HTTP method: `export function GET() {}`, `export function
+  // POST() {}`, etc. Tag each.
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isFunctionDeclaration(stmt) || !stmt.name) continue
+    if (!hasExportModifier(stmt)) continue
+    if (!ROUTE_HTTP_NAMES.has(stmt.name.text)) continue
+    tagSymbolByName(ctx, stmt.name.text, role)
+  }
+}
+
+function findDefaultExportName(sourceFile: ts.SourceFile): string | null {
+  for (const stmt of sourceFile.statements) {
+    // export default function Foo() {}
+    if (ts.isFunctionDeclaration(stmt) && stmt.name && hasExportDefaultModifiers(stmt)) {
+      return stmt.name.text
+    }
+    // export default class Foo {}
+    if (ts.isClassDeclaration(stmt) && stmt.name && hasExportDefaultModifiers(stmt)) {
+      return stmt.name.text
+    }
+    // export default <Identifier>
+    if (ts.isExportAssignment(stmt) && !stmt.isExportEquals && ts.isIdentifier(stmt.expression)) {
+      return stmt.expression.text
+    }
+  }
+  return null
+}
+
+function hasExportDefaultModifiers(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined
+  if (!modifiers) return false
+  let hasExport = false
+  let hasDefault = false
+  for (const mod of modifiers) {
+    if (mod.kind === ts.SyntaxKind.ExportKeyword) hasExport = true
+    if (mod.kind === ts.SyntaxKind.DefaultKeyword) hasDefault = true
+  }
+  return hasExport && hasDefault
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined
+  if (!modifiers) return false
+  for (const mod of modifiers) {
+    if (mod.kind === ts.SyntaxKind.ExportKeyword) return true
+  }
+  return false
+}
+
+function tagSymbolByName(ctx: DetectNextjsFrameworkContext, name: string, role: SpiFrameworkRole): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -71,3 +71,8 @@ export {
   detectExpressFramework,
   type DetectExpressFrameworkContext,
 } from './framework-express.js'
+
+export {
+  detectNextjsFramework,
+  type DetectNextjsFrameworkContext,
+} from './framework-nextjs.js'

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -229,6 +229,7 @@ export function projectSpiToExtraction(
 function frameworkForRole(role: NonNullable<SpiSymbol['framework_role']>): string {
   if (role.startsWith('nest_')) return 'nestjs'
   if (role.startsWith('express_')) return 'express'
+  if (role.startsWith('nextjs_')) return 'nextjs'
   return 'unknown'
 }
 
@@ -236,6 +237,8 @@ function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNul
   switch (role) {
     case 'nest_route':
     case 'express_route':
+    case 'nextjs_app_route':
+    case 'nextjs_pages_api':
       return 'route'
     case 'express_router':
       return 'router'
@@ -248,6 +251,13 @@ function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNul
       return 'class'
     case 'express_app':
     case 'express_middleware':
+    case 'nextjs_middleware':
+    case 'nextjs_app_page':
+    case 'nextjs_app_layout':
+    case 'nextjs_app_loading':
+    case 'nextjs_app_error':
+    case 'nextjs_app_template':
+    case 'nextjs_pages_page':
       return 'function'
     default:
       return null

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -78,6 +78,16 @@ export type SpiFrameworkRole =
   | 'express_router'
   | 'express_route'
   | 'express_middleware'
+  // Next.js roles (slice 1c-iv.a)
+  | 'nextjs_app_page'
+  | 'nextjs_app_route'
+  | 'nextjs_app_layout'
+  | 'nextjs_app_loading'
+  | 'nextjs_app_error'
+  | 'nextjs_app_template'
+  | 'nextjs_pages_page'
+  | 'nextjs_pages_api'
+  | 'nextjs_middleware'
 
 export type SpiSymbol = {
   id: string

--- a/tests/unit/spi-framework-nextjs.test.ts
+++ b/tests/unit/spi-framework-nextjs.test.ts
@@ -1,0 +1,220 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-nextjs-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1c-iv.a',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('SPI Next.js framework detector (slice 1c-iv.a)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('app router file conventions', () => {
+    it('tags the default export of app/<segment>/page.tsx as nextjs_app_page', () => {
+      writeFile(sandbox, 'app/users/page.tsx', [
+        'export default function UsersPage(): null { return null }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'app/users/page.tsx', 'UsersPage')
+      expect(sym?.framework_role).toBe('nextjs_app_page')
+    })
+
+    it('tags the default export of app/<segment>/layout.tsx as nextjs_app_layout', () => {
+      writeFile(sandbox, 'app/layout.tsx', [
+        'export default function RootLayout(): null { return null }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'app/layout.tsx', 'RootLayout')
+      expect(sym?.framework_role).toBe('nextjs_app_layout')
+    })
+
+    it('tags loading.tsx, error.tsx, and template.tsx with their respective roles', () => {
+      writeFile(sandbox, 'app/users/loading.tsx', 'export default function L(): null { return null }\n')
+      writeFile(sandbox, 'app/users/error.tsx', 'export default function E(): null { return null }\n')
+      writeFile(sandbox, 'app/users/template.tsx', 'export default function T(): null { return null }\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'app/users/loading.tsx', 'L')?.framework_role).toBe('nextjs_app_loading')
+      expect(findSymbol(spi, 'app/users/error.tsx', 'E')?.framework_role).toBe('nextjs_app_error')
+      expect(findSymbol(spi, 'app/users/template.tsx', 'T')?.framework_role).toBe('nextjs_app_template')
+    })
+
+    it('tags every HTTP-method named export of app/<segment>/route.ts as nextjs_app_route', () => {
+      writeFile(sandbox, 'app/api/users/route.ts', [
+        'export function GET(): Response { return new Response() }',
+        'export function POST(): Response { return new Response() }',
+        'export function helper(): void {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'app/api/users/route.ts', 'GET')?.framework_role).toBe('nextjs_app_route')
+      expect(findSymbol(spi, 'app/api/users/route.ts', 'POST')?.framework_role).toBe('nextjs_app_route')
+      // Non-HTTP-named exports stay untagged.
+      expect(findSymbol(spi, 'app/api/users/route.ts', 'helper')?.framework_role).toBeUndefined()
+    })
+
+    it('recognizes all standard HTTP method names on a route.ts', () => {
+      writeFile(sandbox, 'app/api/x/route.ts', [
+        'export function GET(): Response { return new Response() }',
+        'export function POST(): Response { return new Response() }',
+        'export function PUT(): Response { return new Response() }',
+        'export function PATCH(): Response { return new Response() }',
+        'export function DELETE(): Response { return new Response() }',
+        'export function OPTIONS(): Response { return new Response() }',
+        'export function HEAD(): Response { return new Response() }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const taggedCount = spi.symbols.filter((s) => s.framework_role === 'nextjs_app_route').length
+      expect(taggedCount).toBe(7)
+    })
+  })
+
+  describe('pages router file conventions', () => {
+    it('tags the default export of pages/<segment>.tsx as nextjs_pages_page', () => {
+      writeFile(sandbox, 'pages/about.tsx', [
+        'export default function About(): null { return null }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'pages/about.tsx', 'About')
+      expect(sym?.framework_role).toBe('nextjs_pages_page')
+    })
+
+    it('tags the default export of pages/api/<segment>.ts as nextjs_pages_api', () => {
+      writeFile(sandbox, 'pages/api/users.ts', [
+        'export default function handler(): void {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'pages/api/users.ts', 'handler')
+      expect(sym?.framework_role).toBe('nextjs_pages_api')
+    })
+
+    it('skips Next.js underscore-prefixed special files (_app, _document, _error)', () => {
+      writeFile(sandbox, 'pages/_app.tsx', 'export default function App(): null { return null }\n')
+      writeFile(sandbox, 'pages/_document.tsx', 'export default function Doc(): null { return null }\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'pages/_app.tsx', 'App')?.framework_role).toBeUndefined()
+      expect(findSymbol(spi, 'pages/_document.tsx', 'Doc')?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('middleware', () => {
+    it('tags the default export of root middleware.ts as nextjs_middleware', () => {
+      writeFile(sandbox, 'middleware.ts', [
+        'export default function middleware(): void {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'middleware.ts', 'middleware')
+      expect(sym?.framework_role).toBe('nextjs_middleware')
+    })
+  })
+
+  describe('src/ prefix support', () => {
+    it('recognizes Next.js conventions under src/app/', () => {
+      writeFile(sandbox, 'src/app/users/page.tsx', [
+        'export default function UsersPage(): null { return null }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/app/users/page.tsx', 'UsersPage')
+      expect(sym?.framework_role).toBe('nextjs_app_page')
+    })
+
+    it('recognizes src/pages/api/ routes', () => {
+      writeFile(sandbox, 'src/pages/api/users.ts', [
+        'export default function handler(): void {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/pages/api/users.ts', 'handler')
+      expect(sym?.framework_role).toBe('nextjs_pages_api')
+    })
+  })
+
+  describe('export shapes', () => {
+    it('handles `export default function Foo() {}` and `function Foo() {}; export default Foo`', () => {
+      writeFile(sandbox, 'app/inline/page.tsx', 'export default function Inline(): null { return null }\n')
+      writeFile(sandbox, 'app/separate/page.tsx', [
+        'function Separate(): null { return null }',
+        'export default Separate',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'app/inline/page.tsx', 'Inline')?.framework_role).toBe('nextjs_app_page')
+      expect(findSymbol(spi, 'app/separate/page.tsx', 'Separate')?.framework_role).toBe('nextjs_app_page')
+    })
+
+    it('handles `export default class Foo {}`', () => {
+      writeFile(sandbox, 'app/cls/page.tsx', [
+        'export default class ClassPage { render(): null { return null } }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'app/cls/page.tsx', 'ClassPage')
+      expect(sym?.framework_role).toBe('nextjs_app_page')
+    })
+  })
+
+  describe('non-Next.js files', () => {
+    it('does not tag files outside the recognized conventions', () => {
+      writeFile(sandbox, 'src/lib/utils.ts', 'export function helper(): void {}\n')
+      writeFile(sandbox, 'components/Button.tsx', 'export default function Button(): null { return null }\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/lib/utils.ts', 'helper')?.framework_role).toBeUndefined()
+      expect(findSymbol(spi, 'components/Button.tsx', 'Button')?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('projector — framework propagation', () => {
+    it('projects nextjs_app_page → framework: nextjs, node_kind: function', async () => {
+      writeFile(sandbox, 'app/users/page.tsx', 'export default function UsersPage(): null { return null }\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'UsersPage()')
+      expect(node?.framework).toBe('nextjs')
+      expect(node?.framework_role).toBe('nextjs_app_page')
+      expect(node?.node_kind).toBe('function')
+    })
+
+    it('projects nextjs_app_route → framework: nextjs, node_kind: route', async () => {
+      writeFile(sandbox, 'app/api/users/route.ts', [
+        'export function GET(): Response { return new Response() }',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'GET()')
+      expect(node?.framework).toBe('nextjs')
+      expect(node?.framework_role).toBe('nextjs_app_route')
+      expect(node?.node_kind).toBe('route')
+    })
+  })
+})


### PR DESCRIPTION
First Next.js slice — substrate-level detection that recognises Next.js file conventions and tags exported symbols accordingly.

## Why file-convention detection

Next.js is structurally different from Express. Routes/layouts/middleware aren't identified by AST patterns or decorator calls — they're identified by **file path patterns**:

| Convention | Path pattern | Tag |
|---|---|---|
| App Router page | \`app/<segments>/page.tsx\` | \`nextjs_app_page\` (default export) |
| App Router route handler | \`app/<segments>/route.ts\` | \`nextjs_app_route\` (named HTTP-method exports) |
| App Router layout | \`app/<segments>/layout.tsx\` | \`nextjs_app_layout\` (default export) |
| App Router loading | \`app/<segments>/loading.tsx\` | \`nextjs_app_loading\` (default export) |
| App Router error | \`app/<segments>/error.tsx\` | \`nextjs_app_error\` (default export) |
| App Router template | \`app/<segments>/template.tsx\` | \`nextjs_app_template\` (default export) |
| Pages Router page | \`pages/<segments>.tsx\` | \`nextjs_pages_page\` (default export) |
| Pages Router API | \`pages/api/<segments>.ts\` | \`nextjs_pages_api\` (default export) |
| Middleware | \`middleware.ts\` at root | \`nextjs_middleware\` (default export) |

The detector accepts paths with or without a leading \`src/\` directory (the common Next.js configuration). Special files \`_app\`, \`_document\`, \`_error\`, \`_middleware\` in \`pages/\` are intentionally skipped — those are framework files, not route components.

## Projector wiring

- \`frameworkForRole\` maps the \`nextjs_*\` prefix → \`'nextjs'\`.
- \`nodeKindForRole\` maps \`nextjs_app_route\` + \`nextjs_pages_api\` → \`'route'\` (HTTP handlers); every other \`nextjs_*\` role → \`'function'\` (component-shaped).

## Out of scope (deferred to follow-up slices)

- **\`route_path\` metadata derived from the file path**: e.g., \`app/users/[id]/page.tsx\` → \`route_path: '/users/:id'\`. The substrate slot exists (slice 1c-ii.f's \`framework_metadata\`) but the path-to-route conversion lands in slice 1c-iv.b.
- **Dynamic segments and route groups**: \`[id]\`, \`[[...slug]]\`, \`(group)\` — same metadata work above.
- **'use client' directive detection** for server/client component disambiguation.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 95 files / **1659** tests pass (16 new for Next.js + 1643 pre-existing)
- [x] Tests cover: every app router convention (page/layout/loading/error/template), app router route.ts HTTP-method named exports (all 7 verbs), pages router page + api, special-file skip (_app/_document), root middleware.ts, src/-prefix variants of both routers, three export AST shapes (\`export default function\`, \`function + export default name\`, \`export default class\`), negative cases (lib/utils not tagged), end-to-end projection through to the ExtractionNode shape.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

Refs #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Next.js framework detection to the semantic analysis pipeline, supporting App Router conventions (pages, layouts, routes, middleware) and Pages Router patterns (page components and API routes).
  * Extended framework role categorization to properly recognize and classify Next.js application structures.

* **Tests**
  * Added comprehensive unit tests validating Next.js framework pattern detection, role assignment, and extraction behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->