### PR TITLE
feat: v0.15 finishers — diagnostics (#78) + delta context packs (#81) + value-per-token (#74)

### DIFF
--- a/src/contracts/context-pack-diagnostics.ts
+++ b/src/contracts/context-pack-diagnostics.ts
@@ -1,0 +1,62 @@
+// Context-pack quality diagnostics contract (#78).
+//
+// Surfaces objective signals about a compiled context-pack so callers can
+// detect "bad runs" — packs that are likely to underperform downstream —
+// without having to re-implement the heuristics in every consumer.
+//
+// The diagnostics surface is INTENTIONALLY conservative: every warning is
+// derived from a structural property of the pack (missing required
+// evidence, zero claims, undersized retrieval, empty graph signals, etc.)
+// rather than from a model judgement. That keeps the surface fully
+// deterministic and CI-asseratable.
+
+/** The categories of structural problems a context-pack can exhibit. Each
+ *  enum value maps to one rule in computeContextPackDiagnostics. */
+export type ContextPackDiagnosticKind =
+  | 'missing_required_evidence'
+  | 'missing_required_semantic'
+  | 'zero_claims'
+  | 'undersized_retrieval'
+  | 'budget_underutilized'
+  | 'missing_snippets'
+  | 'low_avg_match_score'
+  | 'orphan_nodes'
+  | 'no_graph_signals'
+
+export type ContextPackDiagnosticSeverity = 'info' | 'warn' | 'error'
+
+export interface ContextPackDiagnosticWarning {
+  kind: ContextPackDiagnosticKind
+  severity: ContextPackDiagnosticSeverity
+  message: string
+  /** Optional structured detail — kind-specific. Consumers can read this
+   *  for finer-grained UX (e.g., listing the missing evidence classes). */
+  detail?: Record<string, unknown>
+}
+
+export interface ContextPackQualitySignals {
+  /** Number of nodes in the pack. */
+  node_count: number
+  /** Number of relationships in the pack. */
+  relationship_count: number
+  /** Number of claims emitted by the pack. */
+  claim_count: number
+  /** Share of nodes carrying a non-empty snippet, 0..1. */
+  snippet_coverage: number
+  /** Average match_score across nodes that have one, 0..1 (NaN-safe). */
+  avg_match_score: number
+  /** token_count from the pack as a fraction of task_contract.budget.
+   *  Capped at 1.0 for over-budget packs. */
+  budget_utilization: number
+}
+
+export interface ContextPackDiagnostics {
+  /** Overall quality score, 0..1. 1.0 means no warnings triggered;
+   *  weighted-deductions reduce the score toward 0 for problem packs. */
+  quality_score: number
+  /** Triggered warnings, ordered by severity desc then kind asc. */
+  warnings: ContextPackDiagnosticWarning[]
+  /** Raw signals used to compute the score — useful for telemetry and
+   *  for consumers that want to apply their own thresholds. */
+  signals: ContextPackQualitySignals
+}

--- a/src/runtime/context-pack-diagnostics.ts
+++ b/src/runtime/context-pack-diagnostics.ts
@@ -1,0 +1,233 @@
+// Context-pack quality diagnostics — pure scorer (#78).
+//
+// Takes a compiled context-pack and returns a deterministic diagnostics
+// payload that downstream tools (the MCP `context_pack` response, CI
+// regression tests, telemetry) can surface to humans or agents.
+//
+// Rules:
+//   1. missing_required_evidence  — coverage flags any required class as
+//      missing (severity: error). The model has no chance of producing
+//      a correct answer without the requested evidence class.
+//   2. missing_required_semantic  — same for semantic-required categories
+//      (severity: warn — semantic_required is softer than evidence_required).
+//   3. zero_claims                — the claims array is empty. Either the
+//      retrieval missed everything or the claim extractor under-produced.
+//   4. undersized_retrieval       — nodes.length < 3 with a non-trivial
+//      budget. Most non-trivial questions need more than two nodes.
+//   5. budget_underutilized       — token_count < 25% of the requested
+//      budget. Likely an under-confident retrieval.
+//   6. missing_snippets           — share of nodes without a snippet
+//      exceeds 50%. The agent can't ground answers without source text.
+//   7. low_avg_match_score        — mean match_score across scored nodes
+//      < 0.30. Indicates weak retrieval.
+//   8. orphan_nodes               — nodes.length > 1 and
+//      relationships.length === 0. The pack contains entities but no
+//      structural relationships between them.
+//   9. no_graph_signals           — both god_nodes and bridge_nodes are
+//      empty. Architectural context is absent.
+//
+// The score is computed as 1 - sum(weight * triggered) / sum(weight) where
+// every rule has a weight ∈ {1, 2}. Errors weight 2, warns and infos weight 1.
+
+import type { CompiledContextPack } from '../contracts/context-pack.js'
+import type {
+  ContextPackDiagnosticKind,
+  ContextPackDiagnosticSeverity,
+  ContextPackDiagnosticWarning,
+  ContextPackDiagnostics,
+  ContextPackQualitySignals,
+} from '../contracts/context-pack-diagnostics.js'
+
+const RULE_WEIGHTS: ReadonlyMap<ContextPackDiagnosticKind, number> = new Map([
+  ['missing_required_evidence', 2],
+  ['missing_required_semantic', 1],
+  ['zero_claims', 1],
+  ['undersized_retrieval', 1],
+  ['budget_underutilized', 1],
+  ['missing_snippets', 1],
+  ['low_avg_match_score', 1],
+  ['orphan_nodes', 1],
+  ['no_graph_signals', 1],
+])
+
+const SEVERITY_ORDER: Record<ContextPackDiagnosticSeverity, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+}
+
+const UNDERSIZED_RETRIEVAL_THRESHOLD = 3
+const BUDGET_UNDERUTILIZED_FRACTION = 0.25
+const MIN_BUDGET_FOR_UNDERUTILIZATION = 500
+const MISSING_SNIPPETS_FRACTION = 0.5
+const LOW_AVG_MATCH_SCORE = 0.30
+
+export interface ComputeContextPackDiagnosticsOptions {
+  /** Skip the budget-underutilized rule. Useful for callers that already
+   *  know the pack is small-by-design (e.g., delta packs after dedup). */
+  skipBudgetUnderutilization?: boolean
+}
+
+/**
+ * Compute structural quality diagnostics for a compiled context-pack.
+ * Pure, deterministic, no I/O.
+ */
+export function computeContextPackDiagnostics(
+  pack: CompiledContextPack,
+  options: ComputeContextPackDiagnosticsOptions = {},
+): ContextPackDiagnostics {
+  const signals = computeSignals(pack)
+  const warnings: ContextPackDiagnosticWarning[] = []
+
+  const missingRequired = pack.coverage.missing_required
+  if (missingRequired.length > 0) {
+    warnings.push({
+      kind: 'missing_required_evidence',
+      severity: 'error',
+      message: `Pack is missing required evidence classes: ${missingRequired.join(', ')}.`,
+      detail: { classes: missingRequired },
+    })
+  }
+
+  const missingSemantic = pack.coverage.missing_semantic
+  if (missingSemantic.length > 0) {
+    warnings.push({
+      kind: 'missing_required_semantic',
+      severity: 'warn',
+      message: `Pack is missing required semantic categories: ${missingSemantic.join(', ')}.`,
+      detail: { categories: missingSemantic },
+    })
+  }
+
+  if (signals.claim_count === 0) {
+    warnings.push({
+      kind: 'zero_claims',
+      severity: 'warn',
+      message: 'Pack contains no claims — retrieval likely under-grounded the answer.',
+    })
+  }
+
+  if (signals.node_count > 0 && signals.node_count < UNDERSIZED_RETRIEVAL_THRESHOLD) {
+    warnings.push({
+      kind: 'undersized_retrieval',
+      severity: 'warn',
+      message: `Pack contains only ${signals.node_count} node(s); expected at least ${UNDERSIZED_RETRIEVAL_THRESHOLD} for a non-trivial query.`,
+      detail: { node_count: signals.node_count, threshold: UNDERSIZED_RETRIEVAL_THRESHOLD },
+    })
+  }
+
+  if (
+    !options.skipBudgetUnderutilization &&
+    pack.task_contract.budget >= MIN_BUDGET_FOR_UNDERUTILIZATION &&
+    signals.budget_utilization < BUDGET_UNDERUTILIZED_FRACTION
+  ) {
+    warnings.push({
+      kind: 'budget_underutilized',
+      severity: 'info',
+      message: `Pack used only ${Math.round(signals.budget_utilization * 100)}% of the ${pack.task_contract.budget}-token budget.`,
+      detail: { utilization: signals.budget_utilization, budget: pack.task_contract.budget },
+    })
+  }
+
+  if (signals.node_count > 0 && signals.snippet_coverage < (1 - MISSING_SNIPPETS_FRACTION)) {
+    warnings.push({
+      kind: 'missing_snippets',
+      severity: 'warn',
+      message: `${Math.round((1 - signals.snippet_coverage) * 100)}% of nodes lack a source snippet — agent cannot ground answers.`,
+      detail: { snippet_coverage: signals.snippet_coverage },
+    })
+  }
+
+  if (
+    signals.node_count >= UNDERSIZED_RETRIEVAL_THRESHOLD &&
+    !Number.isNaN(signals.avg_match_score) &&
+    signals.avg_match_score > 0 &&
+    signals.avg_match_score < LOW_AVG_MATCH_SCORE
+  ) {
+    warnings.push({
+      kind: 'low_avg_match_score',
+      severity: 'warn',
+      message: `Average match_score is ${signals.avg_match_score.toFixed(2)} (< ${LOW_AVG_MATCH_SCORE}). Retrieval is weak.`,
+      detail: { avg_match_score: signals.avg_match_score, threshold: LOW_AVG_MATCH_SCORE },
+    })
+  }
+
+  if (signals.node_count > 1 && signals.relationship_count === 0) {
+    warnings.push({
+      kind: 'orphan_nodes',
+      severity: 'warn',
+      message: `Pack has ${signals.node_count} nodes but no relationships — entities are not structurally connected.`,
+      detail: { node_count: signals.node_count },
+    })
+  }
+
+  const graphSignals = pack.graph_signals
+  const hasArchSignals = !!graphSignals && (
+    (graphSignals.god_nodes?.length ?? 0) > 0 ||
+    (graphSignals.bridge_nodes?.length ?? 0) > 0
+  )
+  if (!hasArchSignals && signals.node_count >= UNDERSIZED_RETRIEVAL_THRESHOLD) {
+    warnings.push({
+      kind: 'no_graph_signals',
+      severity: 'info',
+      message: 'Pack lacks architectural signals (god_nodes / bridge_nodes).',
+    })
+  }
+
+  warnings.sort((a, b) => {
+    const sevDelta = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
+    if (sevDelta !== 0) return sevDelta
+    return a.kind.localeCompare(b.kind)
+  })
+
+  const qualityScore = computeQualityScore(warnings)
+
+  return {
+    quality_score: qualityScore,
+    warnings,
+    signals,
+  }
+}
+
+function computeSignals(pack: CompiledContextPack): ContextPackQualitySignals {
+  const nodeCount = pack.nodes.length
+  const relationshipCount = pack.relationships.length
+  const claimCount = pack.claims.length
+
+  let snippetNodes = 0
+  let scoreSum = 0
+  let scoreCount = 0
+  for (const node of pack.nodes) {
+    if (typeof node.snippet === 'string' && node.snippet.length > 0) snippetNodes += 1
+    if (typeof node.match_score === 'number' && Number.isFinite(node.match_score)) {
+      scoreSum += node.match_score
+      scoreCount += 1
+    }
+  }
+
+  const snippetCoverage = nodeCount === 0 ? 0 : snippetNodes / nodeCount
+  const avgMatchScore = scoreCount === 0 ? Number.NaN : scoreSum / scoreCount
+  const budget = pack.task_contract.budget
+  const budgetUtilization = budget > 0 ? Math.min(1, pack.token_count / budget) : 0
+
+  return {
+    node_count: nodeCount,
+    relationship_count: relationshipCount,
+    claim_count: claimCount,
+    snippet_coverage: snippetCoverage,
+    avg_match_score: avgMatchScore,
+    budget_utilization: budgetUtilization,
+  }
+}
+
+function computeQualityScore(warnings: ContextPackDiagnosticWarning[]): number {
+  let totalWeight = 0
+  for (const weight of RULE_WEIGHTS.values()) totalWeight += weight
+  if (totalWeight === 0) return 1
+  let triggeredWeight = 0
+  for (const warning of warnings) {
+    triggeredWeight += RULE_WEIGHTS.get(warning.kind) ?? 1
+  }
+  const score = 1 - (triggeredWeight / totalWeight)
+  return Math.max(0, Math.min(1, Number(score.toFixed(3))))
+}

