### PR TITLE
Add Codex CLI integration profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
+- **Codex CLI integration profile**: `graphify-ts codex install` now writes Codex-specific context-pack-first AGENTS.md guidance, registers a Codex hook reminder, documents uninstall behavior, and includes generated-text/config tests without requiring Codex during automated runs.
 - **Interactive CLI update notices**: interactive `graphify-ts` runs now check npm for newer releases using a cached user-level registry lookup, print a short upgrade hint when a newer version exists, and stay silent for `--help`, `--version`, `--json`, CI, and explicitly disabled runs (`GRAPHIFY_DISABLE_UPDATE_NOTIFIER=1`).
 
 ## [0.22.8] - 2026-05-13

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ graphify-ts cursor install      # Cursor
 graphify-ts copilot install     # GitHub Copilot CLI
 graphify-ts gemini install      # Gemini CLI
 graphify-ts aider install       # Aider
+graphify-ts codex install       # Codex CLI
 graphify-ts opencode install    # OpenCode
 ```
 
@@ -116,9 +117,12 @@ graphify-ts produces local context packs that any modern coding agent can consum
 | Gemini CLI | MCP server | `graphify-ts gemini install` |
 | Aider | MCP server | `graphify-ts aider install` |
 | OpenCode | MCP server | `graphify-ts opencode install` |
-| Codex CLI / Windsurf / others | Pipe `graphify-ts prompt` output | `graphify-ts prompt "..." --provider claude` |
+| Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `graphify-ts codex install` |
+| Windsurf / others | Pipe `graphify-ts prompt` output | `graphify-ts prompt "..." --provider claude` |
 
 These are local installers that write the agent's own MCP config to point at the graphify-ts subprocess. No code is uploaded.
+
+Codex is intentionally context-pack-first: run `graphify-ts generate .`, install with `graphify-ts codex install`, and start broad codebase work with `graphify-ts pack "<task>" --task explain` before raw file search. To remove the profile, run `graphify-ts codex uninstall`; it removes the graphify-ts AGENTS.md section and Codex hook while preserving unrelated content. Manual verification does not require Codex to be installed: inspect `AGENTS.md` and `.codex/hooks.json` after install, then confirm uninstall removes only graphify-ts content.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "pack:dry-run": "npm pack --dry-run",
         "publish:public": "npm publish --access public",
         "publish:dry-run": "npm publish --dry-run",
-        "postinstall": "node -e \"try{const g=process.env.npm_config_global==='true';const d=!process.env.INIT_CWD;if(g||d)console.log('\\n  graphify-ts updated — re-run your platform install for latest agent rules:\\n  graphify-ts claude install | cursor install | gemini install\\n')}catch{}\""
+        "postinstall": "node -e \"try{const g=process.env.npm_config_global==='true';const d=!process.env.INIT_CWD;if(g||d)console.log('\\n  graphify-ts updated — re-run your platform install for latest agent rules:\\n  graphify-ts claude install | cursor install | gemini install | codex install\\n')}catch{}\""
     },
     "devDependencies": {
         "@types/node": "^25.6.0",

--- a/src/infrastructure/install-skill-templates.ts
+++ b/src/infrastructure/install-skill-templates.ts
@@ -205,7 +205,7 @@ function semanticDispatchSection(kind: PlatformKind): string {
   if (kind === 'codex') {
     return `**Step B2 - Dispatch with Codex workers**
 
