### PR TITLE
feat(#72): SPI v1 slice 1c-ii.h — cross-file mount-prefix resolution

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -649,6 +649,8 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
     // synthetic route nodes land in 1c-ii.d and 1c-ii.e respectively.
     // The checker is passed through for declaration-identity resolution
     // so lexical shadows don't produce false-positive route tags.
+    // pathToFileId unlocks slice 1c-ii.h's cross-file mount resolution
+    // (imported routers mounted via app.use('/prefix', importedRouter)).
     detectExpressFramework({
       sourceFile,
       fileId: file.id,
@@ -656,6 +658,7 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
       symbols,
       edges,
       checker,
+      pathToFileId,
     })
     // Slice 1c-iv.a: convention-based Next.js detector. Tags exported
     // symbols in app/.../page.tsx, app/.../route.ts, pages/api/...,

--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -73,6 +73,12 @@ export type DetectExpressFrameworkContext = {
    *  matching, which is correct only when no inner scope shadows the
    *  receiver or handler identifier. */
   checker?: ts.TypeChecker
+  /** Map from a source file's POSIX-normalized fileName to its SpiFile
+   *  id. Used by slice 1c-ii.h's cross-file mount resolution to look up
+   *  an imported router's SpiSymbol when the mount call lives in a
+   *  different file from the router's declaration. Optional — falls
+   *  back to current-file-only resolution if absent. */
+  pathToFileId?: Map<string, string>
 }
 
 /** Internal record: pairs a tagged Express binding's SpiSymbol with the
@@ -182,6 +188,15 @@ function emitMiddlewareForCall(
     let handlerSymbol: SpiSymbol | null = null
     if (ts.isIdentifier(arg)) {
       handlerSymbol = resolveHandlerSymbol(arg, ctx)
+      // Slice 1c-ii.h — cross-file fallback. When the current-file
+      // resolution misses, the argument is likely an imported binding
+      // (commonly `import { usersRouter } from './routes/users.js'`
+      // followed by `app.use('/api', usersRouter)`). Walk through the
+      // type checker to the symbol's declaration, derive its file_id,
+      // and look up the matching SpiSymbol there.
+      if (!handlerSymbol) {
+        handlerSymbol = resolveCrossFileSymbol(arg, ctx)
+      }
     } else if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
       handlerSymbol = mintSyntheticHandlerSymbol(ctx, callExpr, arg, 'express_middleware')
     }
@@ -426,6 +441,66 @@ function rangeOfNode(node: ts.Node, sourceFile: ts.SourceFile): SpiSymbol['range
     start: { line: start.line + 1, column: start.character + 1 },
     end: { line: end.line + 1, column: end.character + 1 },
   }
+}
+
+/**
+ * Slice 1c-ii.h — cross-file symbol resolution. When an imported
+ * identifier appears as the mounted-router argument of
+ * `app.use('/prefix', importedRouter)`, this resolves the import alias
+ * through ts.TypeChecker to the symbol's *originating* declaration,
+ * derives the declaration's file_id via pathToFileId, and finds the
+ * matching SpiSymbol in that file's index.
+ *
+ * Returns null when:
+ *   * No checker or pathToFileId on the context (graceful fallback).
+ *   * The identifier doesn't resolve to a symbol with declarations.
+ *   * The declaration's file isn't in the SPI (e.g., imports from
+ *     node_modules or files outside the workspace root).
+ *   * The declared symbol exists in the SPI but isn't a tagged Express
+ *     binding (express_app or express_router).
+ */
+function resolveCrossFileSymbol(
+  identifier: ts.Identifier,
+  ctx: DetectExpressFrameworkContext,
+): SpiSymbol | null {
+  if (!ctx.checker || !ctx.pathToFileId) return null
+  const localSymbol = ctx.checker.getSymbolAtLocation(identifier)
+  if (!localSymbol) return null
+  const aliasedSymbol = (localSymbol.flags & ts.SymbolFlags.Alias) !== 0
+    ? safeGetAliasedSymbol(localSymbol, ctx.checker)
+    : localSymbol
+  if (!aliasedSymbol) return null
+  const declaration = aliasedSymbol.declarations?.[0]
+  if (!declaration) return null
+  if (!isTopLevelDeclaration(declaration)) return null
+
+  const declSourceFile = declaration.getSourceFile()
+  const declaredFileId = ctx.pathToFileId.get(declSourceFile.fileName)
+  if (!declaredFileId) return null
+
+  // Find the SpiSymbol in the declaration's file. Match by name (the
+  // declaration's identifier name). Constraint to function / constant /
+  // variable kinds matches the routes/handlers/routers we care about.
+  const declName = declaredName(declaration)
+  if (!declName) return null
+  const fileSymbols = ctx.symbolsByFile.get(declaredFileId) ?? []
+  return fileSymbols.find((s) =>
+    s.name === declName && (s.kind === 'function' || s.kind === 'constant' || s.kind === 'variable'),
+  ) ?? null
+}
+
+function safeGetAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol | null {
+  try {
+    return checker.getAliasedSymbol(symbol)
+  } catch {
+    return null
+  }
+}
+
+function declaredName(decl: ts.Declaration): string | null {
+  if (ts.isFunctionDeclaration(decl) && decl.name) return decl.name.text
+  if (ts.isVariableDeclaration(decl) && ts.isIdentifier(decl.name)) return decl.name.text
+  return null
 }
 
 function resolveHandlerSymbol(

--- a/tests/unit/spi-express-mount-prefix.test.ts
+++ b/tests/unit/spi-express-mount-prefix.test.ts
@@ -103,17 +103,8 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
     })
   })
 
