### PR TITLE
chore(release): v0.15.0 — context-pack quality signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-11
+
+### Added
+
+- **Context-pack quality diagnostics (#78)**: new `computeContextPackDiagnostics(pack)` scorer emits a deterministic `quality_score` (0–1), severity-ordered warnings, and the raw signals used to compute them. Nine weighted rules detect bad runs: missing required evidence (error), missing required semantic categories, zero claims, undersized retrieval, budget underutilization, missing snippets, low average match_score (now firing on the worst case `avg=0`), orphan nodes (entities with no relationships), and absent architectural signals. Wired into the stdio `context_pack` response (explain branch) so callers see quality flags inline.
+- **Delta-only context packs via stdio (#81)**: new `delta_session_id` parameter on `context_pack` makes subsequent calls in the same session ship only nodes the agent hasn't seen yet, plus `referenced_ids[]` for dropped nodes and a `bytes_saved` estimate. New MCP tool `context_pack_session_reset` clears a delta session. Backed by a per-MCP-process LRU `Map<sessionId, Set<nodeId>>` (256 sessions, same bound as prompt sessions).
+- **Value-per-token budget selector (#74)**: new pure helper `selectByValuePerToken(candidates, options)` ranks candidates by `score / token_cost` density (greedy bounded-knapsack approximation) and returns the prefix that fits within budget. Deterministic tie-breaking (score desc → cost asc → id asc). Returns per-candidate ranking with rank/density/included flags for diagnostics. Available as a building block for future selection refinements in `retrieve.ts`.
+
+### Notes
+
+- v0.15.0 is the **quality-signals** release: every context_pack response now carries machine-readable feedback on its own structural quality, and per-session dedup makes multi-turn agents cheaper.
+- The three v0.15 items deferred to v0.16: PR-impact coverage calibration (#79, needs real PRs), cache-aware prompt-layout measurement (#80, sort_key bands already shipped), and multi-resolution context representations (#76, new representation layer).
+
 ## [0.14.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ Planned:
 
 - 🔜 Better PR-impact coverage scoring on diff hotspots
 - 🔜 Cache-aware prompt layout that minimizes Claude session-cache invalidation
-- 🔜 Delta-only context packs between runs (only ship what the agent doesn't already have)
+- ✅ Delta-only context packs between runs — `delta_session_id` on `context_pack` ships only new nodes per session (#81)
+- ✅ Context-pack quality diagnostics & bad-run detection — `quality_score` + structural warnings on every pack (#78)
+- ✅ Budgeted value-per-token selection helper — density-greedy `selectByValuePerToken` (#74)
 - ✅ Tighter cold-start MCP overhead (core profile ~3,000 bytes, down from ~4,270 — 30% drop, see #82)
 - 🔜 More framework-aware passes (Prisma, tRPC, Hono, Fastify)
 - 🔜 Deeper Python / Go semantic passes beyond tree-sitter AST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

Cuts the v0.15.0 release covering the quality-signals slice train from #78, #81, #74 (all merged via PR #121).

- Bumps `package.json` from `0.14.0` → `0.15.0`
- Adds the `[0.15.0]` entry to `CHANGELOG.md`
- Updates README roadmap (3 items flipped to ✅)

## What's in v0.15.0

**Context-pack quality diagnostics (#78):**
- `computeContextPackDiagnostics(pack)` scorer with 9 weighted rules
- Deterministic `quality_score` (0–1), severity-ordered warnings, raw signals
- Wired into the stdio `context_pack` response (explain branch + delta branch)

**Delta-only context packs via stdio (#81):**
- `delta_session_id` parameter on `context_pack`
- New MCP tool `context_pack_session_reset`
- Per-MCP-process LRU session store (256 sessions)
- Returns `referenced_ids[]` + `bytes_saved` so the agent can resolve dropped nodes from session state

**Value-per-token budget selector (#74):**
- `selectByValuePerToken(candidates, options)` density-greedy selector
- Deterministic tie-breaking, per-candidate ranking with rank/density/included
- Pure helper — adopting inside `retrieve.ts` is a follow-up once we have a benchmark

## Deferred to v0.16

- **#79** PR-impact coverage calibration (needs real PRs)
- **#80** cache-aware prompt-layout measurement (sort_key bands already shipped earlier)
- **#76** multi-resolution context representations (new representation layer)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1761/1761 pass (103 files)
- [x] CHANGELOG and README roadmap updated
- [ ] After merge: tag `v0.15.0` and `npm publish` (you handle publish per pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context-pack quality diagnostics for assessing reliability
  * Delta-only context packs optimized for multi-turn sessions
  * Value-per-token budget selector helper

* **Documentation**
  * Updated README roadmap with specific planned features
  * Added v0.15.0 release notes to CHANGELOG

* **Chores**
  * Version bump to v0.15.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/122)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->