### PR TITLE
chore(release): v0.14.0 — Semantic Program Index v1 + framework metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-11
+
+### Added
+
+- **Semantic Program Index (SPI) v1 substrate (#72)**: complete versioned, typed, deterministic internal representation of TypeScript/Node workspaces — files, symbols (functions/classes/interfaces/types/enums/methods/constants/variables/namespaces), and edges (declares, imports, exports, calls, extends, implements, param_type, return_type, covered_by). Built once via `ts.Program` + the TypeScript type checker, with workspace fingerprinting and deterministic serialization.
+- **Framework-aware semantic substrates**: five framework detectors layered over SPI:
+  - **NestJS** — modules, controllers, providers, guards/pipes/interceptors, route methods, constructor + `@Inject('TOKEN')` injects edges, dynamic module diagnostics.
+  - **Express** — apps, routers, named/inline route handlers with `route_path` + `http_method` metadata, middleware, **cross-file mount-prefix resolution** via the type checker (alias-following + same-file router lookup), router-root trailing-slash normalization.
+  - **Next.js** — file-convention tagging for `app/*/page.tsx`, `app/*/route.ts`, `app/*/layout.tsx` (+ loading/error/template), `pages/*`, `pages/api/*`, root `middleware.ts`; `route_path` derived from file path with dynamic segments (`[id]` → `:id`), catch-alls (`[...slug]` → `*`), optional catch-alls (`[[...slug]]` → `*?`), route groups (`(auth)` stripped), parallel routes (`@modal` stripped), and intercepting-route prefixes (`(.)/(..)/( ...)` stripped); HTTP-method exports get `http_method` metadata.
+  - **React Router** — `createBrowserRouter` / `createHashRouter` / `createMemoryRouter` / `createStaticRouter` detection, in-config loader/action tagging with `route_path`, nested children path composition, index/pathless layout handling, hoisted same-file route-config arrays (`const routes = [...]; createBrowserRouter(routes)`).
+  - **Redux Toolkit** — `createSlice` (slice_name, reducer_keys, action_creators), `configureStore` (reducer_keys), `createAsyncThunk` (type_prefix), `createApi` / RTK Query (endpoint_names from both concise and block arrow-function bodies), `createSelector` / `createDraftSafeSelector` role tagging.
+- **SPI → ExtractionData projector**: `projectSpiToExtraction(spi, { root })` bridges the SPI substrate to the existing `buildFromJson → cluster → analyze → graph.json` pipeline. Propagates `framework_role` + `framework_metadata` onto every projected `ExtractionNode` so downstream consumers (retrieval, context packs, MCP) can filter by framework without re-parsing.
+- **SPI diff overlay**: `computeSpiDiffOverlay` projects PR-impact deltas through the SPI substrate (slice 3a of #72).
+
+### Changed
+
+- **Express route_path normalization**: `joinRoutePath` collapses the router-root `'/'` case (`app.use('/api/users', router)` + `router.get('/', ...)` → `/api/users`), matching the legacy extractor's emission. Non-root Express semantics preserved unchanged (`/api` + `/api` → `/api/api`).
+- **Mount-prefix resolution**: workspace-level finalizer (`finalizeExpressMountPrefixes`) runs after per-file detection so cross-file router mounts resolve regardless of file order.
+
+### Notes
+
+- The SPI substrate is **additive** — the existing `extract()` pipeline remains untouched. Consumers can adopt incrementally via `buildSpi` / `projectSpiToExtraction`.
+- Full byte-equivalence with the legacy `extract()` on `examples/demo-repo/graphify-out/graph.json` is **not** asserted in this release; the parity tests pin shape parity and the documented taxonomy divergence (legacy emits separate synthesized route nodes, SPI tags handlers directly). Strict byte-equivalence is deferred to a follow-up release.
+
 ## [0.13.3] - 2026-05-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ We measure and publish honest numbers, including the trade-offs. Smaller context
 Implemented today:
 
 - ✅ Local graph build for TS/JS/Python/Ruby/Go/Java/Rust + framework-aware TS/JS
+- ✅ Semantic Program Index (SPI) v1 — TypeScript type-checker-backed substrate with NestJS / Express / Next.js / React Router / Redux Toolkit framework metadata (`route_path`, slice/store keys, RTK Query endpoints, mount-prefix resolution)
 - ✅ MCP server with core (6 tools) and full (25 tools) profiles
 - ✅ `pr_impact` + `review-compare` for diff-aware PR review
 - ✅ Provider-aware prompt compiler (`prompt`) with Claude cache-reuse semantics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.13.3",
+    "version": "0.14.0",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

Cuts the v0.14.0 release covering the complete Semantic Program Index (SPI) v1 substrate from #72 plus all framework metadata work landed in #98 — #119.

- Bumps `package.json` from `0.13.3` → `0.14.0`
- Adds the `[0.14.0]` entry to `CHANGELOG.md`
- Flags the SPI substrate on the README roadmap as ✅

## What's in v0.14.0

**SPI v1 substrate (#72):**
- Type-checker-backed file/symbol/call/type/test layers
- Workspace fingerprinting + deterministic output
- `buildSpi` → `SemanticProgramIndex` entry point

**Framework substrates:**
- NestJS (modules / controllers / providers / guards / pipes / interceptors / injects)
- Express (apps / routers / routes / middleware / cross-file mount-prefix resolution + `route_path` + `http_method`)
- Next.js (app + pages + middleware conventions, dynamic segments `[id]` → `:id`, catch-alls, route groups, intercepting routes)
- React Router (`createBrowserRouter` config trees, in-config loader/action tagging, hoisted same-file configs)
- Redux Toolkit (`createSlice` / `configureStore` / `createAsyncThunk` / `createApi` metadata)

**Projector:**
- `projectSpiToExtraction(spi, { root })` bridges the SPI substrate to the existing `buildFromJson → cluster → analyze → graph.json` pipeline
- Propagates `framework_role` + `framework_metadata` onto every `ExtractionNode`

## Notes

- The SPI substrate is **additive** — the existing `extract()` pipeline remains untouched. Consumers can adopt incrementally via `buildSpi` / `projectSpiToExtraction`.
- Full byte-equivalence on the legacy `extract()` demo-repo output is **not** asserted in this release; the parity tests pin shape parity and the documented taxonomy divergence (legacy emits separate synthesized route nodes, SPI tags handlers directly). Strict byte-equivalence is deferred.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1733/1733 pass (101 files)
- [x] CHANGELOG and README roadmap updated
- [ ] After merge: tag `v0.14.0` and `npm publish` (requires explicit go-ahead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Semantic Program Index (SPI) v1, providing TypeScript type-checker-backed semantic analysis.
  * Added framework-aware semantic layers for NestJS, Express, Next.js, React Router, and Redux Toolkit.
  * Integrated SPI projection with diff overlay support and improved cross-file router mount mapping.
  * Enhanced Express route path normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->