-  describe('cross-file mount (deferred to slice 1c-ii.h)', () => {
-    it('today: cross-file mount does NOT propagate the prefix (current limitation)', () => {
-      // The middleware detector's handler resolution is currently
-      // current-file only — an imported router identifier in server.ts
-      // doesn't resolve to the router's SpiSymbol in routes/users.ts.
-      // Adding cross-file resolution requires plumbing pathToFileId
-      // through the detector context and following the type checker
-      // across file boundaries. Slice 1c-ii.h.
-      //
-      // This test documents the current behavior so we can detect when
-      // 1c-ii.h flips it.
+  describe('cross-file mount (slice 1c-ii.h)', () => {
+    it('prefixes routes when the mount call lives in a different file from the router', () => {
       writeFile(sandbox, 'src/routes/users.ts', [
         'import { Router } from "express"',
         'export const usersRouter = Router()',
@@ -128,7 +119,76 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       ].join('\n') + '\n')
       const spi = build(sandbox)
       const handler = findSymbol(spi, 'src/routes/users.ts', 'listUsers')
-      expect(handler?.framework_metadata?.route_path).toBe('/')
+      // The detector resolves `usersRouter` in server.ts to its
+      // declaration in routes/users.ts via the type checker's
+      // alias-following + pathToFileId lookup. mount_path is stamped
+      // on the router's SpiSymbol; the workspace-level finalizer then
+      // propagates the prefix to all routes registered on that router.
+      expect(handler?.framework_metadata?.route_path).toBe('/api/users/')
+    })
+
+    it('handles aliased imports across files (`import { usersRouter as users } from ...`)', () => {
+      writeFile(sandbox, 'src/routes/users.ts', [
+        'import { Router } from "express"',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
+        'usersRouter.get("/", listUsers)',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'import { usersRouter as users } from "./routes/users.js"',
+        'export const app = express()',
+        'app.use("/v2", users)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/routes/users.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/v2/')
+    })
+
+    it('handles default-import re-exported routers (`export default usersRouter`)', () => {
+      writeFile(sandbox, 'src/routes/users.ts', [
+        'import { Router } from "express"',
+        'export const usersRouter = Router()',
+        'export function listUsers(): void {}',
+        'usersRouter.get("/", listUsers)',
+        'export default usersRouter',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/server.ts', [
+        'import express from "express"',
+        'import usersRouter from "./routes/users.js"',
+        'export const app = express()',
+        'app.use("/api", usersRouter)',
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const handler = findSymbol(spi, 'src/routes/users.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/api/')
+    })
+
+    it('does NOT mis-tag local same-named identifiers in unrelated files', () => {
+      // Sanity: a local `usersRouter` const in another file that is NOT
+      // an Express router (and NOT imported from the routes file) should
+      // not get mount_path stamped just because server.ts has a mount
+      // call with the same identifier text.
+      writeFile(sandbox, 'src/other.ts', [
+        'export const usersRouter = { foo: 1 }',
+      ].join('\n') + '\n')
+      writeFile(sandbox, 'src/server.ts', [
+        'import express, { Router } from "express"',
+        'export const app = express()',
+        'export const usersRouter = Router()',  // local router
+        'export function listUsers(): void {}',
+        'usersRouter.get("/", listUsers)',
+        'app.use("/api", usersRouter)',  // mounts the LOCAL router, not src/other.ts's
+      ].join('\n') + '\n')
+      const spi = build(sandbox)
+      const other = findSymbol(spi, 'src/other.ts', 'usersRouter')
+      // Other's usersRouter should not be tagged express_router (it's
+      // a plain object) and not pick up any mount_path.
+      expect(other?.framework_role).toBeUndefined()
+      expect(other?.framework_metadata?.mount_path).toBeUndefined()
+      // The LOCAL router in server.ts gets the prefix.
+      const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+      expect(handler?.framework_metadata?.route_path).toBe('/api/')
     })
   })
 


### PR DESCRIPTION
Closes the cross-file gap left by slice 1c-ii.g. After this slice, the canonical Express layout — \`server.ts\` mounts routers imported from \`./routes/<resource>.ts\` files — gets full \`route_path\` resolution end-to-end.

## Plumbing

\`DetectExpressFrameworkContext\` gains an optional \`pathToFileId?: Map<string, string>\`. \`build.ts\` passes the existing \`pathToFileId\` map (built once during file collection) through.

## Cross-file resolution mechanism

\`emitMiddlewareForCall\` now falls back to a new \`resolveCrossFileSymbol\` helper when current-file resolution misses on an \`Identifier\` argument:

1. \`checker.getSymbolAtLocation(identifier)\` → ts.Symbol for the imported binding
2. Follow the alias if \`SymbolFlags.Alias\` is set (handles \`import { x }\`, \`import x from\`, and \`import { x as y }\` forms uniformly)
3. \`declarations[0]\` → originating ts.Node (FunctionDeclaration or VariableDeclaration in the source file)
4. \`declaration.getSourceFile().fileName\` → declared file path
5. \`pathToFileId.get(declaredPath)\` → SpiFile id
6. \`symbolsByFile.get(file_id)\` → search by declared name + kind ∈ {function, constant, variable} → the SpiSymbol

Top-level constraint via \`isTopLevelDeclaration\` mirrors the existing same-file handler resolution guard.

## What works after this slice

| Pattern | Result |
|---|---|
| \`import { usersRouter } from './routes/users.js'\` + \`app.use('/api', usersRouter)\` | ✅ \`route_path\` prefixed |
| \`import { usersRouter as users } from ...\` + \`app.use('/v2', users)\` | ✅ aliased imports work |
| \`import usersRouter from ...\` + \`export default usersRouter\` | ✅ default-import re-exports work |
| Two files with a same-named \`usersRouter\` identifier, only one is the real router | ✅ declaration identity prevents mis-tagging |

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm run test:run\` — 99 files / **1702** tests pass (4 new + 1698 pre-existing). The previously-deferred cross-file regression in spi-express-mount-prefix.test.ts is now flipped to assert correct behavior.
- [ ] CI must pass on Ubuntu/macOS/Windows matrix before merge.

## Express substrate progression — complete

| Slice | PR | Status |
|---|---|---|
| 1c-ii.b Express factory tagging | #107 | ✅ |
| 1c-ii.c named route detection | #108 | ✅ |
| 1c-ii.d middleware detection | #109 | ✅ |
| 1c-ii.e inline arrow synthesis | #110 | ✅ |
| 1c-ii.f route_path metadata | #111 | ✅ |
| 1c-ii.g mounted-router prefix (same-file) | #116 | ✅ |
| **1c-ii.h cross-file mount** (this PR) | #117 | ⏳ |

Refs #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Express router detection for imported routers mounted in different files. The framework now correctly propagates mount prefixes across files and supports aliased imports and default imports in cross-file routing scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->