### PR TITLE
Prepare v0.22.7 compare summary patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.7] - 2026-05-12
+
+### Changed
+
+- **Native-agent compare summaries keep the right direction**: human-readable `graphify-ts compare --baseline-mode native_agent` output now says `x more` / `x slower` when Graphify uses more turns, latency, or input tokens than baseline, instead of incorrectly rendering `0.33x fewer` / `0.33x faster`.
+
 ## [0.22.6] - 2026-05-12
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.22.6",
+    "version": "0.22.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.22.6",
+            "version": "0.22.7",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.22.6",
+    "version": "0.22.7",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1597,6 +1597,23 @@ function computeReduction(baseline: number, graphify: number): number | null {
   return Number((baseline / graphify).toFixed(2))
 }
 
+function formatDirectionalDelta(
+  baseline: number,
+  graphify: number,
+  decreasedLabel: string,
+  increasedLabel: string,
+): string {
+  if (baseline <= 0 || graphify <= 0 || baseline === graphify) {
+    return ''
+  }
+
+  if (graphify < baseline) {
+    return ` (${Number((baseline / graphify).toFixed(2))}x ${decreasedLabel})`
+  }
+
+  return ` (${Number((graphify / baseline).toFixed(2))}x ${increasedLabel})`
+}
+
 function isNativeAgentRunFailure(run: NativeAgentRunStatus): boolean {
   return run.kind === 'runner_error'
 }
@@ -1884,12 +1901,11 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       continue
     }
 
-    const reductions = report.reductions
     lines.push(
       `- "${report.question}"`,
-      `    num_turns: baseline ${baseline.num_turns} → graphify ${graphify.num_turns}${reductions?.num_turns ? ` (${reductions.num_turns}x fewer)` : ''}`,
-      `    latency:   baseline ${baseline.duration_ms}ms → graphify ${graphify.duration_ms}ms${reductions?.duration_ms ? ` (${reductions.duration_ms}x faster)` : ''}`,
-      `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → graphify ${graphify.total_input_tokens_anthropic_exact}${reductions?.input_tokens ? ` (${reductions.input_tokens}x less)` : ''}`,
+      `    num_turns: baseline ${baseline.num_turns} → graphify ${graphify.num_turns}${formatDirectionalDelta(baseline.num_turns, graphify.num_turns, 'fewer', 'more')}`,
+      `    latency:   baseline ${baseline.duration_ms}ms → graphify ${graphify.duration_ms}ms${formatDirectionalDelta(baseline.duration_ms, graphify.duration_ms, 'faster', 'slower')}`,
+      `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → graphify ${graphify.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, graphify.total_input_tokens_anthropic_exact, 'less', 'more')}`,
       `    provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs`,
     )
   }

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   executeNativeAgentCompare,
+  formatNativeAgentCompareSummary,
   parseAnthropicResultEvent,
   type CompareRunMode,
+  type NativeAgentCompareResult,
   type NativeAgentCompareReport,
   type NativeAgentRunner,
 } from '../../src/infrastructure/compare.js'
@@ -80,6 +82,89 @@ function scriptedRunner(payloads: { baseline: unknown; graphify: unknown }): Nat
     stderr: '',
     elapsedMs: input.mode === 'baseline' ? 96368 : 34744,
   })
