### PR TITLE
Prepare v0.22.8 CLI version and benchmark docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.8] - 2026-05-13
+
+### Added
+
+- **CLI version flags for reproducible runs**: `graphify-ts --version` and `graphify-ts -v` now print the installed package version and exit cleanly without requiring graph generation.
+
+### Docs
+
+- **Conservative GoValidate report-generation benchmark note**: adds a dated benchmark artifact for one real `compare --baseline-mode native_agent` run on the prompt `"Explain how idea report is getting generated"`, including the exact Anthropic-reported token/turn/latency numbers used, the compact `pack` quality gate values, and explicit safe vs unsafe interpretations.
+- **Benchmark caveats are explicit**: the new benchmark note calls out that the result is one prompt/project, that native-agent runs are stochastic and tool-usage-sensitive, and that the measurement does not prove universal token reduction.
+
 ## [0.22.7] - 2026-05-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Interactive CLI update notices**: interactive `graphify-ts` runs now check npm for newer releases using a cached user-level registry lookup, print a short upgrade hint when a newer version exists, and stay silent for `--help`, `--version`, `--json`, CI, and explicitly disabled runs (`GRAPHIFY_DISABLE_UPDATE_NOTIFIER=1`).
+
 ## [0.22.8] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ PR-review proof on a real diff: prompt tokens 63,024 → **8,690** (**7.25× few
 
 Latest runtime-pack refinement: **runtime-generation prompts stay compact** by following the strongest backend runtime path and suppressing sibling routes, script/migration noise, and shared-hub fan-out on broad backend-generation questions.
 
+Single-prompt backend benchmark snapshot: in one real GoValidate `compare --baseline-mode native_agent` run for `"Explain how idea report is getting generated"`, graphify-ts reduced Anthropic-reported input tokens from **1,653,307** to **498,280** (~**69.9%** lower). Details and caveats: [`docs/benchmarks/2026-05-12-govalidate-report-generation/`](docs/benchmarks/2026-05-12-govalidate-report-generation/).
+
 [Reproduce them](docs/benchmarks/2026-04-30-govalidate/verify.sh) with one shell script against the committed evidence files.
 
 ---

--- a/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
+++ b/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
@@ -1,0 +1,116 @@
+# 2026-05-12 — GoValidate report-generation explanation benchmark
+
+This directory records a **single real-world** `graphify-ts compare --baseline-mode native_agent` benchmark on GoValidate for the prompt:
+
+> `"Explain how idea report is getting generated"`
+
+The goal is not to claim a universal win. The goal is to publish one reproducible, sober benchmark note for the first strong real token reduction after the runtime-pack quality fixes in `v0.22.7`.
+
+## Summary
+
+- **Project:** GoValidate backend / monorepo
+- **Version under test:** `@mohammednagy/graphify-ts@0.22.7`
+- **Mode:** `graphify-ts compare --baseline-mode native_agent`
+- **Model/runtime:** Claude CLI via `cat {prompt_file} | claude -p --output-format json`
+- **Token source:** Anthropic-reported input/cache/total token usage captured by `graphify-ts compare`
+
+### Result
+
+| Metric | Baseline | Graphify | Derived change |
+|---|---:|---:|---:|
+| Input tokens (Anthropic-reported) | 1,653,307 | 498,280 | 1,155,027 saved (**~69.9% reduction**) |
+| Turns | 19 | 8 | 11 saved (**~57.9% reduction**) |
+| Latency | 116,029 ms | 67,454 ms | 48,575 ms saved (**~41.9% reduction**, **1.72x faster**) |
+
+This is the exact compare summary captured for the run:
+
+```text
+[graphify compare] completed 1 native_agent question(s)
+- Output: /Users/mohammednaji/Desktop/projects/works/govalidate/graphify-out/compare/2026-05-12T19-18-26
+- "Explain how idea report is getting generated"
+    num_turns: baseline 19 → graphify 8 (2.38x fewer)
+    latency:   baseline 116029ms → graphify 67454ms (1.72x faster)
+    input_tokens (Anthropic-reported): baseline 1653307 → graphify 498280 (3.32x less)
+    provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs
+```
+
+## Commands
+
+`0.22.7` is the version used for this benchmark. Future versions may improve or regress; do not read this as “install 0.22.7 forever.”
+
+```bash
+npm install -g @mohammednagy/graphify-ts@0.22.7
+
+rm -rf graphify-out
+graphify-ts generate . --spi
+
+graphify-ts pack "Explain how idea report is getting generated" \
+  --task explain \
+  --retrieval-level 4 \
+  --retrieval-strategy slice-v1 \
+  --budget 4000 \
+  --graph graphify-out/graph.json
+
+graphify-ts compare "Explain how idea report is getting generated " \
+  --exec 'cat {prompt_file} | claude -p --output-format json' \
+  --yes \
+  --baseline-mode native_agent
+```
+
+If you want a machine-readable copy of the pack output for archival, redirect the `pack` command to a file yourself (for example `> pack.json`). This directory does **not** ship a synthetic `pack.json`.
+
+## Pack quality gate
+
+The compare win only became credible after the runtime pack stopped filling the full 4000-token budget and returned a compact runtime slice instead of near-whole-backend noise.
+
+The `v0.22.7` pack quality gate for this prompt was:
+
+```text
+token_count: 1456
+matched_nodes: 38
+relationships: 57
+missing required runtime path nodes: none
+forbidden sibling/script/share nodes: none
+script sources: none
+LLM fanout: none
+coverage: primary/supporting/structural/implementation/structure covered
+diagnostics: none
+```
+
+Why this matters: a 3.32x input-token reduction is not persuasive if the compiled pack still expands to the full budget. Here the pack stayed compact **and** preserved the required runtime path.
+
+## Reproducing from this directory
+
+Drop the `report.json` from:
+
+```text
+graphify-out/compare/2026-05-12T19-18-26/report.json
+```
+
+into this directory, then run:
+
+```bash
+bash docs/benchmarks/2026-05-12-govalidate-report-generation/verify.sh
+```
+
+The script recomputes the saved-token, saved-turn, and latency deltas directly from the compare report. It does **not** rely on local `cl100k_base` estimates.
+
+## Caveats
+
+- This is a **single prompt / single project** benchmark.
+- Native-agent behavior is stochastic; reruns can vary.
+- Claude MCP/tool usage can change turn count and token totals.
+- Anthropic provider-reported tokens include cache creation/read details; `compare` records provider/runtime proof for both runs.
+- This benchmark does **not** prove universal token reduction.
+- More benchmark cases are needed across prompts, repositories, and task types.
+
+## Safe interpretation
+
+In this one real GoValidate benchmark, graphify-ts provided a compact runtime context that reduced Claude Code input tokens by ~70%, reduced turns by ~58%, and reduced latency by ~42% compared with the native-agent baseline.
+
+## Unsafe claims
+
+- “Always 70% token reduction”
+- “Guaranteed faster”
+- “Works equally on every repo”
+- “Graphify replaces code search entirely”

