### PR TITLE
feat(v0.17 #83): Hono / Fastify / tRPC / Prisma framework substrates

### DIFF
--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -67,6 +67,10 @@ import { detectExpressFramework, finalizeExpressMountPrefixes } from './framewor
 import { detectNextjsFramework } from './framework-nextjs.js'
 import { detectReactRouterFramework } from './framework-react-router.js'
 import { detectReduxFramework } from './framework-redux.js'
+import { detectHonoFramework } from './framework-hono.js'
+import { detectFastifyFramework } from './framework-fastify.js'
+import { detectTrpcFramework } from './framework-trpc.js'
+import { detectPrismaFramework } from './framework-prisma.js'
 
 export type BuildSpiOptions = {
   root: string
@@ -682,6 +686,36 @@ function addTypeCheckerEdges(ctx: TypeCheckerEdgeContext): void {
     // configureStore / createSelector / createAsyncThunk / createApi
     // factory results in files importing from a Redux module.
     detectReduxFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
+    })
+    // v0.17 (#83): Hono substrate. Tags `new Hono()` apps, http-method
+    // route registrations, and `app.use(...)` middleware.
+    detectHonoFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
+    })
+    // v0.17 (#83): Fastify substrate. Tags `Fastify()` apps, route
+    // registrations, and `app.register(plugin)` plugin registrations.
+    detectFastifyFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
+    })
+    // v0.17 (#83): tRPC substrate. Tags `t.router({...})` results and
+    // synthesizes procedure entries for `.query` / `.mutation` /
+    // `.subscription` properties. Needs the global symbols array
+    // because procedure synthesis appends new entries.
+    detectTrpcFramework({
+      sourceFile,
+      fileId: file.id,
+      symbolsByFile,
+      symbols,
+    })
+    // v0.17 (#83): Prisma substrate. Tags `new PrismaClient()` bindings.
+    detectPrismaFramework({
       sourceFile,
       fileId: file.id,
       symbolsByFile,

--- a/src/pipeline/spi/framework-fastify.ts
+++ b/src/pipeline/spi/framework-fastify.ts
@@ -1,0 +1,184 @@
+// SPI v1 — Fastify framework layer (v0.17 #83).
+//
+// Fastify uses a factory function + chainable registration API:
+//
+//   import Fastify from 'fastify'
+//   const app = Fastify()                          // factory call
+//   app.get('/users', listUsers)                   // route
+//   app.post('/users/:id', updateUser)             // route
+//   app.register(authPlugin, { prefix: '/api' })   // plugin registration
+//   app.addHook('preHandler', authHook)            // hook registration
+//
+// Detection:
+//
+//   * `Fastify()` / `fastify()` (default-imported factory)  → `fastify_app`
+//   * `app.<HTTP_METHOD>(path, [opts,] handler)`            → `fastify_route`
+//                                                             with `route_path` + `http_method`
+//   * `app.register(plugin, [opts])`                        → `fastify_plugin`
+//                                                             on the plugin identifier
+//
+// Out of scope: route-options objects (preHandler, schema, etc.) — they
+// belong on the route node but adding them requires walking the second
+// argument; deferred until a real codebase asks for it.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const FASTIFY_MODULE_SPECIFIERS: ReadonlySet<string> = new Set([
+  'fastify',
+])
+
+const HTTP_METHODS: ReadonlySet<string> = new Set([
+  'get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'all',
+])
+
+export type DetectFastifyFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+interface FastifyBindings {
+  hasFastifyImport: boolean
+  /** Local names that refer to the Fastify factory (default import or
+   *  named import `import { fastify } from 'fastify'`). */
+  factoryNames: Set<string>
+}
+
+export function detectFastifyFramework(ctx: DetectFastifyFrameworkContext): void {
+  const bindings = collectBindings(ctx.sourceFile)
+  if (!bindings.hasFastifyImport || bindings.factoryNames.size === 0) return
+
+  // 1. Find Fastify app bindings: `const app = Fastify()` / `fastify()`.
+  const appNames = new Set<string>()
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      if (!ts.isCallExpression(decl.initializer)) continue
+      const callee = decl.initializer.expression
+      if (!ts.isIdentifier(callee)) continue
+      if (!bindings.factoryNames.has(callee.text)) continue
+      appNames.add(decl.name.text)
+      tagSymbolByName(ctx, decl.name.text, 'fastify_app', null)
+    }
+  }
+  if (appNames.size === 0) return
+
+  // 2. Walk for `<app>.<method>(path, [opts,] handler)` and `<app>.register(plugin, ...)`.
+  const walk = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      appNames.has(node.expression.expression.text)
+    ) {
+      const methodName = node.expression.name.text
+      if (HTTP_METHODS.has(methodName)) {
+        handleRouteCall(ctx, node, methodName)
+      } else if (methodName === 'register') {
+        handlePluginCall(ctx, node)
+      }
+    }
+    ts.forEachChild(node, walk)
+  }
+  walk(ctx.sourceFile)
+}
+
+function handleRouteCall(
+  ctx: DetectFastifyFrameworkContext,
+  call: ts.CallExpression,
+  httpMethod: string,
+): void {
+  // Fastify signature: app.METHOD(path, [opts,] handler). Last arg is
+  // always the handler.
+  const args = call.arguments
+  if (args.length < 2) return
+  const pathArg = args[0]
+  if (!pathArg || !ts.isStringLiteralLike(pathArg)) return
+  const routePath = pathArg.text
+  const handler = args[args.length - 1]
+  if (!handler || !ts.isIdentifier(handler)) return
+  tagSymbolByName(ctx, handler.text, 'fastify_route', {
+    route_path: routePath,
+    http_method: httpMethod.toUpperCase(),
+  })
+}
+
+function handlePluginCall(
+  ctx: DetectFastifyFrameworkContext,
+  call: ts.CallExpression,
+): void {
+  // Fastify signature: app.register(plugin, [opts]). First arg is the
+  // plugin function — tag it. Options' `prefix` field could be a mount
+  // path, but that lives on the plugin's internal routes; not surfaced here.
+  const first = call.arguments[0]
+  if (!first || !ts.isIdentifier(first)) return
+  let prefix: string | null = null
+  const opts = call.arguments[1]
+  if (opts && ts.isObjectLiteralExpression(opts)) {
+    for (const prop of opts.properties) {
+      if (
+        ts.isPropertyAssignment(prop) &&
+        ts.isIdentifier(prop.name) &&
+        prop.name.text === 'prefix' &&
+        ts.isStringLiteralLike(prop.initializer)
+      ) {
+        prefix = prop.initializer.text
+      }
+    }
+  }
+  tagSymbolByName(ctx, first.text, 'fastify_plugin', prefix !== null ? { mount_path: prefix } : null)
+}
+
+function collectBindings(sourceFile: ts.SourceFile): FastifyBindings {
+  const bindings: FastifyBindings = {
+    hasFastifyImport: false,
+    factoryNames: new Set<string>(),
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!FASTIFY_MODULE_SPECIFIERS.has(stmt.moduleSpecifier.text)) continue
+    bindings.hasFastifyImport = true
+    // default import: `import Fastify from 'fastify'`
+    if (stmt.importClause.name) {
+      bindings.factoryNames.add(stmt.importClause.name.text)
+    }
+    // named import: `import { fastify } from 'fastify'`
+    const named = stmt.importClause.namedBindings
+    if (named && ts.isNamedImports(named)) {
+      for (const element of named.elements) {
+        const importedName = element.propertyName?.text ?? element.name.text
+        if (importedName === 'fastify' || importedName === 'default') {
+          bindings.factoryNames.add(element.name.text)
+        }
+      }
+    }
+  }
+  return bindings
+}
+
+function tagSymbolByName(
+  ctx: DetectFastifyFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+  metadata: Record<string, unknown> | null,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      if (metadata && Object.keys(metadata).length > 0) {
+        const merged: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined) merged[key] = value
+        }
+        symbol.framework_metadata = merged
+      }
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/framework-hono.ts
+++ b/src/pipeline/spi/framework-hono.ts
@@ -1,0 +1,185 @@
+// SPI v1 — Hono framework layer (v0.17 #83).
+//
+// Hono is a small, edge-friendly web framework with an Express-like
+// routing API:
+//
+//   import { Hono } from 'hono'
+//   const app = new Hono()
+//   app.get('/users', listUsers)
+//   app.post('/users/:id', updateUser)
+//   app.use('/api/*', authMiddleware)
+//
+// Detection mirrors the Express substrate's first-pass shape:
+//
+//   * `new Hono()` (or sub-router via `new Hono()`) → `hono_app`
+//   * `app.<HTTP_METHOD>(path, ...handlers)`        → `hono_route` on the
+//                                                     last handler with
+//                                                     `route_path`, `http_method`
+//   * `app.use(...)`                                → `hono_middleware`
+//
+// Out of scope for this initial slice:
+//   * `app.route('/prefix', subApp)` mount-prefix propagation (parallels
+//     Express slice 1c-ii.g; can land later if codebases ask for it)
+//   * Inline arrow-function handler synthesis (deferred — Hono usage
+//     overwhelmingly defines handlers as separate functions)
+//   * `c.json(...)` / `c.text(...)` response-shape detection — out of
+//     SPI's structural scope.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const HONO_MODULE_SPECIFIERS: ReadonlySet<string> = new Set([
+  'hono',
+  'hono/quick',
+])
+
+const HTTP_METHODS: ReadonlySet<string> = new Set([
+  'get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'all',
+])
+
+export type DetectHonoFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+interface HonoBindings {
+  /** True iff the file imports anything from `hono`. */
+  hasHonoImport: boolean
+  /** Local names of identifiers imported as `Hono` (class). */
+  honoClassNames: Set<string>
+}
+
+export function detectHonoFramework(ctx: DetectHonoFrameworkContext): void {
+  const bindings = collectBindings(ctx.sourceFile)
+  if (!bindings.hasHonoImport) return
+
+  // 1. Find Hono app bindings: `const app = new Hono()`.
+  const honoAppNames = new Set<string>()
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      if (!ts.isNewExpression(decl.initializer)) continue
+      if (!ts.isIdentifier(decl.initializer.expression)) continue
+      if (!bindings.honoClassNames.has(decl.initializer.expression.text)) continue
+      honoAppNames.add(decl.name.text)
+      tagSymbolByName(ctx, decl.name.text, 'hono_app', null)
+    }
+  }
+  if (honoAppNames.size === 0) return
+
+  // 2. Walk all expression statements for `<app>.<method>(path, ...handlers)`.
+  const walk = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      honoAppNames.has(node.expression.expression.text)
+    ) {
+      const methodName = node.expression.name.text
+      if (HTTP_METHODS.has(methodName)) {
+        handleRouteCall(ctx, node, methodName)
+      } else if (methodName === 'use') {
+        handleMiddlewareCall(ctx, node)
+      }
+    }
+    ts.forEachChild(node, walk)
+  }
+  walk(ctx.sourceFile)
+}
+
+function handleRouteCall(
+  ctx: DetectHonoFrameworkContext,
+  call: ts.CallExpression,
+  httpMethod: string,
+): void {
+  // Hono signature: app.METHOD(path, [middleware...,] handler).
+  // The last argument is the route handler; tag it with route_path +
+  // http_method.
+  const args = call.arguments
+  if (args.length < 2) return
+  const pathArg = args[0]
+  if (!pathArg || !ts.isStringLiteralLike(pathArg)) return
+  const routePath = pathArg.text
+  const handler = args[args.length - 1]
+  if (!handler || !ts.isIdentifier(handler)) return
+  tagSymbolByName(ctx, handler.text, 'hono_route', {
+    route_path: routePath,
+    http_method: httpMethod.toUpperCase(),
+  })
+}
+
+function handleMiddlewareCall(
+  ctx: DetectHonoFrameworkContext,
+  call: ts.CallExpression,
+): void {
+  // Hono signature: app.use([path], ...middleware). Path is optional.
+  const args = call.arguments
+  if (args.length === 0) return
+  const first = args[0]
+  if (!first) return
+  let mountPath: string | null = null
+  let firstHandlerIndex = 0
+  if (ts.isStringLiteralLike(first)) {
+    mountPath = first.text
+    firstHandlerIndex = 1
+  }
+  for (let i = firstHandlerIndex; i < args.length; i += 1) {
+    const handler = args[i]
+    if (handler && ts.isIdentifier(handler)) {
+      tagSymbolByName(
+        ctx,
+        handler.text,
+        'hono_middleware',
+        mountPath !== null ? { mount_path: mountPath } : null,
+      )
+    }
+  }
+}
+
+function collectBindings(sourceFile: ts.SourceFile): HonoBindings {
+  const bindings: HonoBindings = {
+    hasHonoImport: false,
+    honoClassNames: new Set<string>(),
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!HONO_MODULE_SPECIFIERS.has(stmt.moduleSpecifier.text)) continue
+    bindings.hasHonoImport = true
+    const named = stmt.importClause.namedBindings
+    if (!named || !ts.isNamedImports(named)) continue
+    for (const element of named.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      if (importedName === 'Hono') {
+        bindings.honoClassNames.add(element.name.text)
+      }
+    }
+  }
+  return bindings
+}
+
+function tagSymbolByName(
+  ctx: DetectHonoFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+  metadata: Record<string, unknown> | null,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      if (metadata && Object.keys(metadata).length > 0) {
+        const merged: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined) merged[key] = value
+        }
+        symbol.framework_metadata = merged
+      }
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/framework-prisma.ts
+++ b/src/pipeline/spi/framework-prisma.ts
@@ -1,0 +1,104 @@
+// SPI v1 — Prisma framework layer (v0.17 #83).
+//
+// Prisma's main schema lives in `schema.prisma` (a Prisma-specific DSL),
+// not TypeScript. The TypeScript surface is the generated client:
+//
+//   import { PrismaClient } from '@prisma/client'
+//   const prisma = new PrismaClient()
+//   await prisma.user.findMany()      // model access pattern
+//   await prisma.user.create({...})
+//
+// Detection scope (intentionally narrow for this initial slice):
+//
+//   * `new PrismaClient()` instantiation → variable tagged `prisma_client`
+//
+// Out of scope (deferred):
+//   * Model-access tagging (`prisma.user.findMany`) — would require
+//     visiting every property-access chain in the workspace; substantial
+//     and noisy. Would need careful per-symbol attribution.
+//   * schema.prisma parsing — Prisma DSL isn't TypeScript; a real schema
+//     substrate is its own slice train.
+//   * Custom-named client imports / re-exports — covered for the most
+//     common `import { PrismaClient } from '@prisma/client'` pattern.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const PRISMA_MODULE_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@prisma/client',
+])
+
+export type DetectPrismaFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+}
+
+interface PrismaBindings {
+  hasPrismaImport: boolean
+  /** Local names that refer to PrismaClient class. */
+  prismaClassNames: Set<string>
+}
+
+export function detectPrismaFramework(ctx: DetectPrismaFrameworkContext): void {
+  const bindings = collectBindings(ctx.sourceFile)
+  if (!bindings.hasPrismaImport || bindings.prismaClassNames.size === 0) return
+
+  // Find `const prisma = new PrismaClient()` patterns and tag the binding.
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      if (!ts.isNewExpression(decl.initializer)) continue
+      if (!ts.isIdentifier(decl.initializer.expression)) continue
+      if (!bindings.prismaClassNames.has(decl.initializer.expression.text)) continue
+      tagSymbolByName(ctx, decl.name.text, 'prisma_client', null)
+    }
+  }
+}
+
+function collectBindings(sourceFile: ts.SourceFile): PrismaBindings {
+  const bindings: PrismaBindings = {
+    hasPrismaImport: false,
+    prismaClassNames: new Set<string>(),
+  }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!PRISMA_MODULE_SPECIFIERS.has(stmt.moduleSpecifier.text)) continue
+    bindings.hasPrismaImport = true
+    const named = stmt.importClause.namedBindings
+    if (!named || !ts.isNamedImports(named)) continue
+    for (const element of named.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      if (importedName === 'PrismaClient') {
+        bindings.prismaClassNames.add(element.name.text)
+      }
+    }
+  }
+  return bindings
+}
+
+function tagSymbolByName(
+  ctx: DetectPrismaFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+  metadata: Record<string, unknown> | null,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      if (metadata && Object.keys(metadata).length > 0) {
+        const merged: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined) merged[key] = value
+        }
+        symbol.framework_metadata = merged
+      }
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/framework-trpc.ts
+++ b/src/pipeline/spi/framework-trpc.ts
@@ -1,0 +1,208 @@
+// SPI v1 — tRPC framework layer (v0.17 #83).
+//
+// tRPC builds typed RPC routers from a builder instance:
+//
+//   import { initTRPC } from '@trpc/server'
+//   const t = initTRPC.create()
+//   export const appRouter = t.router({
+//     getUser: t.procedure.input(z.string()).query(({ input }) => ...),
+//     createUser: t.procedure.input(schema).mutation(({ input }) => ...),
+//     onMessage: t.procedure.subscription(() => ...),
+//   })
+//
+// The substrate captures three structural facts:
+//
+//   * `t.router({...})` factory call result → `trpc_router` (variable holding it)
+//   * Object-literal entries inside the router whose value chain ends in
+//     `.query(...)`, `.mutation(...)`, or `.subscription(...)`
+//     are tagged with `trpc_procedure_query/mutation/subscription` and
+//     get `procedure_name` on framework_metadata.
+//
+// Since procedures live as object-literal entries (not standalone
+// variables), the detector synthesises SpiSymbol entries when the
+// procedure has a property-name identifier — mirroring slice 1c-ii.e's
+// inline-handler synthesis for Express. If the file already has a
+// same-named top-level symbol, the existing symbol is tagged in place.
+//
+// Out of scope:
+//   * `mergeRouters({...})` composition — secondary; same pattern as
+//     factory call.
+//   * Procedure input/output type analysis (`.input(schema)`,
+//     `.output(schema)`) — would require the type checker; deferred.
+//   * Subroutes (nested router objects) — punted to a follow-up slice.
+
+import ts from 'typescript'
+
+import type { SpiFrameworkRole, SpiSymbol } from './types.js'
+
+const TRPC_MODULE_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@trpc/server',
+  '@trpc/server/adapters',
+  '@trpc/client',
+])
+
+const PROCEDURE_METHOD_TO_ROLE: ReadonlyMap<string, SpiFrameworkRole> = new Map([
+  ['query', 'trpc_procedure_query'],
+  ['mutation', 'trpc_procedure_mutation'],
+  ['subscription', 'trpc_procedure_subscription'],
+])
+
+export type DetectTrpcFrameworkContext = {
+  sourceFile: ts.SourceFile
+  fileId: string
+  symbolsByFile: Map<string, SpiSymbol[]>
+  /** Global symbols array — synthesized procedure symbols must be
+   *  pushed here too so they appear in spi.symbols, not just in the
+   *  per-file lookup map. */
+  symbols: SpiSymbol[]
+}
+
+interface TrpcBindings {
+  hasTrpcImport: boolean
+}
+
+export function detectTrpcFramework(ctx: DetectTrpcFrameworkContext): void {
+  const bindings = collectBindings(ctx.sourceFile)
+  if (!bindings.hasTrpcImport) return
+
+  // Walk top-level variable declarations. For each, check if the
+  // initializer is a `<builder>.router({...})` call — if so, tag the
+  // variable as `trpc_router` and walk the object literal for procedures.
+  for (const stmt of ctx.sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue
+      const routerArg = extractRouterCall(decl.initializer)
+      if (!routerArg) continue
+      tagSymbolByName(ctx, decl.name.text, 'trpc_router', null)
+      walkProcedures(ctx, routerArg, decl.name.text)
+    }
+  }
+}
+
+/** Returns the first-argument object literal if expr is `X.router({...})`. */
+function extractRouterCall(expr: ts.Expression): ts.ObjectLiteralExpression | null {
+  if (!ts.isCallExpression(expr)) return null
+  if (!ts.isPropertyAccessExpression(expr.expression)) return null
+  if (expr.expression.name.text !== 'router') return null
+  const arg = expr.arguments[0]
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return null
+  return arg
+}
+
+/** Walk an object literal looking for `<key>: <chain>.query/mutation/subscription(...)` */
+function walkProcedures(
+  ctx: DetectTrpcFrameworkContext,
+  obj: ts.ObjectLiteralExpression,
+  routerName: string,
+): void {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    const key = readPropertyKey(prop.name)
+    if (!key) continue
+    const role = procedureRole(prop.initializer)
+    if (!role) continue
+    // Procedures don't exist as top-level SpiSymbols, so synthesize a
+    // dedicated entry — same pattern Express slice 1c-ii.e used for
+    // inline arrow-function handlers.
+    synthesizeProcedureSymbol(ctx, key, role, routerName, prop)
+  }
+}
+
+/** Returns the matching role iff the expression chain ends in
+ *  `.query(...)`, `.mutation(...)`, or `.subscription(...)`. */
+function procedureRole(expr: ts.Expression): SpiFrameworkRole | null {
+  if (!ts.isCallExpression(expr)) return null
+  const callee = expr.expression
+  if (!ts.isPropertyAccessExpression(callee)) return null
+  return PROCEDURE_METHOD_TO_ROLE.get(callee.name.text) ?? null
+}
+
+function synthesizeProcedureSymbol(
+  ctx: DetectTrpcFrameworkContext,
+  procedureName: string,
+  role: SpiFrameworkRole,
+  routerName: string,
+  prop: ts.PropertyAssignment,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+
+  // If a top-level symbol with the same name already exists, tag it in
+  // place. Otherwise synthesize a new entry.
+  const existing = symbols.find((s) => s.name === procedureName && s.framework_role === undefined)
+  if (existing) {
+    existing.framework_role = role
+    existing.framework_metadata = {
+      ...(existing.framework_metadata ?? {}),
+      procedure_name: procedureName,
+      router_name: routerName,
+    }
+    return
+  }
+
+  // Synthesize. Range from the property assignment's location.
+  const sourceFile = prop.getSourceFile()
+  const start = sourceFile.getLineAndCharacterOfPosition(prop.getStart(sourceFile))
+  const end = sourceFile.getLineAndCharacterOfPosition(prop.getEnd())
+  const synthetic: SpiSymbol = {
+    id: `symbol:${ctx.fileId}/function/${routerName}.${procedureName}.L${start.line + 1}`,
+    file_id: ctx.fileId,
+    name: `${routerName}.${procedureName}`,
+    kind: 'function',
+    range: {
+      start: { line: start.line + 1, column: start.character + 1 },
+      end: { line: end.line + 1, column: end.character + 1 },
+    },
+    exported: false,
+    framework_role: role,
+    framework_metadata: {
+      procedure_name: procedureName,
+      router_name: routerName,
+    },
+  }
+  symbols.push(synthetic)
+  // Also push to the global symbols array so the synthesized symbol
+  // appears in spi.symbols, not just the per-file lookup map.
+  ctx.symbols.push(synthetic)
+}
+
+function readPropertyKey(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name)) return name.text
+  if (ts.isStringLiteralLike(name)) return name.text
+  return null
+}
+
+function collectBindings(sourceFile: ts.SourceFile): TrpcBindings {
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (TRPC_MODULE_SPECIFIERS.has(stmt.moduleSpecifier.text)) {
+      return { hasTrpcImport: true }
+    }
+  }
+  return { hasTrpcImport: false }
+}
+
+function tagSymbolByName(
+  ctx: DetectTrpcFrameworkContext,
+  name: string,
+  role: SpiFrameworkRole,
+  metadata: Record<string, unknown> | null,
+): void {
+  const symbols = ctx.symbolsByFile.get(ctx.fileId)
+  if (!symbols) return
+  for (const symbol of symbols) {
+    if (symbol.name === name && symbol.framework_role === undefined) {
+      symbol.framework_role = role
+      if (metadata && Object.keys(metadata).length > 0) {
+        const merged: Record<string, unknown> = { ...(symbol.framework_metadata ?? {}) }
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined) merged[key] = value
+        }
+        symbol.framework_metadata = merged
+      }
+      return
+    }
+  }
+}

