### PR TITLE
Improve broad runtime pack compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Broad runtime-generation packs are more compact**: slice-v1 now follows forward runtime `calls` paths for broad backend generation prompts while preserving bounded controller/provider context, suppressing shared-hub fan-out, sibling route families, and script/migration noise.
+- **Runtime over-expansion diagnostics**: context-pack diagnostics can now flag runtime-generation packs that fill the budget with sibling routes, hubs, or script/migration nodes after the core runtime path is already covered.
+- **Noisy NestJS regression coverage**: the realistic SPI fixture now includes sibling controllers, shared auth/LLM hubs, queue registration, and migration scripts to prove report-generation retrieval stays under budget without losing the backend runtime path.
+
 ## [0.22.5] - 2026-05-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.6] - 2026-05-12
+
 ### Changed
 
-- **Broad runtime-generation packs are more compact**: slice-v1 now follows forward runtime `calls` paths for broad backend generation prompts while preserving bounded controller/provider context, suppressing shared-hub fan-out, sibling route families, and script/migration noise.
-- **Runtime over-expansion diagnostics**: context-pack diagnostics can now flag runtime-generation packs that fill the budget with sibling routes, hubs, or script/migration nodes after the core runtime path is already covered.
-- **Noisy NestJS regression coverage**: the realistic SPI fixture now includes sibling controllers, shared auth/LLM hubs, queue registration, and migration scripts to prove report-generation retrieval stays under budget without losing the backend runtime path.
+- **Broad runtime-generation packs stay compact**: slice-v1 now follows the strongest backend runtime anchor forward through runtime `calls` while preserving bounded controller/provider context and suppressing sibling route families, shared-hub fan-out, and script/migration noise for broad report-generation prompts.
+- **Cross-platform runtime path scoring is consistent**: retrieval tokenization and source-path matching now normalize Windows-style paths so the same backend runtime anchors win across Linux, macOS, and Windows runs.
+- **Graph seed prompts no longer bypass script penalties**: bare `seed` phrasing no longer grants script/migration permission, so graph seed and seed-node questions still penalize migration/script candidates unless the prompt explicitly asks for seeding or scripts.
+- **Runtime over-expansion diagnostics and regressions are stronger**: context-pack diagnostics now flag overfilled runtime-generation packs, and the realistic NestJS SPI fixture covers noisy sibling controllers, shared auth/LLM hubs, queue registration, migration scripts, and input-validation review fixes.
 
 ## [0.22.5] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ PR-review proof on a real diff: prompt tokens 63,024 → **8,690** (**7.25× few
 
 `--spi` benchmark (bundled fixture, 7 prompts): **better framework-shaped correctness**, **operational retrieval-level expansion**, **graph.json size −32%**, **cache-hit rebuild −27% vs legacy**, but **no measured explain-pack token win on that fixture**. Receipts: [`docs/benchmarks/2026-05-11-spi-vs-legacy/`](docs/benchmarks/2026-05-11-spi-vs-legacy/).
 
+Latest runtime-pack refinement: **runtime-generation prompts stay compact** by following the strongest backend runtime path and suppressing sibling routes, script/migration noise, and shared-hub fan-out on broad backend-generation questions.
+
 [Reproduce them](docs/benchmarks/2026-04-30-govalidate/verify.sh) with one shell script against the committed evidence files.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.22.5",
+    "version": "0.22.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.22.5",
+            "version": "0.22.6",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.22.5",
+    "version": "0.22.6",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/src/contracts/context-pack-diagnostics.ts
+++ b/src/contracts/context-pack-diagnostics.ts
@@ -34,6 +34,7 @@ export type ContextPackDiagnosticKind =
   | 'slice_path_nodes_not_promoted'
   | 'polluted_source_path_selected'
   | 'missing_structural_evidence'
+  | 'runtime_pack_overexpanded'
 
 export type ContextPackDiagnosticSeverity = 'info' | 'warn' | 'error'
 

--- a/src/runtime/context-pack-diagnostics.ts
+++ b/src/runtime/context-pack-diagnostics.ts
@@ -59,6 +59,7 @@ const RULE_WEIGHTS: ReadonlyMap<ContextPackDiagnosticKind, number> = new Map([
   ['slice_path_nodes_not_promoted', 1],
   ['polluted_source_path_selected', 2],
   ['missing_structural_evidence', 1],
+  ['runtime_pack_overexpanded', 1],
 ])
 
 const SEVERITY_ORDER: Record<ContextPackDiagnosticSeverity, number> = {
@@ -281,6 +282,16 @@ export function computeContextPackDiagnostics(
       kind: 'missing_method_anchor',
       severity: 'warn',
       message: 'Prompt requested a specific method anchor but the selected slice did not anchor that method.',
+    })
+  }
+
+  const overexpandedRuntimePack = runtimePackOverexpanded(pack, signals)
+  if (overexpandedRuntimePack !== undefined) {
+    warnings.push({
+      kind: 'runtime_pack_overexpanded',
+      severity: 'warn',
+      message: 'Runtime-generation pack filled the budget with sibling routes, shared hubs, or script/migration noise after covering the core runtime path.',
+      detail: overexpandedRuntimePack,
     })
   }
 
