### PR TITLE
chore(release): v0.18.0 — CLI integration of SPI substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
-- **`graphify-ts generate --spi`** opt-in flag wires the v0.14–v0.17 SPI substrate into the CLI for the first time. When set, `generateGraph` uses `buildSpiCached` + `projectSpiToExtraction` instead of the legacy `extract()` pipeline. Default behavior is unchanged — pass `--spi` to enable. User-visible wins:
+- **`graphify-ts generate . --spi`** opt-in flag wires the v0.14–v0.17 SPI substrate into the CLI for the first time. When set, `generateGraph` uses `buildSpiCached` + `projectSpiToExtraction` instead of the legacy `extract()` pipeline. Default behavior is unchanged — pass `--spi` to enable. User-visible wins:
   - `framework_role` + `framework_metadata` from all 9 framework substrates (NestJS, Express, Next.js, React Router, Redux Toolkit, Hono, Fastify, tRPC, Prisma) flow into the projected `ExtractionData`.
   - Repeat builds on an unchanged workspace hit the on-disk SPI cache (`graphify-out/.spi-cache/`, see #77) — near-zero rebuild time.
   - Build notes include `"SPI cache hit (N files, key XXXXXXXX)"` or `"SPI build via projector (reason=...)"` so users can see which path ran.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-11
+
+### Added
+
+- **`graphify-ts generate --spi`** opt-in flag wires the v0.14–v0.17 SPI substrate into the CLI for the first time. When set, `generateGraph` uses `buildSpiCached` + `projectSpiToExtraction` instead of the legacy `extract()` pipeline. Default behavior is unchanged — pass `--spi` to enable. User-visible wins:
+  - `framework_role` + `framework_metadata` from all 9 framework substrates (NestJS, Express, Next.js, React Router, Redux Toolkit, Hono, Fastify, tRPC, Prisma) flow into the projected `ExtractionData`.
+  - Repeat builds on an unchanged workspace hit the on-disk SPI cache (`graphify-out/.spi-cache/`, see #77) — near-zero rebuild time.
+  - Build notes include `"SPI cache hit (N files, key XXXXXXXX)"` or `"SPI build via projector (reason=...)"` so users can see which path ran.
+
+### Notes
+
+- v0.18 is the **CLI-integration** release: the substrate work from v0.14–v0.17 is now actually reachable from `graphify-ts generate` without writing library code.
+- The default pipeline stays on legacy `extract()` for safety — the SPI parity tests pin shape parity but not strict byte-equivalence. A future release can flip the default once `--spi` has been validated against real workspaces.
+
 ## [0.17.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ We measure and publish honest numbers, including the trade-offs. Smaller context
 Implemented today:
 
 - ✅ Local graph build for TS/JS/Python/Ruby/Go/Java/Rust + framework-aware TS/JS
-- ✅ Semantic Program Index (SPI) v1 — TypeScript type-checker-backed substrate with NestJS / Express / Next.js / React Router / Redux Toolkit / **Hono / Fastify / tRPC / Prisma** framework metadata (`route_path`, slice/store keys, RTK Query endpoints, mount-prefix resolution, tRPC procedure synthesis)
+- ✅ Semantic Program Index (SPI) v1 — TypeScript type-checker-backed substrate with NestJS / Express / Next.js / React Router / Redux Toolkit / **Hono / Fastify / tRPC / Prisma** framework metadata (`route_path`, slice/store keys, RTK Query endpoints, mount-prefix resolution, tRPC procedure synthesis). Opt in via `graphify-ts generate --spi` to ship framework metadata in `graph.json` and use the SPI disk cache.
 - ✅ MCP server with core (6 tools) and full (25 tools) profiles
 - ✅ `pr_impact` + `review-compare` for diff-aware PR review
 - ✅ Provider-aware prompt compiler (`prompt`) with Claude cache-reuse semantics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

Cuts the v0.18.0 release covering the `--spi` flag wiring from PR #127.

- Bumps `package.json` from `0.17.0` → `0.18.0`
- Adds the `[0.18.0]` entry to `CHANGELOG.md`
- README: SPI line updated to point to `--spi`

## What's in v0.18.0

**Opt-in SPI pipeline via `--spi` flag on `graphify-ts generate`:**
```bash
graphify-ts generate . --spi
```
- Uses `buildSpiCached` + `projectSpiToExtraction` instead of legacy `extract()`
- `framework_role` + `framework_metadata` from all 9 framework substrates flow into `graph.json`
- Repeat builds hit the on-disk SPI cache (`graphify-out/.spi-cache/`)
- Notes report which path ran (cache hit vs. fresh build)

Default unchanged for safety — legacy `extract()` is still the default pipeline.

## What this makes possible

For the first time, users can actually **see** the v0.14–v0.17 work in their `graph.json`:
- NestJS / Express / Next.js / React Router / Redux Toolkit / Hono / Fastify / tRPC / Prisma metadata
- `route_path`, `http_method`, `mount_path`, `slice_name`, `reducer_keys`, `procedure_name`, etc.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1812/1812 pass (109 files)
- [x] CHANGELOG and README updated
- [ ] After merge: tag `v0.18.0` and `npm publish` (you handle publish per pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in CLI flag to route generation through the SPI pathway.
  * Framework metadata now flows into generated output.
  * Reuse of an on-disk SPI cache for faster repeat builds with build-status indicators.

* **Chores**
  * Version bumped to 0.18.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/128)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->