--- a/src/runtime/context-pack-diagnostics.ts
+++ b/src/runtime/context-pack-diagnostics.ts
@@ -141,9 +141,11 @@ export function computeContextPackDiagnostics(
   if (
     signals.node_count >= UNDERSIZED_RETRIEVAL_THRESHOLD &&
     !Number.isNaN(signals.avg_match_score) &&
-    signals.avg_match_score > 0 &&
     signals.avg_match_score < LOW_AVG_MATCH_SCORE
   ) {
+    // CodeRabbit fix: do NOT exclude avg_match_score === 0. That is the
+    // worst-possible retrieval and must fire the warning. The NaN guard
+    // above already prevents firing on packs with no scored nodes.
     warnings.push({
       kind: 'low_avg_match_score',
       severity: 'warn',

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1017,7 +1017,13 @@ function fallbackRetrieveCoverage(result: RetrieveResult): ContextPackCoverage {
   }
 }
 
-function contextPackFromRetrieveResult(
+/**
+ * Build the full CompiledContextPack representation of a RetrieveResult.
+ * Exported in v0.15 so the context-pack diagnostics scorer (#78) can
+ * compute structural quality signals against the same shape the compact
+ * stdio response is derived from.
+ */
+export function contextPackFromRetrieveResult(
   result: RetrieveResult,
 ): CompiledContextPack<ContextPackNode, RetrieveRelationship, RetrieveCommunityContext> {
   return {

--- a/src/runtime/stdio-server.ts
+++ b/src/runtime/stdio-server.ts
@@ -55,10 +55,17 @@ const MAX_LOG_NOTIFICATION_CHARS = 10_000
 
 type McpLogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency'
 
+/** Per-session record of node ids already shipped to a given `delta_session_id`.
+ *  Used by the context_pack delta surface (#81) so subsequent calls return
+ *  only nodes the agent hasn't already received. */
+type ContextPackNodeIdStore = Map<string, Set<string>>
+
 interface StdioSessionState extends ResourceSessionState {
   logLevel: McpLogLevel
   contextPromptSessions?: Map<string, ContextSessionState>
   contextPackHandles?: Map<string, unknown>
+  /** Slice #81 — per-delta-session node ids already shipped. */
+  contextPackNodeIds?: ContextPackNodeIdStore
 }
 
 interface JsonRpcNotification {
@@ -91,6 +98,7 @@ function createSessionState(): StdioSessionState {
     resourceListSignature: null,
     contextPromptSessions: new Map<string, ContextSessionState>(),
     contextPackHandles: new Map<string, unknown>(),
+    contextPackNodeIds: new Map<string, Set<string>>(),
   }
 }
 
@@ -171,6 +179,13 @@ function ensureContextPackHandles(state: StdioSessionState): Map<string, unknown
   }
 
   return state.contextPackHandles
+}
+
+function ensureContextPackNodeIds(state: StdioSessionState): ContextPackNodeIdStore {
+  if (!state.contextPackNodeIds) {
+    state.contextPackNodeIds = new Map<string, Set<string>>()
+  }
+  return state.contextPackNodeIds
 }
 
 function requestId(request: StdioRequest): string | number | null {
@@ -607,6 +622,26 @@ export function handleStdioRequest(
              sessions.set(sessionId, nextState)
            },
            clearContextPromptSession: (sessionId) => ensureContextPromptSessions(sessionState).delete(sessionId),
+           getContextPackNodeIds: (sessionId) => {
+             const store = ensureContextPackNodeIds(sessionState).get(sessionId)
+             return store ? Array.from(store) : []
+           },
+           recordContextPackNodeIds: (sessionId, nodeIds) => {
+             const store = ensureContextPackNodeIds(sessionState)
+             let bucket = store.get(sessionId)
+             if (!bucket) {
+               if (store.size >= MAX_CONTEXT_PROMPT_SESSIONS) {
+                 const oldestSessionId = store.keys().next().value as string | undefined
+                 if (oldestSessionId !== undefined) {
+                   store.delete(oldestSessionId)
+                 }
+               }
+               bucket = new Set<string>()
+               store.set(sessionId, bucket)
+             }
+             for (const id of nodeIds) bucket.add(id)
+           },
+           clearContextPackNodeIds: (sessionId) => ensureContextPackNodeIds(sessionState).delete(sessionId),
            getContextPackHandle: (handleId) => ensureContextPackHandles(sessionState).get(handleId),
            setContextPackHandle: (handleId, expansion) => {
              const handles = ensureContextPackHandles(sessionState)

--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -229,7 +229,7 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   {
     name: 'context_pack',
     description:
-      'Build a compact explain/review/impact context pack for a downstream agent. Use when you need expandable refs plus coverage and missing-context signals instead of the full graph payload.',
+      'Build a compact explain/review/impact context pack for a downstream agent. Use when you need expandable refs plus coverage and missing-context signals instead of the full graph payload. Pass delta_session_id to ship only new nodes.',
     inputSchema: {
       type: 'object',
       required: ['prompt'],
@@ -237,6 +237,18 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         prompt: { type: 'string', description: 'Task prompt or question to build context for' },
         task: { type: 'string', enum: ['explain', 'review', 'impact'], description: 'Context-pack mode (default: explain)' },
         budget: { type: 'number', description: 'Optional: maximum token budget for the pack (default 3000)' },
+        delta_session_id: { type: 'string', description: 'Optional (#81): delta-pack session key for per-session dedup.' },
+      },
+    },
+  },
+  {
+    name: 'context_pack_session_reset',
+    description: 'Reset a delta-pack session so the next context_pack ships the full pack.',
+    inputSchema: {
+      type: 'object',
+      required: ['delta_session_id'],
+      properties: {
+        delta_session_id: { type: 'string', description: 'Delta session key' },
       },
     },
   },

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -25,7 +25,8 @@ import { pickImpactTarget } from '../context-pack-target.js'
 import { analyzeImpact, callChains, compactImpactResult, type ImpactResult } from '../impact.js'
 import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
 import { relevantFiles } from '../relevant-files.js'
-import { collectRelationships, compactRetrieveResult, readSnippet, retrieveContext, retrieveContextAsync, type RetrieveResult } from '../retrieve.js'
+import { collectRelationships, compactRetrieveResult, contextPackFromRetrieveResult, readSnippet, retrieveContext, retrieveContextAsync, type RetrieveResult } from '../retrieve.js'
+import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
 import { riskMap } from '../risk-map.js'
 import { buildTaskContextPlan } from '../task-context-planner.js'
 import type { TimeTravelView } from '../time-travel.js'
@@ -870,9 +871,14 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const compactPack = compactRetrieveResult(retrieval)
       const metadata = contextMetadata(retrieval)
       storeExpandableHandles(prompt, task, initialPlan.evidence.recipe_id, metadata.expandable, helpers)
+      // Slice #78: emit context-pack quality diagnostics so callers can
+      // detect bad runs (missing required evidence, zero claims, weak
+      // retrieval, etc.) without re-implementing the heuristics.
+      const diagnostics = computeContextPackDiagnostics(contextPackFromRetrieveResult(retrieval))
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
         pack: compactPack,
+        diagnostics,
         ...metadata,
       })))
     }

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -27,6 +27,7 @@ import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
 import { relevantFiles } from '../relevant-files.js'
 import { collectRelationships, compactRetrieveResult, contextPackFromRetrieveResult, readSnippet, retrieveContext, retrieveContextAsync, type RetrieveResult } from '../retrieve.js'
 import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
