### PR TITLE
feat(#72): SPI v1 slice 1c-ii.g — mounted-router prefix resolution (same-file)

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -63,7 +63,7 @@ import type {
 } from './types.js'
 import { addTestLayerEdges } from './test-layer.js'
 import { collectNestTokenMap, detectNestFramework } from './framework-nestjs.js'
-import { detectExpressFramework } from './framework-express.js'
+import { detectExpressFramework, finalizeExpressMountPrefixes } from './framework-express.js'
 import { detectNextjsFramework } from './framework-nextjs.js'
 import { detectReactRouterFramework } from './framework-react-router.js'
 import { detectReduxFramework } from './framework-redux.js'
@@ -684,6 +684,14 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       symbolsByFile,
     })
   }
+
+  // Slice 1c-ii.g — workspace-level finalizer that applies mounted-router
+  // prefixes to route handlers. Runs once after every per-file detector
+  // has had a chance to record the necessary metadata (each router's
+  // mount_path + each route handler's route_path). Works cross-file
+  // because the per-router symbol is mutated regardless of which file
+  // detected the mount call.
+  finalizeExpressMountPrefixes({ symbols, edges })
 }
 
 function walkCallExpressions(

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -186,6 +186,20 @@ function emitMiddlewareForCall(
       handlerSymbol = mintSyntheticHandlerSymbol(ctx, callExpr, arg, 'express_middleware')
     }
     if (!handlerSymbol) continue
+
+    // Slice 1c-ii.g — record mount_path on the router's symbol even when
+    // the router already has its own express_router role. The mount call
+    // attaches the router to the app at the given prefix; downstream
+    // consumers + the finalizer use this to compute resolved route paths.
+    // Setting mount_path BEFORE the role guard so a router being mounted
+    // gets its prefix while keeping its express_router identity.
+    if (mountPath !== null) {
+      handlerSymbol.framework_metadata = {
+        ...(handlerSymbol.framework_metadata ?? {}),
+        mount_path: mountPath,
+      }
+    }
+
     // Never overwrite an existing framework_role. A symbol that already
     // has a role carries more semantic weight than the middleware
     // fallback:
@@ -198,13 +212,66 @@ function emitMiddlewareForCall(
     //     fallback for symbols that have no other Express identity.
     if (handlerSymbol.framework_role !== undefined && handlerSymbol.framework_role !== 'express_middleware') continue
     handlerSymbol.framework_role = 'express_middleware'
-    if (mountPath !== null) {
-      handlerSymbol.framework_metadata = {
-        ...(handlerSymbol.framework_metadata ?? {}),
-        mount_path: mountPath,
-      }
+  }
+}
+
+/**
+ * Slice 1c-ii.g — workspace-level finalizer that applies mounted-router
+ * prefixes to the route_path on each route handler. Called once by
+ * buildSpi after all per-file detectors have run, so it works even when
+ * the mount call lives in a different file than the route registrations
+ * (the router symbol is mutated workspace-wide).
+ *
+ * Mechanism:
+ *   1. Index every express_router symbol by id; capture its mount_path
+ *      (set by emitMiddlewareForCall when the binding appeared as the
+ *      second arg of an `app.use('/prefix', router)` call).
+ *   2. Walk every route_handler edge in the SPI. For each edge whose
+ *      from-symbol is a router with a mount_path, look up the to-symbol
+ *      and prepend the mount_path to its route_path.
+ *
+ * The finalizer is idempotent: route_paths that already include the
+ * mount prefix (e.g., a previous run propagated them) stay correct
+ * because the joinRoutePath helper detects an already-prefixed path
+ * and is conservative about double-application. In practice the
+ * finalizer runs exactly once per buildSpi invocation.
+ */
+export function finalizeExpressMountPrefixes(opts: {
+  symbols: SpiSymbol[]
+  edges: SpiEdge[]
+}): void {
+  const routerById = new Map<string, SpiSymbol>()
+  const routeHandlerById = new Map<string, SpiSymbol>()
+  for (const sym of opts.symbols) {
+    if (sym.framework_role === 'express_router') routerById.set(sym.id, sym)
+    if (sym.framework_role === 'express_route') routeHandlerById.set(sym.id, sym)
+  }
+
+  for (const edge of opts.edges) {
+    if (edge.kind !== 'route_handler') continue
+    const router = routerById.get(edge.from)
+    if (!router) continue
+    const mountPath = router.framework_metadata?.mount_path
+    if (typeof mountPath !== 'string' || mountPath.length === 0) continue
+    const handler = routeHandlerById.get(edge.to)
+    if (!handler) continue
+    const existingPath = handler.framework_metadata?.route_path
+    if (typeof existingPath !== 'string') continue
+    handler.framework_metadata = {
+      ...(handler.framework_metadata ?? {}),
+      route_path: joinRoutePath(mountPath, existingPath),
     }
   }
+}
+
+function joinRoutePath(prefix: string, path: string): string {
+  const cleanPrefix = prefix.replace(/\/+$/, '')
+  const cleanPath = path.startsWith('/') ? path : '/' + path
+  // Skip double application: if the existing path already starts with
+  // the prefix, return it as-is. Defends against re-runs of the
+  // finalizer over the same SPI.
+  if (cleanPath.startsWith(cleanPrefix + '/') || cleanPath === cleanPrefix) return cleanPath
+  return cleanPrefix + cleanPath
 }
 
 /** Returns true iff the call-site receiver identifier resolves to the

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -218,23 +218,32 @@ function emitMiddlewareForCall(
 /**
  * Slice 1c-ii.g — workspace-level finalizer that applies mounted-router
  * prefixes to the route_path on each route handler. Called once by
- * buildSpi after all per-file detectors have run, so it works even when
- * the mount call lives in a different file than the route registrations
- * (the router symbol is mutated workspace-wide).
+ * buildSpi after all per-file detectors have run.
+ *
+ * **Same-file only in this slice.** The mount-call detection itself
+ * (in emitMiddlewareForCall) resolves the second-positional argument
+ * via the current file's symbol list, so a mount call that imports
+ * the router from another file does not get a mount_path recorded on
+ * the imported router's SpiSymbol. As a result, the finalizer below
+ * has nothing to apply for cross-file mounts. Cross-file resolution
+ * (plumbing pathToFileId through the detector context and following
+ * the type checker across boundaries) is slice 1c-ii.h.
  *
  * Mechanism:
  *   1. Index every express_router symbol by id; capture its mount_path
  *      (set by emitMiddlewareForCall when the binding appeared as the
- *      second arg of an `app.use('/prefix', router)` call).
+ *      second arg of an `app.use('/prefix', router)` call in the SAME
+ *      file as the router's declaration).
  *   2. Walk every route_handler edge in the SPI. For each edge whose
  *      from-symbol is a router with a mount_path, look up the to-symbol
  *      and prepend the mount_path to its route_path.
  *
- * The finalizer is idempotent: route_paths that already include the
- * mount prefix (e.g., a previous run propagated them) stay correct
- * because the joinRoutePath helper detects an already-prefixed path
- * and is conservative about double-application. In practice the
- * finalizer runs exactly once per buildSpi invocation.
+ * The finalizer runs exactly once per buildSpi invocation — it does
+ * NOT guard against being re-run with idempotence checks because:
+ *   (a) such checks confuse legitimate Express semantics where a route
+ *       path can match its mount prefix (e.g., usersRouter.get('/api')
+ *       mounted at '/api' must resolve to '/api/api', not '/api'), and
+ *   (b) the single-run invariant is enforced by build.ts.
  */
 export function finalizeExpressMountPrefixes(opts: {
   symbols: SpiSymbol[]
@@ -265,12 +274,14 @@ export function finalizeExpressMountPrefixes(opts: {
 }
 
 function joinRoutePath(prefix: string, path: string): string {
+  // Express mount semantics: the mount prefix is ALWAYS prepended to
+  // each router-local route path, even when the path happens to equal
+  // or begin with the prefix. A router mounted at '/api' with a route
+  // literally at '/api' answers '/api/api', not '/api'. The function
+  // is intentionally unconditional — caller's single-run invariant
+  // prevents double-application.
   const cleanPrefix = prefix.replace(/\/+$/, '')
   const cleanPath = path.startsWith('/') ? path : '/' + path
-  // Skip double application: if the existing path already starts with
-  // the prefix, return it as-is. Defends against re-runs of the
-  // finalizer over the same SPI.
-  if (cleanPath.startsWith(cleanPrefix + '/') || cleanPath === cleanPrefix) return cleanPath
   return cleanPrefix + cleanPath
 }
 

--- a/tests/unit/spi-express-mount-prefix.test.ts
+++ b/tests/unit/spi-express-mount-prefix.test.ts
@@ -132,21 +132,39 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
     })
   })
 
