### PR TITLE
feat(#72): SPI v1 slice 1c-v.a — React Router substrate

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -65,6 +65,7 @@ import { addTestLayerEdges } from './test-layer.js'
 import { collectNestTokenMap, detectNestFramework } from './framework-nestjs.js'
 import { detectExpressFramework } from './framework-express.js'
 import { detectNextjsFramework } from './framework-nextjs.js'
+import { detectReactRouterFramework } from './framework-react-router.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -663,6 +664,14 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       sourceFile,
       fileId: file.id,
       filePath: file.path,
+      symbolsByFile,
+    })
+    // Slice 1c-v.a: React Router substrate. Tags createBrowserRouter
+    // results and named loader/action exports in files importing
+    // react-router(-dom).
+    detectReactRouterFramework({
+      sourceFile,
+      fileId: file.id,
       symbolsByFile,
     })
   }

--- a/src/pipeline/spi/framework-react-router.ts
+++ b/src/pipeline/spi/framework-react-router.ts
@@ -1,0 +1,147 @@
+// SPI v1 — React Router framework layer (slice 1c-v.a of #72).
+//
+// React Router (v6.4+ data-router idiom) has two structural patterns the
+// SPI substrate cares about:
+//
+//   1. Router factories — `createBrowserRouter([...])`,
+//      `createHashRouter([...])`, `createMemoryRouter([...])`, and
+//      `createStaticRouter([...])`. The factory call's receiving variable
+//      is tagged with framework_role: 'react_router_router'.
+//
+//   2. Route-module convention — when a file imports from 'react-router'
+//      or 'react-router-dom' AND exports a named function or const called
+//      exactly `loader` or `action`, those exports are tagged with
+//      framework_role: 'react_router_loader' / 'react_router_action'.
+//
+// JSX route definitions (`<Route path="/x" element={<X />} />`) and
+// hook-based detection (useNavigate, useLoaderData, etc.) are intentionally
+// out of scope for this substrate slice — they're structurally more
+// invasive and land in slice 1c-v.b once the basic shape is proven.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const REACT_ROUTER_MODULE_SPECIFIERS: ReadonlySet<string> = new Set([
+  'react-router',
+  'react-router-dom',
+])
+
+const ROUTER_FACTORY_NAMES: ReadonlySet<string> = new Set([
+  'createBrowserRouter',
+  'createHashRouter',
+  'createMemoryRouter',
+  'createStaticRouter',
+])
+
+const ROUTE_MODULE_EXPORT_NAMES: ReadonlyMap<string, SpiFrameworkRole> = new Map([
+  ['loader', 'react_router_loader'],
+  ['action', 'react_router_action'],
+])
+
+type ReactRouterBindings = {
+  /** Local names for the named factory imports. */
+  routerFactories: Set<string>
+  /** True when the file imports anything from react-router(-dom). */
+  hasReactRouterImport: boolean
+}
+
+export type DetectReactRouterFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+export function detectReactRouterFramework(ctx: DetectReactRouterFrameworkContext): void {
+  const bindings = collectBindings(ctx.sourceFile)
+  if (!bindings.hasReactRouterImport) return
+
+  // 1. Router factory detection: walk top-level variable declarations,
+  // tag those initialised with a known factory call.
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      if (isFactoryCall(decl.initializer, bindings.routerFactories)) {
+        tagSymbolByName(ctx, decl.name.text, 'react_router_router')
+      }
+    }
+  }
+
+  // 2. Route-module convention: tag named exports called `loader` or
+  // `action`. Three AST shapes to recognise:
+  //   * export function loader() {}
+  //   * export const loader = () => {}
+  //   * function loader() {}; export { loader }   (re-export form — skipped here)
+  for (const stmt of ctx.sourceFile.statements) {
+    // export function loader() {}
+    if (ts.isFunctionDeclaration(stmt) && stmt.name && hasExportModifier(stmt)) {
+      const role = ROUTE_MODULE_EXPORT_NAMES.get(stmt.name.text)
+      if (role) tagSymbolByName(ctx, stmt.name.text, role)
+      continue
+    }
+
+    // export const loader = ...
+    if (ts.isVariableStatement(stmt) && hasExportModifier(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name)) continue
+        const role = ROUTE_MODULE_EXPORT_NAMES.get(decl.name.text)
+        if (role) tagSymbolByName(ctx, decl.name.text, role)
+      }
+    }
+  }
+}
+
+function collectBindings(sourceFile: ts.SourceFile): ReactRouterBindings {
+  const bindings: ReactRouterBindings = {
+    routerFactories: new Set<string>(),
+    hasReactRouterImport: false,
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!REACT_ROUTER_MODULE_SPECIFIERS.has(stmt.moduleSpecifier.text)) continue
+
+    bindings.hasReactRouterImport = true
+    const named = stmt.importClause.namedBindings
+    if (!named || !ts.isNamedImports(named)) continue
+    for (const element of named.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      if (ROUTER_FACTORY_NAMES.has(importedName)) {
+        bindings.routerFactories.add(element.name.text)
+      }
+    }
+  }
+  return bindings
+}
+
+function isFactoryCall(expression: ts.Expression, factoryNames: ReadonlySet<string>): boolean {
+  if (!ts.isCallExpression(expression)) return false
+  const callee = expression.expression
+  if (ts.isIdentifier(callee)) return factoryNames.has(callee.text)
+  return false
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined
+  if (!modifiers) return false
+  for (const mod of modifiers) {
+    if (mod.kind === ts.SyntaxKind.ExportKeyword) return true
+  }
+  return false
+}
+
+function tagSymbolByName(
+  ctx: DetectReactRouterFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -76,3 +76,8 @@ export {
   detectNextjsFramework,
   type DetectNextjsFrameworkContext,
 } from './framework-nextjs.js'
+
+export {
+  detectReactRouterFramework,
+  type DetectReactRouterFrameworkContext,
+} from './framework-react-router.js'

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -230,6 +230,7 @@ function frameworkForRole(role: NonNullable<SpiSymbol['framework_role']>): strin
   if (role.startsWith('nest_')) return 'nestjs'
   if (role.startsWith('express_')) return 'express'
   if (role.startsWith('nextjs_')) return 'nextjs'
+  if (role.startsWith('react_router_')) return 'react-router'
   return 'unknown'
 }
 