+import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-delta.js'
 import { riskMap } from '../risk-map.js'
 import { buildTaskContextPlan } from '../task-context-planner.js'
 import type { TimeTravelView } from '../time-travel.js'
@@ -70,6 +71,12 @@ interface ToolHelpers {
   clearContextPromptSession(sessionId: string): boolean
   getContextPackHandle(handleId: string): unknown
   setContextPackHandle(handleId: string, expansion: unknown): void
+  /** Slice #81 — returns node ids already shipped to this delta session. */
+  getContextPackNodeIds(sessionId: string): string[]
+  /** Slice #81 — records additional node ids shipped to a delta session. */
+  recordContextPackNodeIds(sessionId: string, nodeIds: string[]): void
+  /** Slice #81 — clears the recorded node-id set for a delta session. */
+  clearContextPackNodeIds(sessionId: string): boolean
   readStoredCommunityLabels(graphPath: string): Record<number, string>
   jsonrpcInvalidParams: number
   jsonrpcServerError: number
@@ -868,18 +875,65 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         })))
       }
 
+      const fullPack = contextPackFromRetrieveResult(retrieval)
       const compactPack = compactRetrieveResult(retrieval)
       const metadata = contextMetadata(retrieval)
       storeExpandableHandles(prompt, task, initialPlan.evidence.recipe_id, metadata.expandable, helpers)
       // Slice #78: emit context-pack quality diagnostics so callers can
       // detect bad runs (missing required evidence, zero claims, weak
       // retrieval, etc.) without re-implementing the heuristics.
