### PR TITLE
Add contributor issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark.yml
@@ -1,0 +1,58 @@
+name: Benchmark or measurement
+description: Propose a benchmark, reproduce a benchmark result, or report a measurement issue.
+title: "[Benchmark]: "
+labels:
+  - type:benchmark
+  - area:benchmarks
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Benchmarks should be reproducible, scoped, and honest about limits. Do not attach private corpora, secrets, proprietary prompts, or raw logs with sensitive data.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Measurement question
+      description: What are you trying to learn or verify?
+      placeholder: Does slice-v1 reduce prompt size on a backend-runtime explanation task?
+    validations:
+      required: true
+
+  - type: textarea
+    id: setup
+    attributes:
+      label: Setup
+      description: Repo or fixture, graphify-ts version, Node.js version, OS, and relevant flags.
+      placeholder: |
+        graphify-ts 0.22.8
+        Node.js 20.x
+        macOS 15
+        Fixture: examples/demo-repo
+    validations:
+      required: true
+
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands
+      description: Exact commands or scripts needed to reproduce the measurement.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: results
+    attributes:
+      label: Results
+      description: Numbers, artifacts, and where they are stored.
+    validations:
+      required: true
+
+  - type: textarea
+    id: interpretation
+    attributes:
+      label: Interpretation and limits
+      description: What is safe to conclude, and what should not be generalized?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/benchmark.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark.yml
@@ -25,7 +25,7 @@ body:
       label: Setup
       description: Repo or fixture, graphify-ts version, Node.js version, OS, and relevant flags.
       placeholder: |
-        graphify-ts 0.22.8
+        graphify-ts <version>
         Node.js 20.x
         macOS 15
         Fixture: examples/demo-repo

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Contribution guide
     url: https://github.com/mohanagy/graphify-ts/blob/main/CONTRIBUTING.md
     about: Read local setup, testing, and pull request expectations before contributing.
+  - name: Public roadmap
+    url: https://github.com/mohanagy/graphify-ts/issues/155
+    about: See planned work and roadmap-linked issues before proposing larger changes.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,56 @@
+name: Documentation
+description: Improve README, guides, examples, benchmark notes, or contributor docs.
+title: "[Docs]: "
+labels:
+  - type:docs
+  - area:docs
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for improving the docs. Keep the request focused on one page, workflow, or confusing gap.
+
+  - type: textarea
+    id: gap
+    attributes:
+      label: Documentation gap
+      description: What is missing, unclear, stale, or hard to follow?
+      placeholder: The quickstart explains X, but it does not show how to verify Y.
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Affected page or file
+      description: Link or path if known.
+      placeholder: README.md, docs/proof-workflows.md, examples/mcp-tool-examples.md
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Audience
+      options:
+        - new user
+        - contributor
+        - maintainer
+        - benchmark reader
+        - AI agent / MCP user
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change
+      description: Describe the smallest useful docs update.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: How should the docs change be reviewed or checked?
+      placeholder: Read-through only; npm run typecheck; npm run build.

--- a/.github/ISSUE_TEMPLATE/research_design.yml
+++ b/.github/ISSUE_TEMPLATE/research_design.yml
@@ -1,0 +1,51 @@
+name: Research or design
+description: Propose a design direction, research spike, or architecture decision.
+title: "[Research]: "
+labels:
+  - type:research
+  - research
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for design and research work that needs evidence before implementation. Keep it practical and scoped.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or decision
+      description: What needs to be understood, decided, or de-risked?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Relevant issues, docs, code paths, benchmarks, or prior decisions.
+      placeholder: Roadmap item, affected CLI/MCP command, related benchmark artifact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Options considered
+      description: List the realistic approaches and trade-offs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence needed
+      description: Tests, fixtures, measurements, prototypes, or docs needed before implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: What should stay out of scope?
+      placeholder: Do not require private corpora, secrets, paid benchmarks, or broad governance changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,3 +21,7 @@
 ## Related issues
 
 <!-- Closes #123 -->
+
+## Data safety
+
+- [ ] This PR does not include private corpora, secrets, credentials, proprietary prompts, or sensitive raw logs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,13 +15,9 @@
 
 - [ ] I updated docs for any user-visible change
 - [ ] I added or updated tests when behavior changed
-- [ ] I did not commit secrets, private corpora, or accidental generated artifacts
+- [ ] This PR does not include private corpora, secrets, credentials, proprietary prompts, sensitive raw logs, or accidental generated artifacts
 - [ ] I kept this PR focused on a single change or tightly related set of changes
 
 ## Related issues
 
 <!-- Closes #123 -->
-
-## Data safety
-
-- [ ] This PR does not include private corpora, secrets, credentials, proprietary prompts, or sensitive raw logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Added
 
 - **Interactive CLI update notices**: interactive `graphify-ts` runs now check npm for newer releases using a cached user-level registry lookup, print a short upgrade hint when a newer version exists, and stay silent for `--help`, `--version`, `--json`, CI, and explicitly disabled runs (`GRAPHIFY_DISABLE_UPDATE_NOTIFIER=1`).
+- **Contributor issue templates**: contributor docs now link the public roadmap and GitHub issue forms cover docs, benchmark, and research/design requests with explicit private-data and reproducibility expectations.
 
 ## [0.22.8] - 2026-05-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ A few high-value ways to help:
 - tighten CI, release, or repository hygiene
 - reduce graph noise or improve community labeling
 
+The public roadmap lives in [#155](https://github.com/mohanagy/graphify-ts/issues/155). If you are unsure where to start, pick a small issue linked from the roadmap or one tagged `good first issue` / `help wanted`, and keep the pull request scoped to that issue.
+
 ## Development setup
 
 Prerequisites:
@@ -29,6 +31,8 @@ npm run typecheck
 npm run test:run
 npm run build
 ```
+
+For documentation-only changes, still run `npm run typecheck` and `npm run build` when practical so broken links in generated docs or TypeScript examples do not slip through. If a command is not relevant or cannot be run locally, note that in the pull request.
 
 If you are changing packaging or install behavior, also run:
 
@@ -47,6 +51,12 @@ Before opening a pull request:
 5. Avoid committing secrets, private corpora, or accidental generated artifacts.
 
 If your change affects extraction behavior, prefer adding a small fixture and a targeted test under `tests/unit/` or `tests/fixtures/`.
+
+## Data, benchmarks, and private material
+
+Do not include private repositories, private corpora, proprietary prompts, API keys, tokens, credentials, customer data, or raw logs that may contain sensitive data.
+
+Benchmark and research contributions should be reproducible from committed fixtures or clearly anonymized summaries. When real-world measurements are useful, document the environment, command, and interpretation limits without requiring maintainers or contributors to run paid benchmarks.
 
 ## Documentation expectations
 


### PR DESCRIPTION
## Summary
- add GitHub issue forms for docs, benchmark/measurement, and research/design requests
- link the public roadmap from the contribution guide and issue chooser
- extend the PR checklist and contributor guide with private-data and reproducibility expectations

Closes #167

## Testing
- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'`\n- `git diff --check`\n- `npm run typecheck`\n- `npm run build`\n\nNote: `npm ci` completed with an engine warning because this machine is on Node 23.9.0 while Vitest declares support for Node 20/22/24+; install and checks still completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added standardized issue templates for benchmarks, docs, and research/design with reproducibility and private-data guidance
  * Updated CONTRIBUTING with clearer onboarding, required checks for doc changes, and stricter data/benchmark rules
  * Broadened PR checklist privacy assertion and linked the public roadmap in contributor guidance and the changelog

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/171)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->