### PR TITLE
feat(#72): SPI v1 slice 1c-vi.a — Redux Toolkit substrate

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -66,6 +66,7 @@ import { collectNestTokenMap, detectNestFramework } from './framework-nestjs.js'
 import { detectExpressFramework } from './framework-express.js'
 import { detectNextjsFramework } from './framework-nextjs.js'
 import { detectReactRouterFramework } from './framework-react-router.js'
+import { detectReduxFramework } from './framework-redux.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -670,6 +671,14 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
     // results and named loader/action exports in files importing
     // react-router(-dom).
     detectReactRouterFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
+    })
+    // Slice 1c-vi.a: Redux Toolkit substrate. Tags createSlice /
+    // configureStore / createSelector / createAsyncThunk / createApi
+    // factory results in files importing from a Redux module.
+    detectReduxFramework({
       sourceFile,
       fileId: file.id,
       symbolsByFile,

--- a/src/pipeline/spi/framework-redux.ts
+++ b/src/pipeline/spi/framework-redux.ts
@@ -1,0 +1,132 @@
+// SPI v1 — Redux Toolkit framework layer (slice 1c-vi.a of #72).
+//
+// Redux Toolkit's idiomatic surface is a small set of factory functions:
+//
+//   const counterSlice = createSlice({ name: 'counter', ... })
+//   const store        = configureStore({ reducer: ... })
+//   const api          = createApi({ ... })                  // RTK Query
+//   const selectFoo    = createSelector([...], (...) => ...)
+//   const fetchUser    = createAsyncThunk('user/fetch', ...)
+//
+// Each factory call's receiving variable is tagged with a matching
+// SpiFrameworkRole. Selectors built via `reselect` (`createSelector` from
+// 'reselect' rather than '@reduxjs/toolkit') are accepted too because
+// they're functionally identical and routinely re-exported from RTK.
+//
+// Detection is import-gated: a file must import from one of the Redux
+// module specifiers for any tagging to happen. This avoids tagging
+// same-named local helpers in unrelated files.
+//
+// Out of scope (deferred to follow-up slices):
+//
+//   * Slice metadata: extracting `name`, reducer keys, and the auto-
+//     generated action-creator surface. Requires walking the object-
+//     literal argument to createSlice and may want a framework_metadata
+//     entry similar to slice 1c-ii.f's route_path.
+//   * `createReducer` (functional reducer composition) — non-essential
+//     and can be added when a real codebase asks for it.
+//   * `useSelector` / `useDispatch` hook detection — structural noise;
+//     consumers should locate selectors via framework_role instead.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const REDUX_MODULE_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@reduxjs/toolkit',
+  '@reduxjs/toolkit/query',
+  '@reduxjs/toolkit/query/react',
+  'redux',
+  'reselect',
+])
+
+const FACTORY_TO_ROLE: ReadonlyMap<string, SpiFrameworkRole> = new Map([
+  ['createSlice', 'redux_slice'],
+  ['configureStore', 'redux_store'],
+  ['createStore', 'redux_store'],
+  ['createSelector', 'redux_selector'],
+  ['createDraftSafeSelector', 'redux_selector'],
+  ['createAsyncThunk', 'redux_async_thunk'],
+  ['createApi', 'redux_rtk_query_api'],
+])
+
+type ReduxBindings = {
+  /** Local name → role for every imported Redux factory. Aliased
+   *  imports (`createSlice as makeSlice`) use the local name as the key
+   *  and resolve the role from the original imported name. */
+  factories: Map<string, SpiFrameworkRole>
+  /** True iff the file imported anything from a Redux module specifier. */
+  hasReduxImport: boolean
+}
+
+export type DetectReduxFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+export function detectReduxFramework(ctx: DetectReduxFrameworkContext): void {
+  const bindings = collectBindings(ctx.sourceFile)
+  if (!bindings.hasReduxImport || bindings.factories.size === 0) return
+
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      const role = factoryCallRole(decl.initializer, bindings.factories)
+      if (!role) continue
+      tagSymbolByName(ctx, decl.name.text, role)
+    }
+  }
+}
+
+function collectBindings(sourceFile: ts.SourceFile): ReduxBindings {
+  const bindings: ReduxBindings = {
+    factories: new Map<string, SpiFrameworkRole>(),
+    hasReduxImport: false,
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!REDUX_MODULE_SPECIFIERS.has(stmt.moduleSpecifier.text)) continue
+
+    bindings.hasReduxImport = true
+    const named = stmt.importClause.namedBindings
+    if (!named || !ts.isNamedImports(named)) continue
+    for (const element of named.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      const role = FACTORY_TO_ROLE.get(importedName)
+      if (role) bindings.factories.set(element.name.text, role)
+    }
+  }
+  return bindings
+}
+
+function factoryCallRole(
+  expression: ts.Expression,
+  factories: Map<string, SpiFrameworkRole>,
+): SpiFrameworkRole | null {
+  if (!ts.isCallExpression(expression)) return null
+  const callee = expression.expression
+  // createSlice(...)
+  if (ts.isIdentifier(callee)) return factories.get(callee.text) ?? null
+  // api.injectEndpoints(...) and other property-access factory variants
+  // are intentionally NOT tagged in this slice — they're derived
+  // operations on already-tagged factory results, not new factory calls.
+  return null
+}
+
+function tagSymbolByName(
+  ctx: DetectReduxFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -81,3 +81,8 @@ export {
   detectReactRouterFramework,
   type DetectReactRouterFrameworkContext,
 } from './framework-react-router.js'
+
+export {
+  detectReduxFramework,
+  type DetectReduxFrameworkContext,
+} from './framework-redux.js'

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -231,6 +231,7 @@ function frameworkForRole(role: NonNullable<SpiSymbol['framework_role']>): strin
   if (role.startsWith('express_')) return 'express'
   if (role.startsWith('nextjs_')) return 'nextjs'
   if (role.startsWith('react_router_')) return 'react-router'
+  if (role.startsWith('redux_')) return 'redux'
   return 'unknown'
 }
 