-      const diagnostics = computeContextPackDiagnostics(contextPackFromRetrieveResult(retrieval))
+      const diagnostics = computeContextPackDiagnostics(fullPack)
+
+      // Slice #81: delta-only context packs. When the caller passes a
+      // delta_session_id we filter out nodes the agent has already
+      // received in earlier turns of the same session, ship only the
+      // delta + referenced_ids, and record the new ids for the next call.
+      // The session store is per-MCP-process (in-memory) so two parallel
+      // agents using the same id naturally diverge — that's intentional.
+      const deltaSessionId = helpers.stringParamAlias(toolArguments, ['delta_session_id', 'deltaSessionId'])
+      if (deltaSessionId) {
+        const previouslySent = helpers.getContextPackNodeIds(deltaSessionId)
+        const deltaResult = computeDeltaContextPack(fullPack, previouslySent)
+        // Record the newly-shipped node ids so the next call's delta is
+        // computed against the union of everything sent so far.
+        helpers.recordContextPackNodeIds(deltaSessionId, collectPackNodeIds(deltaResult.delta_pack))
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+          ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
+          mode: 'delta',
+          delta_session_id: deltaSessionId,
+          delta_applied: deltaResult.delta_applied,
+          referenced_ids: deltaResult.referenced_ids,
+          bytes_saved: deltaResult.bytes_saved,
+          pack: {
+            question: prompt,
+            token_count: deltaResult.delta_pack.token_count,
+            matched_nodes: deltaResult.delta_pack.nodes.map((node) => {
+              const { evidence_class: _evidenceClass, ...rest } = node
+              return rest
+            }),
+            relationships: deltaResult.delta_pack.relationships,
+            community_context: deltaResult.delta_pack.community_context,
+            graph_signals: deltaResult.delta_pack.graph_signals ?? { god_nodes: [], bridge_nodes: [] },
+          },
+          diagnostics: computeContextPackDiagnostics(deltaResult.delta_pack, { skipBudgetUnderutilization: true }),
+          ...metadata,
+        })))
+      }
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
         pack: compactPack,
         diagnostics,
         ...metadata,
