### PR TITLE
Add doctor and status CLI health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the TypeScript package will be documented in this file.
 - **Release checklist page**: adds `docs/release.md` with a repeatable maintainer checklist covering version bumps, changelog updates, verification commands, package dry-runs, CLI smoke checks, and post-release verification.
 - **Public roadmap page**: adds `docs/roadmap.md` with contributor-facing P0/P1/P2 tracks, issue links, label explanations, and a README pointer back to the main roadmap tracker.
 - **End-to-end getting started tutorial**: adds `docs/tutorials/getting-started.md` with a local-first sample-workspace walkthrough covering install, graph generation, `pack`, `prompt`, and a safe `compare` smoke check without requiring paid model usage.
+- **Doctor and status health checks**: added `graphify-ts doctor` and `graphify-ts status` commands to report installed version, graph freshness, local agent wiring (Claude/Cursor/Gemini/Copilot), MCP config validity, and actionable next commands when setup is missing or stale.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ npm install -g @mohammednagy/graphify-ts
 cd your-project
 graphify-ts generate .          # builds graphify-out/graph.json (no API key, no cloud)
 graphify-ts claude install      # wires Claude Code to use it via MCP
+graphify-ts doctor              # checks graph freshness + agent/MCP wiring
+graphify-ts status              # compact readiness summary + next commands
 
 # Or use the opt-in SPI pipeline for framework-aware metadata + disk cache:
 graphify-ts generate . --spi

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure
 import { runCompareCommand } from '../infrastructure/compare.js'
 import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
 import { runContextPromptCommand } from '../infrastructure/context-prompt-command.js'
+import { runDoctorCommand, runStatusCommand } from '../infrastructure/doctor.js'
 import { runReviewCompareCommand } from '../infrastructure/review-compare.js'
 import { compareRefs } from '../infrastructure/time-travel.js'
 import { federate } from '../pipeline/federate.js'