@@ -640,6 +651,83 @@ function runtimeSliceCallChainPresent(pack: CompiledContextPack): boolean {
 function pipelineRuntimeLikeNode(node: ContextPackNode): boolean {
   const lower = `${node.label} ${node.framework_role ?? ''} ${node.source_file} ${node.node_kind ?? ''}`.toLowerCase()
   return /\bpipeline|trigger|queue|job|worker|orchestrator|planner|research|agent|scoring|report|repository|persistence|save|process|search|score\b/.test(lower)
+}
+
+function runtimePackOverexpanded(
+  pack: CompiledContextPack,
+  signals: ContextPackQualitySignals,
+): Record<string, unknown> | undefined {
+  const gate = pack.retrieval_gate
+  if (
+    gate?.signals.generation_intent !== 'runtime_generation'
+    || gate.signals.target_domain_hint !== 'backend_runtime'
+    || !pipelinePrompt(pack)
+    || signals.budget_utilization < 0.9
+    || !runtimeSliceCallChainPresent(pack)
+  ) {
+    return undefined
+  }
+
+  const anchors = new Set((pack.slice?.anchors ?? []).flatMap((anchor) => {
+    const values = [anchor.label]
+    if (typeof anchor.node_id === 'string') values.push(anchor.node_id)
+    return values
+  }))
+  let siblingRouteCount = 0
+  let sharedHubCount = 0
+  let scriptMigrationCount = 0
+  const relationshipDegree = relationshipDegreeByNode(pack)
+  for (const node of pack.nodes) {
+    const key = typeof node.node_id === 'string' ? node.node_id : node.label
+    if (!anchors.has(key) && siblingRouteLikeNode(node)) {
+      siblingRouteCount += 1
+    }
+    if (sharedRuntimeHubLikeNode(node, relationshipDegree.get(key) ?? relationshipDegree.get(node.label) ?? 0)) {
+      sharedHubCount += 1
+    }
+    if (scriptMigrationLikeNode(node)) {
+      scriptMigrationCount += 1
+    }
+  }
+
+  if (siblingRouteCount + sharedHubCount + scriptMigrationCount < 3) {
+    return undefined
+  }
+
+  return {
+    budget_utilization: signals.budget_utilization,
+    sibling_route_count: siblingRouteCount,
+    shared_hub_count: sharedHubCount,
+    script_migration_count: scriptMigrationCount,
+  }
+}
+
+function siblingRouteLikeNode(node: ContextPackNode): boolean {
+  const lower = `${node.label} ${node.framework_role ?? ''} ${node.source_file} ${node.node_kind ?? ''}`.toLowerCase()
+  return (lower.includes('controller') || lower.includes('route'))
+    && /\b(?:get|list|publish|delete|retry|status|export|share|sign|validate|lifecycle|artifact)\b/.test(lower)
+}
+
+function sharedRuntimeHubLikeNode(node: ContextPackNode, degree: number): boolean {
+  const label = node.label.toLowerCase()
+  return degree >= 12 || /\b(?:requireideasuserid|callllm|resolve|logger|registry|provider)\b/.test(label)
+}
+
+function scriptMigrationLikeNode(node: ContextPackNode): boolean {
+  const lower = `${node.label} ${node.source_file}`.toLowerCase()
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/.test(lower)
+}
+
+function relationshipDegreeByNode(pack: CompiledContextPack): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const relationship of pack.relationships) {
+    for (const key of [relationship.from_id, relationship.from, relationship.to_id, relationship.to]) {
+      if (typeof key === 'string' && key.length > 0) {
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+      }
+    }
+  }
+  return counts
 }
 
 function computeQualityScore(warnings: ContextPackDiagnosticWarning[]): number {

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -714,7 +714,8 @@ function looksArtifact(sourceFile: string): boolean {
 }
 
 function looksScriptMigration(sourceFile: string, label: string): boolean {
-  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(sourceFile)
+  const normalizedSourceFile = sourceFile.replace(/\\/g, '/')
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(normalizedSourceFile)
     || /\b(?:migrate|migration|backfill|seed)\b/i.test(label)
 }
 

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -713,6 +713,15 @@ function looksArtifact(sourceFile: string): boolean {
   return /(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|dist\/|build\/|coverage\/|graphify-out\/)/i.test(sourceFile)
 }
 
+function looksScriptMigration(sourceFile: string, label: string): boolean {
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(sourceFile)
+    || /\b(?:migrate|migration|backfill|seed)\b/i.test(label)
+}
+
+function promptAllowsScriptMigration(prompt: string | undefined): boolean {
+  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|seed|cli|one-off|repair|old pipeline)\b/i.test(prompt ?? '')
+}
+
 function sourceDomainPenalty(view: CandidateScoringView, taskContract: ContextPackTaskContract): number {
   switch (view.source_domain) {
     case 'test':
@@ -881,6 +890,11 @@ function computeContextCandidateValue(
   if (looksArtifact(view.source_file)) {
     score -= 4
     pushUnique(penalties, 'build artifact penalty')
+  }
+
+  if (looksScriptMigration(view.source_file, view.label) && !promptAllowsScriptMigration(taskContract.prompt)) {
+    score -= 3
+    pushUnique(penalties, 'script/migration penalty')
   }
 
   if (looksTypeOnly(view) && !taskContract.semantic_required.includes('contracts') && !taskContract.semantic_optional.includes('contracts')) {

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -720,7 +720,7 @@ function looksScriptMigration(sourceFile: string, label: string): boolean {
 }
 
 function promptAllowsScriptMigration(prompt: string | undefined): boolean {
-  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|seed|cli|one-off|repair|old pipeline)\b/i.test(prompt ?? '')
+  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|cli|one-off|repair|old pipeline|seed(?:ing|ers?)|seeds?\s+(?:data|db|database|scripts?|files?))\b/i.test(prompt ?? '')
 }
 
 function sourceDomainPenalty(view: CandidateScoringView, taskContract: ContextPackTaskContract): number {

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -173,7 +173,7 @@ export function tokenizeQuestion(question: string): string[] {
   return question
     .replace(/([a-z])([A-Z])/g, '$1 $2')
     .toLowerCase()
-    .split(/[\s_\-./,:;!?'"()[\]{}]+/)
+    .split(/[\s_\\\-./,:;!?'"()[\]{}]+/)
     .filter((token) => token.length > 1 && !STOP_WORDS.has(token))
 }
 
@@ -181,7 +181,7 @@ export function tokenizeLabel(label: string): string[] {
   return label
     .replace(/([a-z])([A-Z])/g, '$1 $2')
     .toLowerCase()
-    .split(/[\s_\-./,:;!?'"()[\]{}]+/)
+    .split(/[\s_\\\-./,:;!?'"()[\]{}]+/)
     .filter((token) => token.length > 1)
 }
 
@@ -840,7 +840,11 @@ function sourceFileMatchesMentionedPath(sourceFile: string, mentionedPaths: read
     return false
   }
 
-  return mentionedPaths.some((path) => sourceFile === path || sourceFile.endsWith(`/${path}`))
+  const normalizedSourceFile = sourceFile.replace(/\\/g, '/')
+  return mentionedPaths.some((path) => {
+    const normalizedPath = path.replace(/\\/g, '/')
+    return normalizedSourceFile === normalizedPath || normalizedSourceFile.endsWith(`/${normalizedPath}`)
+  })
 }
 
 function exclusionTokens(value: string): Set<string> {
@@ -1073,7 +1077,8 @@ function scriptMigrationPathPenalty(
     return 0
   }
 
-  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(sourceFile)
+  const normalizedSourceFile = sourceFile.replace(/\\/g, '/')
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(normalizedSourceFile)
     || /\b(?:migrate|migration|backfill|seed)\b/i.test(label)
     ? 6
     : 0

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1058,7 +1058,7 @@ function runtimeGenerationSourceDomainPenalty(
 }
 
 function promptAllowsScriptMigration(question: string): boolean {
-  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|seed|cli|one-off|repair|old pipeline)\b/i.test(question)
+  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|cli|one-off|repair|old pipeline|seed(?:ing|ers?)|seeds?\s+(?:data|db|database|scripts?|files?))\b/i.test(question)
 }
 
 function scriptMigrationPathPenalty(

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1053,6 +1053,32 @@ function runtimeGenerationSourceDomainPenalty(
   }
 }
 
+function promptAllowsScriptMigration(question: string): boolean {
+  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|seed|cli|one-off|repair|old pipeline)\b/i.test(question)
+}
+
+function scriptMigrationPathPenalty(
+  retrievalGate: RetrievalGateDecision,
+  sourceFile: string,
+  label: string,
+  question: string,
+  explicitlyAnchored: boolean,
+): number {
+  if (
+    explicitlyAnchored
+    || retrievalGate.signals.generation_intent !== 'runtime_generation'
+    || retrievalGate.signals.target_domain_hint !== 'backend_runtime'
+    || promptAllowsScriptMigration(question)
+  ) {
+    return 0
+  }
+
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(sourceFile)
+    || /\b(?:migrate|migration|backfill|seed)\b/i.test(label)
+    ? 6
+    : 0
+}
+
 function shouldDemoteSourcePathMatchForIntent(
   retrievalGate: RetrievalGateDecision,
   node: {
@@ -2128,8 +2154,10 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
         }
       : score
 
-    const domainIntentPenalty = runtimeGenerationSourceDomainPenalty(retrievalGate, sourceDomain, exactAnchorMatch || mentionedPathMatch)
-    const totalSeedScore = effectiveScore.total + anchorScore + metadataBoost + domainAdjustment - sourceDomainPenalty - domainIntentPenalty
+    const explicitlyAnchored = exactAnchorMatch || mentionedPathMatch
+    const domainIntentPenalty = runtimeGenerationSourceDomainPenalty(retrievalGate, sourceDomain, explicitlyAnchored)
+    const scriptMigrationPenalty = scriptMigrationPathPenalty(retrievalGate, sourceFile, label, question, explicitlyAnchored)
+    const totalSeedScore = effectiveScore.total + anchorScore + metadataBoost + domainAdjustment - sourceDomainPenalty - domainIntentPenalty - scriptMigrationPenalty
     const hasPositiveSeedEvidence = totalSeedScore > 0 || exactAnchorMatch || mentionedPathMatch
     if (hasPositiveSeedEvidence) {
       const resolvedLine = resolvedLineNumber(attributes)
@@ -2213,7 +2241,8 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
         + candidate.frameworkBoost
         + retrievalDomainAdjustment(retrievalGate, candidate)
         - defaultSourceDomainPenalty(candidate.sourceDomain, retrievalGate.intent, question, questionTokens)
-        - runtimeGenerationSourceDomainPenalty(retrievalGate, candidate.sourceDomain, candidate.exactLabelMatch || candidate.literalPathMatch),
+        - runtimeGenerationSourceDomainPenalty(retrievalGate, candidate.sourceDomain, candidate.exactLabelMatch || candidate.literalPathMatch)
+        - scriptMigrationPathPenalty(retrievalGate, candidate.sourceFile, candidate.label, question, candidate.exactLabelMatch || candidate.literalPathMatch),
     ),
     relevanceBand: candidate.relevanceBand,
     sourceDomain: candidate.sourceDomain,
@@ -2390,7 +2419,9 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       continue
     }
     const sourceDomainPenalty = defaultSourceDomainPenalty(sourceDomain, retrievalGate.intent, question, questionTokens)
-    const domainIntentPenalty = runtimeGenerationSourceDomainPenalty(retrievalGate, sourceDomain, symbolMatch > 0 || pathMatch)
+    const explicitlyAnchored = symbolMatch > 0 || pathMatch
+    const domainIntentPenalty = runtimeGenerationSourceDomainPenalty(retrievalGate, sourceDomain, explicitlyAnchored)
+    const scriptMigrationPenalty = scriptMigrationPathPenalty(retrievalGate, sourceFile, label, question, explicitlyAnchored)
     const domainAdjustment = retrievalDomainAdjustment(retrievalGate, {
       label,
       sourceFile,
@@ -2421,7 +2452,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       literalPathMatch: pathMatch,
       sourcePathMatch: pathMatch,
       evidenceTier: hopDistances.get(nodeId) === 1 ? (hopEvidenceTiers.get(nodeId) ?? 0) : 0,
-      score: Math.max(0.05, hopScore + domainAdjustment - sourceDomainPenalty - domainIntentPenalty),
+      score: Math.max(0.05, hopScore + domainAdjustment - sourceDomainPenalty - domainIntentPenalty - scriptMigrationPenalty),
       relevanceBand: hopDistances.get(nodeId) === 1 ? 'related' : 'peripheral',
     })
   }

--- a/src/runtime/retrieve/slicing.ts
+++ b/src/runtime/retrieve/slicing.ts
@@ -220,7 +220,7 @@ function effectivePolicy(
 }
 
 function isBarrelLike(label: string, sourceFile: string): boolean {
-  return label.trim().toLowerCase() === 'index.ts' || /(?:^|\/)index\.ts$/i.test(sourceFile)
+  return label.trim().toLowerCase() === 'index.ts' || /(?:^|\/)index\.ts$/i.test(sourceFile.replace(/\\/g, '/'))
 }
 
 function broadRuntimeGenerationPrompt(options: SliceOptions): boolean {
@@ -235,12 +235,13 @@ function promptAllowsScriptMigration(options: SliceOptions): boolean {
 }
 
 function scriptMigrationLikeNode(node: SliceScoredNode): boolean {
-  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(node.sourceFile)
+  const normalizedSourceFile = node.sourceFile.replace(/\\/g, '/')
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(normalizedSourceFile)
     || /\b(?:migrate|migration|backfill|seed)\b/i.test(node.label)
 }
 
 function routeOrControllerLikeNode(node: SliceScoredNode): boolean {
-  const lower = `${node.label} ${node.nodeKind ?? ''} ${node.frameworkRole ?? ''} ${node.sourceFile}`.toLowerCase()
+  const lower = `${node.label} ${node.nodeKind ?? ''} ${node.frameworkRole ?? ''} ${node.sourceFile.replace(/\\/g, '/')}`.toLowerCase()
   return /\b(?:route|controller|nest_route|nest_controller)\b/.test(lower)
     || /(?:^|\/)(?:controllers?|interface\/http)(?:\/|$)/.test(lower)
 }

--- a/src/runtime/retrieve/slicing.ts
+++ b/src/runtime/retrieve/slicing.ts
@@ -231,7 +231,7 @@ function broadRuntimeGenerationPrompt(options: SliceOptions): boolean {
 
 function promptAllowsScriptMigration(options: SliceOptions): boolean {
   const prompt = options.prompt ?? ''
-  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|seed|cli|one-off|repair|old pipeline)\b/i.test(prompt)
+  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|cli|one-off|repair|old pipeline|seed(?:ing|ers?)|seeds?\s+(?:data|db|database|scripts?|files?))\b/i.test(prompt)
 }
 
 function scriptMigrationLikeNode(node: SliceScoredNode): boolean {

--- a/src/runtime/retrieve/slicing.ts
+++ b/src/runtime/retrieve/slicing.ts
@@ -148,7 +148,7 @@ function effectivePolicy(
   intent: RetrievalIntent,
   anchors: readonly ContextPackSliceAnchor[],
   anchorNodes: readonly SliceScoredNode[],
-  prompt: string | undefined,
+  options: SliceOptions,
 ): SlicePolicy {
   const base = policyForIntent(intent)
   const hasMethodAnchor = anchorNodes.some((anchor) => methodLikeNode(anchor))
@@ -158,10 +158,26 @@ function effectivePolicy(
       && methodLikeNode(node)
       && (anchor.reason === 'symbol mention' || anchor.reason === 'path mention')
   })
-  const pipelinePrompt = promptWantsRuntimePipeline(prompt)
+  const pipelinePrompt = promptWantsRuntimePipeline(options.prompt)
+  const broadRuntimeGeneration = options.generationIntent === 'runtime_generation'
+    && options.targetDomainHint === 'backend_runtime'
+    && !hasExactMethodAnchor
 
   if (!hasMethodAnchor && !pipelinePrompt) {
     return base
+  }
+
+  if (broadRuntimeGeneration && hasMethodAnchor && pipelinePrompt) {
+    return {
+      ...base,
+      directions: ['backward', 'forward'],
+      backward_relations: new Set(['controller_route', 'route_handler', 'method']),
+      forward_relations: new Set(['calls']),
+      helper_relations: new Set(['injects', 'depends_on', 'module_provides']),
+      backward_depth: 1,
+      forward_depth: Math.max(base.forward_depth, 4),
+      runtime_flow_only: true,
+    }
   }
 
   if (hasExactMethodAnchor && pipelinePrompt) {
@@ -205,6 +221,28 @@ function effectivePolicy(
 
 function isBarrelLike(label: string, sourceFile: string): boolean {
   return label.trim().toLowerCase() === 'index.ts' || /(?:^|\/)index\.ts$/i.test(sourceFile)
+}
+
+function broadRuntimeGenerationPrompt(options: SliceOptions): boolean {
+  return options.generationIntent === 'runtime_generation'
+    && options.targetDomainHint === 'backend_runtime'
+    && promptWantsRuntimePipeline(options.prompt)
+}
+
+function promptAllowsScriptMigration(options: SliceOptions): boolean {
+  const prompt = options.prompt ?? ''
+  return /\b(?:scripts?|migrat(?:e|ed|es|ing|ion)|backfill|seed|cli|one-off|repair|old pipeline)\b/i.test(prompt)
+}
+
+function scriptMigrationLikeNode(node: SliceScoredNode): boolean {
+  return /(?:^|\/)(?:scripts?|migrations?|seeds?|backfills?)(?:\/|$)|\b(?:migrate|migration|backfill|seed)\b/i.test(node.sourceFile)
+    || /\b(?:migrate|migration|backfill|seed)\b/i.test(node.label)
+}
+
+function routeOrControllerLikeNode(node: SliceScoredNode): boolean {
+  const lower = `${node.label} ${node.nodeKind ?? ''} ${node.frameworkRole ?? ''} ${node.sourceFile}`.toLowerCase()
+  return /\b(?:route|controller|nest_route|nest_controller)\b/.test(lower)
+    || /(?:^|\/)(?:controllers?|interface\/http)(?:\/|$)/.test(lower)
 }
 
 function frontendDisplayLikeNode(node: SliceScoredNode): boolean {
@@ -269,6 +307,9 @@ function shouldSuppressNode(
   if (isBarrelLike(node.label, node.sourceFile)) {
     return true
   }
+  if (broadRuntimeGenerationPrompt(options) && !promptAllowsScriptMigration(options) && scriptMigrationLikeNode(node)) {
+    return true
+  }
 
   return graph.degree(node.id) >= 40
 }
@@ -279,6 +320,7 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
   const matchedAnchors = scored.filter((node) => node.exactLabelMatch || node.sourcePathMatch)
   const exactMethodAnchors = matchedAnchors.filter((node) => node.exactLabelMatch && methodLikeNode(node))
   const nonBarrelMatchedAnchors = matchedAnchors.filter((node) => !isBarrelLike(node.label, node.sourceFile))
+  const broadRuntimeGeneration = broadRuntimeGenerationPrompt(options)
   const intentAnchors = (() => {
     if (options.generationIntent === 'runtime_generation' && options.targetDomainHint === 'backend_runtime') {
       return matchedAnchors
@@ -303,7 +345,7 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
   const anchorPool = exactMethodAnchors.length > 0
     ? exactMethodAnchors.slice(0, 1)
     : intentAnchors.length > 0
-    ? intentAnchors.slice(0, 2)
+    ? intentAnchors.slice(0, broadRuntimeGeneration ? 1 : 2)
     : matchedAnchors.length > 0
     ? (nonBarrelMatchedAnchors.length > 0 ? nonBarrelMatchedAnchors : matchedAnchors)
     : scored.filter((node) => !isBarrelLike(node.label, node.sourceFile)).slice(0, 1)
@@ -399,6 +441,15 @@ function traverseDirection(
 
       const neighbor = scoredById.get(neighborId) ?? sliceNodeFromGraph(graph, neighborId)
       scoredById.set(neighborId, neighbor)
+      if (
+        direction === 'forward'
+        && runtimeFlowOnly
+        && broadRuntimeGenerationPrompt(options)
+        && routeOrControllerLikeNode(neighbor)
+        && !anchoredIds.has(neighborId)
+      ) {
+        continue
+      }
       if (shouldSuppressNode(graph, neighbor, anchoredIds, options)) {
         continue
       }
@@ -578,7 +629,7 @@ export function sliceCandidatesForRetrieve(
   const anchorNodes = anchors
     .map((anchor) => scoredCandidates.find((candidate) => candidate.id === anchor.node_id))
     .filter((candidate): candidate is SliceScoredNode => candidate !== undefined)
-  const policy = effectivePolicy(intent, anchors, anchorNodes, options.prompt)
+  const policy = effectivePolicy(intent, anchors, anchorNodes, options)
   const anchorIds = anchors.map((anchor) => anchor.node_id).filter((id): id is string => typeof id === 'string')
   const orderedIds = [...anchorIds]
   const selectedIds = new Set(anchorIds)

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/infrastructure/services/build-perspective.service.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/infrastructure/services/build-perspective.service.ts
@@ -1,0 +1,13 @@
+export class BuildPerspectiveService {
+  async generateBuildPerspective(userId: string, ideaId: string): Promise<string> {
+    return `${userId}:${ideaId}:build-perspective`
+  }
+
+  async generateLetsBuild(userId: string, ideaId: string): Promise<string> {
+    return `${userId}:${ideaId}:lets-build`
+  }
+
+  async getBuildPerspective(userId: string, ideaId: string): Promise<string> {
+    return `${userId}:${ideaId}:current-build-perspective`
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/infrastructure/services/title-generation.service.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/infrastructure/services/title-generation.service.ts
@@ -1,11 +1,16 @@
+import { LlmProviderResolverService } from '../../../pipeline/providers/llm-provider-resolver.service'
+
 export class TitleGenerationService {
+  constructor(private readonly llmProviderResolverService: LlmProviderResolverService) {}
+
   async generateTitle(
     problem: string,
     userId: string,
     ideaId: string,
   ): Promise<{ summarizedTitle: string }> {
+    const title = await this.llmProviderResolverService.callLlm(problem)
     return {
-      summarizedTitle: `${problem}:${userId}:${ideaId}`,
+      summarizedTitle: `${title}:${userId}:${ideaId}`,
     }
   }
 }

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-artifacts.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-artifacts.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Get, Req } from '@nestjs/common'
+
+import { BuildPerspectiveService } from '../../infrastructure/services/build-perspective.service'
+import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
+
+@Controller('ideas/artifacts')
+export class IdeaArtifactsController {
+  constructor(private readonly buildPerspectiveService: BuildPerspectiveService) {}
+
+  @Get('build-perspective')
+  async generateBuildPerspective(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return this.buildPerspectiveService.generateBuildPerspective(
+      requireIdeasUserId(req),
+      dto.ideaId,
+    )
+  }
+
+  @Get('pdf')
+  async exportIdeaToPdf(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}:pdf`
+  }
+
+  @Get('lets-build')
+  async generateLetsBuild(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return this.buildPerspectiveService.generateLetsBuild(
+      requireIdeasUserId(req),
+      dto.ideaId,
+    )
+  }
+
+  @Get('build-perspective/:id')
+  async getBuildPerspective(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return this.buildPerspectiveService.getBuildPerspective(
+      requireIdeasUserId(req),
+      dto.ideaId,
+    )
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-artifacts.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-artifacts.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Req } from '@nestjs/common'
+import { Controller, Get, Param, Query, Req } from '@nestjs/common'
 
 import { BuildPerspectiveService } from '../../infrastructure/services/build-perspective.service'
 import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
@@ -9,42 +9,42 @@ export class IdeaArtifactsController {
 
   @Get('build-perspective')
   async generateBuildPerspective(
-    @Body() dto: { ideaId: string },
+    @Query('ideaId') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
     return this.buildPerspectiveService.generateBuildPerspective(
       requireIdeasUserId(req),
-      dto.ideaId,
+      ideaId,
     )
   }
 
   @Get('pdf')
   async exportIdeaToPdf(
-    @Body() dto: { ideaId: string },
+    @Query('ideaId') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
-    return `${requireIdeasUserId(req)}:${dto.ideaId}:pdf`
+    return `${requireIdeasUserId(req)}:${ideaId}:pdf`
   }
 
   @Get('lets-build')
   async generateLetsBuild(
-    @Body() dto: { ideaId: string },
+    @Query('ideaId') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
     return this.buildPerspectiveService.generateLetsBuild(
       requireIdeasUserId(req),
-      dto.ideaId,
+      ideaId,
     )
   }
 
   @Get('build-perspective/:id')
   async getBuildPerspective(
-    @Body() dto: { ideaId: string },
+    @Param('id') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
     return this.buildPerspectiveService.getBuildPerspective(
       requireIdeasUserId(req),
-      dto.ideaId,
+      ideaId,
     )
   }
 }

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-generation.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-generation.controller.ts
@@ -15,7 +15,7 @@ import { InputValidationService } from '../../infrastructure/services/input-vali
 import { ProblemSuggestionService } from '../../infrastructure/services/problem-suggestion.service'
 import { TitleGenerationService } from '../../infrastructure/services/title-generation.service'
 import { GenerateFromProblemDto } from './dto/generate-from-problem.dto'
-import type { AuthenticatedIdeasRequest } from './ideas-authenticated-request'
+import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
 
 class AuthGuard {}
 class LoggingInterceptor {}
@@ -32,10 +32,6 @@ function createIdeasControllerLogger(
       appLogger.log(`${context}:${message}`)
     },
   }
-}
-
-function requireIdeasUserId(req: AuthenticatedIdeasRequest): string {
-  return req.userId
 }
 
 @Controller('ideas')

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-lifecycle.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-lifecycle.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Req } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common'
 
 import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
 
@@ -6,10 +6,10 @@ import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-auth
 export class IdeaLifecycleController {
   @Get(':id')
   async getIdea(
-    @Body() dto: { ideaId: string },
+    @Param('id') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
-    return `${requireIdeasUserId(req)}:${dto.ideaId}`
+    return `${requireIdeasUserId(req)}:${ideaId}`
   }
 
   @Get()

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-lifecycle.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-lifecycle.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Get, Post, Req } from '@nestjs/common'
+
+import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
+
+@Controller('ideas/lifecycle')
+export class IdeaLifecycleController {
+  @Get(':id')
+  async getIdea(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}`
+  }
+
+  @Get()
+  async listIdeas(@Req() req: AuthenticatedIdeasRequest): Promise<string[]> {
+    return [requireIdeasUserId(req)]
+  }
+
+  @Post('publish')
+  async publishIdea(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}:published`
+  }
+
+  @Post('delete')
+  async deleteIdea(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}:deleted`
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-pipeline.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-pipeline.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Post, Req } from '@nestjs/common'
+
+import { PipelineTriggerService } from '../../../pipeline/api/pipeline-trigger.service'
+import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
+
+@Controller('ideas/pipeline')
+export class IdeaPipelineController {
+  constructor(private readonly pipelineTriggerService: PipelineTriggerService) {}
+
+  @Get('status')
+  async getPipelineStatus(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}:status`
+  }
+
+  @Post('retry')
+  async retryPipeline(
+    @Body() dto: { problem: string; ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<unknown> {
+    return this.pipelineTriggerService.startPipeline(
+      requireIdeasUserId(req),
+      dto.problem,
+      dto.ideaId,
+    )
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-pipeline.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-pipeline.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Query, Req } from '@nestjs/common'
+import { BadRequestException, Body, Controller, Get, Post, Query, Req } from '@nestjs/common'
 
 import { PipelineTriggerService } from '../../../pipeline/api/pipeline-trigger.service'
 import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
@@ -12,6 +12,10 @@ export class IdeaPipelineController {
     @Query('ideaId') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
+    if (!ideaId?.trim()) {
+      throw new BadRequestException('ideaId is required')
+    }
+
     return `${requireIdeasUserId(req)}:${ideaId}:status`
   }
 
@@ -20,6 +24,13 @@ export class IdeaPipelineController {
     @Body() dto: { problem: string; ideaId: string },
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<unknown> {
+    if (!dto.ideaId?.trim()) {
+      throw new BadRequestException('ideaId is required')
+    }
+    if (!dto.problem?.trim()) {
+      throw new BadRequestException('problem is required')
+    }
+
     return this.pipelineTriggerService.startPipeline(
       requireIdeasUserId(req),
       dto.problem,

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-pipeline.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/idea-pipeline.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Req } from '@nestjs/common'
+import { Body, Controller, Get, Post, Query, Req } from '@nestjs/common'
 
 import { PipelineTriggerService } from '../../../pipeline/api/pipeline-trigger.service'
 import { requireIdeasUserId, type AuthenticatedIdeasRequest } from './ideas-authenticated-request'
@@ -9,10 +9,10 @@ export class IdeaPipelineController {
 
   @Get('status')
   async getPipelineStatus(
-    @Body() dto: { ideaId: string },
+    @Query('ideaId') ideaId: string,
     @Req() req: AuthenticatedIdeasRequest,
   ): Promise<string> {
-    return `${requireIdeasUserId(req)}:${dto.ideaId}:status`
+    return `${requireIdeasUserId(req)}:${ideaId}:status`
   }
 
   @Post('retry')

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/ideas-authenticated-request.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/ideas/interface/http/ideas-authenticated-request.ts
@@ -1,3 +1,7 @@
 export interface AuthenticatedIdeasRequest {
   userId: string
 }
+
+export function requireIdeasUserId(req: AuthenticatedIdeasRequest): string {
+  return req.userId
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/nda-share/controllers/nda-share-owner.controller.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/nda-share/controllers/nda-share-owner.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Post, Req } from '@nestjs/common'
+
+import { requireIdeasUserId, type AuthenticatedIdeasRequest } from '../../ideas/interface/http/ideas-authenticated-request'
+
+@Controller('nda-share')
+export class NdaShareOwnerController {
+  @Post('create')
+  async createShare(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}:share`
+  }
+
+  @Post('sign')
+  async signNDA(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<string> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}:signed`
+  }
+
+  @Post('validate')
+  async validateShareAccess(
+    @Body() dto: { ideaId: string },
+    @Req() req: AuthenticatedIdeasRequest,
+  ): Promise<boolean> {
+    return `${requireIdeasUserId(req)}:${dto.ideaId}`.length > 0
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/pipeline/api/pipeline-trigger.service.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/pipeline/api/pipeline-trigger.service.ts
@@ -1,15 +1,20 @@
 import { OrchestratorWorker } from '../workers/orchestrator.worker'
+import { QueueRegistryService } from './queue-registry.service'
 
 export class PipelineTriggerService {
-  constructor(private readonly orchestratorWorker: OrchestratorWorker) {}
+  constructor(
+    private readonly orchestratorWorker: OrchestratorWorker,
+    private readonly queueRegistryService: QueueRegistryService,
+  ) {}
 
   async startPipeline(
     userId: string,
     problem: string,
     ideaId: string,
   ): Promise<{ jobId: string; result: unknown }> {
+    const job = await this.queueRegistryService.addJob({ userId, problem, ideaId })
     return {
-      jobId: `${ideaId}:job`,
+      jobId: job.jobId,
       result: await this.orchestratorWorker.process({ userId, problem, ideaId }),
     }
   }

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/pipeline/api/queue-registry.service.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/pipeline/api/queue-registry.service.ts
@@ -1,0 +1,7 @@
+export class QueueRegistryService {
+  async addJob(input: { userId: string; problem: string; ideaId: string }): Promise<{ jobId: string }> {
+    return {
+      jobId: `${input.userId}:${input.problem}:${input.ideaId}:job`,
+    }
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/pipeline/providers/llm-provider-resolver.service.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/modules/pipeline/providers/llm-provider-resolver.service.ts
@@ -1,0 +1,10 @@
+export class LlmProviderResolverService {
+  async resolve(prompt: string): Promise<string> {
+    return `provider:${prompt.length}`
+  }
+
+  async callLlm(prompt: string): Promise<string> {
+    const provider = await this.resolve(prompt)
+    return `${provider}:${prompt}`
+  }
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/scripts/migrate-old-pipeline-ideas.ts
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/src/scripts/migrate-old-pipeline-ideas.ts
@@ -1,0 +1,10 @@
+import { IdeasService } from '../modules/ideas/core/application/ideas.service'
+
+export async function migrateIdea(ideasService: IdeasService, userId: string, problem: string): Promise<string> {
+  const idea = await ideasService.createIdea(userId, problem)
+  return idea.id
+}
+
+export async function main(): Promise<void> {
+  await migrateIdea(new IdeasService(), 'system', 'old pipeline idea')
+}

--- a/tests/fixtures/spi/nest-di-runtime-calls-realistic/tsconfig.json
+++ b/tests/fixtures/spi/nest-di-runtime-calls-realistic/tsconfig.json
@@ -13,6 +13,7 @@
     "src/**/*.ts",
     "platform/**/*.tsx",
     "benchmark/**/*.ts",
-    "fixtures/**/*.ts"
+    "fixtures/**/*.ts",
+    "src/scripts/**/*.ts"
   ]
 }

--- a/tests/unit/context-pack-value-per-token-131.test.ts
+++ b/tests/unit/context-pack-value-per-token-131.test.ts
@@ -254,7 +254,7 @@ describe('compileContextPack selection_strategy=value-per-token (#131)', () => {
   it('does not treat graph seed prompts as permission to include script seed files', () => {
     const pack = compileContextPack({
       task_contract: task({
-        budget: 80,
+        budget: 10,
         prompt: 'Explain how graph seed nodes affect retrieval ranking',
         required_evidence: [],
         preferred_evidence: ['supporting'],
@@ -273,11 +273,14 @@ describe('compileContextPack selection_strategy=value-per-token (#131)', () => {
       selection_strategy: 'value-per-token',
     })
 
+    expect(pack.nodes.map((node) => node.label)).toEqual(['GraphSeedNode'])
     const byLabel = new Map(pack.selection_diagnostics?.ranking.map((entry) => [entry.label, entry]) ?? [])
     expect(byLabel.get('seedOldReports')).toEqual(expect.objectContaining({
+      included: false,
       penalties: expect.arrayContaining(['script/migration penalty']),
     }))
     expect(byLabel.get('GraphSeedNode')).toEqual(expect.objectContaining({
+      included: true,
       penalties: expect.not.arrayContaining(['script/migration penalty']),
     }))
   })

--- a/tests/unit/context-pack-value-per-token-131.test.ts
+++ b/tests/unit/context-pack-value-per-token-131.test.ts
@@ -250,4 +250,35 @@ describe('compileContextPack selection_strategy=value-per-token (#131)', () => {
       penalties: expect.arrayContaining(['barrel export penalty']),
     }))
   })
+
+  it('does not treat graph seed prompts as permission to include script seed files', () => {
+    const pack = compileContextPack({
+      task_contract: task({
+        budget: 80,
+        prompt: 'Explain how graph seed nodes affect retrieval ranking',
+        required_evidence: [],
+        preferred_evidence: ['supporting'],
+        semantic_required: ['implementation'],
+      }),
+      nodes: [
+        candidate('seedOldReports', 'supporting', 10, {
+          source_file: '/src/scripts/seed-old-reports.ts',
+          match_score: 5,
+        }),
+        candidate('GraphSeedNode', 'supporting', 10, {
+          source_file: '/src/runtime/retrieve.ts',
+          match_score: 4,
+        }),
+      ],
+      selection_strategy: 'value-per-token',
+    })
+
+    const byLabel = new Map(pack.selection_diagnostics?.ranking.map((entry) => [entry.label, entry]) ?? [])
+    expect(byLabel.get('seedOldReports')).toEqual(expect.objectContaining({
+      penalties: expect.arrayContaining(['script/migration penalty']),
+    }))
+    expect(byLabel.get('GraphSeedNode')).toEqual(expect.objectContaining({
+      penalties: expect.not.arrayContaining(['script/migration penalty']),
+    }))
+  })
 })

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -38,6 +38,10 @@ function loadReadme(): string {
   return readFileSync(join(process.cwd(), 'README.md'), 'utf8')
 }
 
+function loadChangelog(): string {
+  return readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf8')
+}
+
 function loadContributingGuide(): string {
   return readFileSync(join(process.cwd(), 'CONTRIBUTING.md'), 'utf8')
 }
@@ -115,6 +119,12 @@ describe('package metadata', () => {
     expect(packageLock.packages?.['']?.version).toBe(manifest.version)
   })
 
+  it('documents the current package version in the changelog', () => {
+    const manifest = loadPackageManifest()
+
+    expect(loadChangelog()).toContain(`## [${manifest.version}]`)
+  })
+
   it('positions package metadata around the context plane and context compiler surface', () => {
     const manifest = loadPackageManifest()
     const readme = loadReadme().toLowerCase()
@@ -133,6 +143,13 @@ describe('package metadata', () => {
     expect(readme).toContain('graphify-ts prompt')
     expect(readme).toContain('context_pack')
     expect(readme).toContain('context_prompt')
+  })
+
+  it('documents broad runtime-generation pack compaction in the README', () => {
+    const readme = loadReadme().toLowerCase()
+
+    expect(readme).toContain('runtime-generation prompts stay compact')
+    expect(readme).toContain('shared-hub fan-out')
   })
 
   it('avoids circular maintainer guidance in the contributing guide', () => {

--- a/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
+++ b/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
@@ -1,4 +1,4 @@
-import { resolve as pathResolve } from 'node:path'
+import { relative as pathRelative, resolve as pathResolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -25,9 +25,15 @@ const FIXTURE_ROOT = pathResolve(
   __dirname,
   '../fixtures/spi/nest-di-runtime-calls-realistic',
 )
+const WINDOWS_FIXTURE_ROOT = 'C:\\repo\\nest-di-runtime-calls-realistic'
 
 function normalizePathForAssertion(value: string): string {
   return value.replaceAll('\\', '/')
+}
+
+function toWindowsFixturePath(sourceFile: string): string {
+  const relativePath = pathRelative(FIXTURE_ROOT, sourceFile).replaceAll('/', '\\')
+  return `${WINDOWS_FIXTURE_ROOT}\\${relativePath}`
 }
 
 function buildFixtureSpi(): SemanticProgramIndex {
@@ -43,9 +49,24 @@ function buildFixtureExtraction(): ExtractionData {
   return projectSpiToExtraction(buildFixtureSpi(), { root: FIXTURE_ROOT })
 }
 
-function buildFixtureGraph(): KnowledgeGraph {
+function buildFixtureGraph(options: { windowsSourcePaths?: boolean } = {}): KnowledgeGraph {
   const extraction = buildFixtureExtraction()
-  return buildFromJson({ ...extraction, root_path: FIXTURE_ROOT }, { directed: true })
+  if (!options.windowsSourcePaths) {
+    return buildFromJson({ ...extraction, root_path: FIXTURE_ROOT }, { directed: true })
+  }
+
+  return buildFromJson({
+    ...extraction,
+    root_path: WINDOWS_FIXTURE_ROOT,
+    nodes: extraction.nodes.map((node) => ({
+      ...node,
+      source_file: toWindowsFixturePath(node.source_file),
+    })),
+    edges: extraction.edges.map((edge) => ({
+      ...edge,
+      source_file: edge.source_file ? toWindowsFixturePath(edge.source_file) : undefined,
+    })),
+  }, { directed: true })
 }
 
 function findSymbol(
@@ -304,7 +325,7 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
   })
 
   it('routes broad report-generation prompts to backend runtime nodes instead of frontend display helpers', () => {
-    const result = retrieveContext(buildFixtureGraph(), {
+    const result = retrieveContext(buildFixtureGraph({ windowsSourcePaths: true }), {
       question: 'Explain how idea report is getting generated',
       budget: 4000,
       retrievalLevel: 4,

--- a/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
+++ b/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
@@ -314,6 +314,7 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
     const labels = result.matched_nodes.map((node) => node.label)
     const sourceFiles = result.matched_nodes.map((node) => normalizePathForAssertion(node.source_file))
     const frontendLabels = ['ReportFooter', 'pickGeneratedAt', 'pickPipelineLabel']
+    const diagnostics = computeContextPackDiagnostics(contextPackFromRetrieveResult(result))
 
     expect(result.retrieval_gate?.signals.generation_intent).toBe('runtime_generation')
     expect(result.retrieval_gate?.signals.target_domain_hint).toBe('backend_runtime')
@@ -321,8 +322,37 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
       expect.arrayContaining([
         '.generateFromProblem()',
         '.createIdea()',
+        '.generateTitle()',
+        '.updateTitle()',
+        '.startPipeline()',
+        '.claimQueuedPipelineRun()',
+        '.cancelPipeline()',
+        '.addJob()',
       ]),
     )
+    expect(labels).toEqual(expect.arrayContaining(['.process()']))
+    expect(labels).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^\.(search|score|save)\(\)$/),
+    ]))
+    expect(labels).not.toEqual(expect.arrayContaining([
+      '.generateBuildPerspective()',
+      '.exportIdeaToPdf()',
+      '.generateLetsBuild()',
+      '.getBuildPerspective()',
+      '.deleteIdea()',
+      '.getIdea()',
+      '.listIdeas()',
+      '.publishIdea()',
+      '.retryPipeline()',
+      '.createShare()',
+      '.signNDA()',
+      '.validateShareAccess()',
+      'migrateIdea()',
+      'main()',
+    ]))
+    expect(labels.filter((label) => ['.callLlm()', '.resolve()'].includes(label)).length).toBeLessThanOrEqual(1)
+    expect(result.token_count).toBeLessThan(2500)
+    expect(diagnostics.warnings.map((warning) => warning.kind)).not.toContain('runtime_pack_overexpanded')
     expect(sourceFiles.some((sourceFile) => sourceFile.includes('src/modules/ideas/'))).toBe(true)
     expect(labels.filter((label) => frontendLabels.includes(label))).toHaveLength(0)
     expect(sourceFiles.some((sourceFile) => sourceFile.includes('platform/src/features/idea-detail/components/ReportFooter.tsx'))).toBe(false)


### PR DESCRIPTION
## Summary
- compact broad backend runtime-generation slices around the strongest runtime anchor while preserving bounded controller/provider context
- suppress sibling route fan-out, script/migration noise, and shared-hub over-expansion in broad runtime packs
- add runtime over-expansion diagnostics plus noisy NestJS fixture coverage

## Verification
- npm run typecheck
- npm run build
- npm run test:run
- GoValidate smoke: generated graph with local CLI, backend pack token_count 1517/no warnings, frontend display pack token_count 549/no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime over-expansion diagnostic that warns when runtime packs include excessive irrelevant nodes.

* **Improvements**
  * More compact runtime-generation traversal that favors forward runtime paths and suppresses unrelated context.
  * Script/migration detection and scoring penalties to deprioritize script-like candidates unless explicitly requested.
  * Improved path/token matching with Windows-style path normalization.

* **Tests**
  * Expanded realistic fixtures and unit tests to cover controllers, services, queue flows, and migration/script handling.

* **Documentation**
  * Changelog and README updated describing the runtime-pack refinements.

* **Chores**
  * Package version bumped to 0.22.6.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/152)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->