+}
+
+function buildSummaryResult(overrides: {
+  question: string
+  baselineTurns: number
+  graphifyTurns: number
+  baselineDurationMs: number
+  graphifyDurationMs: number
+  baselineInputTokens: number
+  graphifyInputTokens: number
+  reductions: NonNullable<NativeAgentCompareReport['reductions']>
+}): NativeAgentCompareResult {
+  return {
+    graph_path: '/tmp/project/graphify-out/graph.json',
+    output_root: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z',
+    reports: [
+      {
+        baseline_mode: 'native_agent',
+        question: overrides.question,
+        graph_path: '/tmp/project/graphify-out/graph.json',
+        exec_command: { command: null, redacted: true, placeholders: [] },
+        baseline: {
+          kind: 'succeeded',
+          model: 'claude-sonnet',
+          usage: {
+            input_tokens: overrides.baselineInputTokens,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 100,
+          },
+          total_input_tokens_anthropic_exact: overrides.baselineInputTokens,
+          total_cost_usd: 1,
+          num_turns: overrides.baselineTurns,
+          duration_ms: overrides.baselineDurationMs,
+          result_path: '/tmp/project/baseline.txt',
+        },
+        graphify: {
+          kind: 'succeeded',
+          model: 'claude-sonnet',
+          usage: {
+            input_tokens: overrides.graphifyInputTokens,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 100,
+          },
+          total_input_tokens_anthropic_exact: overrides.graphifyInputTokens,
+          total_cost_usd: 1,
+          num_turns: overrides.graphifyTurns,
+          duration_ms: overrides.graphifyDurationMs,
+          result_path: '/tmp/project/graphify.txt',
+        },
+        reductions: overrides.reductions,
+        prompt_token_source: {
+          baseline: 'anthropic_provider_reported',
+          graphify: 'anthropic_provider_reported',
+        },
+        provider_proof: {
+          baseline: {
+            provider: 'anthropic',
+            input_tokens_source: 'anthropic_provider_reported',
+            effective_tokens_source: 'anthropic_provider_reported',
+            total_tokens_source: 'anthropic_provider_reported',
+          },
+          graphify: {
+            provider: 'anthropic',
+            input_tokens_source: 'anthropic_provider_reported',
+            effective_tokens_source: 'anthropic_provider_reported',
+            total_tokens_source: 'anthropic_provider_reported',
+          },
+          reduction_basis: 'provider_reported',
+        },
+        started_at: '2026-05-12T00:00:00.000Z',
+        completed_at: '2026-05-12T00:00:01.000Z',
+        paths: {
+          output_dir: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z',
+          report: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/report.json',
+          baseline_answer: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/baseline.md',
+          graphify_answer: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/graphify.md',
+          prompt_file: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/prompt.txt',
+        },
+      },
+    ],
+  }
 }
 
 describe('parseAnthropicResultEvent', () => {
@@ -359,5 +444,54 @@ describe('executeNativeAgentCompare', () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
+  })
+})
+
+describe('formatNativeAgentCompareSummary', () => {
+  it('describes wins as fewer, less, and faster', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'win case',
+      baselineTurns: 9,
+      graphifyTurns: 3,
+      baselineDurationMs: 9000,
+      graphifyDurationMs: 3000,
+      baselineInputTokens: 900,
+      graphifyInputTokens: 300,
+      reductions: {
+        num_turns: 3,
+        duration_ms: 3,
+        input_tokens: 3,
+        cost_usd: 1,
+      },
+    }))
+
+    expect(summary).toContain('num_turns: baseline 9 → graphify 3 (3x fewer)')
+    expect(summary).toContain('latency:   baseline 9000ms → graphify 3000ms (3x faster)')
+    expect(summary).toContain('input_tokens (Anthropic-reported): baseline 900 → graphify 300 (3x less)')
+  })
+
+  it('describes regressions as more and slower instead of fewer and faster', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'loss case',
+      baselineTurns: 3,
+      graphifyTurns: 9,
+      baselineDurationMs: 3000,
+      graphifyDurationMs: 9000,
+      baselineInputTokens: 300,
+      graphifyInputTokens: 900,
+      reductions: {
+        num_turns: 0.33,
+        duration_ms: 0.33,
+        input_tokens: 0.33,
+        cost_usd: 1,
+      },
+    }))
+
+    expect(summary).toContain('num_turns: baseline 3 → graphify 9 (3x more)')
+    expect(summary).toContain('latency:   baseline 3000ms → graphify 9000ms (3x slower)')
+    expect(summary).toContain('input_tokens (Anthropic-reported): baseline 300 → graphify 900 (3x more)')
+    expect(summary).not.toContain('0.33x fewer')
+    expect(summary).not.toContain('0.33x faster')
+    expect(summary).not.toContain('0.33x less')
   })
 })


### PR DESCRIPTION
## Summary
- fix native-agent compare summaries so regressions render as `x more` / `x slower` instead of incorrect `0.33x fewer` / `0.33x faster`
- add regression coverage for both compare-summary directions and bump release metadata to `0.22.7`
- confirm on the real GoValidate workspace that the previously reported broad runtime-pack issue no longer reproduces on this branch, so retrieval stays unchanged

## Test Plan
- [x] npm run test:run -- tests/unit/compare-native-agent.test.ts tests/unit/package-metadata.test.ts
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run
- [x] npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directional reporting in comparison summaries to correctly indicate whether Graphify uses more or fewer turns, latency, and input tokens versus baseline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->