### PR TITLE
feat(#72): v0.14 finishers — route_path metadata across all framework substrates

### DIFF
--- a/src/pipeline/spi/framework-express.ts
+++ b/src/pipeline/spi/framework-express.ts
@@ -295,7 +295,15 @@ function joinRoutePath(prefix: string, path: string): string {
   // literally at '/api' answers '/api/api', not '/api'. The function
   // is intentionally unconditional — caller's single-run invariant
   // prevents double-application.
+  //
+  // Slice 1c-ii.i (v0.14 finisher): normalize the router-root '/' case
+  // so it doesn't produce a redundant trailing slash. A router mounted
+  // at '/api/users' with a root route ('/') answers '/api/users' — the
+  // legacy extractor emits this form, and we match it now so the SPI
+  // projector's route_path is byte-equivalent to the legacy extractor's
+  // for the most common mounted-router shape.
   const cleanPrefix = prefix.replace(/\/+$/, '')
+  if (path === '/' || path === '') return cleanPrefix === '' ? '/' : cleanPrefix
   const cleanPath = path.startsWith('/') ? path : '/' + path
   return cleanPrefix + cleanPath
 }

--- a/src/pipeline/spi/framework-nextjs.ts
+++ b/src/pipeline/spi/framework-nextjs.ts
@@ -1,11 +1,11 @@
-// SPI v1 — Next.js framework layer (slice 1c-iv.a of #72).
+// SPI v1 — Next.js framework layer (slices 1c-iv.a + 1c-iv.b of #72).
 //
 // Next.js is convention-based rather than call-based: routes, layouts,
 // middleware, and API handlers are identified by file path patterns, not
 // by AST shapes. This detector walks each file's path and applies the
 // matching SpiFrameworkRole to the file's exports.
 //
-// Conventions recognized in this slice:
+// Conventions recognized:
 //
 //   app/<segments>/page.tsx          → nextjs_app_page     (default export)
 //   app/<segments>/route.ts          → nextjs_app_route    (named HTTP-method exports)
@@ -17,20 +17,23 @@
 //   pages/<segments>.tsx             → nextjs_pages_page   (default export)
 //   middleware.ts (workspace root)   → nextjs_middleware   (default export)
 //
-// For app-router route.ts files the convention is **named** exports per
-// HTTP method (`export function GET() {}`, `export function POST() {}`),
-// so the detector tags every named export whose name is a recognized
-// HTTP verb. For every other convention the convention's payload lives
-// on the default export.
+// Slice 1c-iv.b adds `route_path` to framework_metadata for every tagged
+// symbol — derived deterministically from the file path:
 //
-// Out of scope for this slice (deferred to follow-ups):
+//   app/users/page.tsx              → /users
+//   app/users/[id]/page.tsx         → /users/:id
+//   app/(auth)/login/page.tsx       → /login          (route groups stripped)
+//   app/blog/[...slug]/page.tsx     → /blog/*         (catch-all)
+//   app/blog/[[...slug]]/page.tsx   → /blog/*?        (optional catch-all)
+//   app/api/users/route.ts          → /api/users
+//   pages/users/[id].tsx            → /users/:id
+//   pages/api/users/[id].ts         → /api/users/:id  (api prefix preserved)
+//   middleware.ts                   → /*              (matches all paths)
 //
-//   * route_path metadata derived from the file path
-//     (e.g. `app/users/[id]/page.tsx` → route_path: '/users/:id'). Slot
-//     in framework_metadata reserved for slice 1c-iv.b.
-//   * Dynamic segments and route groups: [id], [[...slug]], (group) —
-//     same metadata work above.
-//   * server/client component detection via the 'use client' directive.
+// The path layer is the same for both routers, modulo the file-name
+// stripping rule (app/* uses file basename as the convention key and the
+// path ends at the directory; pages/* uses the file basename minus the
+// extension as the last segment).
 
 import ts from 'typescript'
 
@@ -49,8 +52,8 @@ const ROUTE_HTTP_NAMES: ReadonlySet<string> = new Set([
 ])
 
 type NextjsConventionMatch =
-  | { kind: 'default'; role: SpiFrameworkRole }
-  | { kind: 'http_methods'; role: SpiFrameworkRole }
+  | { kind: 'default'; role: SpiFrameworkRole; routePath: string }
+  | { kind: 'http_methods'; role: SpiFrameworkRole; routePath: string }
 
 export type DetectNextjsFrameworkContext = {
   sourceFile: ts.SourceFile
@@ -65,9 +68,9 @@ export function detectNextjsFramework(ctx: DetectNextjsFrameworkContext): void {
   if (!match) return
 
   if (match.kind === 'default') {
-    tagDefaultExport(ctx, match.role)
+    tagDefaultExport(ctx, match.role, match.routePath)
   } else {
-    tagHttpMethodExports(ctx, match.role)
+    tagHttpMethodExports(ctx, match.role, match.routePath)
   }
 }
 
@@ -80,7 +83,7 @@ function matchConvention(filePath: string): NextjsConventionMatch | null {
 
   // Root middleware: `middleware.ts` or `middleware.tsx`.
   if (normalized === 'middleware.ts' || normalized === 'middleware.tsx') {
-    return { kind: 'default', role: 'nextjs_middleware' }
+    return { kind: 'default', role: 'nextjs_middleware', routePath: '/*' }
   }
 
   // App router conventions: `app/.../<basename>.tsx?` for pages/layouts/
@@ -88,10 +91,10 @@ function matchConvention(filePath: string): NextjsConventionMatch | null {
   if (normalized.startsWith('app/')) {
     const basename = stripExtension(getBasename(normalized))
     if (basename === 'route') {
-      return { kind: 'http_methods', role: 'nextjs_app_route' }
+      return { kind: 'http_methods', role: 'nextjs_app_route', routePath: appRoutePath(normalized) }
     }
     const role = APP_FILE_CONVENTIONS.get(basename)
-    if (role) return { kind: 'default', role }
+    if (role) return { kind: 'default', role, routePath: appRoutePath(normalized) }
     return null
   }
 
@@ -99,17 +102,73 @@ function matchConvention(filePath: string): NextjsConventionMatch | null {
   if (normalized.startsWith('pages/')) {
     // `pages/api/...` files are API routes (default export).
     if (normalized.startsWith('pages/api/')) {
-      return { kind: 'default', role: 'nextjs_pages_api' }
+      return { kind: 'default', role: 'nextjs_pages_api', routePath: pagesRoutePath(normalized) }
     }
     // Other pages/* files are page components, but skip Next.js'
     // special files (_app, _document, _error, _middleware) and any
     // co-located non-routable file like `_components`.
     const basename = stripExtension(getBasename(normalized))
     if (basename.startsWith('_')) return null
-    return { kind: 'default', role: 'nextjs_pages_page' }
+    return { kind: 'default', role: 'nextjs_pages_page', routePath: pagesRoutePath(normalized) }
   }
 
   return null
+}
+
+/** Derive a URL path from a Next.js app-router file path. The file's
+ *  basename (`page`, `layout`, `route`, etc.) is stripped because in the
+ *  app router the URL is determined by the *directory* containing the
+ *  convention file, not the file name. */
+function appRoutePath(normalized: string): string {
+  // Drop the leading "app/" segment and the final file name.
+  const withoutPrefix = normalized.slice('app/'.length)
+  const segments = withoutPrefix.split('/').slice(0, -1)
+  return segmentsToRoutePath(segments)
+}
+
+/** Derive a URL path from a Next.js pages-router file path. Both regular
+ *  pages and pages/api use the basename (minus extension) as the trailing
+ *  segment — except `index`, which collapses to the parent directory. */
+function pagesRoutePath(normalized: string): string {
+  const withoutPrefix = normalized.slice('pages/'.length)
+  const parts = withoutPrefix.split('/')
+  const last = parts[parts.length - 1] ?? ''
+  const lastStem = stripExtension(last)
+  const allSegments = parts.slice(0, -1)
+  if (lastStem !== 'index') allSegments.push(lastStem)
+  return segmentsToRoutePath(allSegments)
+}
+
+/** Normalise the list of route segments into a leading-`/` URL string.
+ *  Applies Next.js' three dynamic-segment transforms:
+ *    [foo]      → :foo
+ *    [...foo]   → *           (catch-all)
+ *    [[...foo]] → *?          (optional catch-all)
+ *  Route groups `(group)` and parallel routes `@group` are erased from the
+ *  URL — they exist only in the file layout. */
+function segmentsToRoutePath(segments: string[]): string {
+  const transformed: string[] = []
+  for (const raw of segments) {
+    // Strip route groups (auth) and parallel/intercepted segments @modal —
+    // they are layout-only and produce NO URL segment.
+    if (raw.startsWith('(') && raw.endsWith(')')) continue
+    if (raw.startsWith('@')) continue
+    transformed.push(normalizeSegment(raw))
+  }
+  if (transformed.length === 0) return '/'
+  return '/' + transformed.join('/')
+}
+
+function normalizeSegment(segment: string): string {
+  // Optional catch-all: [[...slug]] → *?
+  if (segment.startsWith('[[...') && segment.endsWith(']]')) return '*?'
+  // Catch-all: [...slug] → *
+  if (segment.startsWith('[...') && segment.endsWith(']')) return '*'
+  // Dynamic: [id] → :id
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    return ':' + segment.slice(1, -1)
+  }
+  return segment
 }
 
 function stripLeadingSrc(filePath: string): string {
@@ -126,7 +185,7 @@ function stripExtension(name: string): string {
   return dot === -1 ? name : name.slice(0, dot)
 }
 
-function tagDefaultExport(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkRole): void {
+function tagDefaultExport(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkRole, routePath: string): void {
   // A Next.js page/layout/etc. is whatever symbol the file exports as
   // its default. Two AST shapes produce a default export:
   //   1. `export default function Foo() {}` — direct on a declaration.
@@ -138,18 +197,19 @@ function tagDefaultExport(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkR
   // in a follow-up slice mirroring slice 1c-ii.e's pattern.
   const defaultExportName = findDefaultExportName(ctx.sourceFile)
   if (defaultExportName === null) return
-  tagSymbolByName(ctx, defaultExportName, role)
+  tagSymbolByName(ctx, defaultExportName, role, routePath)
 }
 
-function tagHttpMethodExports(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkRole): void {
+function tagHttpMethodExports(ctx: DetectNextjsFrameworkContext, role: SpiFrameworkRole, routePath: string): void {
   // App-router route handlers (`app/.../route.ts`) export one function
   // per HTTP method: `export function GET() {}`, `export function
-  // POST() {}`, etc. Tag each.
+  // POST() {}`, etc. Tag each; record the HTTP method on framework_metadata
+  // so consumers can filter by verb.
   for (const stmt of ctx.sourceFile.statements) {
     if (!ts.isFunctionDeclaration(stmt) || !stmt.name) continue
     if (!hasExportModifier(stmt)) continue
     if (!ROUTE_HTTP_NAMES.has(stmt.name.text)) continue
-    tagSymbolByName(ctx, stmt.name.text, role)
+    tagSymbolByName(ctx, stmt.name.text, role, routePath, stmt.name.text)
   }
 }
 
@@ -192,12 +252,22 @@ function hasExportModifier(node: ts.Node): boolean {
   return false
 }
 
-function tagSymbolByName(ctx: DetectNextjsFrameworkContext, name: string, role: SpiFrameworkRole): void {
+function tagSymbolByName(
+  ctx: DetectNextjsFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+  routePath: string,
+  httpMethod?: string,
+): void {
   const symbols = ctx.symbolsByFile.get(ctx.fileId)
   if (!symbols) return
   for (const symbol of symbols) {
     if (symbol.name === name && symbol.framework_role === undefined) {
       symbol.framework_role = role
+      const metadata: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+      metadata.route_path = routePath
+      if (httpMethod) metadata.http_method = httpMethod
+      symbol.framework_metadata = metadata
       return
     }
   }

--- a/src/pipeline/spi/framework-nextjs.ts
+++ b/src/pipeline/spi/framework-nextjs.ts
@@ -149,11 +149,19 @@ function pagesRoutePath(normalized: string): string {
 function segmentsToRoutePath(segments: string[]): string {
   const transformed: string[] = []
   for (const raw of segments) {
-    // Strip route groups (auth) and parallel/intercepted segments @modal —
-    // they are layout-only and produce NO URL segment.
+    // Strip route groups (auth) and parallel/intercepted parent slots
+    // @modal — they are layout-only and produce NO URL segment.
     if (raw.startsWith('(') && raw.endsWith(')')) continue
     if (raw.startsWith('@')) continue
-    transformed.push(normalizeSegment(raw))
+
+    // Strip Next.js intercepting-route prefixes from the folder name:
+    //   (.)photo    → photo   (intercept same level)
+    //   (..)photo   → photo   (intercept one level up)
+    //   (...)photo  → photo   (intercept from root)
+    // The folder name itself IS the URL segment; the prefix is metadata
+    // that only affects intercept routing, not the final route_path.
+    const stripped = raw.replace(/^\(\.{1,3}\)/, '')
+    transformed.push(normalizeSegment(stripped))
   }
   if (transformed.length === 0) return '/'
   return '/' + transformed.join('/')

--- a/src/pipeline/spi/framework-react-router.ts
+++ b/src/pipeline/spi/framework-react-router.ts
@@ -1,4 +1,4 @@
-// SPI v1 — React Router framework layer (slice 1c-v.a of #72).
+// SPI v1 — React Router framework layer (slices 1c-v.a + 1c-v.b of #72).
 //
 // React Router (v6.4+ data-router idiom) has two structural patterns the
 // SPI substrate cares about:
@@ -6,17 +6,27 @@
 //   1. Router factories — `createBrowserRouter([...])`,
 //      `createHashRouter([...])`, `createMemoryRouter([...])`, and
 //      `createStaticRouter([...])`. The factory call's receiving variable
-//      is tagged with framework_role: 'react_router_router'.
+//      is tagged with framework_role: 'react_router_router'. Slice 1c-v.b
+//      additionally walks the route-config array (first argument) and
+//      tags any locally-defined loader / action functions whose names
+//      appear in the config with the matching route's `route_path`.
 //
 //   2. Route-module convention — when a file imports from 'react-router'
 //      or 'react-router-dom' AND exports a named function or const called
 //      exactly `loader` or `action`, those exports are tagged with
 //      framework_role: 'react_router_loader' / 'react_router_action'.
 //
+// Slice 1c-v.b adds `route_path` to framework_metadata for both router
+// objects (the concatenated tree of paths) and for in-config loaders/
+// actions. Nested children inherit their parent path with `/` join. Index
+// routes (`{ index: true }`) reuse the parent path verbatim. Path-less
+// pathless layout routes (`{ children: [...] }` with no `path`) are
+// transparent — children inherit the grandparent path.
+//
 // JSX route definitions (`<Route path="/x" element={<X />} />`) and
-// hook-based detection (useNavigate, useLoaderData, etc.) are intentionally
-// out of scope for this substrate slice — they're structurally more
-// invasive and land in slice 1c-v.b once the basic shape is proven.
+// hook-based detection (useNavigate, useLoaderData, etc.) remain out of
+// scope — they're structurally more invasive and would land in a follow-
+// up after a real codebase asks for them.
 
 import ts from 'typescript'
 
@@ -57,14 +67,49 @@ export function detectReactRouterFramework(ctx: DetectReactRouterFrameworkContex
   if (!bindings.hasReactRouterImport) return
 
   // 1. Router factory detection: walk top-level variable declarations,
-  // tag those initialised with a known factory call.
+  // tag those initialised with a known factory call. While we're walking
+  // the call, also collect the route-config tree so we can derive
+  // route_path metadata and tag in-config loader/action identifiers.
+  const routeAssignments: RouteAssignment[] = []
   for (const stmt of ctx.sourceFile.statements) {
     if (!ts.isVariableStatement(stmt)) continue
     for (const decl of stmt.declarationList.declarations) {
       if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
-      if (isFactoryCall(decl.initializer, bindings.routerFactories)) {
-        tagSymbolByName(ctx, decl.name.text, 'react_router_router')
+      if (!isFactoryCall(decl.initializer, bindings.routerFactories)) continue
+
+      // Collect route assignments from the config array (first argument).
+      const configArg = (decl.initializer as ts.CallExpression).arguments[0]
+      const collected: RouteAssignment[] = []
+      if (configArg && ts.isArrayLiteralExpression(configArg)) {
+        collectRouteAssignments(configArg, '', collected)
       }
+
+      // The router symbol's route_path is the canonical roots joined; for
+      // a typical single-tree router this is just '/'. Tag the router
+      // with the union of all top-level paths so consumers can find it.
+      const topPaths = collected
+        .filter((a) => a.depth === 0)
+        .map((a) => a.routePath)
+      const routerRoutePath = topPaths.length === 1
+        ? topPaths[0]
+        : (topPaths.length === 0 ? '/' : topPaths.join('|'))
+      tagSymbolByName(ctx, decl.name.text, 'react_router_router', { route_path: routerRoutePath })
+
+      // Tag in-file loader/action identifiers that the config references.
+      routeAssignments.push(...collected)
+    }
+  }
+
+  for (const assignment of routeAssignments) {
+    if (assignment.loaderName) {
+      tagSymbolByName(ctx, assignment.loaderName, 'react_router_loader', {
+        route_path: assignment.routePath,
+      })
+    }
+    if (assignment.actionName) {
+      tagSymbolByName(ctx, assignment.actionName, 'react_router_action', {
+        route_path: assignment.routePath,
+      })
     }
   }
 
@@ -90,6 +135,129 @@ export function detectReactRouterFramework(ctx: DetectReactRouterFrameworkContex
       }
     }
   }
+}
+
+/** A flat record describing one route node in the config tree, after path
+ *  composition with its ancestors. `depth` is the nesting level — top-
+ *  level routes have depth 0. */
+type RouteAssignment = {
+  routePath: string
+  depth: number
+  loaderName: string | null
+  actionName: string | null
+}
+
+/** Walks a route-config array literal and emits one RouteAssignment per
+ *  recognised object literal. Children inherit the parent's path; index
+ *  routes (`{ index: true }`) reuse the parent's path verbatim. Pathless
+ *  layout routes (no `path` property but `children` present) pass through
+ *  transparently — the grandparent's path is used for children. */
+function collectRouteAssignments(
+  array: ts.ArrayLiteralExpression,
+  parentPath: string,
+  out: RouteAssignment[],
+  depth = 0,
+): void {
+  for (const element of array.elements) {
+    if (!ts.isObjectLiteralExpression(element)) continue
+    const fields = readRouteFields(element)
+
+    // Resolve this route's path. Three cases:
+    //  - explicit `path`: join with parent
+    //  - `index: true` (no path): reuse parent verbatim
+    //  - no path, has children: pathless layout — keep parent unchanged
+    let effectivePath: string
+    if (fields.path !== null) {
+      effectivePath = joinRoutePaths(parentPath, fields.path)
+    } else if (fields.isIndex) {
+      effectivePath = parentPath === '' ? '/' : parentPath
+    } else {
+      effectivePath = parentPath
+    }
+
+    // Emit an assignment if there's anything to tag (path-bearing route,
+    // index route, or a route that names a loader/action even on a
+    // pathless layout — the layout's loader is real).
+    if (fields.path !== null || fields.isIndex || fields.loaderName || fields.actionName) {
+      out.push({
+        routePath: effectivePath === '' ? '/' : effectivePath,
+        depth,
+        loaderName: fields.loaderName,
+        actionName: fields.actionName,
+      })
+    }
+
+    // Recurse into children.
+    if (fields.children) {
+      collectRouteAssignments(fields.children, effectivePath, out, depth + 1)
+    }
+  }
+}
+
+type RouteFields = {
+  path: string | null
+  isIndex: boolean
+  loaderName: string | null
+  actionName: string | null
+  children: ts.ArrayLiteralExpression | null
+}
+
+function readRouteFields(obj: ts.ObjectLiteralExpression): RouteFields {
+  const fields: RouteFields = {
+    path: null,
+    isIndex: false,
+    loaderName: null,
+    actionName: null,
+    children: null,
+  }
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      // Shorthand property like `{ loader, action }` resolves to the
+      // local identifier with the same name as the property.
+      if (ts.isShorthandPropertyAssignment(prop)) {
+        const key = prop.name.text
+        if (key === 'loader') fields.loaderName = prop.name.text
+        else if (key === 'action') fields.actionName = prop.name.text
+      }
+      continue
+    }
+    const key = readPropertyKey(prop.name)
+    if (key === null) continue
+    if (key === 'path' && ts.isStringLiteralLike(prop.initializer)) {
+      fields.path = prop.initializer.text
+    } else if (key === 'index' && prop.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+      fields.isIndex = true
+    } else if (key === 'loader' && ts.isIdentifier(prop.initializer)) {
+      fields.loaderName = prop.initializer.text
+    } else if (key === 'action' && ts.isIdentifier(prop.initializer)) {
+      fields.actionName = prop.initializer.text
+    } else if (key === 'children' && ts.isArrayLiteralExpression(prop.initializer)) {
+      fields.children = prop.initializer
+    }
+  }
+  return fields
+}
+
+function readPropertyKey(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name)) return name.text
+  if (ts.isStringLiteralLike(name)) return name.text
+  return null
+}
+
+/** Join the parent's URL path with a child's URL fragment. React Router
+ *  treats trailing/leading slashes leniently — we apply the same rule:
+ *  the join is exactly one `/` between the two parts, and the result has
+ *  no trailing slash (unless the result IS just `/`). */
+function joinRoutePaths(parent: string, child: string): string {
+  // Absolute child: replaces parent entirely (React Router allows this).
+  if (child.startsWith('/')) {
+    return child === '/' ? '/' : child.replace(/\/+$/, '')
+  }
+  const trimmedParent = parent.replace(/\/+$/, '')
+  const trimmedChild = child.replace(/^\/+/, '').replace(/\/+$/, '')
+  if (trimmedChild === '') return trimmedParent === '' ? '/' : trimmedParent
+  const joined = trimmedParent + '/' + trimmedChild
+  return joined.startsWith('/') ? joined : '/' + joined
 }
 
 function collectBindings(sourceFile: ts.SourceFile): ReactRouterBindings {
@@ -135,12 +303,20 @@ function tagSymbolByName(
   ctx: DetectReactRouterFrameworkContext,
   name: string,
   role: SpiFrameworkRole,
+  metadata?: Record<string, unknown>,
 ): void {
   const symbols = ctx.symbolsByFile.get(ctx.fileId)
   if (!symbols) return
   for (const symbol of symbols) {
     if (symbol.name === name && symbol.framework_role === undefined) {
       symbol.framework_role = role
+      if (metadata) {
+        const merged: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined) merged[key] = value
+        }
+        symbol.framework_metadata = merged
+      }
       return
     }
   }

--- a/src/pipeline/spi/framework-react-router.ts
+++ b/src/pipeline/spi/framework-react-router.ts
@@ -78,10 +78,19 @@ export function detectReactRouterFramework(ctx: DetectReactRouterFrameworkContex
       if (!isFactoryCall(decl.initializer, bindings.routerFactories)) continue
 
       // Collect route assignments from the config array (first argument).
+      // Two AST shapes accepted:
+      //   1. Inline literal: createBrowserRouter([{path:...}, ...])
+      //   2. Hoisted: const routes = [{path:...}]; createBrowserRouter(routes)
+      // For (2) we walk the file's top-level VariableDeclarations to find
+      // the same-file source array. Cross-file hoisting (a const exported
+      // from another file) remains out of scope — requires the type
+      // checker and produces strictly diminishing returns; can be added
+      // later if a real codebase asks for it.
       const configArg = (decl.initializer as ts.CallExpression).arguments[0]
       const collected: RouteAssignment[] = []
-      if (configArg && ts.isArrayLiteralExpression(configArg)) {
-        collectRouteAssignments(configArg, '', collected)
+      const resolvedArray = resolveRouteConfigArray(configArg, ctx.sourceFile)
+      if (resolvedArray) {
+        collectRouteAssignments(resolvedArray, '', collected)
       }
 
       // The router symbol's route_path is the canonical roots joined; for
@@ -135,6 +144,35 @@ export function detectReactRouterFramework(ctx: DetectReactRouterFrameworkContex
       }
     }
   }
+}
+
+/** Resolve the config argument to an ArrayLiteralExpression. Accepts:
+ *   - the array literal directly (the common inline case)
+ *   - an Identifier that refers to a same-file const/let/var whose
+ *     initializer is an array literal
+ *  Returns null when neither shape matches; the detector skips route-
+ *  assignment collection but still tags the router with its role. */
+function resolveRouteConfigArray(
+  expr: ts.Expression | undefined,
+  sourceFile: ts.SourceFile,
+): ts.ArrayLiteralExpression | null {
+  if (!expr) return null
+  if (ts.isArrayLiteralExpression(expr)) return expr
+  if (!ts.isIdentifier(expr)) return null
+  const name = expr.text
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== name) continue
+      if (decl.initializer && ts.isArrayLiteralExpression(decl.initializer)) {
+        return decl.initializer
+      }
+      // Same-name identifier exists but isn't an array literal — bail out
+      // rather than falling through to a different declaration.
+      return null
+    }
+  }
+  return null
 }
 
 /** A flat record describing one route node in the config tree, after path

--- a/src/pipeline/spi/framework-redux.ts
+++ b/src/pipeline/spi/framework-redux.ts
@@ -1,4 +1,4 @@
-// SPI v1 — Redux Toolkit framework layer (slice 1c-vi.a of #72).
+// SPI v1 — Redux Toolkit framework layer (slices 1c-vi.a + 1c-vi.b of #72).
 //
 // Redux Toolkit's idiomatic surface is a small set of factory functions:
 //
@@ -8,25 +8,33 @@
 //   const selectFoo    = createSelector([...], (...) => ...)
 //   const fetchUser    = createAsyncThunk('user/fetch', ...)
 //
-// Each factory call's receiving variable is tagged with a matching
-// SpiFrameworkRole. Selectors built via `reselect` (`createSelector` from
-// 'reselect' rather than '@reduxjs/toolkit') are accepted too because
-// they're functionally identical and routinely re-exported from RTK.
+// Slice 1c-vi.a tagged the receiving variable's `framework_role`. Slice
+// 1c-vi.b adds structural metadata so consumers don't have to re-read the
+// AST to learn the slice's name, reducer keys, thunk type prefix, or
+// RTK Query endpoint names. Tagged shapes:
+//
+//   createSlice          → { slice_name, reducer_keys[], action_creators[] }
+//   configureStore       → { reducer_keys[] }       (if `reducer: {...}`)
+//   createAsyncThunk     → { type_prefix }          (first-arg string)
+//   createApi            → { endpoint_names[] }     (object keys of `endpoints` fn)
+//   createSelector       → no metadata (selectors are anonymous-by-design)
 //
 // Detection is import-gated: a file must import from one of the Redux
 // module specifiers for any tagging to happen. This avoids tagging
 // same-named local helpers in unrelated files.
 //
-// Out of scope (deferred to follow-up slices):
+// Out of scope (deferred):
 //
-//   * Slice metadata: extracting `name`, reducer keys, and the auto-
-//     generated action-creator surface. Requires walking the object-
-//     literal argument to createSlice and may want a framework_metadata
-//     entry similar to slice 1c-ii.f's route_path.
+//   * Following the auto-generated action creators back to the
+//     individual `actions.fooBar` properties on the slice export. The
+//     `action_creators` list is the names from the reducers object,
+//     which IS the canonical surface — consumers can look up
+//     `<sliceName>.actions.<name>` themselves.
 //   * `createReducer` (functional reducer composition) — non-essential
 //     and can be added when a real codebase asks for it.
-//   * `useSelector` / `useDispatch` hook detection — structural noise;
-//     consumers should locate selectors via framework_role instead.
+//   * Property-access factory variants (`api.injectEndpoints({...})`)
+//     remain unhandled — they're derived operations on already-tagged
+//     factory results, not new factory calls.
 
 import ts from 'typescript'
 
@@ -73,9 +81,9 @@ export function detectReduxFramework(ctx: DetectReduxFrameworkContext): void {
     if (!ts.isVariableStatement(stmt)) continue
     for (const decl of stmt.declarationList.declarations) {
       if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
-      const role = factoryCallRole(decl.initializer, bindings.factories)
-      if (!role) continue
-      tagSymbolByName(ctx, decl.name.text, role)
+      const tag = factoryCallTag(decl.initializer, bindings.factories)
+      if (!tag) continue
+      tagSymbolByName(ctx, decl.name.text, tag.role, tag.metadata)
     }
   }
 }
@@ -102,30 +110,181 @@ function collectBindings(sourceFile: ts.SourceFile): ReduxBindings {
   return bindings
 }
 
-function factoryCallRole(
+type FactoryTag = {
+  role: SpiFrameworkRole
+  metadata: Record<string, unknown> | null
+}
+
+function factoryCallTag(
   expression: ts.Expression,
   factories: Map<string, SpiFrameworkRole>,
-): SpiFrameworkRole | null {
+): FactoryTag | null {
   if (!ts.isCallExpression(expression)) return null
   const callee = expression.expression
   // createSlice(...)
-  if (ts.isIdentifier(callee)) return factories.get(callee.text) ?? null
-  // api.injectEndpoints(...) and other property-access factory variants
-  // are intentionally NOT tagged in this slice — they're derived
-  // operations on already-tagged factory results, not new factory calls.
+  if (!ts.isIdentifier(callee)) {
+    // api.injectEndpoints(...) and other property-access factory variants
+    // are intentionally NOT tagged — they're derived operations on
+    // already-tagged factory results, not new factory calls.
+    return null
+  }
+  const role = factories.get(callee.text)
+  if (!role) return null
+  return { role, metadata: extractFactoryMetadata(role, expression) }
+}
+
+/** Extract per-factory metadata from the call's argument shape. Each
+ *  factory has a stable single-argument convention — when the argument
+ *  isn't the expected shape, return null and rely on the role tag alone. */
+function extractFactoryMetadata(
+  role: SpiFrameworkRole,
+  call: ts.CallExpression,
+): Record<string, unknown> | null {
+  const arg0 = call.arguments[0]
+  if (!arg0) return null
+
+  if (role === 'redux_slice') {
+    if (!ts.isObjectLiteralExpression(arg0)) return null
+    const sliceName = readStringProperty(arg0, 'name')
+    const reducers = readObjectProperty(arg0, 'reducers')
+    const reducerKeys = reducers ? readObjectLiteralKeys(reducers) : []
+    return {
+      slice_name: sliceName,
+      reducer_keys: reducerKeys,
+      action_creators: reducerKeys,
+    }
+  }
+
+  if (role === 'redux_store') {
+    if (!ts.isObjectLiteralExpression(arg0)) return null
+    const reducer = readObjectProperty(arg0, 'reducer')
+    // `configureStore({ reducer: { auth, posts } })` exposes the slice
+    // namespace; `{ reducer: rootReducer }` does not.
+    const reducerKeys = reducer ? readObjectLiteralKeys(reducer) : []
+    return reducerKeys.length > 0 ? { reducer_keys: reducerKeys } : null
+  }
+
+  if (role === 'redux_async_thunk') {
+    // createAsyncThunk('user/fetch', ...) — first arg is the type prefix.
+    if (ts.isStringLiteralLike(arg0)) return { type_prefix: arg0.text }
+    return null
+  }
+
+  if (role === 'redux_rtk_query_api') {
+    if (!ts.isObjectLiteralExpression(arg0)) return null
+    // `endpoints: (build) => ({ getUser: ..., updateUser: ... })` —
+    // endpoints is an arrow function whose body is the object literal
+    // we care about. The value is not itself an object literal, so we
+    // read the raw initializer expression and walk inside the function.
+    const endpointsExpr = readPropertyInitializer(arg0, 'endpoints')
+    if (!endpointsExpr) return null
+    const obj = unwrapEndpointsObject(endpointsExpr)
+    if (!obj) return null
+    const endpointNames = readObjectLiteralKeys(obj)
+    return endpointNames.length > 0 ? { endpoint_names: endpointNames } : null
+  }
+
   return null
+}
+
+function readStringProperty(obj: ts.ObjectLiteralExpression, key: string): string | null {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    if (!matchesPropertyName(prop.name, key)) continue
+    if (ts.isStringLiteralLike(prop.initializer)) return prop.initializer.text
+    return null
+  }
+  return null
+}
+
+function readObjectProperty(
+  obj: ts.ObjectLiteralExpression,
+  key: string,
+): ts.ObjectLiteralExpression | null {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    if (!matchesPropertyName(prop.name, key)) continue
+    if (ts.isObjectLiteralExpression(prop.initializer)) return prop.initializer
+    return null
+  }
+  return null
+}
+
+function readPropertyInitializer(
+  obj: ts.ObjectLiteralExpression,
+  key: string,
+): ts.Expression | null {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    if (!matchesPropertyName(prop.name, key)) continue
+    return prop.initializer
+  }
+  return null
+}
+
+function readObjectLiteralKeys(obj: ts.ObjectLiteralExpression): string[] {
+  const keys: string[] = []
+  for (const prop of obj.properties) {
+    if (ts.isPropertyAssignment(prop) || ts.isShorthandPropertyAssignment(prop) || ts.isMethodDeclaration(prop)) {
+      const name = prop.name
+      if (ts.isIdentifier(name)) keys.push(name.text)
+      else if (ts.isStringLiteralLike(name)) keys.push(name.text)
+    }
+  }
+  return keys
+}
+
+/** `endpoints: (build) => ({ getUser: build.query(...), ... })`. Reach
+ *  through the arrow function's body to find the returned object literal.
+ *  Accepts both the concise form `(b) => ({...})` and the block form
+ *  `(b) => { return { ... } }`. */
+function unwrapEndpointsObject(expr: ts.Expression): ts.ObjectLiteralExpression | null {
+  if (!ts.isArrowFunction(expr) && !ts.isFunctionExpression(expr)) return null
+  const body = expr.body
+  // Concise: (b) => ({...}) — the parser wraps the object in
+  // ParenthesizedExpression to disambiguate from a block.
+  if (ts.isParenthesizedExpression(body) && ts.isObjectLiteralExpression(body.expression)) {
+    return body.expression
+  }
+  if (ts.isObjectLiteralExpression(body)) return body
+  if (ts.isBlock(body)) {
+    for (const stmt of body.statements) {
+      if (ts.isReturnStatement(stmt) && stmt.expression) {
+        const ret = stmt.expression
+        if (ts.isParenthesizedExpression(ret) && ts.isObjectLiteralExpression(ret.expression)) {
+          return ret.expression
+        }
+        if (ts.isObjectLiteralExpression(ret)) return ret
+      }
+    }
+  }
+  return null
+}
+
+function matchesPropertyName(name: ts.PropertyName, key: string): boolean {
+  if (ts.isIdentifier(name)) return name.text === key
+  if (ts.isStringLiteralLike(name)) return name.text === key
+  return false
 }
 
 function tagSymbolByName(
   ctx: DetectReduxFrameworkContext,
   name: string,
   role: SpiFrameworkRole,
+  metadata: Record<string, unknown> | null,
 ): void {
   const symbols = ctx.symbolsByFile.get(ctx.fileId)
   if (!symbols) return
   for (const symbol of symbols) {
     if (symbol.name === name && symbol.framework_role === undefined) {
       symbol.framework_role = role
+      if (metadata && Object.keys(metadata).length > 0) {
+        const merged: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined) merged[key] = value
+        }
+        symbol.framework_metadata = merged
+      }
       return
     }
   }

