### PR TITLE
feat(#72): projector — propagate framework_metadata onto ExtractionNode

### DIFF
--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -166,6 +166,23 @@ export function projectSpiToExtraction(
       }
     }
 
+    // Propagate framework_metadata onto the ExtractionNode. Today's
+    // callers set keys like `route_path` (Express routes), `mount_path`
+    // (Express middleware), and future framework slices may add more.
+    // The legacy extractor uses `route_path` as a top-level field on
+    // ExtractionNodes, so spreading the bag onto the node brings parity
+    // and keeps consumers (graph.json shape, downstream retrieval) able
+    // to filter by these fields without round-tripping through the SPI
+    // substrate. ExtractionNode's index signature allows arbitrary keys,
+    // so the spread is type-safe.
+    if (symbol.framework_metadata) {
+      for (const [key, value] of Object.entries(symbol.framework_metadata)) {
+        if (value !== undefined) {
+          node[key] = value
+        }
+      }
+    }
+
     addNode(nodes, seenNodeIds, node)
   }
 

--- a/tests/unit/spi-projector-framework-metadata.test.ts
+++ b/tests/unit/spi-projector-framework-metadata.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import { projectSpiToExtraction } from '../../src/pipeline/spi/projector.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-proj-meta-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function project(root: string) {
+  const spi = buildSpi({ root, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+  return projectSpiToExtraction(spi, { root })
+}
+
+describe('projector — framework_metadata propagation onto ExtractionNode', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('Express route_path metadata', () => {
+    it('surfaces route_path on a named-handler Express route node', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function listUsers(): void {}',
+        'app.get("/users/:id", listUsers)',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const node = extraction.nodes.find((n) => n.label === 'listUsers()')
+      expect(node?.framework).toBe('express')
+      expect(node?.framework_role).toBe('express_route')
+      expect((node as Record<string, unknown> | undefined)?.route_path).toBe('/users/:id')
+    })
+
+    it('surfaces route_path on a synthesized inline-handler route node', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'app.post("/users", (_req, _res) => { void 0 })',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const routeNode = extraction.nodes.find((n) => n.framework === 'express' && n.framework_role === 'express_route')
+      expect((routeNode as Record<string, unknown> | undefined)?.route_path).toBe('/users')
+    })
+
+    it('does NOT add route_path when the source route had a dynamic path string', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'const prefix = "/api"',
+        'export function h(): void {}',
+        'app.get(`${prefix}/x`, h)',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const node = extraction.nodes.find((n) => n.label === 'h()')
+      expect(node?.framework).toBe('express')
+      // Dynamic path → SPI did not capture route_path → projector emits
+      // no key on the ExtractionNode.
+      expect((node as Record<string, unknown> | undefined)?.route_path).toBeUndefined()
+    })
+  })
+
+  describe('Express mount_path metadata', () => {
+    it('surfaces mount_path on prefixed middleware', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function authMw(): void {}',
+        'app.use("/api", authMw)',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const node = extraction.nodes.find((n) => n.label === 'authMw()')
+      expect(node?.framework_role).toBe('express_middleware')
+      expect((node as Record<string, unknown> | undefined)?.mount_path).toBe('/api')
+    })
+
+    it('omits mount_path on globally-registered middleware', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'export const app = express()',
+        'export function globalMw(): void {}',
+        'app.use(globalMw)',
+      ].join('\n') + '\n')
+      const extraction = project(sandbox)
+      const node = extraction.nodes.find((n) => n.label === 'globalMw()')
+      expect(node?.framework_role).toBe('express_middleware')
+      expect((node as Record<string, unknown> | undefined)?.mount_path).toBeUndefined()
+    })
+  })
+
+  describe('symbols without framework_metadata', () => {
+    it('does not add stray keys when the symbol carries no framework_metadata', () => {
+      writeFile(sandbox, 'src/plain.ts', 'export function helper(): void {}\n')
+      const extraction = project(sandbox)
+      const node = extraction.nodes.find((n) => n.label === 'helper()')
+      // No metadata → no route_path / mount_path / etc.
+      expect((node as Record<string, unknown> | undefined)?.route_path).toBeUndefined()
+      expect((node as Record<string, unknown> | undefined)?.mount_path).toBeUndefined()
+    })
+  })
+
+  describe('forward-compatibility with future framework_metadata keys', () => {
+    it('propagates arbitrary keys, not just route_path/mount_path', () => {
+      // Direct SPI build → mutate one symbol's framework_metadata with a
+      // hypothetical future key → project → assert the key surfaces.
+      writeFile(sandbox, 'src/x.ts', 'export function foo(): void {}\n')
+      const spi = buildSpi({ root: sandbox, graphifyVersion: 'test-0.0.0', now: FROZEN_NOW })
+      const foo = spi.symbols.find((s) => s.name === 'foo')
+      if (foo) {
+        foo.framework_role = 'express_route'
+        foo.framework_metadata = { route_path: '/foo', some_future_key: 42 }
+      }
+      const extraction = projectSpiToExtraction(spi, { root: sandbox })
+      const node = extraction.nodes.find((n) => n.label === 'foo()')
+      expect((node as Record<string, unknown> | undefined)?.route_path).toBe('/foo')
+      expect((node as Record<string, unknown> | undefined)?.some_future_key).toBe(42)
+    })
+  })
+})


### PR DESCRIPTION
Closes the consumer gap left open by slice 1c-ii.f.

## What

The substrate detectors (Express via 1c-ii.f, future framework slices) attach keys like \`route_path\` and \`mount_path\` to \`SpiSymbol.framework_metadata\`, but the projector ignored those keys. Metadata accumulated on the SPI but never reached graph.json or any downstream consumer.

## Fix

In \`projectSpiToExtraction\`'s symbol loop, after \`framework_role\` / \`framework\` / \`node_kind\` are derived from the role, spread \`symbol.framework_metadata\`'s entries onto the produced \`ExtractionNode\`. \`ExtractionNode\`'s index signature (\`[key: string]: unknown\`) allows arbitrary keys, so the spread is type-safe. \`undefined\` values are skipped so missing metadata never produces literal-undefined fields.

## Impact

| Before | After |
|---|---|
| Express route node | \`{ framework: 'express', framework_role: 'express_route' }\` |
| | \`+ { route_path: '/users/:id' }\` |
| Prefixed middleware node | \`{ framework: 'express', framework_role: 'express_middleware' }\` |
| | \`+ { mount_path: '/api' }\` |
| Future framework keys | Already supported — propagation is generic over the metadata bag's entries |

This is the projector half of slice 1c-ii.f. After this lands, Express route nodes in the projected graph.json carry the same \`route_path\` field the legacy extractor would emit — one concrete step closer to demo-repo byte-equivalence (the v0.14.0 trigger).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 98 files / **1691** tests pass (7 new + 1684 pre-existing)
- [x] Tests cover: named-handler \`route_path\`, synthesized-handler \`route_path\`, dynamic-path skip (no key emitted), prefixed-middleware \`mount_path\`, global-middleware \`mount_path\` absence, symbols with no framework_metadata stay clean, forward-compat arbitrary-key propagation via a direct-SPI-mutation fixture.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

Refs #72, #111 (slice 1c-ii.f), #100 (slice 1c-i — original projector).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework-specific metadata such as route paths and mount paths is now included in extraction results, providing detailed framework information.

* **Tests**
  * Added comprehensive test coverage validating framework metadata propagation across various routing scenarios, handler types, and middleware configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->