-  describe('finalizer idempotence', () => {
-    it('does not double-apply the prefix when the route_path already starts with it', () => {
+  describe('Express mount semantics: prefix is ALWAYS prepended', () => {
+    it('prepends the mount prefix even when the router-local path equals the prefix (CodeRabbit fix)', () => {
+      // Express semantics: a router mounted at '/api' that has a route
+      // registered at '/api' answers requests to '/api/api', NOT '/api'.
+      // The previous slice 1c-ii.g implementation incorrectly collapsed
+      // this case via a misguided idempotence check; the regression
+      // pins the corrected behavior.
       writeFile(sandbox, 'src/server.ts', [
         'import express, { Router } from "express"',
         'export const app = express()',
         'export const usersRouter = Router()',
         'export function listUsers(): void {}',
-        // Path that already includes the mount prefix — the finalizer
-        // must not produce /api/api/users.
+        'usersRouter.get("/api", listUsers)',
+        'app.use("/api", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/api/api')
+    })
+
+    it('prepends the mount prefix even when the router-local path begins with the prefix (CodeRabbit fix)', () => {
+      // Same correction. /api + /api/users → /api/api/users, not /api/users.
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
         'usersRouter.get("/api/users", listUsers)',
         'app.use("/api", usersRouter)',
       ].join('\n') + '\n')
       const spi = build(sandbox)
       const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
-      expect(handler?.framework_metadata?.route_path).toBe('/api/users')
+      expect(handler?.framework_metadata?.route_path).toBe('/api/api/users')
     })
   })
 

--- a/tests/unit/spi-express-mount-prefix.test.ts
+++ b/tests/unit/spi-express-mount-prefix.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(): string {
+  return mkdtempSync(join(tmpdir(), 'spi-express-mount-tests-'))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-slice-1c-ii.g',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
+  let sandbox: string
+  beforeEach(() => {
+    sandbox = mkSandbox()
+  })
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  describe('same-file mount', () => {
+    it('prefixes a route registered on a router mounted via app.use', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
+        'usersRouter.get("/", listUsers)',
+        'app.use("/api/users", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/api/users/')
+    })
+
+    it('works when the mount call appears BEFORE the route registration', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'app.use("/api/users", usersRouter)',
+        'export function listUsers(): void {}',
+        'usersRouter.get("/:id", listUsers)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      // The finalizer runs after all per-file detection completes, so
+      // declaration order in the source file doesn't affect prefixing.
+      expect(handler?.framework_metadata?.route_path).toBe('/api/users/:id')
+    })
+
+    it('applies the prefix to inline (synthesized) route handlers too', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'usersRouter.post("/", (_req, _res) => { void 0 })',
+        'app.use("/api/users", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const synthetic = spi.symbols.find((s) => s.framework_role === 'express_route' && s.kind === 'function')
+      expect(synthetic?.framework_metadata?.route_path).toBe('/api/users/')
+    })
+
+    it('does not prefix when the router is registered without a path prefix', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
+        'usersRouter.get("/users", listUsers)',
+        'app.use(usersRouter)', // no path → no mount_path on router
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      // No mount path captured → finalizer leaves route_path alone.
+      expect(handler?.framework_metadata?.route_path).toBe('/users')
+    })
+  })
+
+  describe('cross-file mount (deferred to slice 1c-ii.h)', () => {
+    it('today: cross-file mount does NOT propagate the prefix (current limitation)', () => {
+      // The middleware detector's handler resolution is currently
+      // current-file only — an imported router identifier in server.ts
+      // doesn't resolve to the router's SpiSymbol in routes/users.ts.
+      // Adding cross-file resolution requires plumbing pathToFileId
+      // through the detector context and following the type checker
+      // across file boundaries. Slice 1c-ii.h.
+      //
+      // This test documents the current behavior so we can detect when
+      // 1c-ii.h flips it.
+      writeFile(sandbox, 'src/routes/users.ts', [
+        'import { Router } from "express"',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
+        'usersRouter.get("/", listUsers)',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'import { usersRouter } from "./routes/users.js"',
+        'export const app = express()',
+        'app.use("/api/users", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/routes/users.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/')
+    })
+  })
+
+  describe('finalizer idempotence', () => {
+    it('does not double-apply the prefix when the route_path already starts with it', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
+        // Path that already includes the mount prefix — the finalizer
+        // must not produce /api/api/users.
+        'usersRouter.get("/api/users", listUsers)',
+        'app.use("/api", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/api/users')
+    })
+  })
+
+  describe('router preserves its express_router role', () => {
+    it('the router stays tagged express_router even after the mount records mount_path', () => {
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',
+        'app.use("/api/users", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const router = findSymbol(spi, 'src/server.ts', 'usersRouter')
+      expect(router?.framework_role).toBe('express_router')
+      expect(router?.framework_metadata?.mount_path).toBe('/api/users')
+    })
+  })
+})