+      })))
+    }
+    case 'context_pack_session_reset': {
+      const sessionId = helpers.stringParamAlias(toolArguments, ['delta_session_id', 'deltaSessionId', 'session_id', 'sessionId'])
+      if (!sessionId) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'context_pack_session_reset requires a string delta_session_id parameter')
+      }
+      return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        delta_session_id: sessionId,
+        cleared: helpers.clearContextPackNodeIds(sessionId),
       })))
     }
     case 'context_expand': {

--- a/src/runtime/value-per-token.ts
+++ b/src/runtime/value-per-token.ts
@@ -1,0 +1,133 @@
+// Value-per-token budget selector (#74).
+//
+// Pure helper that ranks a candidate set by score / token_cost ratio (the
+// classical density heuristic used in the bounded-knapsack approximation)
+// and picks the prefix that fits within a token budget.
+//
+// Why density rather than raw relevance: the budgeted context-pack
+// surface (#74) is "how much information per token of context can we
+// afford?" — a 2x-relevance node that costs 4x the tokens is worse than
+// two ~1x-relevance nodes that fit in the same budget.
+//
+// This module is intentionally generic so the retrieve.ts surface can
+// adopt it incrementally without coupling to a concrete node shape: the
+// caller provides any T plus a relevance scorer and a token-cost
+// estimator; the helper returns the selected subset, the budget remaining,
+// and per-item debug info (rank, density, included).
+//
+// Out of scope for this slice:
+//   * Per-evidence-class quotas — already enforced upstream in
+//     compileContextPack via the task contract's required_evidence list.
+//     The value-per-token selector runs WITHIN the candidate pool a
+//     given recipe class has already been narrowed to.
+//   * Submodular selection (diversity bonuses for non-redundant
+//     candidates). The current scorer treats each candidate as a single
+//     independent item; submodular variants land later when measurement
+//     shows a regression on real corpora.
+
+export interface ValuePerTokenCandidate<T> {
+  /** Stable identity for dedup + reporting. */
+  id: string
+  /** The underlying payload returned to the caller in `selected`. */
+  payload: T
+  /** Caller-computed relevance score; the only constraint is that higher
+   *  values mean MORE relevant. Normalized internally. */
+  score: number
+  /** Estimated token cost of including the payload in the final pack.
+   *  Must be > 0; zero-cost items are pinned (always included). */
+  token_cost: number
+}
+
+export interface ValuePerTokenResult<T> {
+  /** Selected candidates in selection order (density-descending). */
+  selected: ValuePerTokenCandidate<T>[]
+  /** Token cost of the selected set. */
+  total_cost: number
+  /** Token cost remaining under the budget. */
+  remaining_budget: number
+  /** Per-candidate breakdown — useful for diagnostics and replay. */
+  ranking: Array<{
+    id: string
+    score: number
+    token_cost: number
+    density: number
+    rank: number
+    included: boolean
+  }>
+}
+
+export interface ValuePerTokenOptions {
+  /** Maximum total token cost the selection may consume. Items already
+   *  costing more than the budget on their own are skipped — they
+   *  cannot fit by definition. */
+  budget: number
+  /** When true, items with `token_cost === 0` are unconditionally
+   *  included regardless of budget. Useful for cost-free metadata that
+   *  carries information density bonuses (anchors, claims). Default true. */
+  pinZeroCost?: boolean
+}
+
+/** Select a subset of candidates that maximises Σ score subject to
+ *  Σ token_cost ≤ budget, using the greedy density heuristic. Returns
+ *  selection plus per-candidate rank info. Deterministic — ties resolved
+ *  by score desc, then token_cost asc, then id asc. */
+export function selectByValuePerToken<T>(
+  candidates: ReadonlyArray<ValuePerTokenCandidate<T>>,
+  options: ValuePerTokenOptions,
+): ValuePerTokenResult<T> {
+  const pinZeroCost = options.pinZeroCost ?? true
+  const budget = Math.max(0, options.budget)
+
+  // Annotate with density and sort descending. Skip items that can never
+  // fit (cost > budget AND not pinnable). Skip non-finite scores/costs.
+  const annotated = candidates
+    .filter((c) => Number.isFinite(c.score) && Number.isFinite(c.token_cost) && c.token_cost >= 0)
+    .map((c) => ({
+      candidate: c,
+      density: c.token_cost === 0 ? Number.POSITIVE_INFINITY : c.score / c.token_cost,
+    }))
+    .sort((a, b) => {
+      if (a.density !== b.density) return b.density - a.density
+      if (a.candidate.score !== b.candidate.score) return b.candidate.score - a.candidate.score
+      if (a.candidate.token_cost !== b.candidate.token_cost) {
+        return a.candidate.token_cost - b.candidate.token_cost
+      }
+      return a.candidate.id.localeCompare(b.candidate.id)
+    })
+
+  const selected: ValuePerTokenCandidate<T>[] = []
+  const ranking: ValuePerTokenResult<T>['ranking'] = []
+  let consumed = 0
+
+  annotated.forEach(({ candidate, density }, index) => {
+    let included = false
+    if (candidate.token_cost === 0) {
+      // Zero-cost candidates are gated on pinZeroCost. The default
+      // (pinZeroCost=true) ALWAYS includes them; turning it off lets
+      // callers exclude free items they don't actually want.
+      if (pinZeroCost) {
+        selected.push(candidate)
+        included = true
+      }
+    } else if (consumed + candidate.token_cost <= budget) {
+      selected.push(candidate)
+      consumed += candidate.token_cost
+      included = true
+    }
+    ranking.push({
+      id: candidate.id,
+      score: candidate.score,
+      token_cost: candidate.token_cost,
+      density,
+      rank: index + 1,
+      included,
+    })
+  })
+
+  return {
+    selected,
+    total_cost: consumed,
+    remaining_budget: Math.max(0, budget - consumed),
+    ranking,
+  }
+}

--- a/tests/unit/context-pack-diagnostics.test.ts
+++ b/tests/unit/context-pack-diagnostics.test.ts
@@ -1,0 +1,280 @@
+// Context-pack quality diagnostics tests (#78).
+// Pure unit tests against synthetic CompiledContextPack inputs — no I/O,
+// no graph build. Validates every rule fires when expected, doesn't fire
+// when not expected, and the quality_score moves in the right direction.
+
+import { describe, expect, it } from 'vitest'
+
+import type {
+  CompiledContextPack,
+  ContextPackClaim,
+  ContextPackNode,
+  ContextPackRelationship,
+  ContextPackTaskContract,
+} from '../../src/contracts/context-pack.js'
+import { computeContextPackDiagnostics } from '../../src/runtime/context-pack-diagnostics.js'
+
+function taskContract(overrides: Partial<ContextPackTaskContract> = {}): ContextPackTaskContract {
+  return {
+    version: 1,
+    task_kind: 'explain',
+    evidence_recipe_id: 'explain',
+    budget: 3000,
+    required_evidence: ['primary'],
+    preferred_evidence: ['supporting'],
+    semantic_required: ['implementation'],
+    semantic_optional: ['tests'],
+    ...overrides,
+  }
+}
+
+function makeNode(overrides: Partial<ContextPackNode> = {}): ContextPackNode {
+  return {
+    node_id: overrides.node_id ?? 'node-1',
+    label: 'fooBar()',
+    source_file: '/repo/src/foo.ts',
+    line_number: 10,
+    snippet: 'export function fooBar() { return 1 }',
+    match_score: 0.8,
+    ...overrides,
+  }
+}
+
+function makeRelationship(from: string, to: string, relation = 'calls'): ContextPackRelationship {
+  return { from_id: from, from, to_id: to, to, relation }
+}
+
+function makeClaim(text = 'fooBar returns 1'): ContextPackClaim {
+  return { evidence_class: 'primary', text, node_labels: ['fooBar()'] }
+}
+
+function makePack(overrides: Partial<CompiledContextPack> = {}): CompiledContextPack {
+  const base: CompiledContextPack = {
+    task_contract: taskContract(),
+    token_count: 800,
+    nodes: [
+      makeNode({ node_id: 'a' }),
+      makeNode({ node_id: 'b', label: 'baz()', match_score: 0.6 }),
+      makeNode({ node_id: 'c', label: 'qux()', match_score: 0.7 }),
+    ],
+    relationships: [
+      makeRelationship('a', 'b'),
+      makeRelationship('b', 'c'),
+    ],
+    community_context: [],
+    claims: [makeClaim(), makeClaim('baz calls qux')],
+    expandable: [],
+    coverage: {
+      required_evidence: ['primary'],
+      semantic_required: ['implementation'],
+      semantic_optional: ['tests'],
+      entries: [],
+      semantic_entries: [],
+      missing_required: [],
+      missing_semantic: [],
+      available_relationships: 2,
+      selected_relationships: 2,
+    },
+    graph_signals: { god_nodes: ['Logger'], bridge_nodes: [] },
+  }
+  return { ...base, ...overrides }
+}
+
+describe('computeContextPackDiagnostics', () => {
+  it('emits zero warnings on a healthy pack', () => {
+    const diag = computeContextPackDiagnostics(makePack())
+    expect(diag.warnings).toEqual([])
+    expect(diag.quality_score).toBe(1)
+    expect(diag.signals.node_count).toBe(3)
+    expect(diag.signals.relationship_count).toBe(2)
+    expect(diag.signals.claim_count).toBe(2)
+    expect(diag.signals.snippet_coverage).toBe(1)
+  })
+
+  it('flags missing_required_evidence as error', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      coverage: {
+        required_evidence: ['primary'],
+        semantic_required: ['implementation'],
+        semantic_optional: [],
+        entries: [],
+        semantic_entries: [],
+        missing_required: ['primary'],
+        missing_semantic: [],
+        available_relationships: 2,
+        selected_relationships: 2,
+      },
+    }))
+    const warning = diag.warnings.find((w) => w.kind === 'missing_required_evidence')
+    expect(warning?.severity).toBe('error')
+    expect(warning?.detail).toEqual({ classes: ['primary'] })
+    expect(diag.quality_score).toBeLessThan(1)
+  })
+
+  it('flags missing_required_semantic as warn', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      coverage: {
+        required_evidence: ['primary'],
+        semantic_required: ['implementation'],
+        semantic_optional: [],
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: ['implementation'],
+        available_relationships: 2,
+        selected_relationships: 2,
+      },
+    }))
+    const warning = diag.warnings.find((w) => w.kind === 'missing_required_semantic')
+    expect(warning?.severity).toBe('warn')
+  })
+
+  it('flags zero_claims when claims array is empty', () => {
+    const diag = computeContextPackDiagnostics(makePack({ claims: [] }))
+    expect(diag.warnings.map((w) => w.kind)).toContain('zero_claims')
+  })
+
+  it('flags undersized_retrieval when fewer than 3 nodes', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [makeNode({ node_id: 'a' }), makeNode({ node_id: 'b', label: 'baz()' })],
+      relationships: [makeRelationship('a', 'b')],
+    }))
+    const warning = diag.warnings.find((w) => w.kind === 'undersized_retrieval')
+    expect(warning?.detail).toEqual({ node_count: 2, threshold: 3 })
+  })
+
+  it('flags budget_underutilized when token_count is far below the budget', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      task_contract: taskContract({ budget: 4000 }),
+      token_count: 200,
+    }))
+    const warning = diag.warnings.find((w) => w.kind === 'budget_underutilized')
+    expect(warning?.severity).toBe('info')
+  })
+
+  it('does NOT flag budget_underutilized when skipBudgetUnderutilization is set', () => {
+    const diag = computeContextPackDiagnostics(
+      makePack({ token_count: 200 }),
+      { skipBudgetUnderutilization: true },
+    )
+    expect(diag.warnings.map((w) => w.kind)).not.toContain('budget_underutilized')
+  })
+
+  it('flags missing_snippets when more than 50% of nodes lack a snippet', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [
+        makeNode({ node_id: 'a', snippet: null }),
+        makeNode({ node_id: 'b', snippet: null }),
+        makeNode({ node_id: 'c', snippet: 'has source' }),
+      ],
+    }))
+    const warning = diag.warnings.find((w) => w.kind === 'missing_snippets')
+    expect(warning?.severity).toBe('warn')
+  })
+
+  it('flags low_avg_match_score when average is below 0.30', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [
+        makeNode({ node_id: 'a', match_score: 0.1 }),
+        makeNode({ node_id: 'b', match_score: 0.2 }),
+        makeNode({ node_id: 'c', match_score: 0.15 }),
+      ],
+    }))
+    expect(diag.warnings.map((w) => w.kind)).toContain('low_avg_match_score')
+  })
+
+  it('flags orphan_nodes when nodes>1 but no relationships', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      relationships: [],
+    }))
+    expect(diag.warnings.map((w) => w.kind)).toContain('orphan_nodes')
+  })
+
+  it('flags no_graph_signals when both god/bridge are empty and nodes>=3', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    }))
+    const warning = diag.warnings.find((w) => w.kind === 'no_graph_signals')
+    expect(warning?.severity).toBe('info')
+  })
+
+  it('orders warnings by severity (error → warn → info) then by kind', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      claims: [],
+      task_contract: taskContract({ budget: 4000 }),
+      token_count: 200,
+      coverage: {
+        required_evidence: ['primary'],
+        semantic_required: [],
+        semantic_optional: [],
+        entries: [],
+        semantic_entries: [],
+        missing_required: ['primary'],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    }))
+    const severities = diag.warnings.map((w) => w.severity)
+    // Errors come first, then warns, then infos.
+    let mode: 'error' | 'warn' | 'info' = 'error'
+    for (const sev of severities) {
+      if (mode === 'error' && sev === 'warn') mode = 'warn'
+      else if (mode === 'warn' && sev === 'info') mode = 'info'
+      expect(sev === mode || (mode === 'warn' && sev === 'info') || (mode === 'info' && sev === 'info')).toBe(true)
+    }
+    expect(severities[0]).toBe('error')
+  })
+
+  it('quality_score collapses for a pathologically bad pack', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [],
+      relationships: [],
+      claims: [],
+      token_count: 0,
+      coverage: {
+        required_evidence: ['primary'],
+        semantic_required: ['implementation'],
+        semantic_optional: [],
+        entries: [],
+        semantic_entries: [],
+        missing_required: ['primary'],
+        missing_semantic: ['implementation'],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    }))
+    expect(diag.quality_score).toBeLessThanOrEqual(0.5)
+    expect(diag.warnings.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('quality_score is between 0 and 1 and rounded to 3 decimals', () => {
+    const diag = computeContextPackDiagnostics(makePack({ claims: [] }))
+    expect(diag.quality_score).toBeGreaterThanOrEqual(0)
+    expect(diag.quality_score).toBeLessThanOrEqual(1)
+    expect(diag.quality_score).toEqual(Number(diag.quality_score.toFixed(3)))
+  })
+
+  it('signals.avg_match_score is NaN when no scored nodes exist', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [
+        makeNode({ node_id: 'a', match_score: undefined }),
+        makeNode({ node_id: 'b', match_score: undefined }),
+        makeNode({ node_id: 'c', match_score: undefined }),
+      ],
+    }))
+    expect(Number.isNaN(diag.signals.avg_match_score)).toBe(true)
+    // The low_avg_match_score rule should NOT fire when no scores exist.
+    expect(diag.warnings.map((w) => w.kind)).not.toContain('low_avg_match_score')
+  })
+
+  it('does not flag undersized_retrieval when node_count is 0 (handled by orphan/missing rules)', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [],
+      relationships: [],
+      claims: [],
+    }))
+    expect(diag.warnings.map((w) => w.kind)).not.toContain('undersized_retrieval')
+  })
+})