@@ -43,6 +44,7 @@ import {
   parseAddArgs,
   type BenchmarkCliOptions,
   parseCompareArgs,
+  parseDoctorArgs,
   parsePackArgs,
   parseDiffArgs,
   parseExplainArgs,
@@ -120,6 +122,8 @@ export interface CliDependencies {
   runTimeTravel: (context: TimeTravelCommandContext) => Promise<string | void> | string | void
   runContextPack: (context: ContextPackCommandContext) => Promise<string | void> | string | void
   runContextPrompt: (context: ContextPromptCommandContext) => Promise<string | void> | string | void
+  runDoctor: (graphPath: string) => string
+  runStatus: (graphPath: string) => string
   confirm: (message: string) => Promise<boolean>
   printBenchmark: (result: BenchmarkResult) => void
   installHooks: typeof installHooks
@@ -199,6 +203,8 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   runContextPrompt: async ({ options }) => {
     return await runContextPromptCommand(options)
   },
+  runDoctor: (graphPath) => runDoctorCommand({ graphPath }),
+  runStatus: (graphPath) => runStatusCommand({ graphPath }),
   confirm: async (message) => {
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
       throw new UsageError('error: compare requires --yes in non-interactive mode.')
@@ -379,6 +385,10 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
     '    --json               emit machine-readable JSON',
     '    --refresh            rebuild snapshots instead of using cache',
     '    --limit N            cap view items (default 10)',
+    '  doctor [graph.json]   check graph freshness, agent config, and MCP wiring',
+    '    --graph <path>      path to graph.json to validate (default graphify-out/graph.json)',
+    '  status [graph.json]   compact readiness summary with next commands',
+    '    --graph <path>      path to graph.json to validate (default graphify-out/graph.json)',
     '  install [--platform P] install the platform skill or local graphify config',
     '    platforms            claude|windows|gemini|cursor|codex|opencode|aider|claw|droid|trae|trae-cn|copilot',
     '  hook <action>          manage git hooks for graphify rebuild reminders',
@@ -601,6 +611,18 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (output !== undefined) {
         io.log(output)
       }
+      return 0
+    }
+
+    if (command === 'doctor') {
+      const options = parseDoctorArgs(args, 'doctor')
+      io.log(dependencies.runDoctor(options.graphPath))
+      return 0
+    }
+
+    if (command === 'status') {
+      const options = parseDoctorArgs(args, 'status')
+      io.log(dependencies.runStatus(options.graphPath))
       return 0
     }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -155,6 +155,10 @@ export interface ServeCliOptions {
   transport: 'http' | 'stdio'
 }
 
+export interface DoctorCliOptions {
+  graphPath: string
+}
+
 export interface HookCliOptions {
   action: 'install' | 'uninstall' | 'status'
 }
@@ -1519,6 +1523,42 @@ export function parseServeArgs(args: string[]): ServeCliOptions {
   }
 
   return { graphPath, host, port, transport }
+}
+
+export function parseDoctorArgs(args: string[], commandName: 'doctor' | 'status' = 'doctor'): DoctorCliOptions {
+  const usage = `Usage: graphify-ts ${commandName} [graph.json] [--graph path]`
+  let graphPath = 'graphify-out/graph.json'
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (!argument.startsWith('--')) {
+      if (graphPath !== 'graphify-out/graph.json') {
+        throw new UsageError(usage)
+      }
+      graphPath = argument
+      continue
+    }
+
+    if (argument === '--graph') {
+      graphPath = requireOptionValue('--graph', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--graph=')) {
+      const [, value] = argument.split('=', 2)
+      graphPath = requireOptionValue('--graph', value)
+      continue
+    }
+
+    throw new UsageError(`error: unknown option for ${commandName}: ${argument}`)
+  }
+
+  return { graphPath }
 }
 
 export function parseHookArgs(args: string[]): HookCliOptions {

--- a/src/infrastructure/doctor.ts
+++ b/src/infrastructure/doctor.ts
@@ -1,0 +1,443 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { graphFreshnessMetadata } from '../runtime/freshness.js'
+import { findPackageRoot, readPackageVersion } from '../shared/package-metadata.js'
+
+const GRAPHIFY_SECTION_MARKER = '## graphify-ts'
+const GRAPH_FRESH_THRESHOLD_MS = 60 * 60 * 1000
+const GRAPH_RECENT_THRESHOLD_MS = 24 * 60 * 60 * 1000
+
+type AgentStatus = 'configured' | 'partial' | 'missing'
+type McpStatus = 'ok' | 'missing' | 'stale'
+type GraphFreshness = 'fresh' | 'recent' | 'stale' | 'missing'
+
+interface McpCheck {
+  label: 'claude' | 'cursor' | 'copilot'
+  configPath: string
+  status: McpStatus
+  reason: string
+}
+
+interface AgentCheck {
+  label: 'claude' | 'cursor' | 'gemini' | 'copilot'
+  status: AgentStatus
+  detail: string
+}
+
+interface GraphCheck {
+  graphPath: string
+  exists: boolean
+  freshness: GraphFreshness
+  ageMs: number | null
+  modifiedAt: string | null
+  graphVersion: string | null
+}
+
+interface DoctorReport {
+  packageVersion: string
+  graph: GraphCheck
+  agents: AgentCheck[]
+  mcpChecks: McpCheck[]
+  nextCommands: string[]
+  healthy: boolean
+}
+
+interface JsonObject {
+  [key: string]: unknown
+}
+
+export interface DoctorCommandOptions {
+  graphPath?: string
+  projectDir?: string
+  now?: number
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readJsonObject(filePath: string): JsonObject | null {
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function ageLabel(ageMs: number): string {
+  const minutes = Math.floor(ageMs / 60_000)
+  if (minutes < 1) {
+    return 'just now'
+  }
+  if (minutes < 60) {
+    return `${minutes}m`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const restMinutes = minutes % 60
+  if (hours < 24) {
+    return restMinutes === 0 ? `${hours}h` : `${hours}h ${restMinutes}m`
+  }
+
+  const days = Math.floor(hours / 24)
+  const restHours = hours % 24
+  return restHours === 0 ? `${days}d` : `${days}d ${restHours}h`
+}
+
+function hasSectionMarker(filePath: string): boolean {
+  if (!existsSync(filePath)) {
+    return false
+  }
+  return readFileSync(filePath, 'utf8').includes(GRAPHIFY_SECTION_MARKER)
+}
+
+function findHookEntry(settingsPath: string, hookName: 'PreToolUse' | 'BeforeTool'): boolean {
+  const settings = readJsonObject(settingsPath)
+  if (!settings) {
+    return false
+  }
+
+  const hooks = settings.hooks
+  if (!isRecord(hooks)) {
+    return false
+  }
+
+  const hookEntries = hooks[hookName]
+  if (!Array.isArray(hookEntries)) {
+    return false
+  }
+
+  return hookEntries.some((entry) => JSON.stringify(entry).includes('graphify-out'))
+}
+
+function extractGraphPathFromArgs(args: unknown): string | null {
+  if (!Array.isArray(args)) {
+    return null
+  }
+
+  const normalizedArgs = args.filter((value): value is string => typeof value === 'string')
+  const stdioIndex = normalizedArgs.indexOf('--stdio')
+  if (stdioIndex >= 0) {
+    const candidate = normalizedArgs[stdioIndex + 1]
+    if (candidate && candidate.trim().length > 0) {
+      return candidate
+    }
+  }
+
+  const graphPathCandidate = normalizedArgs.find((value) => /graphify-out[\\/]+graph\.json$/i.test(value))
+  return graphPathCandidate ?? null
+}
+
+function readMcpCheck(
+  label: McpCheck['label'],
+  configPath: string,
+  serversKey: 'mcpServers' | 'servers',
+  expectedGraphPath: string,
+): McpCheck {
+  if (!existsSync(configPath)) {
+    return {
+      label,
+      configPath,
+      status: 'missing',
+      reason: 'config file missing',
+    }
+  }
+
+  const config = readJsonObject(configPath)
+  if (!config) {
+    return {
+      label,
+      configPath,
+      status: 'stale',
+      reason: 'config is not valid JSON object',
+    }
+  }
+
+  const servers = config[serversKey]
+  if (!isRecord(servers)) {
+    return {
+      label,
+      configPath,
+      status: 'missing',
+      reason: `missing '${serversKey}.graphify' entry`,
+    }
+  }
+
+  const server = servers.graphify
+  if (!isRecord(server)) {
+    return {
+      label,
+      configPath,
+      status: 'missing',
+      reason: `missing '${serversKey}.graphify' entry`,
+    }
+  }
+
+  const declaredGraphPath = extractGraphPathFromArgs(server.args)
+  if (!declaredGraphPath) {
+    return {
+      label,
+      configPath,
+      status: 'stale',
+      reason: "graph path is missing from server args (expected '--stdio <graph-path>')",
+    }
+  }
+
+  const resolvedDeclaredGraphPath = resolve(declaredGraphPath)
+  if (resolvedDeclaredGraphPath !== expectedGraphPath) {
+    return {
+      label,
+      configPath,
+      status: 'stale',
+      reason: `points to ${resolvedDeclaredGraphPath}, expected ${expectedGraphPath}`,
+    }
+  }
+
+  return {
+    label,
+    configPath,
+    status: 'ok',
+    reason: 'server entry looks valid',
+  }
+}
+
+function readGraphCheck(graphPath: string, now: number): GraphCheck {
+  const resolvedGraphPath = resolve(graphPath)
+  if (!existsSync(resolvedGraphPath)) {
+    return {
+      graphPath: resolvedGraphPath,
+      exists: false,
+      freshness: 'missing',
+      ageMs: null,
+      modifiedAt: null,
+      graphVersion: null,
+    }
+  }
+
+  const graphStats = statSync(resolvedGraphPath)
+  const ageMs = Math.max(0, Math.trunc(now - graphStats.mtimeMs))
+
+  let freshness: GraphFreshness = 'stale'
+  if (ageMs <= GRAPH_FRESH_THRESHOLD_MS) {
+    freshness = 'fresh'
+  } else if (ageMs <= GRAPH_RECENT_THRESHOLD_MS) {
+    freshness = 'recent'
+  }
+
+  let graphVersion: string | null = null
+  try {
+    graphVersion = graphFreshnessMetadata(resolvedGraphPath).graphVersion
+  } catch {
+    graphVersion = null
+  }
+
+  return {
+    graphPath: resolvedGraphPath,
+    exists: true,
+    freshness,
+    ageMs,
+    modifiedAt: new Date(graphStats.mtimeMs).toISOString(),
+    graphVersion,
+  }
+}
+
+function agentStatusFromFlags(flags: boolean[]): AgentStatus {
+  const positives = flags.filter(Boolean).length
+  if (positives === 0) {
+    return 'missing'
+  }
+  if (positives === flags.length) {
+    return 'configured'
+  }
+  return 'partial'
+}
+
+function computeNextCommands(report: Omit<DoctorReport, 'nextCommands' | 'healthy'>): string[] {
+  const nextCommands = new Set<string>()
+
+  if (!report.graph.exists) {
+    nextCommands.add('graphify-ts generate .')
+  } else if (report.graph.freshness === 'stale') {
+    nextCommands.add('graphify-ts generate . --update')
+  }
+
+  const agentByLabel = new Map(report.agents.map((entry) => [entry.label, entry]))
+  const mcpByLabel = new Map(report.mcpChecks.map((entry) => [entry.label, entry]))
+
+  const claude = agentByLabel.get('claude')
+  if (claude && claude.status !== 'configured') {
+    nextCommands.add('graphify-ts claude install')
+  } else {
+    const claudeMcp = mcpByLabel.get('claude')
+    if (claudeMcp && claudeMcp.status === 'stale') {
+      nextCommands.add('graphify-ts claude install')
+    }
+  }
+
+  const cursor = agentByLabel.get('cursor')
+  if (cursor && cursor.status !== 'configured') {
+    nextCommands.add('graphify-ts cursor install')
+  } else {
+    const cursorMcp = mcpByLabel.get('cursor')
+    if (cursorMcp && cursorMcp.status === 'stale') {
+      nextCommands.add('graphify-ts cursor install')
+    }
+  }
+
+  const gemini = agentByLabel.get('gemini')
+  if (gemini && gemini.status !== 'configured') {
+    nextCommands.add('graphify-ts gemini install')
+  }
+
+  const copilot = agentByLabel.get('copilot')
+  if (copilot && copilot.status !== 'configured') {
+    nextCommands.add('graphify-ts copilot install')
+  } else {
+    const copilotMcp = mcpByLabel.get('copilot')
+    if (copilotMcp && copilotMcp.status === 'stale') {
+      nextCommands.add('graphify-ts copilot install')
+    }
+  }
+
+  return [...nextCommands]
+}
+
+function buildDoctorReport(options: DoctorCommandOptions = {}): DoctorReport {
+  const graphPath = options.graphPath ?? 'graphify-out/graph.json'
+  const projectDir = resolve(options.projectDir ?? '.')
+  const now = options.now ?? Date.now()
+  const resolvedGraphPath = resolve(projectDir, graphPath)
+  const packageVersion = readPackageVersion(findPackageRoot())
+  const graph = readGraphCheck(resolvedGraphPath, now)
+
+  const claudeMcp = readMcpCheck('claude', resolve(projectDir, '.mcp.json'), 'mcpServers', resolvedGraphPath)
+  const cursorMcp = readMcpCheck('cursor', resolve(projectDir, '.cursor', 'mcp.json'), 'mcpServers', resolvedGraphPath)
+  const copilotMcp = readMcpCheck('copilot', resolve(projectDir, '.vscode', 'mcp.json'), 'servers', resolvedGraphPath)
+
+  const claudeRuleConfigured = hasSectionMarker(resolve(projectDir, 'CLAUDE.md'))
+  const claudeHookConfigured = findHookEntry(resolve(projectDir, '.claude', 'settings.json'), 'PreToolUse')
+  const claudeMcpConfigured = claudeMcp.status === 'ok'
+
+  const cursorRuleConfigured = existsSync(resolve(projectDir, '.cursor', 'rules', 'graphify-ts.mdc'))
+  const cursorMcpConfigured = cursorMcp.status === 'ok'
+
+  const geminiRuleConfigured = hasSectionMarker(resolve(projectDir, 'GEMINI.md'))
+  const geminiHookConfigured = findHookEntry(resolve(projectDir, '.gemini', 'settings.json'), 'BeforeTool')
+
+  const copilotMcpConfigured = copilotMcp.status === 'ok'
+
+  const agents: AgentCheck[] = [
+    {
+      label: 'claude',
+      status: agentStatusFromFlags([claudeRuleConfigured, claudeHookConfigured, claudeMcpConfigured]),
+      detail: `rules=${claudeRuleConfigured ? 'yes' : 'no'}, hook=${claudeHookConfigured ? 'yes' : 'no'}, mcp=${claudeMcp.status}`,
+    },
+    {
+      label: 'cursor',
+      status: agentStatusFromFlags([cursorRuleConfigured, cursorMcpConfigured]),
+      detail: `rules=${cursorRuleConfigured ? 'yes' : 'no'}, mcp=${cursorMcp.status}`,
+    },
+    {
+      label: 'gemini',
+      status: agentStatusFromFlags([geminiRuleConfigured, geminiHookConfigured]),
+      detail: `rules=${geminiRuleConfigured ? 'yes' : 'no'}, hook=${geminiHookConfigured ? 'yes' : 'no'}`,
+    },
+    {
+      label: 'copilot',
+      status: copilotMcpConfigured ? 'configured' : copilotMcp.status === 'stale' ? 'partial' : 'missing',
+      detail: `mcp=${copilotMcp.status}`,
+    },
+  ]
+
+  const mcpChecks = [claudeMcp, cursorMcp, copilotMcp]
+
+  const partialReport = {
+    packageVersion,
+    graph,
+    agents,
+    mcpChecks,
+  }
+  const nextCommands = computeNextCommands(partialReport)
+  const healthy = graph.exists && graph.freshness !== 'stale' && agents.every((agent) => agent.status === 'configured') && mcpChecks.every((check) => check.status === 'ok')
+
+  return {
+    ...partialReport,
+    nextCommands,
+    healthy,
+  }
+}
+
+function formatGraphLine(graph: GraphCheck): string[] {
+  if (!graph.exists) {
+    return [
+      `- graph: missing (${graph.graphPath})`,
+      "- graph freshness: missing (run 'graphify-ts generate .')",
+    ]
+  }
+
+  const freshnessText = graph.freshness === 'fresh'
+    ? 'fresh'
+    : graph.freshness === 'recent'
+      ? 'recent'
+      : 'stale'
+  const ageText = graph.ageMs === null ? 'unknown' : ageLabel(graph.ageMs)
+  const modifiedText = graph.modifiedAt ?? 'unknown'
+  const versionText = graph.graphVersion ?? 'unknown'
+
+  return [
+    `- graph: found (${graph.graphPath})`,
+    `- graph freshness: ${freshnessText} (${ageText} old, modified ${modifiedText}, graph_version ${versionText})`,
+  ]
+}
+
+export function runDoctorCommand(options: DoctorCommandOptions = {}): string {
+  const report = buildDoctorReport(options)
+  const lines: string[] = []
+  lines.push(`[graphify doctor] ${report.healthy ? 'healthy' : 'attention needed'}`)
+  lines.push(`- installed version: ${report.packageVersion}`)
+  lines.push(...formatGraphLine(report.graph))
+  lines.push('- agent configs:')
+  for (const agent of report.agents) {
+    lines.push(`  - ${agent.label}: ${agent.status} (${agent.detail})`)
+  }
+  lines.push('- mcp configs:')
+  for (const check of report.mcpChecks) {
+    lines.push(`  - ${check.label}: ${check.status} (${check.configPath}; ${check.reason})`)
+  }
+
+  if (report.nextCommands.length === 0) {
+    lines.push('- next commands: none')
+  } else {
+    lines.push('- next commands:')
+    for (const command of report.nextCommands) {
+      lines.push(`  - ${command}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function runStatusCommand(options: DoctorCommandOptions = {}): string {
+  const report = buildDoctorReport(options)
+  const graphStatus = report.graph.exists
+    ? `${report.graph.freshness} (${report.graph.ageMs === null ? 'unknown age' : ageLabel(report.graph.ageMs)})`
+    : 'missing'
+  const agentSummary = report.agents.map((agent) => `${agent.label}:${agent.status}`).join(' ')
+  const mcpSummary = report.mcpChecks.map((check) => `${check.label}:${check.status}`).join(' ')
+  const nextSummary = report.nextCommands.length === 0 ? 'none' : report.nextCommands.join('; ')
+
+  return [
+    `[graphify status] ${report.healthy ? 'healthy' : 'attention needed'}`,
+    `version ${report.packageVersion}`,
+    `graph ${graphStatus}`,
+    `agents ${agentSummary}`,
+    `mcp ${mcpSummary}`,
+    `next ${nextSummary}`,
+  ].join('\n')
+}

--- a/src/shared/update-notifier.ts
+++ b/src/shared/update-notifier.ts
@@ -212,13 +212,22 @@ export async function getUpdateNotification(options: UpdateNotificationOptions):
   if (shouldRefresh) {
     const fetchText = options.fetchText ?? safeFetchText
     const latestUrl = `https://registry.npmjs.org/${encodeURIComponent(options.packageName)}/latest`
-    const latest = JSON.parse(await fetchText(latestUrl, undefined, REGISTRY_TIMEOUT_MS)) as { version?: unknown }
-    latestVersion = typeof latest.version === 'string' && latest.version.trim().length > 0 ? latest.version : null
-    checkedAt = currentTime
-    saveCache(cacheFile, {
-      checked_at: checkedAt,
-      latest_version: latestVersion,
-    })
+    try {
+      const latest = JSON.parse(await fetchText(latestUrl, undefined, REGISTRY_TIMEOUT_MS)) as { version?: unknown }
+      latestVersion = typeof latest.version === 'string' && latest.version.trim().length > 0 ? latest.version : null
+      checkedAt = currentTime
+      saveCache(cacheFile, {
+        checked_at: checkedAt,
+        latest_version: latestVersion,
+      })
+    } catch {
+      saveCache(cacheFile, {
+        checked_at: currentTime,
+        latest_version: cached?.latest_version ?? null,
+        ...(typeof cached?.notified_at === 'number' ? { notified_at: cached.notified_at } : {}),
+      })
+      return null
+    }
   }
 
   if (!latestVersion || compareVersions(latestVersion, options.currentVersion) <= 0) {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -6,6 +6,7 @@ import {
   parseAddArgs,
   parseBenchmarkArgs,
   parseCompareArgs,
+  parseDoctorArgs,
   parsePackArgs,
   parseDiffArgs,
   parseExplainArgs,
@@ -115,6 +116,8 @@ function createDependencies(): CliDependencies {
     runTimeTravel: async () => 'time-travel command is not implemented yet',
     runContextPack: async () => 'context pack command is not implemented yet',
     runContextPrompt: async () => 'context prompt command is not implemented yet',
+    runDoctor: (graphPath) => `doctor check for ${graphPath}`,
+    runStatus: (graphPath) => `status check for ${graphPath}`,
     confirm: async () => true,
     printBenchmark: () => {},
     installHooks: () => 'hooks installed',
@@ -718,6 +721,15 @@ describe('cli parser', () => {
     expect(() => parseServeArgs(['--transport', 'socket'])).toThrow('error: --transport must be one of http, stdio')
   })
 
+  it('parses doctor and status args', () => {
+    expect(parseDoctorArgs([])).toEqual({ graphPath: 'graphify-out/graph.json' })
+    expect(parseDoctorArgs(['graphify-out/custom.json'])).toEqual({ graphPath: 'graphify-out/custom.json' })
+    expect(parseDoctorArgs(['--graph', 'graphify-out/runtime.json'])).toEqual({ graphPath: 'graphify-out/runtime.json' })
+    expect(parseDoctorArgs(['--graph=graphify-out/runtime.json'], 'status')).toEqual({ graphPath: 'graphify-out/runtime.json' })
+    expect(() => parseDoctorArgs(['--wat'])).toThrow('error: unknown option for doctor: --wat')
+    expect(() => parseDoctorArgs(['--wat'], 'status')).toThrow('error: unknown option for status: --wat')
+  })
+
   it('parses hook args', () => {
     expect(parseHookArgs(['install'])).toEqual({ action: 'install' })
     expect(parseHookArgs(['uninstall'])).toEqual({ action: 'uninstall' })
@@ -873,6 +885,9 @@ describe('cli main', () => {
     expect(help).toContain('    --json               emit machine-readable JSON')
     expect(help).toContain('    --refresh            rebuild snapshots instead of using cache')
     expect(help).toContain('    --limit N            cap view items (default 10)')
+    expect(help).toContain('doctor [graph.json]')
+    expect(help).toContain('status [graph.json]')
+    expect(help).toContain('check graph freshness, agent config, and MCP wiring')
     expect(help).toContain('question coverage')
     expect(help).toContain('hook <action>')
     expect(help).toContain('install [--platform P]')
@@ -1181,6 +1196,28 @@ describe('cli main', () => {
     })
     expect(logs).toEqual(['time-travel result'])
     expect(errors).toEqual([])
+  })
+
+  it('routes doctor and status through injected dependencies', async () => {
+    const doctor = createIo()
+    const status = createIo()
+    const runDoctor = vi.fn<NonNullable<CliDependencies['runDoctor']>>().mockReturnValue('doctor summary')
+    const runStatus = vi.fn<NonNullable<CliDependencies['runStatus']>>().mockReturnValue('status summary')
+    const dependencies: CliDependencies = {
+      ...createDependencies(),
+      runDoctor,
+      runStatus,
+    }
+
+    await expect(executeCli(['doctor', '--graph', 'graphify-out/custom.json'], doctor.io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['status'], status.io, dependencies)).resolves.toBe(0)
+
+    expect(runDoctor).toHaveBeenCalledWith('graphify-out/custom.json')
+    expect(runStatus).toHaveBeenCalledWith('graphify-out/graph.json')
+    expect(doctor.logs).toEqual(['doctor summary'])
+    expect(status.logs).toEqual(['status summary'])
+    expect(doctor.errors).toEqual([])
+    expect(status.errors).toEqual([])
   })
 
   it('routes pack through the injected dependency after parsing args', async () => {

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,123 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, test } from 'vitest'
+
+import { runDoctorCommand, runStatusCommand } from '../../src/infrastructure/doctor.js'
+
+function withSandbox(run: (sandboxDir: string) => void): void {
+  const sandboxDir = mkdtempSync(join(tmpdir(), 'graphify-ts-doctor-'))
+  try {
+    run(sandboxDir)
+  } finally {
+    rmSync(sandboxDir, { recursive: true, force: true })
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function writeText(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content, 'utf8')
+}
+
+function writeMcpServer(path: string, serversKey: 'mcpServers' | 'servers', graphPath: string): void {
+  writeJson(path, {
+    [serversKey]: {
+      graphify: {
+        command: 'npx',
+        args: ['--yes', '@mohammednagy/graphify-ts', 'serve', '--stdio', graphPath],
+      },
+    },
+  })
+}
+
+describe('doctor command', () => {
+  test('reports missing graph and suggests setup commands', () => {
+    withSandbox((sandboxDir) => {
+      const output = runDoctorCommand({
+        projectDir: sandboxDir,
+        now: Date.now(),
+      })
+
+      expect(output).toContain('[graphify doctor] attention needed')
+      expect(output).toContain('graph: missing')
+      expect(output).toContain('graphify-ts generate .')
+      expect(output).toContain('graphify-ts claude install')
+      expect(output).toContain('graphify-ts cursor install')
+      expect(output).toContain('graphify-ts gemini install')
+      expect(output).toContain('graphify-ts copilot install')
+    })
+  })
+
+  test('reports healthy status when graph and configs are wired', () => {
+    withSandbox((sandboxDir) => {
+      const graphPath = resolve(sandboxDir, 'graphify-out', 'graph.json')
+      writeText(graphPath, '{"nodes":[],"edges":[]}\n')
+      writeText(resolve(sandboxDir, 'CLAUDE.md'), '## graphify-ts\n')
+      writeText(resolve(sandboxDir, 'GEMINI.md'), '## graphify-ts\n')
+      writeText(resolve(sandboxDir, '.cursor', 'rules', 'graphify-ts.mdc'), 'rule')
+      writeJson(resolve(sandboxDir, '.claude', 'settings.json'), {
+        hooks: {
+          PreToolUse: [{ matcher: 'Read', hooks: [{ type: 'command', command: 'graphify-out' }] }],
+        },
+      })
+      writeJson(resolve(sandboxDir, '.gemini', 'settings.json'), {
+        hooks: {
+          BeforeTool: [{ matcher: 'read_file', hooks: [{ type: 'command', command: 'graphify-out' }] }],
+        },
+      })
+      writeMcpServer(resolve(sandboxDir, '.mcp.json'), 'mcpServers', graphPath)
+      writeMcpServer(resolve(sandboxDir, '.cursor', 'mcp.json'), 'mcpServers', graphPath)
+      writeMcpServer(resolve(sandboxDir, '.vscode', 'mcp.json'), 'servers', graphPath)
+
+      const doctor = runDoctorCommand({
+        projectDir: sandboxDir,
+        now: Date.now(),
+      })
+      const status = runStatusCommand({
+        projectDir: sandboxDir,
+        now: Date.now(),
+      })
+
+      expect(doctor).toContain('[graphify doctor] healthy')
+      expect(doctor).toContain('claude: configured')
+      expect(doctor).toContain('cursor: configured')
+      expect(doctor).toContain('gemini: configured')
+      expect(doctor).toContain('copilot: configured')
+      expect(doctor).toContain('next commands: none')
+
+      expect(status).toContain('[graphify status] healthy')
+      expect(status).toContain('next none')
+    })
+  })
+
+  test('flags stale mcp path and recommends reinstall', () => {
+    withSandbox((sandboxDir) => {
+      const graphPath = resolve(sandboxDir, 'graphify-out', 'graph.json')
+      const wrongGraphPath = resolve(sandboxDir, 'graphify-out', 'old-graph.json')
+      writeText(graphPath, '{"nodes":[],"edges":[]}\n')
+      writeText(resolve(sandboxDir, 'CLAUDE.md'), '## graphify-ts\n')
+      writeJson(resolve(sandboxDir, '.claude', 'settings.json'), {
+        hooks: {
+          PreToolUse: [{ matcher: 'Read', hooks: [{ type: 'command', command: 'graphify-out' }] }],
+        },
+      })
+      writeMcpServer(resolve(sandboxDir, '.mcp.json'), 'mcpServers', wrongGraphPath)
+
+      const output = runDoctorCommand({
+        projectDir: sandboxDir,
+        now: Date.now(),
+      })
+
+      expect(output).toContain('claude: partial')
+      expect(output).toContain('.mcp.json')
+      expect(output).toContain('stale')
+      expect(output).toContain('graphify-ts claude install')
+    })
+  })
+})

--- a/tests/unit/update-notifier.test.ts
+++ b/tests/unit/update-notifier.test.ts
@@ -108,6 +108,58 @@ describe('update notifier', () => {
     }
   })
 
+  it('writes a backoff cache entry when the registry refresh fails', async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
+    const cacheFile = join(cacheRoot, 'graphify-ts', 'update-check.json')
+    let fetchCalls = 0
+
+    try {
+      mkdirSync(join(cacheRoot, 'graphify-ts'), { recursive: true })
+      writeFileSync(cacheFile, JSON.stringify({
+        checked_at: 1_700_000_000_000,
+        latest_version: '0.22.9',
+        notified_at: 1_700_000_000_000,
+      }))
+
+      const notice = await getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000,
+        fetchText: async () => {
+          fetchCalls += 1
+          throw new Error('offline')
+        },
+      })
+
+      const secondNotice = await getUpdateNotification({
+        packageName: '@mohammednagy/graphify-ts',
+        currentVersion: '0.22.8',
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000 + 1_000,
+        fetchText: async () => {
+          fetchCalls += 1
+          return JSON.stringify({ version: '9.9.9' })
+        },
+      })
+
+      expect(notice).toBeNull()
+      expect(secondNotice).toBeNull()
+      expect(fetchCalls).toBe(1)
+      expect(JSON.parse(readFileSync(cacheFile, 'utf8'))).toEqual({
+        checked_at: 1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000,
+        latest_version: '0.22.9',
+        notified_at: 1_700_000_000_000,
+      })
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
   it('skips checks when disabled or non-interactive', async () => {
     const cacheRoot = mkdtempSync(join(tmpdir(), 'graphify-update-notifier-'))
     let fetchCalls = 0


### PR DESCRIPTION
## Summary
- add new doctor and status CLI commands for local health checks
- report installed package version, graph presence/freshness, local agent wiring (Claude/Cursor/Gemini/Copilot), MCP config validity, and actionable next commands
- wire parser/help/main routing, update README + changelog, and add focused unit coverage for parser routing and formatted doctor/status output

## Testing
- [x] npm run typecheck
- [x] npm run build
- [x] npx vitest run tests/unit/cli.test.ts tests/unit/doctor.test.ts
- [ ] npm run test:run (fails on Windows in pre-existing benchmark tests that spawn ash)

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `graphify-ts doctor` to report graph freshness, installed version, agent/MCP wiring and next-step commands.
  * Added `graphify-ts status` for a compact readiness summary with suggested next steps.

* **Documentation**
  * Quickstart and CHANGELOG updated to include the new commands.

* **Bug Fixes**
  * Update-checker now handles registry fetch failures gracefully.

* **Tests**
  * Added unit tests for doctor/status, CLI parsing, and update-notifier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->