--- a/src/pipeline/spi/index.ts
+++ b/src/pipeline/spi/index.ts
@@ -95,3 +95,23 @@ export {
   detectReduxFramework,
   type DetectReduxFrameworkContext,
 } from './framework-redux.js'
+
+export {
+  detectHonoFramework,
+  type DetectHonoFrameworkContext,
+} from './framework-hono.js'
+
+export {
+  detectFastifyFramework,
+  type DetectFastifyFrameworkContext,
+} from './framework-fastify.js'
+
+export {
+  detectTrpcFramework,
+  type DetectTrpcFrameworkContext,
+} from './framework-trpc.js'
+
+export {
+  detectPrismaFramework,
+  type DetectPrismaFrameworkContext,
+} from './framework-prisma.js'

--- a/src/pipeline/spi/projector.ts
+++ b/src/pipeline/spi/projector.ts
@@ -249,6 +249,10 @@ function frameworkForRole(role: NonNullable<SpiSymbol['framework_role']>): strin
   if (role.startsWith('nextjs_')) return 'nextjs'
   if (role.startsWith('react_router_')) return 'react-router'
   if (role.startsWith('redux_')) return 'redux'
+  if (role.startsWith('hono_')) return 'hono'
+  if (role.startsWith('fastify_')) return 'fastify'
+  if (role.startsWith('trpc_')) return 'trpc'
+  if (role.startsWith('prisma_')) return 'prisma'
   return 'unknown'
 }
 
