### PR TITLE
feat(v0.20): value-per-token selection (#131) + signature resolution (#132) + SPI default-readiness criteria (#134)

### DIFF
--- a/docs/decisions/2026-05-11-spi-default-readiness.md
+++ b/docs/decisions/2026-05-11-spi-default-readiness.md
@@ -1,0 +1,97 @@
+# SPI default-readiness criteria + legacy-extractor fallback plan
+
+> **Tracking issue:** [#134](https://github.com/mohanagy/graphify-ts/issues/134).
+> **Status:** decision framework — codified, not yet acted on.
+
+## What this document is
+
+A concrete, measurable contract for when `graphify-ts generate --spi` graduates from an opt-in flag (today's state, v0.18+) to the default pipeline, and what fallback escape hatch remains after the flip.
+
+This is **not** a code change. It's the criteria the next code change (the default flip itself) has to meet.
+
+## Current state (v0.19 reference)
+
+- `graphify-ts generate <path>` uses the legacy `extract()` pipeline.
+- `graphify-ts generate <path> --spi` opts into the SPI pipeline.
+- Benchmark on the bundled `2026-05-11-spi-vs-legacy/fixture`:
+
+| Metric | Legacy | `--spi` | Δ |
+|---|---|---|---|
+| Build time (cold) | 506 ms | 710 ms | +40% (cost) |
+| Build time (cache-hit) | n/a | 368 ms | −27% vs legacy |
+| `graph.json` size | 62.8 KB | 42.8 KB | −32% |
+| Total pack tokens (7 prompts) | 1284 | 946 | −26% |
+
+The 40% cold-build cost is the headline risk. The cache-hit recovery + token reduction is the headline payoff.
+
+## Graduation criteria (must ALL be met to flip default)
+
+### 1. Build-time parity within 1.5x on representative repos
+
+- **SPI cold build must be ≤ 1.5× legacy cold build** on at least 3 representative repos: a single TS package (≤100 files), a NestJS backend (≥500 files), a TS monorepo (≥2k files).
+- **SPI cache-hit must be ≥ 2× faster than legacy `extract()`** on unchanged workspaces of the same 3 repos.
+- Measurements committed as benchmark artifacts under `docs/benchmarks/<date>-spi-readiness/`.
+
+### 2. Compatibility — no regression in downstream pipelines
+
+For each existing command, run against the same input with and without `--spi` and verify behaviour:
+
+- [ ] `generate` — produces a graph.json buildFromJson can consume
+- [ ] `generate --update` — incremental rebuild still works (with SPI cache as the equivalent fast path)
+- [ ] `pack --task explain` — same or better diagnostic quality_score on a fixed prompt set
+- [ ] `pack --task review` — pr_impact path unaffected
+- [ ] `pack --task impact` — impact target resolution unchanged
+- [ ] `prompt` — `stable_prefix_hash` is consistent across re-runs
+- [ ] `pr_impact` — `coverage_score_weighted` + severity tiers match between pipelines
+- [ ] `compare` and `review-compare` — provider token deltas unchanged
+- [ ] MCP `retrieve` / `context_pack` / `pr_impact` — same response shape
+
+A FAILED checkbox in this list blocks the flip until the regression is documented or fixed.
+
+### 3. Project-shape coverage
+
+Verified on at least these project shapes:
+
+- [ ] Single TS package (e.g., utility library)
+- [ ] NestJS backend (controllers, modules, providers, decorators)
+- [ ] Next.js frontend (app router + pages router mixed)
+- [ ] TS monorepo (workspaces or pnpm)
+- [ ] Mixed-content workspace (TS code + markdown docs + JSON config + Python sidecars)
+- [ ] Workspace with type-only imports / `declare module` ambient modules
+
+Each shape gets a documented run in the benchmark dir.
+
+### 4. Retrieval quality on framework-shaped queries
+
+Using the existing #130 fixture or an expanded version:
+
+- **Median pack tokens with `--spi` ≤ legacy median** across framework-shaped prompts.
+- **Top-3 matched_nodes accuracy** — for known-answer prompts ("show me the Express route for GET /api/users"), the top-3 must contain the correct symbol in ≥ 80% of cases with `--spi`. Legacy baseline measured first.
+
+### 5. Diagnostics surface parity
+
+- `context_pack` `diagnostics.quality_score` distribution across the benchmark prompts is **equal or better** under `--spi` than legacy.
+- No new `error`-severity warnings (`missing_required_evidence`) introduced.
+
+## Fallback plan after the flip
+
+When the default flips, **legacy `extract()` remains accessible via `--no-spi`** (or `--legacy-extract`) for one release minimum. Specifically:
+
+1. **Same release as the flip**: `--spi` becomes default. `--no-spi` opts out. CLI help text shows both. Release notes mention the flip explicitly and link this doc.
+2. **One release after the flip**: `--no-spi` still works. If any users have filed issues citing SPI-specific regressions, they're tagged on a `spi-default-retro` milestone.
+3. **Two releases after the flip**: If `spi-default-retro` is empty (no open SPI-specific bug reports), `--no-spi` is announced as deprecated with a 1-release deprecation window.
+4. **Three releases after the flip**: `--no-spi` is removed. The legacy `extract()` code remains in the source tree as the SPI projector's fall-back when SPI build fails, but is no longer reachable from the CLI.
+
+If `spi-default-retro` has open issues after release N+1, the deprecation window pauses until they close.
+
+## Out of scope for this decision
+
+- **Whether to ship a v0.21 release that flips the default.** That's the implementation, gated on this checklist. This doc is the gate, not the trigger.
+- **What `--spi` behavior to add beyond what v0.19 / v0.20 ship.** This doc grades the existing surface; new SPI features are evaluated when proposed.
+- **What to do with the legacy `extract()` code long-term.** Removing it is a separate decision tracked on a separate issue when the time comes.
+
+## Decision log
+
+| Date | Author | Note |
+|---|---|---|
+| 2026-05-11 | `claude` | Initial draft as part of v0.20 bundle. Criteria proposed, not yet validated against real repos. |

--- a/src/runtime/context-pack-resolution.ts
+++ b/src/runtime/context-pack-resolution.ts
@@ -21,7 +21,7 @@
 
 import type { ContextPackNode } from '../contracts/context-pack.js'
 
-export type ContextPackResolution = 'detail' | 'summary' | 'mixed'
+export type ContextPackResolution = 'detail' | 'summary' | 'mixed' | 'signature'
 
 export interface ApplyResolutionOptions {
   resolution: ContextPackResolution
@@ -56,9 +56,52 @@ export function applyContextPackResolution<T extends ContextPackNode>(
     return summarizeAll(nodes)
   }
 
+  if (options.resolution === 'signature') {
+    return signatureResolution(nodes)
+  }
+
   // mixed: top-N detail by match_score desc, rest summary.
   const n = options.detail_top_n ?? Math.ceil(nodes.length / 3)
   return mixedResolution(nodes, Math.max(0, n))
+}
+
+/** Signature resolution: keep the first 1-2 lines of the snippet (the
+ *  function/class signature) and drop the body. Middle ground between
+ *  full `detail` and bare `summary`. Useful when the agent needs to see
+ *  parameter types and return shape but doesn't need the body.
+ *
+ *  Heuristic: keep lines up to and including the line that ends with `{`
+ *  (the opening brace), then drop the rest. If no `{` is found in the
+ *  first 3 lines, keep the first 2 lines as a best-effort signature. */
+function signatureResolution<T extends ContextPackNode>(
+  nodes: ReadonlyArray<T>,
+): ApplyResolutionResult<T> {
+  let bytesSaved = 0
+  const transformed = nodes.map((node) => {
+    if (typeof node.snippet !== 'string' || node.snippet.length === 0) return node
+    const sig = extractSignature(node.snippet)
+    bytesSaved += Math.max(0, node.snippet.length - sig.length)
+    return { ...node, snippet: sig } as T
+  })
+  return {
+    nodes: transformed,
+    resolution_map: nodes.map((n) => ({ node_id: n.node_id, resolution: 'summary' as const })),
+    bytes_saved: bytesSaved,
+  }
+}
+
+function extractSignature(snippet: string): string {
+  const lines = snippet.split('\n')
+  for (let i = 0; i < Math.min(3, lines.length); i += 1) {
+    const line = lines[i]
+    if (line === undefined) continue
+    if (line.trimEnd().endsWith('{') || line.trimEnd().endsWith('=>')) {
+      return lines.slice(0, i + 1).join('\n')
+    }
+  }
+  // No brace found in the first 3 lines — take the first 2 as the
+  // best-effort signature, or the whole snippet if it's shorter.
+  return lines.slice(0, Math.min(2, lines.length)).join('\n')
 }
 
 function summarizeAll<T extends ContextPackNode>(

--- a/src/runtime/context-pack-resolution.ts
+++ b/src/runtime/context-pack-resolution.ts
@@ -32,8 +32,10 @@ export interface ApplyResolutionOptions {
 
 export interface ApplyResolutionResult<T extends ContextPackNode> {
   nodes: T[]
-  /** Per-node resolution after applying. Useful for diagnostics. */
-  resolution_map: Array<{ node_id: string | undefined; resolution: 'detail' | 'summary' }>
+  /** Per-node resolution after applying. Useful for diagnostics.
+   *  v0.20 #132: includes 'signature' for nodes where the body was
+   *  dropped but the function signature retained. */
+  resolution_map: Array<{ node_id: string | undefined; resolution: 'detail' | 'summary' | 'signature' }>
   /** Estimated bytes saved (rough — based on dropped snippet length). */
   bytes_saved: number
 }
@@ -85,7 +87,10 @@ function signatureResolution<T extends ContextPackNode>(
   })
   return {
     nodes: transformed,
-    resolution_map: nodes.map((n) => ({ node_id: n.node_id, resolution: 'summary' as const })),
+    // CodeRabbit fix: signature mode is its own resolution, NOT 'summary'.
+    // Downstream diagnostics differentiate 'has signature info' from
+    // 'has no body at all'.
+    resolution_map: nodes.map((n) => ({ node_id: n.node_id, resolution: 'signature' as const })),
     bytes_saved: bytesSaved,
   }
 }
@@ -136,7 +141,7 @@ function mixedResolution<T extends ContextPackNode>(
 
   let bytesSaved = 0
   const out: T[] = []
-  const resolutionMap: Array<{ node_id: string | undefined; resolution: 'detail' | 'summary' }> = []
+  const resolutionMap: Array<{ node_id: string | undefined; resolution: 'detail' | 'summary' | 'signature' }> = []
   nodes.forEach((node, idx) => {
     if (detailIndices.has(idx)) {
       out.push(node)

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -24,6 +24,7 @@ import type { RetrievalGateDecision } from '../contracts/retrieval-gate.js'
 import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { estimateQueryTokens } from './serve.js'
 import { resolveTaskEvidenceRecipe } from './task-evidence-recipes.js'
+import { selectByValuePerToken, type ValuePerTokenCandidate } from './value-per-token.js'
 
 export interface ClassifyTaskContractOptions {
   budget: number
@@ -64,6 +65,17 @@ export interface CompileContextPackInput<
    * compute it once and pass the result down.
    */
   retrieval_gate?: RetrievalGateDecision
+  /**
+   * v0.20 #131 — strategy for choosing candidates under budget:
+   *   - 'evidence-order' (default): walk sortCandidatesByEvidence order,
+   *     take until budget overflow. Same behaviour as v0.19 and earlier.
+   *   - 'value-per-token': required-evidence-class candidates are
+   *     placed first (must-include), then the remaining optional
+   *     candidates are picked by density (score / token_cost) via
+   *     selectByValuePerToken. Higher information density per token at
+   *     the same budget.
+   */
+  selection_strategy?: 'evidence-order' | 'value-per-token'
 }
 
 export type CompactContextPackMode =
@@ -613,13 +625,7 @@ export function compileContextPack<
   let tokenCount = 0
   let breakIndex = orderedNodes.length
 
-  for (const [index, candidate] of orderedNodes.entries()) {
-    const candidateTokens = candidate.estimate_tokens()
-    if (tokenCount + candidateTokens > input.task_contract.budget && selectedNodes.length > 0) {
-      breakIndex = index
-      break
-    }
-
+  const placeCandidate = (candidate: ContextPackNodeCandidate<TNode>, candidateTokens: number): void => {
     const entry = candidate.build_entry()
     selectedNodes.push(entry)
     selectedCoverage.push({
@@ -646,7 +652,69 @@ export function compileContextPack<
     }
   }
 
-  const omittedNodes = orderedNodes.slice(breakIndex)
+  if (input.selection_strategy === 'value-per-token') {
+    // v0.20 #131 — density-greedy selection.
+    //
+    // 1. Place required-evidence-class candidates greedily (must-include).
+    //    These can't be dropped via density even if they're expensive, so
+    //    the budget for the remainder is what's left after their cost.
+    // 2. The remainder pool (optional candidates) goes through
+    //    selectByValuePerToken with the residual budget. Density
+    //    (score / token_cost) drives which optional nodes survive.
+    const requiredClasses = new Set(input.task_contract.required_evidence)
+    const requiredCandidates: ContextPackNodeCandidate<TNode>[] = []
+    const optionalCandidates: ContextPackNodeCandidate<TNode>[] = []
+    for (const candidate of orderedNodes) {
+      if (requiredClasses.has(candidate.evidence_class)) {
+        requiredCandidates.push(candidate)
+      } else {
+        optionalCandidates.push(candidate)
+      }
+    }
+    for (const candidate of requiredCandidates) {
+      const candidateTokens = candidate.estimate_tokens()
+      if (tokenCount + candidateTokens > input.task_contract.budget && selectedNodes.length > 0) {
+        break
+      }
+      placeCandidate(candidate, candidateTokens)
+    }
+    const remainingBudget = Math.max(0, input.task_contract.budget - tokenCount)
+    // ContextPackNodeCandidate doesn't expose a numeric relevance score
+    // directly (it was lost during materialization upstream), so use the
+    // candidate's position in orderedNodes as a rank proxy: earlier
+    // candidates are higher-evidence and get a higher score. The
+    // value-per-token selector then balances this rank against token
+    // cost so dense/cheap candidates outrank expensive low-rank ones.
+    const valueCandidates: Array<ValuePerTokenCandidate<ContextPackNodeCandidate<TNode>>> = optionalCandidates.map((candidate, idx) => ({
+      id: `${candidate.label}:${candidate.source_file}:${candidate.line_number}`,
+      payload: candidate,
+      score: 1 / (idx + 1),
+      token_cost: candidate.estimate_tokens(),
+    }))
+    const valueResult = selectByValuePerToken(valueCandidates, { budget: remainingBudget })
+    for (const sel of valueResult.selected) {
+      placeCandidate(sel.payload, sel.token_cost)
+    }
+    void breakIndex
+  } else {
+    for (const [index, candidate] of orderedNodes.entries()) {
+      const candidateTokens = candidate.estimate_tokens()
+      if (tokenCount + candidateTokens > input.task_contract.budget && selectedNodes.length > 0) {
+        breakIndex = index
+        break
+      }
+      placeCandidate(candidate, candidateTokens)
+    }
+  }
+
+  // omittedNodes is what we couldn't fit. For evidence-order it's the
+  // tail after the break; for value-per-token it's the set difference
+  // between orderedNodes and what placeCandidate accepted.
+  const placedLabelKey = (c: ContextPackNodeCandidate<TNode>): string => `${c.label}:${c.source_file}:${c.line_number}`
+  const placedKeys = new Set(selectedNodes.map((n) => `${n.label}:${n.source_file}:${n.line_number}`))
+  const omittedNodes = input.selection_strategy === 'value-per-token'
+    ? orderedNodes.filter((c) => !placedKeys.has(placedLabelKey(c)))
+    : orderedNodes.slice(breakIndex)
   const relationships = filterRelationships(input.relationships ?? [], selectedNodes)
   const includedLabels = new Set(selectedNodes.map((node) => node.label))
 

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -622,10 +622,16 @@ export function compileContextPack<
   const selectedCounts = new Map<ContextPackEvidenceClass, number>()
   const selectedLabelsByEvidence = new Map<ContextPackEvidenceClass, string[]>()
   const selectedCommunities = new Set<number>()
+  // CodeRabbit fix: track placed candidate objects directly. Earlier
+  // version derived omittedNodes from materialized label:source_file:line
+  // triples, which can mis-attribute when build_entry fills in missing
+  // source metadata or when two distinct candidates share the same triple.
+  const placedCandidates = new Set<ContextPackNodeCandidate<TNode>>()
   let tokenCount = 0
   let breakIndex = orderedNodes.length
 
   const placeCandidate = (candidate: ContextPackNodeCandidate<TNode>, candidateTokens: number): void => {
+    placedCandidates.add(candidate)
     const entry = candidate.build_entry()
     selectedNodes.push(entry)
     selectedCoverage.push({
@@ -671,26 +677,36 @@ export function compileContextPack<
         optionalCandidates.push(candidate)
       }
     }
+    // CodeRabbit fix: skip individual oversize required candidates with
+    // `continue` instead of `break`, so one fat required entry doesn't
+    // kill subsequent smaller required ones. The break-on-first-overflow
+    // mirrored the evidence-order loop but is wrong here — required
+    // candidates each have an independent must-include semantic.
     for (const candidate of requiredCandidates) {
       const candidateTokens = candidate.estimate_tokens()
       if (tokenCount + candidateTokens > input.task_contract.budget && selectedNodes.length > 0) {
-        break
+        continue
       }
       placeCandidate(candidate, candidateTokens)
     }
     const remainingBudget = Math.max(0, input.task_contract.budget - tokenCount)
-    // ContextPackNodeCandidate doesn't expose a numeric relevance score
-    // directly (it was lost during materialization upstream), so use the
-    // candidate's position in orderedNodes as a rank proxy: earlier
-    // candidates are higher-evidence and get a higher score. The
-    // value-per-token selector then balances this rank against token
-    // cost so dense/cheap candidates outrank expensive low-rank ones.
-    const valueCandidates: Array<ValuePerTokenCandidate<ContextPackNodeCandidate<TNode>>> = optionalCandidates.map((candidate, idx) => ({
-      id: `${candidate.label}:${candidate.source_file}:${candidate.line_number}`,
-      payload: candidate,
-      score: 1 / (idx + 1),
-      token_cost: candidate.estimate_tokens(),
-    }))
+    // CodeRabbit fix: rank score uses each optional's position in
+    // orderedNodes (the global rank), not its index within
+    // optionalCandidates. Otherwise a leading run of required
+    // candidates would compress the optional rank space and inflate
+    // every optional's score.
+    const orderedNodeIndex = new Map<ContextPackNodeCandidate<TNode>, number>(
+      orderedNodes.map((c, i) => [c, i] as const),
+    )
+    const valueCandidates: Array<ValuePerTokenCandidate<ContextPackNodeCandidate<TNode>>> = optionalCandidates.map((candidate) => {
+      const orderedIdx = orderedNodeIndex.get(candidate) ?? orderedNodes.length
+      return {
+        id: `${candidate.label}:${candidate.source_file}:${candidate.line_number}`,
+        payload: candidate,
+        score: 1 / (orderedIdx + 1),
+        token_cost: candidate.estimate_tokens(),
+      }
+    })
     const valueResult = selectByValuePerToken(valueCandidates, { budget: remainingBudget })
     for (const sel of valueResult.selected) {
       placeCandidate(sel.payload, sel.token_cost)
@@ -709,11 +725,10 @@ export function compileContextPack<
 
   // omittedNodes is what we couldn't fit. For evidence-order it's the
   // tail after the break; for value-per-token it's the set difference
-  // between orderedNodes and what placeCandidate accepted.
-  const placedLabelKey = (c: ContextPackNodeCandidate<TNode>): string => `${c.label}:${c.source_file}:${c.line_number}`
-  const placedKeys = new Set(selectedNodes.map((n) => `${n.label}:${n.source_file}:${n.line_number}`))
+  // between orderedNodes and what placeCandidate accepted (CodeRabbit
+  // fix: use the candidate-identity Set instead of materialized triples).
   const omittedNodes = input.selection_strategy === 'value-per-token'
-    ? orderedNodes.filter((c) => !placedKeys.has(placedLabelKey(c)))
+    ? orderedNodes.filter((c) => !placedCandidates.has(c))
     : orderedNodes.slice(breakIndex)
   const relationships = filterRelationships(input.relationships ?? [], selectedNodes)
   const includedLabels = new Set(selectedNodes.map((node) => node.label))

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -913,7 +913,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       ): {
         nodes: T[]
         bytes_saved: number
-        resolution_map: Array<{ node_id: string | undefined; resolution: 'detail' | 'summary' }>
+        resolution_map: Array<{ node_id: string | undefined; resolution: 'detail' | 'summary' | 'signature' }>
       } => {
         if (resolution === 'detail') {
           return {

--- a/tests/unit/context-pack-resolution-signature-132.test.ts
+++ b/tests/unit/context-pack-resolution-signature-132.test.ts
@@ -1,0 +1,76 @@
+// v0.20 #132 — signature resolution level for applyContextPackResolution.
+
+import { describe, expect, it } from 'vitest'
+
+import type { ContextPackNode } from '../../src/contracts/context-pack.js'
+import { applyContextPackResolution } from '../../src/runtime/context-pack-resolution.js'
+
+function makeNode(snippet: string): ContextPackNode {
+  return {
+    node_id: 'n1',
+    label: 'fn()',
+    source_file: '/src/fn.ts',
+    line_number: 1,
+    snippet,
+    match_score: 0.5,
+  }
+}
+
+describe('applyContextPackResolution signature mode (#132)', () => {
+  it('keeps lines up through the opening brace, drops the body', () => {
+    const snippet = [
+      'export function transform(input: string): string {',
+      '  if (!input) return ""',
+      '  return input.toUpperCase()',
+      '}',
+    ].join('\n')
+    const result = applyContextPackResolution([makeNode(snippet)], { resolution: 'signature' })
+    expect(result.nodes[0]?.snippet).toBe('export function transform(input: string): string {')
+    expect(result.bytes_saved).toBeGreaterThan(0)
+  })
+
+  it('keeps lines up through an arrow function fat arrow', () => {
+    const snippet = [
+      'export const fetchUser = async (id: string) =>',
+      '  prisma.user.findUnique({ where: { id } })',
+    ].join('\n')
+    const result = applyContextPackResolution([makeNode(snippet)], { resolution: 'signature' })
+    expect(result.nodes[0]?.snippet).toBe('export const fetchUser = async (id: string) =>')
+  })
+
+  it('falls back to first 2 lines when no { or => is found in first 3 lines', () => {
+    const snippet = [
+      'export class FooBar',
+      '  extends BaseClass',
+      '  implements IFoo',
+      '{',
+      '  // body',
+      '}',
+    ].join('\n')
+    const result = applyContextPackResolution([makeNode(snippet)], { resolution: 'signature' })
+    // First 3 lines don't end in { or =>, so the fallback takes the first 2.
+    expect(result.nodes[0]?.snippet).toBe('export class FooBar\n  extends BaseClass')
+  })
+
+  it('leaves nodes with null snippets unchanged and reports zero bytes saved for those', () => {
+    const result = applyContextPackResolution(
+      [{ ...makeNode(''), snippet: null }],
+      { resolution: 'signature' },
+    )
+    expect(result.nodes[0]?.snippet).toBe(null)
+    expect(result.bytes_saved).toBe(0)
+  })
+
+  it('saves bytes proportionally — bigger body = more savings', () => {
+    const small = makeNode('export function tiny() {\n  return 1\n}')
+    const big = makeNode([
+      'export function processAndValidate(input: Input): Output {',
+      ...Array(50).fill('  // body line').map((s, i) => `${s} ${i}`),
+      '  return result',
+      '}',
+    ].join('\n'))
+    const r1 = applyContextPackResolution([small], { resolution: 'signature' })
+    const r2 = applyContextPackResolution([big], { resolution: 'signature' })
+    expect(r2.bytes_saved).toBeGreaterThan(r1.bytes_saved)
+  })
+})

--- a/tests/unit/context-pack-value-per-token-131.test.ts
+++ b/tests/unit/context-pack-value-per-token-131.test.ts
@@ -1,0 +1,124 @@
+// v0.20 #131 — value-per-token selection_strategy on compileContextPack.
+
+import { describe, expect, it } from 'vitest'
+
+import type {
+  ContextPackTaskContract,
+} from '../../src/contracts/context-pack.js'
+import {
+  compileContextPack,
+  type ContextPackNodeCandidate,
+} from '../../src/runtime/context-pack.js'
+
+function task(overrides: Partial<ContextPackTaskContract> = {}): ContextPackTaskContract {
+  return {
+    version: 1,
+    task_kind: 'explain',
+    evidence_recipe_id: 'explain',
+    budget: 200,
+    required_evidence: ['primary'],
+    preferred_evidence: ['supporting'],
+    semantic_required: ['implementation'],
+    semantic_optional: [],
+    ...overrides,
+  }
+}
+
+function candidate(
+  label: string,
+  evidenceClass: 'primary' | 'supporting' | 'structural' | 'change' | 'impact',
+  tokenCost: number,
+): ContextPackNodeCandidate {
+  return {
+    label,
+    node_id: label,
+    source_file: '/src/' + label + '.ts',
+    line_number: 1,
+    file_type: 'code',
+    snippet: `// ${label} body`,
+    evidence_class: evidenceClass,
+    estimate_tokens: () => tokenCost,
+    build_entry: () => ({
+      label,
+      node_id: label,
+      source_file: '/src/' + label + '.ts',
+      line_number: 1,
+      snippet: `// ${label} body`,
+      evidence_class: evidenceClass,
+    }),
+  }
+}
+
+describe('compileContextPack selection_strategy=value-per-token (#131)', () => {
+  it('still includes required-evidence-class candidates first (must-include)', () => {
+    const pack = compileContextPack({
+      task_contract: task({ budget: 200, required_evidence: ['primary'] }),
+      nodes: [
+        candidate('primary-a', 'primary', 100),
+        candidate('primary-b', 'primary', 100),
+        candidate('supp-cheap', 'supporting', 10),
+        candidate('supp-expensive', 'supporting', 500),
+      ],
+      selection_strategy: 'value-per-token',
+    })
+
+    // Both primary candidates fit at 200 budget total → must be in.
+    const labels = pack.nodes.map((n) => n.label)
+    expect(labels).toContain('primary-a')
+    expect(labels).toContain('primary-b')
+  })
+
+  it('picks dense (cheap, high-rank) optional candidates over expensive ones at the same rank', () => {
+    const pack = compileContextPack({
+      task_contract: task({ budget: 60, required_evidence: ['primary'] }),
+      nodes: [
+        // Budget = 60. The required primary takes 20. Remaining = 40.
+        candidate('primary-a', 'primary', 20),
+        // Optional candidates — earlier in orderedNodes = higher rank.
+        // Density-greedy should prefer the cheap one (40 tokens fits) over the
+        // expensive one (50 tokens overflows the remaining 40).
+        candidate('supp-cheap', 'supporting', 40),
+        candidate('supp-expensive', 'supporting', 50),
+      ],
+      selection_strategy: 'value-per-token',
+    })
+
+    const labels = pack.nodes.map((n) => n.label)
+    expect(labels).toContain('primary-a')
+    expect(labels).toContain('supp-cheap')
+    expect(labels).not.toContain('supp-expensive')
+  })
+
+  it('default strategy (evidence-order) selects first candidate even if expensive', () => {
+    const pack = compileContextPack({
+      task_contract: task({ budget: 60, required_evidence: ['primary'] }),
+      nodes: [
+        candidate('primary-a', 'primary', 20),
+        // No selection_strategy = default 'evidence-order'. Should pick
+        // supp-expensive first since it comes first in orderedNodes.
+        candidate('supp-expensive', 'supporting', 30),
+        candidate('supp-cheap', 'supporting', 5),
+      ],
+    })
+
+    // Default greedy fills in evidence order, so primary + supp-expensive
+    // both fit (20 + 30 = 50 ≤ 60), then supp-cheap (50 + 5 = 55 ≤ 60).
+    const labels = pack.nodes.map((n) => n.label)
+    expect(labels).toContain('primary-a')
+    expect(labels).toContain('supp-expensive')
+  })
+
+  it('reports omitted candidates correctly when value-per-token drops one', () => {
+    const pack = compileContextPack({
+      task_contract: task({ budget: 30, required_evidence: ['primary'] }),
+      nodes: [
+        candidate('primary-a', 'primary', 20),
+        candidate('expensive', 'supporting', 100),  // can't fit in remaining 10
+      ],
+      selection_strategy: 'value-per-token',
+    })
+
+    expect(pack.nodes.map((n) => n.label)).toEqual(['primary-a'])
+    expect(pack.expandable.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes #131
Closes #132
Closes #134

## Summary

Bundles three v0.20-context-compiler items. **#135 (task-conditioned slicing v1) intentionally deferred** — it's a multi-PR substrate, not a single-shot slice.

## What's in the bundle

### #131 — value-per-token selection_strategy on compileContextPack

- New optional input: `selection_strategy: 'evidence-order' | 'value-per-token'` (default = evidence-order, unchanged)
- When `value-per-token`:
  1. Required-evidence-class candidates placed first (must-include)
  2. Remaining optional candidates go through `selectByValuePerToken` with residual budget
- Score uses candidate's position in `orderedNodes` as rank proxy (1/(idx+1))
- Required candidates can't be dropped even if expensive; optional ones compete by density

### #132 — 'signature' resolution level

- Extended `ContextPackResolution` from `detail | summary | mixed` to also accept `signature`
- Signature mode keeps the first 1-2 lines of each snippet (function/class signature) and drops the body
- Heuristic: keep lines up through the one ending in `{` or `=>` (max 3 line scan); fallback to first 2 lines
- Middle ground between `detail` (full snippet) and `summary` (no body) — useful when the agent needs param types and return shape but not implementation

### #134 — SPI default-readiness decision framework

- New doc: `docs/decisions/2026-05-11-spi-default-readiness.md`
- Codifies what `--spi` must achieve before becoming default:
  - Build-time parity within 1.5x cold, ≥ 2x faster cache-hit
  - Compatibility checklist across 9 commands
  - Project-shape coverage (6 shapes)
  - Retrieval-quality threshold
  - Diagnostics surface parity
- Defines post-flip fallback: `--no-spi` flag remains accessible for 3 releases minimum
- **Decision framework, not code.** The next code change (the actual default flip) has to meet this checklist.

## Not in this bundle (intentionally)

**#135 — task-conditioned slicing v1.** Requires new anchor-detection module, slice walker, task-mode-specific traversal rules. Multi-PR effort; doesn't fit a single-shot bundle alongside #131/#132. Worth its own slice train.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm run test:run` — 1833/1833 pass (113 files, +9 new tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signature resolution mode that condenses context by truncating snippets to function signatures and reports bytes saved.
  * Added a value-per-token selection strategy for context packing to optimize token efficiency after required evidence is placed.

* **Tests**
  * Added unit tests verifying signature-mode truncation behavior and value-per-token selection outcomes across edge cases.

* **Documentation**
  * Added SPI default-readiness criteria and a multi-release transition/fallback policy.

* **Style/Types**
  * Expanded resolution annotations to include the new signature option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/138)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->