--- a/docs/benchmarks/2026-05-12-govalidate-report-generation/verify.sh
+++ b/docs/benchmarks/2026-05-12-govalidate-report-generation/verify.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Reproducer for the 2026-05-12 GoValidate report-generation compare benchmark.
+#
+# Drop the compare report.json from:
+#   graphify-out/compare/2026-05-12T19-18-26/report.json
+# into this directory, then run this script to recompute the published totals.
+
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPORT="$DIR/report.json"
+
+if [ ! -f "$REPORT" ]; then
+  echo "[graphify benchmark] $REPORT not found." >&2
+  echo "[graphify benchmark] Drop report.json from your" >&2
+  echo "[graphify benchmark] graphify-out/compare/2026-05-12T19-18-26/ here." >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "[graphify benchmark] node is required (>= 20)." >&2
+  exit 1
+fi
+
+node - <<'NODE' "$REPORT"
+const fs = require('fs')
+
+const reportPath = process.argv[2]
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+
+function pickRun(key) {
+  const run = report?.[key]
+  if (!run || typeof run !== 'object') {
+    throw new Error(`Missing ${key} run in report.json`)
+  }
+  return run
+}
+
+function totalInputTokens(usage) {
+  if (!usage || typeof usage !== 'object') {
+    throw new Error('Missing Anthropic usage block in report.json')
+  }
+  return Number(usage.input_tokens ?? 0)
+    + Number(usage.cache_creation_input_tokens ?? 0)
+    + Number(usage.cache_read_input_tokens ?? 0)
+}
+
+function formatPercent(saved, baseline) {
+  return Number(((saved / baseline) * 100).toFixed(1))
+}
+
+function formatRatio(baseline, graphify) {
+  return Number((baseline / graphify).toFixed(2))
+}
+
+const baseline = pickRun('baseline')
+const graphify = pickRun('graphify')
+
+if (baseline.kind !== 'succeeded' || graphify.kind !== 'succeeded') {
+  throw new Error('Expected succeeded baseline/graphify runs in report.json')
+}
+
+const baselineTokens = totalInputTokens(baseline.usage)
+const graphifyTokens = totalInputTokens(graphify.usage)
+const savedTokens = baselineTokens - graphifyTokens
+const savedTurns = baseline.num_turns - graphify.num_turns
+const savedLatency = baseline.duration_ms - graphify.duration_ms
+
+console.log(`report_path: ${reportPath}`)
+console.log(`input_tokens: baseline ${baselineTokens} -> graphify ${graphifyTokens}`)
+console.log(`input_tokens_saved: ${savedTokens}`)
+console.log(`input_token_reduction_percent: ${formatPercent(savedTokens, baselineTokens)}%`)
+console.log(`input_token_ratio: ${formatRatio(baselineTokens, graphifyTokens)}x less`)
+console.log(`turns: baseline ${baseline.num_turns} -> graphify ${graphify.num_turns}`)
+console.log(`turns_saved: ${savedTurns}`)
+console.log(`turn_reduction_percent: ${formatPercent(savedTurns, baseline.num_turns)}%`)
+console.log(`turn_ratio: ${formatRatio(baseline.num_turns, graphify.num_turns)}x fewer`)
+console.log(`latency_ms: baseline ${baseline.duration_ms} -> graphify ${graphify.duration_ms}`)
+console.log(`latency_saved_ms: ${savedLatency}`)
+console.log(`latency_reduction_percent: ${formatPercent(savedLatency, baseline.duration_ms)}%`)
+console.log(`latency_ratio: ${formatRatio(baseline.duration_ms, graphify.duration_ms)}x faster`)
+NODE
+
+echo
+echo "Expected 2026-05-12 benchmark values:"
+echo "  input_tokens  : 1653307 -> 498280 (1155027 saved, ~69.9% reduction, 3.32x less)"
+echo "  turns         : 19 -> 8 (11 saved, ~57.9% reduction, 2.38x fewer)"
+echo "  latency_ms    : 116029 -> 67454 (48575 saved, ~41.9% reduction, 1.72x faster)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.22.7",
+    "version": "0.22.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.22.7",
+            "version": "0.22.8",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.22.7",
+    "version": "0.22.8",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -36,6 +36,7 @@ import { diffGraphs } from '../runtime/diff.js'
 import { serveGraphStdio } from '../runtime/stdio-server.js'
 import { getNeighbors, getNode, loadGraph, queryGraph, shortestPath } from '../runtime/serve.js'
 import { formatTimeTravelResult } from '../runtime/time-travel.js'