@@ -258,9 +262,27 @@ function nodeKindForRole(role: NonNullable<SpiSymbol['framework_role']>): NonNul
     case 'express_route':
     case 'nextjs_app_route':
     case 'nextjs_pages_api':
+    case 'hono_route':
+    case 'fastify_route':
       return 'route'
     case 'express_router':
       return 'router'
+    case 'hono_app':
+    case 'fastify_app':
+      return 'class'
+    case 'hono_middleware':
+    case 'fastify_plugin':
+      return 'function'
+    case 'trpc_router':
+      return 'router'
+    case 'trpc_procedure_query':
+    case 'trpc_procedure_mutation':
+    case 'trpc_procedure_subscription':
+      return 'route'
+    case 'prisma_client':
+      return 'class'
+    case 'prisma_model_access':
+      return 'function'
     case 'nest_controller':
     case 'nest_module':
     case 'nest_provider':

--- a/src/pipeline/spi/types.ts
+++ b/src/pipeline/spi/types.ts
@@ -98,6 +98,22 @@ export type SpiFrameworkRole =
   | 'redux_selector'
   | 'redux_async_thunk'
   | 'redux_rtk_query_api'
+  // Hono roles (v0.17 #83)
+  | 'hono_app'
+  | 'hono_route'
+  | 'hono_middleware'
+  // Fastify roles (v0.17 #83)
+  | 'fastify_app'
+  | 'fastify_route'
+  | 'fastify_plugin'
+  // tRPC roles (v0.17 #83)
+  | 'trpc_router'
+  | 'trpc_procedure_query'
+  | 'trpc_procedure_mutation'
+  | 'trpc_procedure_subscription'
+  // Prisma roles (v0.17 #83)
+  | 'prisma_client'
+  | 'prisma_model_access'
 
 export type SpiSymbol = {
   id: string

--- a/tests/unit/spi-framework-v0-17.test.ts
+++ b/tests/unit/spi-framework-v0-17.test.ts
@@ -1,0 +1,246 @@
+// v0.17 framework substrates (#83) — Hono, Fastify, tRPC, Prisma.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSpi } from '../../src/pipeline/spi/build.js'
+import type { SemanticProgramIndex, SpiSymbol } from '../../src/pipeline/spi/types.js'
+
+const FROZEN_NOW = () => new Date('2026-05-11T12:34:56.000Z')
+
+function mkSandbox(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function writeFile(root: string, rel: string, content: string): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+function build(root: string): SemanticProgramIndex {
+  return buildSpi({
+    root,
+    graphifyVersion: 'test-0.0.0',
+    extractorVersion: 'spi-v1.0.0-v0.17',
+    now: FROZEN_NOW,
+  })
+}
+
+function findSymbol(spi: SemanticProgramIndex, path: string, name: string): SpiSymbol | undefined {
+  const file = spi.files.find((f) => f.path === path)
+  if (!file) return undefined
+  return spi.symbols.find((s) => s.file_id === file.id && s.name === name)
+}
+
+describe('Hono substrate (v0.17 #83)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-hono-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('tags `new Hono()` results as hono_app', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import { Hono } from "hono"',
+      'export const app = new Hono()',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const app = findSymbol(spi, 'src/server.ts', 'app')
+    expect(app?.framework_role).toBe('hono_app')
+  })
+
+  it('tags app.get/post/etc. handlers with route_path + http_method', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import { Hono } from "hono"',
+      'export const app = new Hono()',
+      'export function listUsers(): void {}',
+      'export function getUser(): void {}',
+      'app.get("/users", listUsers)',
+      'app.get("/users/:id", getUser)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const list = findSymbol(spi, 'src/server.ts', 'listUsers')
+    expect(list?.framework_role).toBe('hono_route')
+    expect(list?.framework_metadata?.route_path).toBe('/users')
+    expect(list?.framework_metadata?.http_method).toBe('GET')
+    const get = findSymbol(spi, 'src/server.ts', 'getUser')
+    expect(get?.framework_metadata?.route_path).toBe('/users/:id')
+  })
+
+  it('tags app.use(...) middleware with mount_path when provided', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import { Hono } from "hono"',
+      'export const app = new Hono()',
+      'export function authMiddleware(): void {}',
+      'app.use("/api/*", authMiddleware)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const mw = findSymbol(spi, 'src/server.ts', 'authMiddleware')
+    expect(mw?.framework_role).toBe('hono_middleware')
+    expect(mw?.framework_metadata?.mount_path).toBe('/api/*')
+  })
+
+  it('ignores files that do not import hono', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'class Hono { get(_p: string, _h: () => void): void {} }',
+      'export const app = new Hono()',
+      'app.get("/users", () => {})',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const app = findSymbol(spi, 'src/server.ts', 'app')
+    expect(app?.framework_role).toBeUndefined()
+  })
+})
+
+describe('Fastify substrate (v0.17 #83)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-fastify-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('tags Fastify() factory result as fastify_app', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import Fastify from "fastify"',
+      'export const app = Fastify()',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const app = findSymbol(spi, 'src/server.ts', 'app')
+    expect(app?.framework_role).toBe('fastify_app')
+  })
+
+  it('tags app.get/post/etc. with route_path + http_method', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import Fastify from "fastify"',
+      'export const app = Fastify()',
+      'export function listUsers(): void {}',
+      'app.get("/users", listUsers)',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const list = findSymbol(spi, 'src/server.ts', 'listUsers')
+    expect(list?.framework_role).toBe('fastify_route')
+    expect(list?.framework_metadata?.route_path).toBe('/users')
+    expect(list?.framework_metadata?.http_method).toBe('GET')
+  })
+
+  it('tags app.register(plugin, { prefix }) with mount_path', () => {
+    writeFile(sandbox, 'src/server.ts', [
+      'import Fastify from "fastify"',
+      'export const app = Fastify()',
+      'export function authPlugin(): void {}',
+      'app.register(authPlugin, { prefix: "/api" })',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const plugin = findSymbol(spi, 'src/server.ts', 'authPlugin')
+    expect(plugin?.framework_role).toBe('fastify_plugin')
+    expect(plugin?.framework_metadata?.mount_path).toBe('/api')
+  })
+})
+
+describe('tRPC substrate (v0.17 #83)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-trpc-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('tags t.router({...}) result as trpc_router and synthesizes procedure entries', () => {
+    writeFile(sandbox, 'src/router.ts', [
+      'import { initTRPC } from "@trpc/server"',
+      'declare const t: ReturnType<typeof initTRPC.create>',
+      'export const appRouter = t.router({',
+      '  getUser: t.procedure.query(() => null),',
+      '  createUser: t.procedure.mutation(() => null),',
+      '  onMessage: t.procedure.subscription(() => null),',
+      '})',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const router = findSymbol(spi, 'src/router.ts', 'appRouter')
+    expect(router?.framework_role).toBe('trpc_router')
+
+    // Procedures are synthesized as `<routerName>.<procedureName>`.
+    const getUser = findSymbol(spi, 'src/router.ts', 'appRouter.getUser')
+    expect(getUser?.framework_role).toBe('trpc_procedure_query')
+    expect(getUser?.framework_metadata?.procedure_name).toBe('getUser')
+
+    const createUser = findSymbol(spi, 'src/router.ts', 'appRouter.createUser')
+    expect(createUser?.framework_role).toBe('trpc_procedure_mutation')
+
+    const onMessage = findSymbol(spi, 'src/router.ts', 'appRouter.onMessage')
+    expect(onMessage?.framework_role).toBe('trpc_procedure_subscription')
+  })
+
+  it('ignores files that do not import @trpc/server', () => {
+    writeFile(sandbox, 'src/router.ts', [
+      'declare const t: any',
+      'export const appRouter = t.router({ x: t.procedure.query(() => null) })',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const router = findSymbol(spi, 'src/router.ts', 'appRouter')
+    expect(router?.framework_role).toBeUndefined()
+  })
+})
+
+describe('Prisma substrate (v0.17 #83)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-prisma-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('tags new PrismaClient() result as prisma_client', () => {
+    writeFile(sandbox, 'src/db.ts', [
+      'import { PrismaClient } from "@prisma/client"',
+      'export const prisma = new PrismaClient()',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const client = findSymbol(spi, 'src/db.ts', 'prisma')
+    expect(client?.framework_role).toBe('prisma_client')
+  })
+
+  it('ignores files that do not import from @prisma/client', () => {
+    writeFile(sandbox, 'src/db.ts', [
+      'class PrismaClient {}',
+      'export const prisma = new PrismaClient()',
+    ].join('\n') + '\n')
+    const spi = build(sandbox)
+    const client = findSymbol(spi, 'src/db.ts', 'prisma')
+    expect(client?.framework_role).toBeUndefined()
+  })
+})
+
+describe('Multi-framework workspace (v0.17 parity)', () => {
+  let sandbox: string
+  beforeEach(() => { sandbox = mkSandbox('spi-v017-multi-') })
+  afterEach(() => { rmSync(sandbox, { recursive: true, force: true }) })
+
+  it('a workspace combining Hono + Fastify + tRPC + Prisma tags each correctly', () => {
+    writeFile(sandbox, 'src/hono-app.ts', [
+      'import { Hono } from "hono"',
+      'export const honoApp = new Hono()',
+      'export function honoPing(): void {}',
+      'honoApp.get("/ping", honoPing)',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'src/fastify-app.ts', [
+      'import Fastify from "fastify"',
+      'export const fastifyApp = Fastify()',
+      'export function fastifyHealth(): void {}',
+      'fastifyApp.get("/health", fastifyHealth)',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'src/trpc.ts', [
+      'import { initTRPC } from "@trpc/server"',
+      'declare const t: ReturnType<typeof initTRPC.create>',
+      'export const appRouter = t.router({ ping: t.procedure.query(() => null) })',
+    ].join('\n') + '\n')
+    writeFile(sandbox, 'src/db.ts', [
+      'import { PrismaClient } from "@prisma/client"',
+      'export const prisma = new PrismaClient()',
+    ].join('\n') + '\n')
+
+    const spi = build(sandbox)
+
+    expect(findSymbol(spi, 'src/hono-app.ts', 'honoApp')?.framework_role).toBe('hono_app')
+    expect(findSymbol(spi, 'src/hono-app.ts', 'honoPing')?.framework_role).toBe('hono_route')
+    expect(findSymbol(spi, 'src/fastify-app.ts', 'fastifyApp')?.framework_role).toBe('fastify_app')
+    expect(findSymbol(spi, 'src/fastify-app.ts', 'fastifyHealth')?.framework_role).toBe('fastify_route')
+    expect(findSymbol(spi, 'src/trpc.ts', 'appRouter')?.framework_role).toBe('trpc_router')
+    expect(findSymbol(spi, 'src/trpc.ts', 'appRouter.ping')?.framework_role).toBe('trpc_procedure_query')
+    expect(findSymbol(spi, 'src/db.ts', 'prisma')?.framework_role).toBe('prisma_client')
+  })
+})


### PR DESCRIPTION
Closes #83

## Summary

Closes out v0.17-language-expansion's TypeScript framework half in one bundled PR. Four new framework detectors added to the SPI substrate, following the same pattern as Express / NestJS / Next.js / React Router / Redux from v0.14.

**#84 (deeper Python/Go semantic passes) is deferred** — each language needs its own substrate runtime (tree-sitter is what we have today; deeper passes mean per-language type-checkers or LSPs). That's a multi-PR effort and doesn't fit a single-shot bundle alongside TypeScript framework work.

## What's in the bundle

### Hono substrate (`framework-hono.ts`)
- `new Hono()` → `hono_app`
- `app.<METHOD>(path, handler)` → `hono_route` with `route_path` + `http_method`
- `app.use([path], middleware)` → `hono_middleware` with optional `mount_path`

### Fastify substrate (`framework-fastify.ts`)
- `Fastify()` / `fastify()` (default + named factory imports) → `fastify_app`
- `app.<METHOD>(path, [opts,] handler)` → `fastify_route` with `route_path` + `http_method`
- `app.register(plugin, { prefix })` → `fastify_plugin` with optional `mount_path`

### tRPC substrate (`framework-trpc.ts`)
- `<builder>.router({...})` → `trpc_router` on receiving variable
- Object-literal entries with `.query` / `.mutation` / `.subscription` value chains get **synthesized** SpiSymbol entries (`<routerName>.<procedureName>`) with `trpc_procedure_query` / `trpc_procedure_mutation` / `trpc_procedure_subscription` + `procedure_name` + `router_name` on `framework_metadata`. Mirrors the Express inline-handler synthesis pattern from slice 1c-ii.e.

### Prisma substrate (`framework-prisma.ts`)
- `new PrismaClient()` → `prisma_client`
- `schema.prisma` parsing + model-access tagging (`prisma.user.findMany`) deferred — they're substantial enough to warrant their own slice trains.

## Wiring

- 11 new `SpiFrameworkRole` entries (`hono_*`, `fastify_*`, `trpc_*`, `prisma_*`)
- `build.ts` orchestrator now runs all 4 detectors after the existing 5
- `projector.ts` maps the new roles to `framework` (hono / fastify / trpc / prisma) and `node_kind` (route / class / function / router)
- `index.ts` re-exports all 4 detectors + context types

## Out of scope (deferred)

- **#84** Deeper Python / Go semantic passes — each language needs its own runtime
- Hono `app.route('/prefix', subApp)` mount-prefix propagation
- tRPC `mergeRouters`, nested routers, `.input()` / `.output()` type analysis
- Prisma `schema.prisma` parsing + model-access tagging
- The current detectors handle the most common idiomatic shapes; deeper coverage lands when real codebases ask for it.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1805/1805 pass (108 files, +12 new tests covering per-framework happy paths, negative cases, and a 4-way multi-framework parity workspace)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection and analysis support for Hono, Fastify, tRPC, and Prisma frameworks
  * Enhanced semantic code indexing to recognize routes, middleware, database connections, and API procedures across these frameworks

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->