--- a/tests/unit/spi-express-mount-prefix.test.ts
+++ b/tests/unit/spi-express-mount-prefix.test.ts
@@ -55,7 +55,11 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       ].join('\n') + '\n')
       const spi = build(sandbox)
       const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
-      expect(handler?.framework_metadata?.route_path).toBe('/api/users/')
+      // Trailing-slash normalization (slice 1c-ii.i): router-root '/'
+      // collapses to the bare mount prefix, matching the legacy
+      // extractor's emission. The router's own mount_path is still
+      // recorded literally on the router symbol.
+      expect(handler?.framework_metadata?.route_path).toBe('/api/users')
     })
 
     it('works when the mount call appears BEFORE the route registration', () => {
@@ -84,7 +88,9 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       ].join('\n') + '\n')
       const spi = build(sandbox)
       const synthetic = spi.symbols.find((s) => s.framework_role === 'express_route' && s.kind === 'function')
-      expect(synthetic?.framework_metadata?.route_path).toBe('/api/users/')
+      // Trailing-slash normalization (slice 1c-ii.i): same rule as named
+      // handlers — router-root '/' collapses to the bare prefix.
+      expect(synthetic?.framework_metadata?.route_path).toBe('/api/users')
     })
 
     it('does not prefix when the router is registered without a path prefix', () => {
@@ -124,7 +130,9 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       // alias-following + pathToFileId lookup. mount_path is stamped
       // on the router's SpiSymbol; the workspace-level finalizer then
       // propagates the prefix to all routes registered on that router.
-      expect(handler?.framework_metadata?.route_path).toBe('/api/users/')
+      // Trailing-slash normalization (slice 1c-ii.i): router-root '/'
+      // collapses to the bare mount prefix.
+      expect(handler?.framework_metadata?.route_path).toBe('/api/users')
     })
 
     it('handles aliased imports across files (`import { usersRouter as users } from ...`)', () => {
@@ -142,7 +150,7 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       ].join('\n') + '\n')
       const spi = build(sandbox)
       const handler = findSymbol(spi, 'src/routes/users.ts', 'listUsers')
