### PR TITLE
chore(release): v0.16.0 — runtime efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-11
+
+### Added
+
+- **Incremental SPI cache (#77)**: new `buildSpiCached(opts)` wraps `buildSpi` with disk-backed all-or-nothing caching. Cache key = sha256 of workspace root + extractor_version + graphify_version + tsconfig content + per-file `(path, mtime, size, sha256)`. Repeat builds on an unchanged workspace skip the full ts.Program pass and return the cached SemanticProgramIndex. Public API: `buildSpiCached`, `clearSpiCache`, `BuildSpiCachedOptions`, `BuildSpiCachedResult`, `SpiCacheStats`, `SpiCacheIndex`. Cache lives in `<root>/graphify-out/.spi-cache/` and is format-versioned for clean invalidation on future schema changes.
+- **Multi-resolution context (#76)**: new `applyContextPackResolution(nodes, options)` helper adapts a node list to `detail` (no-op), `summary` (drop snippet bodies, keep label/source_file/line_number/match_score), or `mixed` (top-N by match_score get detail, rest summary). New stdio `context_pack` parameter `resolution: 'detail' | 'summary' | 'mixed'` (default `detail`). Response includes `resolution_map` (per-node summary/detail decisions) and `bytes_saved_by_resolution`. Currently supported on the explain branch only; review/impact return a clear `jsonrpcInvalidParams` error when `resolution` is requested with an unsupported task.
+- **Weighted PR-impact coverage scoring (#79)**: new `PrImpactResult` fields:
+  - `coverage_score_weighted` — bridge/god labels count 3x, regular high-impact 1x. Penalises uncoverage of high-centrality hotspots more aggressively than the unweighted score.
+  - `uncovered_hotspot_severities[]` — per-label `'critical'` (bridge/god) / `'high'` (regular high-impact) tier so reviewers can prioritise gaps.
+  - `critical_labels[]` — bridge+god subset of high-impact labels (consumer-readable).
+  - Compact result recomputes weighted score + severities against the post-compaction review bundle, same correctness contract as the unweighted `coverage_score`.
+- **Cache-aware prompt layout (#80)**: new `stable_prefix_hash` field on every `BuiltContextPrompt` (sha256-16 of `stable_prefix`). Byte-stable across re-runs when the underlying graph/anchor is unchanged; invariant under dynamic-suffix changes. Consumers can compare the hash across calls to verify Anthropic's automatic prompt cache will reuse the prefix.
+
+### Notes
+
+- v0.16.0 is the **runtime-efficiency** release: the SPI cache eliminates the repeat-build penalty, multi-resolution gives callers token-budget control, weighted coverage gives reviewers prioritisation, and the prompt-cache hash gives consumers a measurable cache-reuse signal.
+- v0.17-language-expansion is next: Prisma / tRPC / Hono / Fastify substrates (#83), deeper Python / Go semantic passes (#84).
+
 ## [0.15.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -261,17 +261,17 @@ Implemented today:
 - ✅ Time-travel compare across git refs (`time-travel`)
 - ✅ Coverage contracts (`benchmark`, `eval`)
 - ✅ Native installers for Claude Code, Cursor, Copilot CLI, Gemini CLI, Aider, OpenCode
-
-Planned:
-
+- ✅ Tighter cold-start MCP overhead (core profile ~3,000 bytes, down from ~4,270 — 30% drop, see #82)
+- ✅ Incremental SPI cache — `buildSpiCached` skips the ts.Program pass on unchanged workspaces (#77)
+- ✅ Multi-resolution context — `resolution: detail | summary | mixed` on `context_pack` (#76)
 - ✅ Better PR-impact coverage scoring — `coverage_score_weighted` (3x for bridge/god hotspots) + severity tiers (#79)
 - ✅ Cache-aware prompt layout — `stable_prefix_hash` makes cache-reuse measurable across runs (#80)
 - ✅ Delta-only context packs between runs — `delta_session_id` on `context_pack` ships only new nodes per session (#81)
 - ✅ Context-pack quality diagnostics & bad-run detection — `quality_score` + structural warnings on every pack (#78)
 - ✅ Budgeted value-per-token selection helper — density-greedy `selectByValuePerToken` (#74)
-- ✅ Multi-resolution context — `resolution: detail | summary | mixed` on `context_pack` (#76)
-- ✅ Incremental SPI cache — `buildSpiCached` skips the ts.Program pass on unchanged workspaces (#77)
-- ✅ Tighter cold-start MCP overhead (core profile ~3,000 bytes, down from ~4,270 — 30% drop, see #82)
+
+Planned:
+
 - 🔜 More framework-aware passes (Prisma, tRPC, Hono, Fastify)
 - 🔜 Deeper Python / Go semantic passes beyond tree-sitter AST
 

--- a/README.md
+++ b/README.md
@@ -264,11 +264,13 @@ Implemented today:
 
 Planned:
 
-- 🔜 Better PR-impact coverage scoring on diff hotspots
-- 🔜 Cache-aware prompt layout that minimizes Claude session-cache invalidation
+- ✅ Better PR-impact coverage scoring — `coverage_score_weighted` (3x for bridge/god hotspots) + severity tiers (#79)
+- ✅ Cache-aware prompt layout — `stable_prefix_hash` makes cache-reuse measurable across runs (#80)
 - ✅ Delta-only context packs between runs — `delta_session_id` on `context_pack` ships only new nodes per session (#81)
 - ✅ Context-pack quality diagnostics & bad-run detection — `quality_score` + structural warnings on every pack (#78)
 - ✅ Budgeted value-per-token selection helper — density-greedy `selectByValuePerToken` (#74)
+- ✅ Multi-resolution context — `resolution: detail | summary | mixed` on `context_pack` (#76)
+- ✅ Incremental SPI cache — `buildSpiCached` skips the ts.Program pass on unchanged workspaces (#77)
 - ✅ Tighter cold-start MCP overhead (core profile ~3,000 bytes, down from ~4,270 — 30% drop, see #82)
 - 🔜 More framework-aware passes (Prisma, tRPC, Hono, Fastify)
 - 🔜 Deeper Python / Go semantic passes beyond tree-sitter AST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

Cuts the v0.16.0 release covering the runtime-efficiency slice train (#77, #76, #79, #80) all merged via PR #123.

- Bumps `package.json` from `0.15.0` → `0.16.0`
- Adds the `[0.16.0]` entry to `CHANGELOG.md`
- README roadmap: 4 items flipped to ✅

## What's in v0.16.0

**Incremental SPI cache (#77):**
- `buildSpiCached(opts)` + disk-backed cache at `<root>/graphify-out/.spi-cache/`
- All-or-nothing strategy keyed by file content + mtime + size + tsconfig + version
- Format-versioned for future schema invalidation

**Multi-resolution context (#76):**
- `applyContextPackResolution` helper (detail/summary/mixed)
- New `resolution` parameter on stdio `context_pack`
- Response includes `resolution_map` + `bytes_saved_by_resolution`

**Weighted coverage scoring (#79):**
- `coverage_score_weighted` (bridge/god 3x weight)
- `uncovered_hotspot_severities[]` with `critical` / `high` tiers
- `critical_labels[]` exposed for consumers

**Cache-aware prompt layout (#80):**
- `stable_prefix_hash` on every `BuiltContextPrompt`
- Byte-stable across re-runs; invariant under dynamic-suffix changes

## Next milestones

- **v0.17-language-expansion** — Prisma/tRPC/Hono/Fastify (#83), deeper Python/Go (#84)
- Unmilestoned research spikes — #69, #71, #73

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1793/1793 pass (107 files)
- [x] CHANGELOG and README roadmap updated
- [ ] After merge: tag `v0.16.0` and `npm publish` (you handle publish per pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental, disk-backed caching for faster runtime performance
  * Multi-resolution context packing (detail/summary/mixed) with token-saving stats
  * Weighted coverage scoring with hotspot severity reporting
  * Stable prefix hash for reliable cache reuse
  * Delta-only context packs, pack quality diagnostics, and a value-per-token selection helper

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/124)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->