### PR TITLE
chore(release): v0.17.0 — framework breadth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-11
+
+### Added
+
+- **Hono framework substrate (#83)**: detects `new Hono()` apps, http-method route registrations (`app.get` / `.post` / etc.) with `route_path` + `http_method` metadata, and `app.use([path], middleware)` registrations with optional `mount_path`. New SpiFrameworkRole values: `hono_app`, `hono_route`, `hono_middleware`.
+- **Fastify framework substrate (#83)**: detects `Fastify()` / `fastify()` factory calls (default and named imports) → `fastify_app`, `app.<method>(path, [opts,] handler)` → `fastify_route` with `route_path` + `http_method`, and `app.register(plugin, { prefix })` → `fastify_plugin` with optional `mount_path`.
+- **tRPC framework substrate (#83)**: detects `<builder>.router({...})` calls → `trpc_router`, and **synthesizes** procedure SpiSymbol entries (`<routerName>.<procedureName>`) for object-literal properties whose value chains end in `.query` / `.mutation` / `.subscription`, with `procedure_name` + `router_name` on framework_metadata. Synthesis mirrors the Express inline-handler pattern from slice 1c-ii.e since tRPC procedures don't have top-level SpiSymbols by default.
+- **Prisma framework substrate (#83)**: detects `new PrismaClient()` bindings → `prisma_client`. Schema.prisma parsing and model-access tagging (`prisma.user.findMany`) intentionally deferred — they're substantial slice trains in their own right.
+
+### Notes
+
+- v0.17.0 is the **framework-breadth** release: four new TypeScript framework detectors slot cleanly into the existing SPI substrate, bringing total framework coverage to nine (NestJS, Express, Next.js, React Router, Redux Toolkit, Hono, Fastify, tRPC, Prisma).
+- #84 (deeper Python / Go semantic passes) deferred — each language needs its own runtime substrate beyond tree-sitter AST, multi-PR effort. Tree-sitter coverage for Python / Go / Ruby / Java / Rust remains shipped as today.
+
 ## [0.16.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ We measure and publish honest numbers, including the trade-offs. Smaller context
 Implemented today:
 
 - ✅ Local graph build for TS/JS/Python/Ruby/Go/Java/Rust + framework-aware TS/JS
-- ✅ Semantic Program Index (SPI) v1 — TypeScript type-checker-backed substrate with NestJS / Express / Next.js / React Router / Redux Toolkit framework metadata (`route_path`, slice/store keys, RTK Query endpoints, mount-prefix resolution)
+- ✅ Semantic Program Index (SPI) v1 — TypeScript type-checker-backed substrate with NestJS / Express / Next.js / React Router / Redux Toolkit / **Hono / Fastify / tRPC / Prisma** framework metadata (`route_path`, slice/store keys, RTK Query endpoints, mount-prefix resolution, tRPC procedure synthesis)
 - ✅ MCP server with core (6 tools) and full (25 tools) profiles
 - ✅ `pr_impact` + `review-compare` for diff-aware PR review
 - ✅ Provider-aware prompt compiler (`prompt`) with Claude cache-reuse semantics
@@ -272,7 +272,6 @@ Implemented today:
 
 Planned:
 
-- 🔜 More framework-aware passes (Prisma, tRPC, Hono, Fastify)
 - 🔜 Deeper Python / Go semantic passes beyond tree-sitter AST
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

Cuts the v0.17.0 release covering the four new TypeScript framework substrates from PR #125.

- Bumps `package.json` from `0.16.0` → `0.17.0`
- Adds the `[0.17.0]` entry to `CHANGELOG.md`
- README: Prisma / tRPC / Hono / Fastify removed from Planned; SPI v1 line lists them as supported framework substrates

## What's in v0.17.0

**Hono** — apps, http-method route registrations with `route_path` + `http_method`, middleware with `mount_path`
**Fastify** — factory-call apps, http-method routes, plugin registrations with `prefix` mount_path
**tRPC** — `<builder>.router({...})` results + synthesized procedure entries (query / mutation / subscription)
**Prisma** — `new PrismaClient()` bindings (schema.prisma parsing + model-access deferred)

Total framework coverage: **9 substrates** (NestJS, Express, Next.js, React Router, Redux Toolkit, Hono, Fastify, tRPC, Prisma).

## What's NOT in this release

- **#84** Deeper Python / Go semantic passes — each language needs its own substrate runtime beyond tree-sitter AST. Multi-PR effort.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1805/1805 pass (108 files)
- [x] CHANGELOG and README updated
- [ ] After merge: tag `v0.17.0` and `npm publish` (you handle publish per pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended framework detection support for Hono, Fastify, tRPC, and Prisma in TypeScript projects.

* **Chores**
  * Version bumped to 0.17.0.
  * Updated changelog and roadmap documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->