-      expect(handler?.framework_metadata?.route_path).toBe('/v2/')
+      expect(handler?.framework_metadata?.route_path).toBe('/v2')
     })
 
     it('handles default-import re-exported routers (`export default usersRouter`)', () => {
@@ -161,7 +169,7 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       ].join('\n') + '\n')
       const spi = build(sandbox)
       const handler = findSymbol(spi, 'src/routes/users.ts', 'listUsers')
-      expect(handler?.framework_metadata?.route_path).toBe('/api/')
+      expect(handler?.framework_metadata?.route_path).toBe('/api')
     })
 
     it('does NOT mis-tag local same-named identifiers in unrelated files', () => {
@@ -188,7 +196,7 @@ describe('SPI Express mount-prefix resolution (slice 1c-ii.g)', () => {
       expect(other?.framework_metadata?.mount_path).toBeUndefined()
       // The LOCAL router in server.ts gets the prefix.
       const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
-      expect(handler?.framework_metadata?.route_path).toBe('/api/')
+      expect(handler?.framework_metadata?.route_path).toBe('/api')
     })
   })
 

--- a/tests/unit/spi-framework-route-metadata.test.ts
+++ b/tests/unit/spi-framework-route-metadata.test.ts
@@ -143,6 +143,33 @@ describe('Next.js route_path derivation (slice 1c-iv.b)', () => {
     expect(mw?.framework_metadata?.route_path).toBe('/*')
   })
 