--- a/tests/unit/context-pack-diagnostics.test.ts
+++ b/tests/unit/context-pack-diagnostics.test.ts
@@ -172,6 +172,21 @@ describe('computeContextPackDiagnostics', () => {
     expect(warning?.severity).toBe('warn')
   })
 
+  it('flags low_avg_match_score even when average is exactly 0 (CodeRabbit fix)', () => {
+    // The worst-case retrieval is 0 match-score across the board. The
+    // predicate must NOT exclude that case via a `> 0` clause — only the
+    // NaN guard protects against "no scored nodes at all".
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [
+        makeNode({ node_id: 'a', match_score: 0 }),
+        makeNode({ node_id: 'b', match_score: 0 }),
+        makeNode({ node_id: 'c', match_score: 0 }),
+      ],
+    }))
+    expect(diag.signals.avg_match_score).toBe(0)
+    expect(diag.warnings.map((w) => w.kind)).toContain('low_avg_match_score')
+  })
+
   it('flags low_avg_match_score when average is below 0.30', () => {
     const diag = computeContextPackDiagnostics(makePack({
       nodes: [

--- a/tests/unit/value-per-token.test.ts
+++ b/tests/unit/value-per-token.test.ts
@@ -1,0 +1,118 @@
+// Value-per-token budget selector tests (#74).
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectByValuePerToken,
+  type ValuePerTokenCandidate,
+} from '../../src/runtime/value-per-token.js'
+
+function c(id: string, score: number, token_cost: number): ValuePerTokenCandidate<string> {
+  return { id, score, token_cost, payload: id }
+}
+
+describe('selectByValuePerToken', () => {
+  it('selects all candidates when the total cost is under budget', () => {
+    const result = selectByValuePerToken(
+      [c('a', 10, 100), c('b', 8, 100), c('c', 6, 100)],
+      { budget: 500 },
+    )
+    expect(result.selected.map((s) => s.id).sort()).toEqual(['a', 'b', 'c'])
+    expect(result.total_cost).toBe(300)
+    expect(result.remaining_budget).toBe(200)
+  })
+
+  it('prefers higher density over higher absolute score', () => {
+    // Candidate a: score 10 / cost 100 = density 0.1
+    // Candidate b: score 8  / cost 40  = density 0.2
+    // With budget 50, only b fits and density wins.
+    const result = selectByValuePerToken(
+      [c('a', 10, 100), c('b', 8, 40)],
+      { budget: 50 },
+    )
+    expect(result.selected.map((s) => s.id)).toEqual(['b'])
+  })
+
+  it('pins zero-cost candidates by default', () => {
+    const result = selectByValuePerToken(
+      [c('a', 5, 0), c('b', 100, 50)],
+      { budget: 40 },  // can't afford b
+    )
+    expect(result.selected.map((s) => s.id)).toEqual(['a'])
+    expect(result.total_cost).toBe(0)
+  })
+
+  it('skips zero-cost candidates when pinZeroCost is false', () => {
+    const result = selectByValuePerToken(
+      [c('a', 5, 0), c('b', 100, 50)],
+      { budget: 40, pinZeroCost: false },
+    )
+    expect(result.selected.map((s) => s.id)).toEqual([])
+  })
+
+  it('respects the budget when greedy adds items', () => {
+    const result = selectByValuePerToken(
+      [c('a', 10, 60), c('b', 5, 50), c('c', 7, 30)],
+      { budget: 100 },
+    )
+    // Densities: a=0.166, b=0.10, c=0.233. Sorted: c, a, b.
+    // Pick c (30), pick a (90), skip b (would be 140 > 100).
+    expect(result.selected.map((s) => s.id)).toEqual(['c', 'a'])
+    expect(result.total_cost).toBe(90)
+  })
+
+  it('skips items with cost > budget even when greedy passes', () => {
+    // a has high density but it alone exceeds budget — must be skipped.
+    const result = selectByValuePerToken([c('a', 100, 1000)], { budget: 100 })
+    expect(result.selected).toEqual([])
+    expect(result.total_cost).toBe(0)
+  })
+
+  it('filters out non-finite scores and costs', () => {
+    const result = selectByValuePerToken(
+      [
+        c('a', Number.NaN, 50),
+        c('b', 5, Number.POSITIVE_INFINITY),
+        c('c', 3, 10),
+      ],
+      { budget: 100 },
+    )
+    expect(result.selected.map((s) => s.id)).toEqual(['c'])
+  })
+
+  it('returns ranking with rank + density + included flags', () => {
+    const result = selectByValuePerToken(
+      [c('a', 10, 50), c('b', 5, 50)],
+      { budget: 60 },
+    )
+    // a fits first (density 0.2), b skipped (would push to 100 > 60).
+    expect(result.ranking).toEqual([
+      { id: 'a', score: 10, token_cost: 50, density: 0.2, rank: 1, included: true },
+      { id: 'b', score: 5, token_cost: 50, density: 0.1, rank: 2, included: false },
+    ])
+  })
+
+  it('is deterministic on ties — score desc, cost asc, id asc', () => {
+    // Two items with identical density and identical score — id breaks tie.
+    const result = selectByValuePerToken(
+      [c('z', 5, 50), c('a', 5, 50)],
+      { budget: 50 },
+    )
+    // Only one fits at cost 50; tie broken by id asc → 'a' wins.
+    expect(result.selected.map((s) => s.id)).toEqual(['a'])
+  })
+
+  it('clamps negative budget to 0', () => {
+    const result = selectByValuePerToken([c('a', 10, 50)], { budget: -100 })
+    expect(result.selected).toEqual([])
+    expect(result.remaining_budget).toBe(0)
+  })
+
+  it('handles empty input', () => {
+    const result = selectByValuePerToken<string>([], { budget: 100 })
+    expect(result.selected).toEqual([])
+    expect(result.ranking).toEqual([])
+    expect(result.total_cost).toBe(0)
+    expect(result.remaining_budget).toBe(100)
+  })
+})


### PR DESCRIPTION
Closes #78
Closes #81
Closes #74

## Summary

Closes out the v0.15 substrate work in one bundled PR (as requested). Three issues landed:

- **#78 — Context-pack quality diagnostics**: structural quality scorer
- **#81 — Delta-only context packs via stdio**: per-session dedup
- **#74 — Value-per-token budget selector**: density-greedy selection

## What's in the bundle

### #78 Context-pack quality diagnostics

New scorer `computeContextPackDiagnostics(pack)` with 9 weighted rules:

| Rule | Severity | Weight | When |
|---|---|---|---|
| `missing_required_evidence` | error | 2 | coverage.missing_required.length > 0 |
| `missing_required_semantic` | warn | 1 | coverage.missing_semantic.length > 0 |
| `zero_claims` | warn | 1 | claims.length === 0 |
| `undersized_retrieval` | warn | 1 | 0 < nodes.length < 3 |
| `budget_underutilized` | info | 1 | token_count < 25% of >= 500-token budget |
| `missing_snippets` | warn | 1 | > 50% of nodes lack a source snippet |
| `low_avg_match_score` | warn | 1 | mean match_score < 0.30 |
| `orphan_nodes` | warn | 1 | nodes>1 but zero relationships |
| `no_graph_signals` | info | 1 | both god_nodes and bridge_nodes empty |

Wired into the stdio `context_pack` response (explain branch + delta branch).

### #81 Delta-only context packs via stdio

- **New parameter** on `context_pack`: `delta_session_id`. When set, the response ships only nodes not already received by this session, plus `referenced_ids[]` and `bytes_saved`.
- **New MCP tool** `context_pack_session_reset` — clears a delta session so the next call ships the full pack again.
- **3 new helpers** on `StdioToolHelpers`: `getContextPackNodeIds`, `recordContextPackNodeIds`, `clearContextPackNodeIds`. Backed by an LRU `Map<sessionId, Set<nodeId>>` (256 sessions, same bound as prompt sessions).
- Reuses `computeDeltaContextPack` (already had the both-endpoints relationship filter from PR #106).
- Diagnostics on delta responses skip the `budget_underutilized` rule (deltas are small-by-design after dedup).

### #74 Value-per-token budget selector

- **New module** `src/runtime/value-per-token.ts` exporting `selectByValuePerToken(candidates, options)`.
- Greedy density heuristic: sort by `score / token_cost` desc, pick the prefix that fits within budget. Deterministic tie-breaking: score desc → cost asc → id asc.
- Optional `pinZeroCost` (default true): zero-cost items always included; flip to exclude.
- Skips items whose individual cost > budget and non-finite scores/costs.
- Returns selected payloads, total_cost, remaining_budget, and per-candidate `ranking[]` with rank/density/included flags for diagnostics.
- Pure helper for now — adopting inside `retrieve.ts`'s candidate selection is a follow-up once we have a benchmark to A/B against.

## Not in this PR (deferred to v0.16)

- **#76 multi-resolution context representations** — needs a new representation layer; structurally invasive.
- **#79 PR-impact coverage calibration** — needs real PRs to calibrate against; not a code-only delivery.
- **#80 cache-aware prompt layout measurement** — purely measurement work; the sort_key bands already shipped earlier.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1760/1760 pass (103 files, +27 new tests)
- [x] MCP tool count = 26 in the full profile; schema-budget test stays under the 12,000-byte ceiling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pack quality diagnostics: pack health score, ordered warnings, and measurable signals (snippet coverage, match scores, budget utilization); diagnostics now included in pack responses.
  * Incremental "delta" context-pack delivery with per-session deduplication and a session-reset tool.
  * Value-per-token selector to greedily pick items by score/token density within a budget.

* **Tests**
  * Comprehensive unit tests covering diagnostics and value-per-token behaviors and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/121)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->