@@ -264,6 +265,14 @@ function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNul
       return 'function'
     case 'react_router_router':
       return 'router'
+    case 'redux_slice':
+      return 'slice'
+    case 'redux_store':
+      return 'store'
+    case 'redux_selector':
+    case 'redux_async_thunk':
+    case 'redux_rtk_query_api':
+      return 'function'
     default:
       return null
   }

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -92,6 +92,12 @@ export type SpiFrameworkRole =
   | 'react_router_router'
   | 'react_router_loader'
   | 'react_router_action'
+  // Redux Toolkit roles (slice 1c-vi.a)
+  | 'redux_slice'
+  | 'redux_store'
+  | 'redux_selector'
+  | 'redux_async_thunk'
+  | 'redux_rtk_query_api'
 
 export type SpiSymbol = {
   id: string

--- a/tests/unit/spi-framework-redux.test.ts
+++ b/tests/unit/spi-framework-redux.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-redux-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1c-vi.a',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('SPI Redux Toolkit framework detector (slice 1c-vi.a)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('factory detection', () => {
+    it('tags createSlice result with redux_slice', () => {
+      writeFile(sandbox, 'src/counter.ts', [
+        'import { createSlice } from "@reduxjs/toolkit"',
+        'export const counterSlice = createSlice({ name: "counter", initialState: 0, reducers: {} })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/counter.ts', 'counterSlice')?.framework_role).toBe('redux_slice')
+    })
+
+    it('tags configureStore result with redux_store', () => {
+      writeFile(sandbox, 'src/store.ts', [
+        'import { configureStore } from "@reduxjs/toolkit"',
+        'export const store = configureStore({ reducer: {} })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/store.ts', 'store')?.framework_role).toBe('redux_store')
+    })
+
+    it('tags legacy `createStore` from redux with redux_store too', () => {
+      writeFile(sandbox, 'src/store.ts', [
+        'import { createStore } from "redux"',
+        'export const store = createStore((s: number) => s)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/store.ts', 'store')?.framework_role).toBe('redux_store')
+    })
+
+    it('tags createSelector / createDraftSafeSelector with redux_selector', () => {
+      writeFile(sandbox, 'src/selectors.ts', [
+        'import { createSelector, createDraftSafeSelector } from "@reduxjs/toolkit"',
+        'export const selectFoo = createSelector(() => 1, (n: number) => n + 1)',
+        'export const selectBar = createDraftSafeSelector(() => 2, (n: number) => n)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/selectors.ts', 'selectFoo')?.framework_role).toBe('redux_selector')
+      expect(findSymbol(spi, 'src/selectors.ts', 'selectBar')?.framework_role).toBe('redux_selector')
+    })
+
+    it('tags createAsyncThunk result with redux_async_thunk', () => {
+      writeFile(sandbox, 'src/thunks.ts', [
+        'import { createAsyncThunk } from "@reduxjs/toolkit"',
+        'export const fetchUser = createAsyncThunk("user/fetch", async () => ({ ok: true }))',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/thunks.ts', 'fetchUser')?.framework_role).toBe('redux_async_thunk')
+    })
+
+    it('tags createApi (RTK Query) result with redux_rtk_query_api', () => {
+      writeFile(sandbox, 'src/api.ts', [
+        'import { createApi } from "@reduxjs/toolkit/query/react"',
+        'export const usersApi = createApi({ reducerPath: "users", baseQuery: () => ({ data: 1 }), endpoints: () => ({}) } as any)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/api.ts', 'usersApi')?.framework_role).toBe('redux_rtk_query_api')
+    })
+
+    it('accepts createSelector from the standalone `reselect` package', () => {
+      writeFile(sandbox, 'src/selectors.ts', [
+        'import { createSelector } from "reselect"',
+        'export const selectFoo = createSelector(() => 1, (n: number) => n + 1)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/selectors.ts', 'selectFoo')?.framework_role).toBe('redux_selector')
+    })
+
+    it('handles aliased imports (`createSlice as makeSlice`)', () => {
+      writeFile(sandbox, 'src/counter.ts', [
+        'import { createSlice as makeSlice } from "@reduxjs/toolkit"',
+        'export const slice = makeSlice({ name: "x", initialState: 0, reducers: {} })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/counter.ts', 'slice')?.framework_role).toBe('redux_slice')
+    })
+  })
+
+  describe('negative cases', () => {
+    it('does not tag when the factory is a local function in an unrelated module', () => {
+      writeFile(sandbox, 'src/fake.ts', [
+        'function createSlice<T>(_: T): T { return _ }',
+        'export const x = createSlice({ name: "y" } as any)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/fake.ts', 'x')?.framework_role).toBeUndefined()
+    })
+
+    it('does not tag when the file imports from Redux but the variable initializer is unrelated', () => {
+      writeFile(sandbox, 'src/store.ts', [
+        'import { configureStore } from "@reduxjs/toolkit"',
+        'export const config = { reducer: {} }',
+        'export const store = configureStore(config)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/store.ts', 'config')?.framework_role).toBeUndefined()
+      expect(findSymbol(spi, 'src/store.ts', 'store')?.framework_role).toBe('redux_store')
+    })
+
+    it('does not tag property-access factory variants (api.injectEndpoints(...) etc.)', () => {
+      writeFile(sandbox, 'src/api.ts', [
+        'import { createApi } from "@reduxjs/toolkit/query/react"',
+        'export const api = createApi({ reducerPath: "x", baseQuery: () => ({ data: 1 }), endpoints: () => ({}) } as any)',
+        'export const enhanced = api.injectEndpoints({ endpoints: () => ({}) })',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      expect(findSymbol(spi, 'src/api.ts', 'api')?.framework_role).toBe('redux_rtk_query_api')
+      // injectEndpoints is a derivation off `api`, not a new factory call.
+      // Slice 1c-vi.a leaves it untagged; a future slice may extend.
+      expect(findSymbol(spi, 'src/api.ts', 'enhanced')?.framework_role).toBeUndefined()
+    })
+  })
+
+  describe('projector — framework propagation', () => {
+    it('projects redux_slice → framework: redux, node_kind: slice', async () => {
+      writeFile(sandbox, 'src/counter.ts', [
+        'import { createSlice } from "@reduxjs/toolkit"',
+        'export const counterSlice = createSlice({ name: "counter", initialState: 0, reducers: {} })',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'counterSlice')
+      expect(node?.framework).toBe('redux')
+      expect(node?.framework_role).toBe('redux_slice')
+      expect(node?.node_kind).toBe('slice')
+    })
+
+    it('projects redux_store → framework: redux, node_kind: store', async () => {
+      writeFile(sandbox, 'src/store.ts', [
+        'import { configureStore } from "@reduxjs/toolkit"',
+        'export const store = configureStore({ reducer: {} })',
+      ].join('\n') + '\n')
+      const { projectSpiToExtraction } = await import('../../src/pipeline/spi/projector.js')
+      const spi = build(sandbox)
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'store')
+      expect(node?.framework).toBe('redux')
+      expect(node?.node_kind).toBe('store')
+    })
+  })
+})


### PR DESCRIPTION
Fifth and final framework substrate. Completes the substrate-level coverage for the framework set the user's roadmap calls out (Express, Next.js, React Router, Redux, plus the pre-existing NestJS).

## Patterns detected

| Factory | Role |
|---|---|
| \`createSlice({...})\` | \`redux_slice\` |
| \`configureStore({...})\` | \`redux_store\` |
| Legacy \`createStore()\` from \`redux\` | \`redux_store\` |
| \`createSelector(...)\` / \`createDraftSafeSelector(...)\` | \`redux_selector\` |
| \`createAsyncThunk(...)\` | \`redux_async_thunk\` |
| \`createApi(...)\` (RTK Query) | \`redux_rtk_query_api\` |

Import-gated to: \`@reduxjs/toolkit\`, \`@reduxjs/toolkit/query\`, \`@reduxjs/toolkit/query/react\`, \`redux\`, \`reselect\` (selectors are routinely re-exported from RTK via reselect).

Aliased imports work — \`import { createSlice as makeSlice } from '@reduxjs/toolkit'\` then \`makeSlice({...})\` tags correctly.

## Projector wiring

| Role | Framework | Node kind |
|---|---|---|
| \`redux_slice\` | \`redux\` | \`slice\` |
| \`redux_store\` | \`redux\` | \`store\` |
| \`redux_selector\` / \`redux_async_thunk\` / \`redux_rtk_query_api\` | \`redux\` | \`function\` |

The \`slice\` and \`store\` \`node_kind\` values already exist in the legacy extractor's taxonomy.

## Out of scope (deferred)

- **Slice metadata extraction**: slice name, reducer keys, auto-generated action creators (\`framework_metadata\` extension). Slice 1c-vi.b candidate.
- **Property-access factory variants**: \`api.injectEndpoints({...})\` is a derivation off an already-tagged \`createApi\` result, not a new factory call. Today the derived variable is intentionally untagged.
- **\`createReducer\`** (functional reducer composition) — non-essential, add when a real codebase asks.
- **\`useSelector\` / \`useDispatch\`** hook detection — structurally non-essential; consumers can locate selectors via \`framework_role\`.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 97 files / **1684** tests pass (13 new for Redux + 1671 pre-existing)
- [x] Tests cover: every factory function, reselect package support, aliased imports, negative cases (local same-named fn not tagged, unrelated initialisers not tagged, property-access derivations not tagged), end-to-end projection through to ExtractionNode shape.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## Framework substrate progress

After this slice merges:

| Framework | Substrate slice | Status |
|---|---|---|
| NestJS | 3b base + 3b-ii (#98, #99) | ✅ merged |
| Express | 1c-ii.b/c/d/e/f (#107–#111) | ✅ merged |
| Next.js | 1c-iv.a (#112) | ✅ merged |
| React Router | 1c-v.a (#113) | ✅ merged |
| Redux Toolkit | 1c-vi.a (this PR) | ⏳ in review |

Refs #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Redux Toolkit framework detection that automatically recognizes and analyzes Redux patterns in your codebase, including slices, stores, selectors, async thunks, and RTK Query APIs for enhanced code analysis support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->