+  it('strips intercepting-route prefixes (.) (..) (...) from folder names (CodeRabbit fix)', () => {
+    // Next.js intercepting routes: `(.)photo`, `(..)photo`, `(...)photo`
+    // are file-system markers for intercept behavior but the URL segment
+    // is still the bare folder name. Without the strip the unstripped
+    // marker would leak into route_path (e.g. `/feed/(.)photo`).
+    writeFile(sandbox, 'app/feed/(.)photo/[id]/page.tsx', [
+      'export default function InterceptedPhotoPage(): null { return null }',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'app/feed/(..)comments/page.tsx', [
+      'export default function InterceptedCommentsPage(): null { return null }',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'app/feed/(...)admin/page.tsx', [
+      'export default function InterceptedAdminPage(): null { return null }',
+    ].join('\n') + '\n')
+
+    const spi = build(sandbox)
+
+    const photo = findSymbol(spi, 'app/feed/(.)photo/[id]/page.tsx', 'InterceptedPhotoPage')
+    expect(photo?.framework_metadata?.route_path).toBe('/feed/photo/:id')
+
+    const comments = findSymbol(spi, 'app/feed/(..)comments/page.tsx', 'InterceptedCommentsPage')
+    expect(comments?.framework_metadata?.route_path).toBe('/feed/comments')
+
+    const admin = findSymbol(spi, 'app/feed/(...)admin/page.tsx', 'InterceptedAdminPage')
+    expect(admin?.framework_metadata?.route_path).toBe('/feed/admin')
+  })
+
   it('strips a leading src/ directory', () => {
     writeFile(sandbox, 'src/app/users/page.tsx', [
       'export default function UsersPage(): null { return null }',
@@ -214,6 +241,27 @@ describe('React Router route_path extraction (slice 1c-v.b)', () => {
     const spi = build(sandbox)
     const loader = findSymbol(spi, 'src/routes.tsx', 'listLoader')
     expect(loader?.framework_metadata?.route_path).toBe('/users')
+  })
+
+  it('resolves hoisted route-config arrays declared in the same file (CodeRabbit fix)', () => {
+    // Idiomatic React Router pattern: declare the route array as a const
+    // and pass it to the factory. Pre-fix only the inline-literal form
+    // was handled, so hoisted configs were silently skipped.
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export function dashboardLoader(): unknown { return null }',
+      'const routes = [',
+      '  { path: "/dashboard", loader: dashboardLoader }',
+      ']',
+      'export const router = createBrowserRouter(routes)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const loader = findSymbol(spi, 'src/routes.tsx', 'dashboardLoader')
+    expect(loader?.framework_role).toBe('react_router_loader')
+    expect(loader?.framework_metadata?.route_path).toBe('/dashboard')
+    const router = findSymbol(spi, 'src/routes.tsx', 'router')
+    expect(router?.framework_role).toBe('react_router_router')
+    expect(router?.framework_metadata?.route_path).toBe('/dashboard')
   })
 
   it('tags action with route_path too', () => {

--- a/tests/unit/spi-framework-route-metadata.test.ts
+++ b/tests/unit/spi-framework-route-metadata.test.ts
@@ -1,0 +1,413 @@
+// v0.14 finisher tests — route_path / slice metadata across all four
+// framework substrates (Express, Next.js, React Router, Redux Toolkit).
+// One file so the cross-framework normalization rules (dynamic segments,
+// route-group stripping, trailing-slash collapse, child-path joining)
+// can be compared side-by-side.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-v0.14-finishers',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('Next.js route_path derivation (slice 1c-iv.b)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-nextjs-route-path-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('derives /users from app/users/page.tsx', () => {
+    writeFile(sandbox, 'app/users/page.tsx', [
+      'export default function UsersPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'app/users/page.tsx', 'UsersPage')
+    expect(page?.framework_role).toBe('nextjs_app_page')
+    expect(page?.framework_metadata?.route_path).toBe('/users')
+  })
+
+  it('collapses /index to / for the app router root', () => {
+    writeFile(sandbox, 'app/page.tsx', [
+      'export default function HomePage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'app/page.tsx', 'HomePage')
+    expect(page?.framework_metadata?.route_path).toBe('/')
+  })
+
+  it('normalizes [id] dynamic segments to :id', () => {
+    writeFile(sandbox, 'app/users/[id]/page.tsx', [
+      'export default function UserPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'app/users/[id]/page.tsx', 'UserPage')
+    expect(page?.framework_metadata?.route_path).toBe('/users/:id')
+  })
+
+  it('normalizes catch-all [...slug] to *', () => {
+    writeFile(sandbox, 'app/blog/[...slug]/page.tsx', [
+      'export default function BlogPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'app/blog/[...slug]/page.tsx', 'BlogPage')
+    expect(page?.framework_metadata?.route_path).toBe('/blog/*')
+  })
+
+  it('normalizes optional catch-all [[...slug]] to *?', () => {
+    writeFile(sandbox, 'app/blog/[[...slug]]/page.tsx', [
+      'export default function BlogPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'app/blog/[[...slug]]/page.tsx', 'BlogPage')
+    expect(page?.framework_metadata?.route_path).toBe('/blog/*?')
+  })
+
+  it('strips route groups (auth) from the URL path', () => {
+    writeFile(sandbox, 'app/(auth)/login/page.tsx', [
+      'export default function LoginPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'app/(auth)/login/page.tsx', 'LoginPage')
+    expect(page?.framework_metadata?.route_path).toBe('/login')
+  })
+
+  it('tags route.ts HTTP method exports with route_path + http_method', () => {
+    writeFile(sandbox, 'app/api/users/route.ts', [
+      'export function GET(): Response { return new Response() }',
+      'export function POST(): Response { return new Response() }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const get = findSymbol(spi, 'app/api/users/route.ts', 'GET')
+    expect(get?.framework_role).toBe('nextjs_app_route')
+    expect(get?.framework_metadata?.route_path).toBe('/api/users')
+    expect(get?.framework_metadata?.http_method).toBe('GET')
+    const post = findSymbol(spi, 'app/api/users/route.ts', 'POST')
+    expect(post?.framework_metadata?.http_method).toBe('POST')
+  })
+
+  it('derives /users/:id from pages/users/[id].tsx', () => {
+    writeFile(sandbox, 'pages/users/[id].tsx', [
+      'export default function UserPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'pages/users/[id].tsx', 'UserPage')
+    expect(page?.framework_metadata?.route_path).toBe('/users/:id')
+  })
+
+  it('preserves the api/ prefix for pages/api routes', () => {
+    writeFile(sandbox, 'pages/api/users/[id].ts', [
+      'export default function handler(): void {}',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const handler = findSymbol(spi, 'pages/api/users/[id].ts', 'handler')
+    expect(handler?.framework_role).toBe('nextjs_pages_api')
+    expect(handler?.framework_metadata?.route_path).toBe('/api/users/:id')
+  })
+
+  it('tags middleware.ts with route_path /*', () => {
+    writeFile(sandbox, 'middleware.ts', [
+      'export default function middleware(): void {}',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const mw = findSymbol(spi, 'middleware.ts', 'middleware')
+    expect(mw?.framework_role).toBe('nextjs_middleware')
+    expect(mw?.framework_metadata?.route_path).toBe('/*')
+  })
+
+  it('strips a leading src/ directory', () => {
+    writeFile(sandbox, 'src/app/users/page.tsx', [
+      'export default function UsersPage(): null { return null }',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const page = findSymbol(spi, 'src/app/users/page.tsx', 'UsersPage')
+    expect(page?.framework_metadata?.route_path).toBe('/users')
+  })
+})
+
+describe('React Router route_path extraction (slice 1c-v.b)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-rr-route-path-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('tags createBrowserRouter result with route_path from the config', () => {
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export const router = createBrowserRouter([',
+      '  { path: "/", element: null }',
+      '])',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const router = findSymbol(spi, 'src/routes.tsx', 'router')
+    expect(router?.framework_role).toBe('react_router_router')
+    expect(router?.framework_metadata?.route_path).toBe('/')
+  })
+
+  it('tags in-config loader with the route_path it serves', () => {
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export function usersLoader(): unknown { return null }',
+      'export const router = createBrowserRouter([',
+      '  { path: "/users", element: null, loader: usersLoader }',
+      '])',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const loader = findSymbol(spi, 'src/routes.tsx', 'usersLoader')
+    expect(loader?.framework_role).toBe('react_router_loader')
+    expect(loader?.framework_metadata?.route_path).toBe('/users')
+  })
+
+  it('joins nested children paths with the parent', () => {
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export function userLoader(): unknown { return null }',
+      'export const router = createBrowserRouter([',
+      '  { path: "/users", children: [',
+      '    { path: ":id", loader: userLoader }',
+      '  ]}',
+      '])',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const loader = findSymbol(spi, 'src/routes.tsx', 'userLoader')
+    expect(loader?.framework_role).toBe('react_router_loader')
+    expect(loader?.framework_metadata?.route_path).toBe('/users/:id')
+  })
+
+  it('reuses the parent path for index routes', () => {
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export function listLoader(): unknown { return null }',
+      'export const router = createBrowserRouter([',
+      '  { path: "/users", children: [',
+      '    { index: true, loader: listLoader }',
+      '  ]}',
+      '])',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const loader = findSymbol(spi, 'src/routes.tsx', 'listLoader')
+    expect(loader?.framework_metadata?.route_path).toBe('/users')
+  })
+
+  it('tags action with route_path too', () => {
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export function createUserAction(): unknown { return null }',
+      'export const router = createBrowserRouter([',
+      '  { path: "/users", action: createUserAction }',
+      '])',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const action = findSymbol(spi, 'src/routes.tsx', 'createUserAction')
+    expect(action?.framework_role).toBe('react_router_action')
+    expect(action?.framework_metadata?.route_path).toBe('/users')
+  })
+})
+
+describe('Redux Toolkit metadata (slice 1c-vi.b)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-redux-meta-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('extracts slice_name and reducer_keys from createSlice', () => {
+    writeFile(sandbox, 'src/counterSlice.ts', [
+      'import { createSlice } from "@reduxjs/toolkit"',
+      'export const counterSlice = createSlice({',
+      '  name: "counter",',
+      '  initialState: 0,',
+      '  reducers: {',
+      '    increment(state: number): number { return state + 1 },',
+      '    decrement(state: number): number { return state - 1 },',
+      '    reset(): number { return 0 },',
+      '  },',
+      '})',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const slice = findSymbol(spi, 'src/counterSlice.ts', 'counterSlice')
+    expect(slice?.framework_role).toBe('redux_slice')
+    expect(slice?.framework_metadata?.slice_name).toBe('counter')
+    expect(slice?.framework_metadata?.reducer_keys).toEqual(['increment', 'decrement', 'reset'])
+    expect(slice?.framework_metadata?.action_creators).toEqual(['increment', 'decrement', 'reset'])
+  })
+
+  it('extracts reducer_keys from configureStore with combined reducer object', () => {
+    writeFile(sandbox, 'src/store.ts', [
+      'import { configureStore } from "@reduxjs/toolkit"',
+      'declare const auth: unknown',
+      'declare const posts: unknown',
+      'export const store = configureStore({',
+      '  reducer: { auth, posts },',
+      '})',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const store = findSymbol(spi, 'src/store.ts', 'store')
+    expect(store?.framework_role).toBe('redux_store')
+    expect(store?.framework_metadata?.reducer_keys).toEqual(['auth', 'posts'])
+  })
+
+  it('extracts type_prefix from createAsyncThunk', () => {
+    writeFile(sandbox, 'src/thunks.ts', [
+      'import { createAsyncThunk } from "@reduxjs/toolkit"',
+      'export const fetchUser = createAsyncThunk("user/fetch", async () => null)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const thunk = findSymbol(spi, 'src/thunks.ts', 'fetchUser')
+    expect(thunk?.framework_role).toBe('redux_async_thunk')
+    expect(thunk?.framework_metadata?.type_prefix).toBe('user/fetch')
+  })
+
+  it('extracts endpoint_names from createApi (RTK Query)', () => {
+    writeFile(sandbox, 'src/api.ts', [
+      'import { createApi } from "@reduxjs/toolkit/query/react"',
+      'declare const fetchBaseQuery: (opts: { baseUrl: string }) => unknown',
+      'export const api = createApi({',
+      '  reducerPath: "api",',
+      '  baseQuery: fetchBaseQuery({ baseUrl: "/" }) as any,',
+      '  endpoints: (build) => ({',
+      '    getUser: build.query<unknown, string>({ query: (id: string) => `/users/${id}` }),',
+      '    updateUser: build.mutation<unknown, unknown>({ query: () => "/users" }),',
+      '  }),',
+      '})',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const api = findSymbol(spi, 'src/api.ts', 'api')
+    expect(api?.framework_role).toBe('redux_rtk_query_api')
+    expect(api?.framework_metadata?.endpoint_names).toEqual(['getUser', 'updateUser'])
+  })
+
+  it('leaves createSelector untouched (no metadata)', () => {
+    writeFile(sandbox, 'src/selectors.ts', [
+      'import { createSelector } from "reselect"',
+      'declare const a: (s: unknown) => unknown',
+      'declare const b: (s: unknown) => unknown',
+      'export const selectFoo = createSelector([a, b], (x: unknown, y: unknown) => x)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const sel = findSymbol(spi, 'src/selectors.ts', 'selectFoo')
+    expect(sel?.framework_role).toBe('redux_selector')
+    expect(sel?.framework_metadata).toBeUndefined()
+  })
+})
+
+describe('Express trailing-slash normalization (slice 1c-ii.i)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-express-normalize-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('collapses router-root / so the mount prefix appears without a trailing slash', () => {
+    // Pre-fix: '/api/users' + '/' → '/api/users/'. Post-fix: '/api/users'.
+    // This is the byte-equivalence finisher mentioned in the PR for #118.
+    writeFile(sandbox, 'src/server.ts', [
+      'import express, { Router } from "express"',
+      'export const app = express()',
+      'export const usersRouter = Router()',
+      'export function listUsers(): void {}',
+      'usersRouter.get("/", listUsers)',
+      'app.use("/api/users", usersRouter)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const handler = findSymbol(spi, 'src/server.ts', 'listUsers')
+    expect(handler?.framework_metadata?.route_path).toBe('/api/users')
+  })
+
+  it('still preserves the non-root path verbatim', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import express, { Router } from "express"',
+      'export const app = express()',
+      'export const usersRouter = Router()',
+      'export function getUser(): void {}',
+      'usersRouter.get("/:id", getUser)',
+      'app.use("/api/users", usersRouter)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const handler = findSymbol(spi, 'src/server.ts', 'getUser')
+    expect(handler?.framework_metadata?.route_path).toBe('/api/users/:id')
+  })
+})
+
+describe('Multi-framework parity bundle (v0.14 finisher)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-v014-parity-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('a workspace with all four frameworks emits route_path / slice metadata on every framework symbol', () => {
+    // One workspace combining all four framework substrates so we can
+    // observe in a single SPI build that:
+    //   - Express: route_path (mounted)
+    //   - Next.js: route_path (file-convention)
+    //   - React Router: route_path (config-array)
+    //   - Redux: slice_name + reducer_keys (createSlice)
+    writeFile(sandbox, 'src/server.ts', [
+      'import express, { Router } from "express"',
+      'export const app = express()',
+      'export const apiRouter = Router()',
+      'export function ping(): void {}',
+      'apiRouter.get("/ping", ping)',
+      'app.use("/api", apiRouter)',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'app/users/[id]/page.tsx', [
+      'export default function UserPage(): null { return null }',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'src/routes.tsx', [
+      'import { createBrowserRouter } from "react-router-dom"',
+      'export function rootLoader(): unknown { return null }',
+      'export const router = createBrowserRouter([',
+      '  { path: "/dashboard", loader: rootLoader }',
+      '])',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'src/counterSlice.ts', [
+      'import { createSlice } from "@reduxjs/toolkit"',
+      'export const counterSlice = createSlice({',
+      '  name: "counter",',
+      '  initialState: 0,',
+      '  reducers: { increment(s: number): number { return s + 1 } },',
+      '})',
+    ].join('\n') + '\n')
+
+    const spi = build(sandbox)
+
+    const expressPing = findSymbol(spi, 'src/server.ts', 'ping')
+    expect(expressPing?.framework_role).toBe('express_route')
+    expect(expressPing?.framework_metadata?.route_path).toBe('/api/ping')
+
+    const nextjsPage = findSymbol(spi, 'app/users/[id]/page.tsx', 'UserPage')
+    expect(nextjsPage?.framework_role).toBe('nextjs_app_page')
+    expect(nextjsPage?.framework_metadata?.route_path).toBe('/users/:id')
+
+    const rrLoader = findSymbol(spi, 'src/routes.tsx', 'rootLoader')
+    expect(rrLoader?.framework_role).toBe('react_router_loader')
+    expect(rrLoader?.framework_metadata?.route_path).toBe('/dashboard')
+
+    const slice = findSymbol(spi, 'src/counterSlice.ts', 'counterSlice')
+    expect(slice?.framework_role).toBe('redux_slice')
+    expect(slice?.framework_metadata?.slice_name).toBe('counter')
+    expect(slice?.framework_metadata?.reducer_keys).toEqual(['increment'])
+  })
+})

--- a/tests/unit/spi-projector-express-parity.test.ts
+++ b/tests/unit/spi-projector-express-parity.test.ts
@@ -102,35 +102,28 @@ describe('Express projector parity (legacy extract vs SPI projector)', () => {
       const projected = projectFromSpi(sandbox)
       const legacy = legacyExtract(sandbox, ['src/server.ts', 'src/routes/users.ts'])
 
-      // SPI projector: listUsers gets framework=express, route_path=/api/users/.
+      // SPI projector: listUsers gets framework=express, route_path=/api/users
+      // (slice 1c-ii.i collapses the router-root '/' so the projector's
+      // output is byte-equivalent to the legacy extractor's emission).
       const projectedListUsers = projected.nodes.find((n) => n.label === 'listUsers()')
       expect(projectedListUsers?.framework).toBe('express')
       expect(projectedListUsers?.framework_role).toBe('express_route')
-      expect((projectedListUsers as Record<string, unknown>)?.route_path).toBe('/api/users/')
+      expect((projectedListUsers as Record<string, unknown>)?.route_path).toBe('/api/users')
 
       // Legacy: assert it produced a node for the handler function and
       // that at least one ExtractionNode in the legacy output carries
-      // the prefixed path in some form. The legacy extractor's exact
-      // shape for cross-file mounts emits a synthesized route node
-      // distinct from the handler function node.
-      // CodeRabbit catch: previous version used `void legacyHandler`
-      // which let the assertion pass vacuously.
+      // the prefixed path in the canonical form. After slice 1c-ii.i
+      // both paths agree on `/api/users` (no trailing slash).
       const legacyHandler = legacy.nodes.find((n) => n.label === 'listUsers()')
       expect(legacyHandler, 'legacy extractor must emit a node for listUsers').toBeTruthy()
 
-      // Both paths register the prefixed path SOMEWHERE; they normalize
-      // trailing slashes differently though: legacy emits `/api/users`
-      // (drops the trailing slash from the router's root-level get),
-      // while the SPI projector preserves the trailing slash from the
-      // raw concatenation (`/api/users` + `/` → `/api/users/`). Both
-      // interpretations are defensible; this assertion accepts either
-      // form so the parity test pins the actual shared behavior. The
-      // trailing-slash normalization itself is a future-slice item.
       const legacyPaths = legacy.nodes
         .map((n) => (n as Record<string, unknown>).route_path)
         .filter((p): p is string => typeof p === 'string')
-      const containsApiUsers = legacyPaths.some((p) => p === '/api/users' || p === '/api/users/')
-      expect(containsApiUsers, 'legacy extractor must register /api/users (with or without trailing slash) somewhere in its node payload').toBe(true)
+      expect(
+        legacyPaths.includes('/api/users'),
+        'legacy extractor must register /api/users somewhere in its node payload',
+      ).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary

Closes out the v0.14 substrate work for #72 in one bundle. Brings the Next.js, React Router, and Redux Toolkit detectors up to the same depth Express reached in slice 1c-ii.h, plus the trailing-slash normalization fix that closes the last byte-equivalence gap between the legacy `extract()` and the SPI projector.

Five connected slices in one PR (bundle requested):

1. **Next.js `route_path` (slice 1c-iv.b)** — derive URL path from file path. Strips route groups `(auth)` and parallel/intercepted `@modal` segments; normalizes `[id]`→`:id`, `[...slug]`→`*`, `[[...slug]]`→`*?`; collapses `/index`→`/`; preserves the `api/` prefix for `pages/api/`; HTTP method exports on `app/.../route.ts` get `route_path` + `http_method`; root `middleware.ts` gets `route_path: '/*'`.

2. **React Router `route_path` (slice 1c-v.b)** — walk the route-config array given to `createBrowserRouter` / `createHashRouter` / etc. Tag in-config `loader` / `action` identifiers with the route's `route_path`. Path composition: parent→child join, index routes reuse parent, pathless layout routes are transparent, absolute children replace the parent.

3. **Redux Toolkit metadata (slice 1c-vi.b)** — structural metadata for the five RTK factories:
   - `createSlice` → `slice_name`, `reducer_keys[]`, `action_creators[]`
   - `configureStore` → `reducer_keys[]` (when reducer is an object literal)
   - `createAsyncThunk` → `type_prefix` (first-arg string)
   - `createApi` (RTK Query) → `endpoint_names[]` (walks the endpoints arrow function body, both concise `(b) => ({...})` and block `(b) => { return { ... } }` forms)
   - `createSelector` intentionally bare (selectors are anonymous-by-design)

4. **Express trailing-slash normalization (slice 1c-ii.i)** — `joinRoutePath` now collapses the router-root `'/'` case. `app.use('/api/users', router)` + `router.get('/', ...)` resolves to `/api/users` (no trailing slash), matching the legacy extractor. Closes the divergence documented in PR #118. Non-root Express semantics are preserved unchanged: `/api` + `/api` still resolves to `/api/api`.

5. **Multi-framework parity bundle test** (`tests/unit/spi-framework-route-metadata.test.ts`) — 24 new tests covering all four substrates side-by-side, including a workspace combining all four under a single `buildSpi` run.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run test:run` — 1731/1731 pass (101 files, +24 new tests)
- [x] Existing tests updated for the new normalized `/api/users` form (`spi-express-mount-prefix.test.ts`, `spi-projector-express-parity.test.ts`)
- [x] No public API changes outside `framework_metadata` additions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework detection now extracts and records route path metadata for Express, Next.js, and React Router.
  * Next.js detection adds route-path and HTTP-method metadata; normalizes dynamic/catch-all segments and middleware routes.
  * React Router detection tags router, loaders, and actions with per-route paths.
  * Redux detection extracts slice/store/thunk/api metadata (names, reducer keys, endpoints, etc.).

* **Bug Fixes**
  * Fixed trailing-slash normalization for Express mounted router paths.

* **Tests**
  * Added comprehensive cross-framework tests and updated assertions for trailing-slash behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/119)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->