-Use ${CODE_SPAN_START}spawn_agent${CODE_SPAN_END} once per chunk and launch all workers in the same response so they run in parallel. Collect results with ${CODE_SPAN_START}wait(handle)${CODE_SPAN_END} and then ${CODE_SPAN_START}close_agent(handle)${CODE_SPAN_END}.
+Use ${CODE_SPAN_START}spawn_agent${CODE_SPAN_END} only after the context pack identifies the files and risks worth parallelizing. Launch all workers in the same response so they run in parallel. Collect results with ${CODE_SPAN_START}wait(handle)${CODE_SPAN_END} and then ${CODE_SPAN_START}close_agent(handle)${CODE_SPAN_END}.
 `
   }
 
@@ -285,6 +285,41 @@ Worker output schema:
 ${CODE_BLOCK_START}json
 {"schema_version":2,"nodes":[{"id":"filestem_entityname","label":"Human Readable Name","file_type":"code|document|paper|image|audio|video|rationale","source_file":"relative/path","source_location":"L1","layer":"base|semantic|media","provenance":[{"capability_id":"builtin:extract:markdown","stage":"extract","source_file":"relative/path","source_location":"L1"}],"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to|rationale_for","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":"L1","layer":"base|semantic|media","provenance":[{"capability_id":"builtin:extract:markdown","stage":"extract","source_file":"relative/path","source_location":"L1"}],"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path","layer":"base|semantic|media","provenance":[{"capability_id":"builtin:extract:markdown","stage":"extract","source_file":"relative/path","source_location":"L1"}]}],"input_tokens":0,"output_tokens":0}
 ${CODE_BLOCK_END}
+`
+}
+
+function codexProfileSection(kind: PlatformKind): string {
+  if (kind !== 'codex') {
+    return ''
+  }
+
+  return `## Codex CLI profile
+
+Use graphify-ts as a context-pack-first layer for Codex CLI. Before broad shell search, raw file reads, or ${CODE_SPAN_START}spawn_agent${CODE_SPAN_END} worker dispatch, generate or refresh the graph and compile the narrow task context:
+
+${CODE_BLOCK_START}bash
+graphify-ts generate .
+graphify-ts pack "<task or question>" --task explain
+# Use --task review, --task debug, or --task impact when that better matches the work.
+${CODE_BLOCK_END}
+
+Install or remove the always-on Codex project profile with:
+
+${CODE_BLOCK_START}bash
+graphify-ts codex install
+graphify-ts codex uninstall
+${CODE_BLOCK_END}
+
+Manual verification:
+1. Run ${CODE_SPAN_START}graphify-ts generate .${CODE_SPAN_END}.
+2. Run ${CODE_SPAN_START}graphify-ts codex install${CODE_SPAN_END}.
+3. Confirm ${CODE_SPAN_START}AGENTS.md${CODE_SPAN_END} contains this context-pack-first rule and ${CODE_SPAN_START}.codex/hooks.json${CODE_SPAN_END} contains the graphify hook.
+4. Run ${CODE_SPAN_START}graphify-ts codex uninstall${CODE_SPAN_END} and confirm unrelated AGENTS.md or hook content remains.
+
+Codex limitations:
+- Automated tests do not require the Codex binary; they verify generated text and hook config.
+- The Codex hook can remind before Bash when ${CODE_SPAN_START}graphify-out/graph.json${CODE_SPAN_END} exists, but AGENTS.md remains the durable always-on instruction.
+- Context packs narrow first-pass discovery. They do not replace targeted reads, tests, or review for code changes.
 `
 }
 
@@ -395,6 +430,7 @@ function buildSkillDocument(kind: PlatformKind): string {
   const parts = [
     FRONTMATTER[kind],
     commonOverview(),
+    codexProfileSection(kind),
     kind === 'windows' ? windowsInstallStep() : posixInstallStep(),
     detectStep(kind === 'windows' ? 'powershell' : 'bash'),
     extractionRules(),

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -118,6 +118,9 @@ const MCP_ROUTING_GUIDANCE =
 const RETRIEVE_FIRST_MESSAGE =
   `STOP. This project has a graphify-ts knowledge graph. ${MCP_ROUTING_GUIDANCE} Graphify answers most codebase questions in 1 focused MCP call instead of 5–10 sequential file reads (3x fewer turns, ~2.8x faster on a real production codebase). Do not use Glob, Grep, Bash, Read, or Agent tools first. Only fall back to raw file tools if the graph tools cannot answer the question or the MCP server is unavailable.`
 
+const CODEX_CONTEXT_PACK_FIRST_MESSAGE =
+  `STOP. This project has a graphify-ts knowledge graph. Follow the Codex context-pack-first workflow: run graphify-ts pack "<task or question>" --task explain before broad Bash search, raw file reads, or spawning workers. Use --task review, --task debug, or --task impact when that better matches the work. If MCP graph tools are available, use retrieve, relevant_files, feature_map, risk_map, implementation_checklist, or impact to refine the pack. Only fall back to raw file tools when the context pack or graph tools are missing, stale, or insufficient; read graphify-out/GRAPH_REPORT.md before expanding manually.`
+
 const SETTINGS_HOOK = {
   // SECURITY: Keep this command static. Do not interpolate user-controlled input here.
   matcher: 'Glob|Grep|Bash|Agent|Read',
@@ -151,7 +154,7 @@ const CODEX_HOOK = {
                   hookEventName: 'PreToolUse',
                   permissionDecision: 'allow',
                 },
-                systemMessage: RETRIEVE_FIRST_MESSAGE,
+                systemMessage: CODEX_CONTEXT_PACK_FIRST_MESSAGE,
               }),
             ),
           },