@@ -258,7 +259,11 @@ function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNul
     case 'nextjs_app_error':
     case 'nextjs_app_template':
     case 'nextjs_pages_page':
+    case 'react_router_loader':
+    case 'react_router_action':
       return 'function'
+    case 'react_router_router':
+      return 'router'
     default:
       return null
   }

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -88,6 +88,10 @@ export type SpiFrameworkRole =
   | 'nextjs_pages_page'
   | 'nextjs_pages_api'
   | 'nextjs_middleware'
+  // React Router roles (slice 1c-v.a)
+  | 'react_router_router'
+  | 'react_router_loader'
+  | 'react_router_action'
 
 export type SpiSymbol = {
   id: string

--- a/tests/unit/spi-framework-react-router.test.ts
+++ b/tests/unit/spi-framework-react-router.test.ts
@@ -1,0 +1,191 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-react-router-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1c-v.a',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('SPI React Router framework detector (slice 1c-v.a)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('router factory detection', () => {
+    it('tags `const router = createBrowserRouter([])` with react_router_router', () => {
+      writeFile(sandbox, 'src/router.ts', [
+        'import { createBrowserRouter } from "react-router-dom"',
+        'export const router = createBrowserRouter([])',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/router.ts', 'router')
+      expect(sym?.framework_role).toBe('react_router_router')
+    })
+
+    it('recognizes createHashRouter, createMemoryRouter, createStaticRouter', () => {
+      writeFile(sandbox, 'src/hash.ts', [
+        'import { createHashRouter } from "react-router-dom"',
+        'export const router = createHashRouter([])',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/memory.ts', [
+        'import { createMemoryRouter } from "react-router-dom"',
+        'export const router = createMemoryRouter([])',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/static.ts', [
+        'import { createStaticRouter } from "react-router-dom"',
+        'export const router = createStaticRouter([])',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/hash.ts', 'router')?.framework_role).toBe('react_router_router')
+      expect(findSymbol(spi, 'src/memory.ts', 'router')?.framework_role).toBe('react_router_router')
+      expect(findSymbol(spi, 'src/static.ts', 'router')?.framework_role).toBe('react_router_router')
+    })
+
+    it('works for imports from `react-router` (not just react-router-dom)', () => {
+      writeFile(sandbox, 'src/router.ts', [
+        'import { createBrowserRouter } from "react-router"',
+        'export const router = createBrowserRouter([])',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/router.ts', 'router')
+      expect(sym?.framework_role).toBe('react_router_router')
+    })
+
+    it('handles aliased imports (`createBrowserRouter as createRouter`)', () => {
+      writeFile(sandbox, 'src/router.ts', [
+        'import { createBrowserRouter as createRouter } from "react-router-dom"',
+        'export const router = createRouter([])',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/router.ts', 'router')
+      expect(sym?.framework_role).toBe('react_router_router')
+    })
+
+    it('does NOT tag when the factory comes from an unrelated module', () => {
+      writeFile(sandbox, 'src/router.ts', [
+        'function createBrowserRouter(_: unknown[]): unknown { return null }',
+        'export const router = createBrowserRouter([])',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const sym = findSymbol(spi, 'src/router.ts', 'router')
+      expect(sym?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('loader / action route-module exports', () => {
+    it('tags `export function loader()` as react_router_loader', () => {
+      writeFile(sandbox, 'src/routes/users.tsx', [
+        'import { useLoaderData } from "react-router-dom"',
+        'export function loader(): { ok: boolean } { return { ok: true } }',
+        'export default function Users(): null { void useLoaderData; return null }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/routes/users.tsx', 'loader')?.framework_role).toBe('react_router_loader')
+    })
+
+    it('tags `export const loader = () => ...` (variable form)', () => {
+      writeFile(sandbox, 'src/routes/users.tsx', [
+        'import { useLoaderData } from "react-router-dom"',
+        'export const loader = (): { ok: boolean } => ({ ok: true })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/routes/users.tsx', 'loader')?.framework_role).toBe('react_router_loader')
+    })
+
+    it('tags `export function action()` as react_router_action', () => {
+      writeFile(sandbox, 'src/routes/users.tsx', [
+        'import { useActionData } from "react-router-dom"',
+        'export function action(): { ok: boolean } { return { ok: true } }',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/routes/users.tsx', 'action')?.framework_role).toBe('react_router_action')
+    })
+
+    it('does NOT tag loader/action in files that do not import react-router(-dom)', () => {
+      writeFile(sandbox, 'src/utils/loader.ts', [
+        'export function loader(): void {}',
+        'export const action = (): void => {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/utils/loader.ts', 'loader')?.framework_role).toBeUndefined()
+      expect(findSymbol(spi, 'src/utils/loader.ts', 'action')?.framework_role).toBeUndefined()
+    })
+
+    it('only tags the exact names `loader` and `action`, not similarly-named exports', () => {
+      writeFile(sandbox, 'src/routes/users.tsx', [
+        'import { useLoaderData } from "react-router-dom"',
+        'export function loaderHelper(): void {}',
+        'export const myAction = (): void => {}',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/routes/users.tsx', 'loaderHelper')?.framework_role).toBeUndefined()
+      expect(findSymbol(spi, 'src/routes/users.tsx', 'myAction')?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('projector — framework propagation', () => {
+    it('projects react_router_router → framework: react-router, node_kind: router', async () => {
+      writeFile(sandbox, 'src/router.ts', [
+        'import { createBrowserRouter } from "react-router-dom"',
+        'export const router = createBrowserRouter([])',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'router')
+      expect(node?.framework).toBe('react-router')
+      expect(node?.framework_role).toBe('react_router_router')
+      expect(node?.node_kind).toBe('router')
+    })
+
+    it('projects loader/action → framework: react-router, node_kind: function', async () => {
+      writeFile(sandbox, 'src/routes/users.tsx', [
+        'import { useLoaderData } from "react-router-dom"',
+        'export function loader(): { ok: boolean } { return { ok: true } }',
+        'export function action(): { ok: boolean } { return { ok: true } }',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const loader = extraction.nodes.find((n) => n.label === 'loader()')
+      const action = extraction.nodes.find((n) => n.label === 'action()')
+      expect(loader?.framework).toBe('react-router')
+      expect(loader?.framework_role).toBe('react_router_loader')
+      expect(loader?.node_kind).toBe('function')
+      expect(action?.framework).toBe('react-router')
+      expect(action?.framework_role).toBe('react_router_action')
+    })
+  })
+})


### PR DESCRIPTION
First React Router slice — substrate-level detection for the v6.4+ data-router patterns.

## Patterns detected

Two structural patterns:

1. **Router factories** — \`createBrowserRouter\` / \`createHashRouter\` / \`createMemoryRouter\` / \`createStaticRouter\`. The factory call's receiving variable is tagged with \`framework_role: 'react_router_router'\`.

2. **Route-module convention** — when a file imports from \`'react-router'\` or \`'react-router-dom'\` AND exports a named function or const called exactly \`loader\` or \`action\`, those exports are tagged with \`framework_role: 'react_router_loader'\` / \`'react_router_action'\`.

## Substrate

Three new \`SpiFrameworkRole\` variants:
- \`react_router_router\`
- \`react_router_loader\`
- \`react_router_action\`

## Projector wiring

| Role | Framework | Node kind |
|---|---|---|
| \`react_router_router\` | \`react-router\` | \`router\` |
| \`react_router_loader\` | \`react-router\` | \`function\` |
| \`react_router_action\` | \`react-router\` | \`function\` |

## Out of scope (deferred)

- **JSX route definitions** \`<Routes><Route path="/x" element={<X />} /></Routes>\` — slice 1c-v.b. Requires JSX walking and is structurally different from the import-call pattern.
- **Hook detection** \`useNavigate\`, \`useLoaderData\`, etc. — structurally non-essential; consumers can filter on \`framework_role\` plus the file having a react-router import.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 96 files / **1671** tests pass (12 new for React Router + 1659 pre-existing)
- [x] Tests cover: all four router factories, aliased factory imports, \`react-router\` (not -dom) module support, function-form vs variable-form loader/action exports, negative case (loader/action in non-react-router file not tagged), exact-name discipline (\`loaderHelper\` / \`myAction\` not matched), end-to-end projection through to the ExtractionNode shape.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

Refs #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added React Router framework detection and analysis, enabling the system to identify and understand router configurations and route handlers (loaders and actions) in React Router applications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->