### PR DESCRIPTION
Resolves mounted-router prefixes onto each route handler's \`route_path\` for the same-file case. Cross-file is documented as slice 1c-ii.h.

## What

Two changes that work together:

### 1. Detector records \`mount_path\` on routers

Previously, the \`mount_path\` was only set inside \`emitMiddlewareForCall\`'s framework_role guard. The guard skipped re-assigning the role when a symbol already had \`express_router\`, and the \`mount_path\` assignment lived inside the same guard — so a router mounted via \`app.use('/api', usersRouter)\` never got \`mount_path\` recorded on its SpiSymbol.

The fix lifts the \`mount_path\` attachment **outside** the role guard. Any symbol resolved as the second-positional argument of \`app.use(path, ident)\` gets \`mount_path\` stamped, regardless of its existing \`framework_role\`. The router keeps its \`express_router\` identity AND gains \`mount_path\`.

### 2. \`finalizeExpressMountPrefixes\` — workspace-level post-pass

Called once by \`buildSpi\` (inside \`addTypeCheckerEdges\`) after every per-file detector has run. Builds two indices (router-by-id, route-handler-by-id), then walks every \`route_handler\` edge. For each edge whose from-symbol is a router with \`mount_path\` metadata, looks up the to-symbol's existing \`route_path\` and prepends the prefix.

\`joinRoutePath\` normalises trailing/leading slashes and skips double-application: if the existing path already begins with the mount prefix, leaves it alone.

## Behavior matrix (same-file)

| Source | Resulting \`route_path\` |
|---|---|
| \`usersRouter.get('/', h); app.use('/api/users', usersRouter)\` | \`/api/users/\` |
| \`app.use('/api/users', usersRouter); usersRouter.get('/:id', h)\` | \`/api/users/:id\` (order-independent) |
| Inline handler: \`usersRouter.post('/', (r,s) => ...)\` mounted at \`/api/users\` | \`/api/users/\` |
| \`app.use(usersRouter)\` (no prefix) | \`/users\` (unchanged — no mount_path captured) |
| Route's path already begins with \`/api\` AND mount prefix is \`/api\` | unchanged (double-application defended) |

## Cross-file: deferred to slice 1c-ii.h

When the mount call lives in a different file than the router declaration (\`app.use('/api', importedRouter)\`), the current detector resolves the second arg only within the current file's symbols. Cross-file resolution requires plumbing \`pathToFileId\` through the detector context and following the type checker across file boundaries. **Slice 1c-ii.h** addresses that.

A regression test pins the current cross-file behavior (\`route_path: '/'\` — unprefixed) so the 1c-ii.h flip is detectable.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 99 files / **1698** tests pass (7 new for mount-prefix + 1691 pre-existing)
- [x] Tests cover: route-before-mount, route-after-mount (order-independence proves the finalizer's value), inline handlers, no-prefix mount, double-application defence, router-preserves-role assertion, current cross-file behavior (deferred-feature pin).
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

Refs #72, #111 (slice 1c-ii.f route_path metadata), #115 (projector framework_metadata propagation — which already surfaces the prefixed route_path onto ExtractionNode for free).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Express mounted-router prefix application so route handlers correctly receive and display mount path prefixes; routers retain their router role and mount metadata is recorded.

* **Tests**
  * Added tests covering mount-prefix resolution: same-file mounts, inline handlers, prepend semantics (including duplicated-prefix cases), and documented cross-file mount limitation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/116)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->