+import { findPackageRoot, readPackageVersion } from '../shared/package-metadata.js'
 import {
   parseBenchmarkArgs,
   parseAddArgs,
@@ -275,7 +276,7 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
   return [
     `Usage: ${binaryName} <command>`,
     '',
-    'Run with --help or -h to see this message.',
+    'Run with --help or -h to see this message, or --version / -v to print the installed version.',
     '',
     'Commands:',
     '  generate [path]       build graph artifacts for a folder (default .)',
@@ -517,6 +518,11 @@ function handleAgentCommand(command: AgentPlatform, args: string[], io: CliIO, d
 
 export async function executeCli(argv: string[], io: CliIO = console, dependencies: CliDependencies = DEFAULT_DEPENDENCIES): Promise<number> {
   const [command, ...args] = argv
+
+  if (command === '-v' || command === '--version') {
+    io.log(readPackageVersion(findPackageRoot()))
+    return 0
+  }
 
   if (!command || command === '-h' || command === '--help') {
     io.log(formatHelp())

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -143,6 +143,7 @@ export interface CliDependencies {
   agentsInstall: typeof agentsInstall
   agentsUninstall: typeof agentsUninstall
   notifyUpdate?: () => Promise<string | null> | string | null
+  readInstalledVersion?: () => string
 }
 
 const COMPARE_WARNING_MESSAGE = 'compare will execute a baseline prompt and a graphify prompt for each question. This may consume paid model tokens.'
@@ -238,6 +239,7 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
     packageName: '@mohammednagy/graphify-ts',
     currentVersion: readPackageVersion(findPackageRoot()),
   }),
+  readInstalledVersion: () => readPackageVersion(findPackageRoot()),
 }
 
 function messageFromError(error: unknown): string {
@@ -525,28 +527,29 @@ function handleAgentCommand(command: AgentPlatform, args: string[], io: CliIO, d
 export async function executeCli(argv: string[], io: CliIO = console, dependencies: CliDependencies = DEFAULT_DEPENDENCIES): Promise<number> {
   const [command, ...args] = argv
 
-  if (command === '-v' || command === '--version') {
-    io.log(readPackageVersion(findPackageRoot()))
-    return 0
-  }
-
   if (!command || command === '-h' || command === '--help') {
     io.log(formatHelp())
     return 0
   }
 
-  if (!args.includes('--json') && dependencies.notifyUpdate) {
-    try {
-      const updateNotice = await dependencies.notifyUpdate()
-      if (updateNotice) {
-        io.log(updateNotice)
-      }
-    } catch {
-      // Update checks are best-effort and must never block the CLI command itself.
-    }
-  }
-
   try {
+    if (command === '-v' || command === '--version') {
+      const readInstalledVersion = dependencies.readInstalledVersion ?? (() => readPackageVersion(findPackageRoot()))
+      io.log(readInstalledVersion())
+      return 0
+    }
+
+    if (!args.includes('--json') && dependencies.notifyUpdate) {
+      try {
+        const updateNotice = await dependencies.notifyUpdate()
+        if (updateNotice) {
+          io.log(updateNotice)
+        }
+      } catch {
+        // Update checks are best-effort and must never block the CLI command itself.
+      }
+    }
+
     if (command === 'compare') {
       const options = parseCompareArgs(args)
       const confirm = async (message: string) => await dependencies.confirm(message)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -37,6 +37,7 @@ import { serveGraphStdio } from '../runtime/stdio-server.js'
 import { getNeighbors, getNode, loadGraph, queryGraph, shortestPath } from '../runtime/serve.js'
 import { formatTimeTravelResult } from '../runtime/time-travel.js'
 import { findPackageRoot, readPackageVersion } from '../shared/package-metadata.js'
+import { getUpdateNotification } from '../shared/update-notifier.js'
 import {
   parseBenchmarkArgs,
   parseAddArgs,
@@ -141,6 +142,7 @@ export interface CliDependencies {
   claudeUninstall: typeof claudeUninstall
   agentsInstall: typeof agentsInstall
   agentsUninstall: typeof agentsUninstall
+  notifyUpdate?: () => Promise<string | null> | string | null
 }
 
 const COMPARE_WARNING_MESSAGE = 'compare will execute a baseline prompt and a graphify prompt for each question. This may consume paid model tokens.'
@@ -232,6 +234,10 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   claudeUninstall,
   agentsInstall,
   agentsUninstall,
+  notifyUpdate: async () => await getUpdateNotification({
+    packageName: '@mohammednagy/graphify-ts',
+    currentVersion: readPackageVersion(findPackageRoot()),
+  }),
 }
 
 function messageFromError(error: unknown): string {
@@ -527,6 +533,17 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
   if (!command || command === '-h' || command === '--help') {
     io.log(formatHelp())
     return 0
+  }
+
+  if (!args.includes('--json') && dependencies.notifyUpdate) {
+    try {
+      const updateNotice = await dependencies.notifyUpdate()
+      if (updateNotice) {
+        io.log(updateNotice)
+      }
+    } catch {
+      // Update checks are best-effort and must never block the CLI command itself.
+    }
   }
 
   try {

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, rmdirSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { getBuiltInSkillContent } from './install-skill-templates.js'
+import { findPackageRoot as resolvePackageRoot, readPackageVersion as resolvePackageVersion } from '../shared/package-metadata.js'
 
 export const SKILL_INSTALL_PLATFORMS = ['claude', 'gemini', 'codex', 'opencode', 'aider', 'claw', 'droid', 'trae', 'trae-cn', 'copilot', 'windows'] as const
 
@@ -1018,21 +1018,8 @@ function removeInstalledSkill(destinationPath: string, stopDirectory: string, la
   return `${label} -> ${destinationPath}`
 }
 
-function findPackageRoot(startDirectory = dirname(fileURLToPath(import.meta.url))): string {
-  let currentDirectory = resolve(startDirectory)
-
-  while (true) {
-    const packageJsonPath = join(currentDirectory, 'package.json')
-    if (existsSync(packageJsonPath)) {
-      return currentDirectory
-    }
-
-    const parentDirectory = dirname(currentDirectory)
-    if (parentDirectory === currentDirectory) {
-      throw new Error('Could not locate package root from install helper module')
-    }
-    currentDirectory = parentDirectory
-  }
+function findPackageRoot(startDirectory?: string): string {
+  return resolvePackageRoot(startDirectory)
 }
 
 function formatPlatformDisplayName(platform: AgentPlatform): string {
@@ -1081,16 +1068,7 @@ function removeEmptyDirectories(startDirectory: string, stopDirectory: string): 
 }
 
 function readPackageVersion(packageRoot: string): string {
-  try {
-    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))
-    if (isRecord(packageJson) && typeof packageJson.version === 'string') {
-      return packageJson.version
-    }
-  } catch {
-    // ignore and fall back below
-  }
-
-  return 'unknown'
+  return resolvePackageVersion(packageRoot)
 }
 
 function resolvePackageCliPath(packageRoot = findPackageRoot()): string {

--- a/src/shared/package-metadata.ts
+++ b/src/shared/package-metadata.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function findPackageRoot(startDirectory = dirname(fileURLToPath(import.meta.url))): string {
+  let currentDirectory = resolve(startDirectory)
+
+  while (true) {
+    const packageJsonPath = join(currentDirectory, 'package.json')
+    if (existsSync(packageJsonPath)) {
+      return currentDirectory
+    }
+
+    const parentDirectory = dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) {
+      throw new Error('Could not locate package root from graphify-ts package metadata helper')
+    }
+    currentDirectory = parentDirectory
+  }
+}
+
+export function readPackageVersion(packageRoot = findPackageRoot()): string {
+  try {
+    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as { version?: unknown }
+    if (typeof packageJson.version === 'string' && packageJson.version.trim().length > 0) {
+      return packageJson.version
+    }
+  } catch {
+    // ignore and fall back below
+  }
+
+  return 'unknown'
+}

--- a/src/shared/update-notifier.ts
+++ b/src/shared/update-notifier.ts
@@ -208,7 +208,8 @@ export async function getUpdateNotification(options: UpdateNotificationOptions):
 
   let latestVersion = cached?.latest_version ?? null
   let checkedAt = cached?.checked_at ?? currentTime
-  if (!cached || currentTime - cached.checked_at >= ttlMs) {
+  const shouldRefresh = !cached || currentTime - cached.checked_at >= ttlMs
+  if (shouldRefresh) {
     const fetchText = options.fetchText ?? safeFetchText
     const latestUrl = `https://registry.npmjs.org/${encodeURIComponent(options.packageName)}/latest`
     const latest = JSON.parse(await fetchText(latestUrl, undefined, REGISTRY_TIMEOUT_MS)) as { version?: unknown }
@@ -217,7 +218,6 @@ export async function getUpdateNotification(options: UpdateNotificationOptions):
     saveCache(cacheFile, {
       checked_at: checkedAt,
       latest_version: latestVersion,
-      ...(latestVersion && compareVersions(latestVersion, options.currentVersion) > 0 ? { notified_at: currentTime } : {}),
     })
   }
 
@@ -225,8 +225,8 @@ export async function getUpdateNotification(options: UpdateNotificationOptions):
     return null
   }
 
-  if (cached && cached.checked_at === currentTime && cached.latest_version === latestVersion) {
-    return formatUpdateNotice(options.packageName, options.currentVersion, latestVersion)
+  if (!shouldRefresh && cached?.latest_version === latestVersion && typeof cached.notified_at === 'number') {
+    return null
   }
 
   saveCache(cacheFile, {

--- a/src/shared/update-notifier.ts
+++ b/src/shared/update-notifier.ts
@@ -1,0 +1,236 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { safeFetchText } from './security.js'
+
+const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000
+const REGISTRY_TIMEOUT_MS = 5_000
+
+interface UpdateCheckCache {
+  checked_at: number
+  latest_version: string | null
+  notified_at?: number
+}
+
+export interface UpdateNotificationOptions {
+  packageName: string
+  currentVersion: string
+  cacheRoot?: string
+  stdoutIsTTY?: boolean
+  env?: NodeJS.ProcessEnv
+  now?: () => number
+  ttlMs?: number
+  fetchText?: (url: string, maxBytes?: number, timeout?: number) => Promise<string>
+}
+
+function defaultCacheRoot(env: NodeJS.ProcessEnv): string {
+  if (typeof env.XDG_CACHE_HOME === 'string' && env.XDG_CACHE_HOME.trim().length > 0) {
+    return env.XDG_CACHE_HOME
+  }
+
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Caches')
+  }
+
+  if (process.platform === 'win32') {
+    if (typeof env.LOCALAPPDATA === 'string' && env.LOCALAPPDATA.trim().length > 0) {
+      return env.LOCALAPPDATA
+    }
+    return join(homedir(), 'AppData', 'Local')
+  }
+
+  return join(homedir(), '.cache')
+}
+
+function updateCacheFilePath(cacheRoot: string): string {
+  return join(cacheRoot, 'graphify-ts', 'update-check.json')
+}
+
+function isNotifierDisabled(env: NodeJS.ProcessEnv, stdoutIsTTY: boolean): boolean {
+  if (!stdoutIsTTY) {
+    return true
+  }
+
+  if (env.CI) {
+    return true
+  }
+
+  if (env.NO_UPDATE_NOTIFIER === '1' || env.GRAPHIFY_DISABLE_UPDATE_NOTIFIER === '1') {
+    return true
+  }
+
+  return false
+}
+
+function parseCache(text: string): UpdateCheckCache | null {
+  try {
+    const parsed = JSON.parse(text) as Partial<UpdateCheckCache>
+    if (typeof parsed.checked_at !== 'number') {
+      return null
+    }
+    if (parsed.latest_version !== null && typeof parsed.latest_version !== 'string') {
+      return null
+    }
+    if (parsed.notified_at !== undefined && typeof parsed.notified_at !== 'number') {
+      return null
+    }
+    return {
+      checked_at: parsed.checked_at,
+      latest_version: parsed.latest_version ?? null,
+      ...(typeof parsed.notified_at === 'number' ? { notified_at: parsed.notified_at } : {}),
+    }
+  } catch {
+    return null
+  }
+}
+
+function loadCache(cacheFile: string): UpdateCheckCache | null {
+  if (!existsSync(cacheFile)) {
+    return null
+  }
+
+  return parseCache(readFileSync(cacheFile, 'utf8'))
+}
+
+function saveCache(cacheFile: string, cache: UpdateCheckCache): void {
+  mkdirSync(dirname(cacheFile), { recursive: true })
+  const tempFile = `${cacheFile}.tmp`
+  try {
+    writeFileSync(tempFile, JSON.stringify(cache))
+    renameSync(tempFile, cacheFile)
+  } catch (error) {
+    rmSync(tempFile, { force: true })
+    throw error
+  }
+}
+
+function parseVersion(version: string): { core: number[]; prerelease: string[] | null } | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+.*)?$/.exec(version.trim())
+  if (!match) {
+    return null
+  }
+
+  const [, major, minor, patch, prerelease] = match
+  return {
+    core: [Number(major), Number(minor), Number(patch)],
+    prerelease: prerelease ? prerelease.split('.') : null,
+  }
+}
+
+function compareIdentifiers(left: string, right: string): number {
+  const leftNumeric = /^\d+$/.test(left)
+  const rightNumeric = /^\d+$/.test(right)
+
+  if (leftNumeric && rightNumeric) {
+    return Number(left) - Number(right)
+  }
+
+  if (leftNumeric) {
+    return -1
+  }
+
+  if (rightNumeric) {
+    return 1
+  }
+
+  return left.localeCompare(right)
+}
+
+export function compareVersions(left: string, right: string): number {
+  const leftVersion = parseVersion(left)
+  const rightVersion = parseVersion(right)
+
+  if (!leftVersion || !rightVersion) {
+    return left.localeCompare(right)
+  }
+
+  for (let index = 0; index < leftVersion.core.length; index += 1) {
+    const difference = (leftVersion.core[index] ?? 0) - (rightVersion.core[index] ?? 0)
+    if (difference !== 0) {
+      return difference
+    }
+  }
+
+  if (!leftVersion.prerelease && !rightVersion.prerelease) {
+    return 0
+  }
+
+  if (!leftVersion.prerelease) {
+    return 1
+  }
+
+  if (!rightVersion.prerelease) {
+    return -1
+  }
+
+  const maxLength = Math.max(leftVersion.prerelease.length, rightVersion.prerelease.length)
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftIdentifier = leftVersion.prerelease[index]
+    const rightIdentifier = rightVersion.prerelease[index]
+
+    if (leftIdentifier === undefined) {
+      return -1
+    }
+    if (rightIdentifier === undefined) {
+      return 1
+    }
+
+    const difference = compareIdentifiers(leftIdentifier, rightIdentifier)
+    if (difference !== 0) {
+      return difference
+    }
+  }
+
+  return 0
+}
+
+function formatUpdateNotice(packageName: string, currentVersion: string, latestVersion: string): string {
+  return [
+    `A newer graphify-ts is available: ${currentVersion} -> ${latestVersion}`,
+    `Update: npm i -g ${packageName}@latest`,
+    'Then re-run: graphify-ts claude install | cursor install | gemini install',
+  ].join('\n')
+}
+
+export async function getUpdateNotification(options: UpdateNotificationOptions): Promise<string | null> {
+  const env = options.env ?? process.env
+  const stdoutIsTTY = options.stdoutIsTTY ?? Boolean(process.stdout.isTTY)
+  if (isNotifierDisabled(env, stdoutIsTTY)) {
+    return null
+  }
+
+  const now = options.now ?? Date.now
+  const currentTime = now()
+  const ttlMs = options.ttlMs ?? UPDATE_CHECK_TTL_MS
+  const cacheFile = updateCacheFilePath(options.cacheRoot ?? defaultCacheRoot(env))
+  const cached = loadCache(cacheFile)
+
+  let latestVersion = cached?.latest_version ?? null
+  if (!cached || currentTime - cached.checked_at >= ttlMs) {
+    const fetchText = options.fetchText ?? safeFetchText
+    const latestUrl = `https://registry.npmjs.org/${encodeURIComponent(options.packageName)}/latest`
+    const latest = JSON.parse(await fetchText(latestUrl, undefined, REGISTRY_TIMEOUT_MS)) as { version?: unknown }
+    latestVersion = typeof latest.version === 'string' && latest.version.trim().length > 0 ? latest.version : null
+    saveCache(cacheFile, {
+      checked_at: currentTime,
+      latest_version: latestVersion,
+      ...(latestVersion && compareVersions(latestVersion, options.currentVersion) > 0 ? { notified_at: currentTime } : {}),
+    })
+  }
+
+  if (!latestVersion || compareVersions(latestVersion, options.currentVersion) <= 0) {
+    return null
+  }
+
+  if (cached && cached.checked_at === currentTime && cached.latest_version === latestVersion) {
+    return formatUpdateNotice(options.packageName, options.currentVersion, latestVersion)
+  }
+
+  saveCache(cacheFile, {
+    checked_at: cached?.checked_at ?? currentTime,
+    latest_version: latestVersion,
+    notified_at: currentTime,
+  })
+  return formatUpdateNotice(options.packageName, options.currentVersion, latestVersion)
+}

--- a/src/shared/update-notifier.ts
+++ b/src/shared/update-notifier.ts
@@ -207,13 +207,15 @@ export async function getUpdateNotification(options: UpdateNotificationOptions):
   const cached = loadCache(cacheFile)
 
   let latestVersion = cached?.latest_version ?? null
+  let checkedAt = cached?.checked_at ?? currentTime
   if (!cached || currentTime - cached.checked_at >= ttlMs) {
     const fetchText = options.fetchText ?? safeFetchText
     const latestUrl = `https://registry.npmjs.org/${encodeURIComponent(options.packageName)}/latest`
     const latest = JSON.parse(await fetchText(latestUrl, undefined, REGISTRY_TIMEOUT_MS)) as { version?: unknown }
     latestVersion = typeof latest.version === 'string' && latest.version.trim().length > 0 ? latest.version : null
+    checkedAt = currentTime
     saveCache(cacheFile, {
-      checked_at: currentTime,
+      checked_at: checkedAt,
       latest_version: latestVersion,
       ...(latestVersion && compareVersions(latestVersion, options.currentVersion) > 0 ? { notified_at: currentTime } : {}),
     })
@@ -228,7 +230,7 @@ export async function getUpdateNotification(options: UpdateNotificationOptions):
   }
 
   saveCache(cacheFile, {
-    checked_at: cached?.checked_at ?? currentTime,
+    checked_at: checkedAt,
     latest_version: latestVersion,
     notified_at: currentTime,
   })

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { type CliDependencies, executeCli, formatHelp } from '../../src/cli/main.js'
@@ -39,6 +39,14 @@ function createIo() {
       },
     },
   }
+}
+
+function loadPackageVersion(): string {
+  const packageJson = JSON.parse(readFileSync(resolve('package.json'), 'utf8')) as { version?: string }
+  if (typeof packageJson.version !== 'string' || packageJson.version.length === 0) {
+    throw new Error('package.json is missing version')
+  }
+  return packageJson.version
 }
 
 function createDependencies(): CliDependencies {
@@ -751,9 +759,24 @@ describe('cli main', () => {
     expect(logs[0]).toContain('Usage: graphify-ts <command>')
   })
 
+  it('prints the package version for --version and -v', async () => {
+    const expectedVersion = loadPackageVersion()
+    const longFlag = createIo()
+    const shortFlag = createIo()
+
+    await expect(executeCli(['--version'], longFlag.io, createDependencies())).resolves.toBe(0)
+    await expect(executeCli(['-v'], shortFlag.io, createDependencies())).resolves.toBe(0)
+
+    expect(longFlag.errors).toHaveLength(0)
+    expect(shortFlag.errors).toHaveLength(0)
+    expect(longFlag.logs).toEqual([expectedVersion])
+    expect(shortFlag.logs).toEqual([expectedVersion])
+  })
+
   it('formats help text with supported commands', () => {
     const help = formatHelp()
     expect(help).toContain('--help')
+    expect(help).toContain('--version')
     expect(help).toContain('generate [path]')
     expect(help).toContain('watch [path]')
     expect(help).toContain('serve [graph.json]')

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -773,6 +773,21 @@ describe('cli main', () => {
     expect(shortFlag.logs).toEqual([expectedVersion])
   })
 
+  it('returns a controlled error when resolving the installed version fails', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & { readInstalledVersion: () => string }
+
+    dependencies.readInstalledVersion = () => {
+      throw new Error('missing package metadata')
+    }
+
+    const exitCode = await executeCli(['--version'], io, dependencies)
+
+    expect(exitCode).toBe(1)
+    expect(logs).toEqual([])
+    expect(errors).toEqual(['error: missing package metadata'])
+  })
+
   it('prints an available update notice before normal command output', async () => {
     const { io, logs, errors } = createIo()
     const dependencies = createDependencies() as CliDependencies & { notifyUpdate: () => Promise<string | null> }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -773,6 +773,41 @@ describe('cli main', () => {
     expect(shortFlag.logs).toEqual([expectedVersion])
   })
 
+  it('prints an available update notice before normal command output', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & { notifyUpdate: () => Promise<string | null> }
+
+    dependencies.notifyUpdate = async () => 'A newer graphify-ts is available: 0.22.8 -> 0.22.9'
+
+    const exitCode = await executeCli(['query', 'how does auth work'], io, dependencies)
+
+    expect(exitCode).toBe(0)
+    expect(errors).toEqual([])
+    expect(logs[0]).toBe('A newer graphify-ts is available: 0.22.8 -> 0.22.9')
+    expect(logs[1]).toBe('how does auth work :: bfs :: 2000')
+  })
+
+  it('skips the update notifier for help, version, and --json output', async () => {
+    const help = createIo()
+    const version = createIo()
+    const json = createIo()
+    const dependencies = createDependencies() as CliDependencies & { notifyUpdate: () => Promise<string | null> }
+    let notifyCalls = 0
+
+    dependencies.notifyUpdate = async () => {
+      notifyCalls += 1
+      return 'A newer graphify-ts is available: 0.22.8 -> 0.22.9'
+    }
+
+    await expect(executeCli(['--help'], help.io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['--version'], version.io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['time-travel', 'HEAD~1', 'HEAD', '--json'], json.io, dependencies)).resolves.toBe(0)
+
+    expect(notifyCalls).toBe(0)
+    expect(help.logs[0]).toContain('Usage: graphify-ts <command>')
+    expect(version.logs).toEqual([loadPackageVersion()])
+  })
+
   it('formats help text with supported commands', () => {
     const help = formatHelp()
     expect(help).toContain('--help')

--- a/tests/unit/update-notifier.test.ts
+++ b/tests/unit/update-notifier.test.ts
@@ -36,7 +36,7 @@ describe('update notifier', () => {
     }
   })
 
-  it('uses a fresh cache instead of refetching the registry', async () => {
+  it('uses a fresh cache instead of refetching the registry or repeating the banner', async () => {
     const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
     let fetchCalls = 0
 
@@ -68,7 +68,7 @@ describe('update notifier', () => {
       })
 
       expect(firstNotice).toContain('0.22.9')
-      expect(secondNotice).toContain('0.22.9')
+      expect(secondNotice).toBeNull()
       expect(fetchCalls).toBe(1)
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true })

--- a/tests/unit/update-notifier.test.ts
+++ b/tests/unit/update-notifier.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -70,6 +70,39 @@ describe('update notifier', () => {
       expect(firstNotice).toContain('0.22.9')
       expect(secondNotice).toContain('0.22.9')
       expect(fetchCalls).toBe(1)
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves the refreshed checked_at timestamp when a stale cache is re-notified', async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
+    const cacheFile = join(cacheRoot, 'graphify-ts', 'update-check.json')
+
+    try {
+      mkdirSync(join(cacheRoot, 'graphify-ts'), { recursive: true })
+      writeFileSync(cacheFile, JSON.stringify({
+        checked_at: 1_700_000_000_000,
+        latest_version: '0.22.9',
+        notified_at: 1_700_000_000_000,
+      }))
+
+      const notice = await getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000,
+        fetchText: async () => JSON.stringify({ version: '0.22.9' }),
+      })
+
+      expect(notice).toContain('0.22.9')
+      expect(JSON.parse(readFileSync(cacheFile, 'utf8'))).toEqual({
+        checked_at: 1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000,
+        latest_version: '0.22.9',
+        notified_at: 1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000,
+      })
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true })
     }

--- a/tests/unit/update-notifier.test.ts
+++ b/tests/unit/update-notifier.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+import { getUpdateNotification } from '../../src/shared/update-notifier.js'
+
+describe('update notifier', () => {
+  it('returns a notice and caches the latest version when a newer release exists', async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
+
+    try {
+      const notice = await getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000,
+        fetchText: async () => JSON.stringify({ version: '0.22.9' }),
+      })
+
+      expect(notice).toContain('0.22.8')
+      expect(notice).toContain('0.22.9')
+      expect(notice).toContain('npm i -g @mohammednagy/graphify-ts@latest')
+
+      const cacheFile = join(cacheRoot, 'graphify-ts', 'update-check.json')
+      expect(JSON.parse(readFileSync(cacheFile, 'utf8'))).toEqual({
+        checked_at: 1_700_000_000_000,
+        latest_version: '0.22.9',
+        notified_at: 1_700_000_000_000,
+      })
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('uses a fresh cache instead of refetching the registry', async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
+    let fetchCalls = 0
+
+    try {
+      const firstNotice = await getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000,
+        fetchText: async () => {
+          fetchCalls += 1
+          return JSON.stringify({ version: '0.22.9' })
+        },
+      })
+
+      const secondNotice = await getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000 + 60_000,
+        fetchText: async () => {
+          fetchCalls += 1
+          return JSON.stringify({ version: '9.9.9' })
+        },
+      })
+
+      expect(firstNotice).toContain('0.22.9')
+      expect(secondNotice).toContain('0.22.9')
+      expect(fetchCalls).toBe(1)
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('skips checks when disabled or non-interactive', async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
+    let fetchCalls = 0
+
+    try {
+      await expect(getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: false,
+        env: {},
+        fetchText: async () => {
+          fetchCalls += 1
+          return JSON.stringify({ version: '0.22.9' })
+        },
+      })).resolves.toBeNull()
+
+      await expect(getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: { GRAPHIFY_DISABLE_UPDATE_NOTIFIER: '1' },
+        fetchText: async () => {
+          fetchCalls += 1
+          return JSON.stringify({ version: '0.22.9' })
+        },
+      })).resolves.toBeNull()
+
+      expect(fetchCalls).toBe(0)
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add top-level `graphify-ts --version` / `-v` support using package metadata lookup that works from compiled `dist`
- add a conservative GoValidate report-generation benchmark artifact with a verifier and explicit safe/unsafe interpretations
- add a cached interactive npm update notice for newer graphify-ts releases, with user-level cache storage and quiet behavior for help/version/json/CI runs
- bump package metadata to `0.22.8` and move the release notes out of `Unreleased`

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run
- [x] npm run test:run -- tests/unit/update-notifier.test.ts tests/unit/cli.test.ts
- [x] node dist/src/cli/bin.js --version
- [x] node dist/src/cli/bin.js -v
- [x] node dist/src/cli/bin.js --help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version` / `-v` CLI flag to print installed package version and exit.
  * Interactive update notifier: cached npm check with brief upgrade hint; suppressed for `--help`/`--version`/`--json`, in CI, non-TTY, or when disabled via env.

* **Documentation**
  * Added a detailed single-run benchmark snapshot, reproducibility notes, caveats, and a verification script with evidence link.

* **Tests**
  * Expanded unit tests for version flag and notifier behaviors.

* **Chores**
  * Bumped package version to 0.22.8.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->