@@ -212,6 +215,36 @@ IMPORTANT: This project has a graphify-ts knowledge graph. You MUST follow these
    - \`impact\` for "what breaks if I change X?"
 2. **Do NOT search the codebase with other tools first** for codebase questions.
 3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read graphify-out/GRAPH_REPORT.md first.
+`
+
+const CODEX_AGENTS_MD_SECTION = `${SECTION_MARKER}
+
+### Codex CLI profile
+
+IMPORTANT: This project has a graphify-ts knowledge graph. Use a strict context-pack-first workflow:
+
+1. **Before broad code search, file reads, or worker dispatch**, compile a task-specific context pack:
+   - \`graphify-ts pack "<task or question>" --task explain\`
+   - use \`--task review\`, \`--task debug\`, or \`--task impact\` when that better matches the work
+2. If MCP graph tools are available, use the focused tool that matches the question after the pack:
+   - \`retrieve\` for direct codebase questions
+   - \`relevant_files\` for where to open first
+   - \`feature_map\` for involved areas and entry points
+   - \`risk_map\` before editing
+   - \`implementation_checklist\` for edit order and validation checkpoints
+   - \`impact\` for blast radius
+3. **Only fall back to raw file tools** when the context pack or graph tools are missing, stale, or insufficient. In that case, read \`graphify-out/GRAPH_REPORT.md\` first.
+4. **Do not dispatch \`spawn_agent\` workers first** for codebase discovery. Let the context pack define likely entry files, risks, and missing context before parallel work.
+5. **Uninstall behavior:** run \`graphify-ts codex uninstall\` to remove this AGENTS.md section and the graphify-ts Codex hook from \`.codex/hooks.json\` while preserving unrelated content.
+
+Manual verification:
+
+\`\`\`bash
+graphify-ts generate .
+graphify-ts codex install
+test -f AGENTS.md && test -f .codex/hooks.json
+graphify-ts codex uninstall
+\`\`\`
 `
 
 const GEMINI_MD_SECTION = `${SECTION_MARKER}
@@ -1666,7 +1699,8 @@ export function agentsInstall(projectDir = '.', platform: AgentPlatform, options
   const resolvedProjectDir = resolve(projectDir)
   const packageRoot = options.packageRoot ? resolve(options.packageRoot) : undefined
   const displayName = formatPlatformDisplayName(platform)
-  const messages = [writeSection(join(resolvedProjectDir, 'AGENTS.md'), AGENTS_MD_SECTION)]
+  const agentsSection = platform === 'codex' ? CODEX_AGENTS_MD_SECTION : AGENTS_MD_SECTION
+  const messages = [writeSection(join(resolvedProjectDir, 'AGENTS.md'), agentsSection)]
 
   if (platform === 'codex') {
     messages.push(installCodexHook(resolvedProjectDir))
@@ -1675,7 +1709,11 @@ export function agentsInstall(projectDir = '.', platform: AgentPlatform, options
     messages.push(installOpencodeMcpServer(resolvedProjectDir, packageRoot))
   }
 
-  messages.push('', `${displayName} will now check the knowledge graph before answering`, 'codebase questions and rebuild it after code changes.')
+  if (platform === 'codex') {
+    messages.push('', 'Codex will now use the graphify-ts context-pack-first profile before broad codebase discovery.', 'Uninstall with: graphify-ts codex uninstall')
+  } else {
+    messages.push('', `${displayName} will now check the knowledge graph before answering`, 'codebase questions and rebuild it after code changes.')
+  }
   if (platform !== 'codex' && platform !== 'opencode') {
     messages.push('', `Note: unlike Claude Code, there is no PreToolUse hook equivalent for ${displayName} - the AGENTS.md rules are the always-on mechanism.`)
   }

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -112,6 +112,46 @@ function hookCommandWithFallback(matchJson: string, missJson: string): string {
   return `node -e "var f;try{require('fs').accessSync('graphify-out/graph.json');f='${b64Match}'}catch(e){f='${b64Miss}'}process.stdout.write(Buffer.from(f,'base64').toString())"`
 }
 
+function decodeGeneratedHookPayloads(command: string): string[] {
+  return [...command.matchAll(/Buffer\.from\('([A-Za-z0-9+/=]{40,})','base64'\)/g)]
+    .map((match) => match[1])
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => Buffer.from(value, 'base64').toString('utf8'))
+}
+
+function isGraphifyCodexHookPayload(payload: string): boolean {
+  const hasCodexOutputShape = payload.includes('"systemMessage"') || payload.includes('"hookSpecificOutput"')
+  const hasGraphifyGuidance =
+    payload.includes('graphify-ts') ||
+    payload.includes('context-pack-first') ||
+    payload.includes('retrieve-first') ||
+    payload.includes('knowledge graph')
+
+  return hasCodexOutputShape && hasGraphifyGuidance
+}
+
+function isGraphifyCodexHookCommand(command: string): boolean {
+  return (
+    command.includes("accessSync('graphify-out/graph.json')") &&
+    command.includes('process.stdout.write(Buffer.from(') &&
+    decodeGeneratedHookPayloads(command).some(isGraphifyCodexHookPayload)
+  )
+}
+
+function isGraphifyCodexHook(hook: unknown): boolean {
+  if (!isRecord(hook) || hook.matcher !== 'Bash' || !Array.isArray(hook.hooks)) {
+    return false
+  }
+
+  return hook.hooks.some(
+    (entry) =>
+      isRecord(entry) &&
+      entry.type === 'command' &&
+      typeof entry.command === 'string' &&
+      isGraphifyCodexHookCommand(entry.command),
+  )
+}
+
 const MCP_ROUTING_GUIDANCE =
   'Use the graph tool that matches the question: retrieve for direct codebase questions, relevant_files for where to open first, feature_map for the main areas and entry points, risk_map before editing, implementation_checklist for edit order and validation, and impact for blast radius.'
 
@@ -1364,9 +1404,22 @@ function installCodexHook(projectDir: string): string {
   const preToolUse = ensureArray(hooks, 'PreToolUse')
 
   const additions = CODEX_HOOK.hooks.PreToolUse as unknown[]
-  const filtered = preToolUse.filter((hook) => !JSON.stringify(hook).includes('graphify-out'))
-  if (filtered.length !== preToolUse.length) {
-    hooks.PreToolUse = [...filtered, ...additions]
+  let replaced = false
+  const updatedPreToolUse = preToolUse.flatMap((hook) => {
+    if (!isGraphifyCodexHook(hook)) {
+      return [hook]
+    }
+
+    if (replaced) {
+      return []
+    }
+
+    replaced = true
+    return additions
+  })
+
+  if (replaced) {
+    hooks.PreToolUse = updatedPreToolUse
     writeJson(hooksPath, hooksConfig)
     return '.codex/hooks.json -> hook updated'
   }
@@ -1385,7 +1438,7 @@ function uninstallCodexHook(projectDir: string): string | undefined {
   const hooksConfig = readJsonObject(hooksPath)
   const hooks = ensureRecord(hooksConfig, 'hooks')
   const preToolUse = ensureArray(hooks, 'PreToolUse')
-  const filtered = preToolUse.filter((hook) => !JSON.stringify(hook).includes('graphify-out'))
+  const filtered = preToolUse.filter((hook) => !isGraphifyCodexHook(hook))
 
   if (filtered.length === preToolUse.length) {
     return undefined

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -1363,11 +1363,14 @@ function installCodexHook(projectDir: string): string {
   const hooks = ensureRecord(hooksConfig, 'hooks')
   const preToolUse = ensureArray(hooks, 'PreToolUse')
 
-  if (preToolUse.some((hook) => JSON.stringify(hook).includes('graphify-out'))) {
-    return '.codex/hooks.json -> hook already registered (no change)'
+  const additions = CODEX_HOOK.hooks.PreToolUse as unknown[]
+  const filtered = preToolUse.filter((hook) => !JSON.stringify(hook).includes('graphify-out'))
+  if (filtered.length !== preToolUse.length) {
+    hooks.PreToolUse = [...filtered, ...additions]
+    writeJson(hooksPath, hooksConfig)
+    return '.codex/hooks.json -> hook updated'
   }
 
-  const additions = CODEX_HOOK.hooks.PreToolUse as unknown[]
   preToolUse.push(...additions)
   writeJson(hooksPath, hooksConfig)
   return '.codex/hooks.json -> PreToolUse hook registered'

--- a/tests/unit/install-templates.test.ts
+++ b/tests/unit/install-templates.test.ts
@@ -4,7 +4,8 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { claudeInstall } from '../../src/infrastructure/install.js'
+import { agentsInstall, claudeInstall } from '../../src/infrastructure/install.js'
+import { getBuiltInSkillContent } from '../../src/infrastructure/install-skill-templates.js'
 
 const STALE_PHRASES = ['384x', '397x', '897x', '384×', '397×', '897×']
 
@@ -76,5 +77,30 @@ describe('install hook payload', () => {
       expect(decoded).toContain('implementation_checklist')
       expect(decoded).toContain('impact')
     })
+  })
+
+  it('decoded Codex hook payload includes context-pack-first guidance', () => {
+    withTempDir((projectDir) => {
+      agentsInstall(projectDir, 'codex')
+      const settings = readFileSync(join(projectDir, '.codex', 'hooks.json'), 'utf8')
+      const decoded = decodeHookPayload(settings)
+      expect(decoded).toContain('context-pack-first')
+      expect(decoded).toContain('graphify-ts pack')
+    })
+  })
+})
+
+describe('built-in install templates', () => {
+  it('documents the Codex profile, limitations, manual verification, and uninstall path', () => {
+    const content = getBuiltInSkillContent('codex')
+
+    expect(content).toContain('Codex CLI profile')
+    expect(content).toContain('context-pack-first')
+    expect(content).toContain('graphify-ts pack')
+    expect(content).toContain('graphify-ts codex install')
+    expect(content).toContain('graphify-ts codex uninstall')
+    expect(content).toContain('Manual verification')
+    expect(content).toContain('Codex limitations')
+    expect(content).toContain('spawn_agent')
   })
 })

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -114,6 +114,14 @@ function readJsoncConfig(filePath: string): OpenCodeConfig {
   return parsed.config as OpenCodeConfig
 }
 
+function decodeHookPayloads(content: string): string {
+  return [...content.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)]
+    .map((match) => match[1])
+    .filter((value): value is string => typeof value === 'string')
+    .map((b64) => Buffer.from(b64, 'base64').toString('utf8'))
+    .join('\n')
+}
+
 describe('install helpers', () => {
   it('chooses the default platform from the host OS', () => {
     expect(defaultInstallPlatform('win32')).toBe('windows')
@@ -567,6 +575,25 @@ describe('install helpers', () => {
           enabled: true,
         })
       })
+    })
+  })
+
+  it('writes Codex-specific context-pack-first guidance and uninstall behavior', () => {
+    withTempDir((projectDir) => {
+      const installMessage = agentsInstall(projectDir, 'codex')
+      const agentsMd = readFileSync(join(projectDir, 'AGENTS.md'), 'utf8')
+      const codexHooks = readFileSync(join(projectDir, '.codex', 'hooks.json'), 'utf8')
+      const decodedHookPayload = decodeHookPayloads(codexHooks)
+
+      expect(installMessage).toContain('Codex')
+      expect(installMessage).toContain('graphify-ts codex uninstall')
+      expect(agentsMd).toContain('Codex CLI profile')
+      expect(agentsMd).toContain('context-pack-first')
+      expect(agentsMd).toContain('graphify-ts pack')
+      expect(agentsMd).toContain('graphify-ts codex uninstall')
+      expect(agentsMd).toContain('Manual verification')
+      expect(decodedHookPayload).toContain('context-pack-first')
+      expect(decodedHookPayload).toContain('graphify-ts pack')
     })
   })
 

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -624,6 +624,15 @@ describe('install helpers', () => {
                   matcher: 'Read',
                   hooks: [{ type: 'command', command: 'echo keep-me' }],
                 },
+                {
+                  matcher: 'Bash',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: `node -e "require('fs').appendFileSync('graphify-out/custom.log','custom')"`,
+                    },
+                  ],
+                },
               ],
             },
           },
@@ -639,6 +648,7 @@ describe('install helpers', () => {
 
       expect(installMessage).toContain('.codex/hooks.json -> hook updated')
       expect(codexHooks).toContain('keep-me')
+      expect(codexHooks).toContain('custom.log')
       expect(decodedHookPayload).toContain('context-pack-first')
       expect(decodedHookPayload).toContain('graphify-ts pack')
       expect(decodedHookPayload).not.toContain('Legacy graphify-out retrieve-first guidance')

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -597,6 +597,54 @@ describe('install helpers', () => {
     })
   })
 
+  it('updates existing Codex graphify hooks during reinstall', () => {
+    withTempDir((projectDir) => {
+      const stalePayload = JSON.stringify({
+        systemMessage: 'Legacy graphify-out retrieve-first guidance',
+      })
+      const stalePayloadB64 = Buffer.from(stalePayload).toString('base64')
+
+      mkdirSync(join(projectDir, '.codex'), { recursive: true })
+      writeFileSync(
+        join(projectDir, '.codex', 'hooks.json'),
+        JSON.stringify(
+          {
+            hooks: {
+              PreToolUse: [
+                {
+                  matcher: 'Bash',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: `node -e "require('fs').accessSync('graphify-out/graph.json');process.stdout.write(Buffer.from('${stalePayloadB64}','base64').toString())"`,
+                    },
+                  ],
+                },
+                {
+                  matcher: 'Read',
+                  hooks: [{ type: 'command', command: 'echo keep-me' }],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+        'utf8',
+      )
+
+      const installMessage = agentsInstall(projectDir, 'codex')
+      const codexHooks = readFileSync(join(projectDir, '.codex', 'hooks.json'), 'utf8')
+      const decodedHookPayload = decodeHookPayloads(codexHooks)
+
+      expect(installMessage).toContain('.codex/hooks.json -> hook updated')
+      expect(codexHooks).toContain('keep-me')
+      expect(decodedHookPayload).toContain('context-pack-first')
+      expect(decodedHookPayload).toContain('graphify-ts pack')
+      expect(decodedHookPayload).not.toContain('Legacy graphify-out retrieve-first guidance')
+    })
+  })
+
   it('preserves unrelated OpenCode config while updating graphify MCP', () => {
     withTempDir((projectDir) => {
       writeFileSync(


### PR DESCRIPTION
## Summary

- add a Codex-specific AGENTS.md profile with strict context-pack-first guidance
- update the Codex hook payload and built-in Codex skill template with install, uninstall, limitations, and manual verification notes
- document Codex install/uninstall in README/CHANGELOG and add generated-text/config coverage

Closes #179.

## Tests

- `npm run test:run -- tests/unit/install.test.ts tests/unit/install-templates.test.ts`
- `npm run typecheck`
- `npm run build`
- manual built-CLI smoke: `codex install` creates `AGENTS.md` + `.codex/hooks.json`, and `codex uninstall` removes graphify content
- clean Linux temp-copy verification: `npm ci && npm run typecheck && npm run build && npm run test:run` (`125/125` test files, `1912` passed, `2` skipped)

Note: the full-suite validation above used a clean Linux copy with fresh git metadata so benchmark tests do not inherit Windows git-worktree pointer or CRLF artifacts from the local Docker bind mount.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex CLI profile: context-pack-first install via `graphify-ts codex install` and uninstall via `graphify-ts codex uninstall`.
  * Interactive CLI now checks npm for updates and shows a short upgrade hint when a newer release exists (silenced for help/version/json, CI, or when disabled).

* **Documentation**
  * README updated with Codex install/uninstall guidance and profile details.

* **Tests**
  * Added unit tests validating Codex install templates, hooks, and reinstall/idempotency behavior.

* **Bug Fixes**
  * Reinstall now replaces outdated Codex hook guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/182)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->