### PR TITLE
[P1][Docs] Add Codex and Claude Code orchestration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
+- **Agent orchestration guide**: adds `docs/integrations/agent-orchestration.md` with conservative multi-agent workflows for Claude Code, Codex, Copilot, Cursor, and Gemini, including when to use installed rules, MCP, `pack`, and `prompt`, plus guidance for avoiding repeated context expansion.
 - **Codex CLI integration profile**: `graphify-ts codex install` now writes Codex-specific context-pack-first AGENTS.md guidance, registers a Codex hook reminder, documents uninstall behavior, and includes generated-text/config tests without requiring Codex during automated runs.
 - **Interactive CLI update notices**: interactive `graphify-ts` runs now check npm for newer releases using a cached user-level registry lookup, print a short upgrade hint when a newer version exists, and stay silent for `--help`, `--version`, `--json`, CI, and explicitly disabled runs (`GRAPHIFY_DISABLE_UPDATE_NOTIFIER=1`).
 - **Contributor issue templates**: contributor docs now link the public roadmap and GitHub issue forms cover docs, benchmark, and research/design requests with explicit private-data and reproducibility expectations.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ These are local installers that write the agent's own MCP config to point at the
 
 Codex is intentionally context-pack-first: run `graphify-ts generate .`, install with `graphify-ts codex install`, and start broad codebase work with `graphify-ts pack "<task>" --task explain` before raw file search. To remove the profile, run `graphify-ts codex uninstall`; it removes the graphify-ts AGENTS.md section and Codex hook while preserving unrelated content. Manual verification does not require Codex to be installed: inspect `AGENTS.md` and `.codex/hooks.json` after install, then confirm uninstall removes only graphify-ts content.
 
+For practical multi-agent workflows across Claude Code, Codex, Copilot, Cursor, and Gemini, see the [agent orchestration guide](docs/integrations/agent-orchestration.md).
+
 ---
 
 ## MCP tools

--- a/docs/integrations/agent-orchestration.md
+++ b/docs/integrations/agent-orchestration.md
@@ -1,0 +1,160 @@
+# Agent orchestration guide
+
+`graphify-ts` works best when it is the shared context layer for your local agents, not another agent doing its own independent repo discovery.
+
+This guide is intentionally conservative:
+
+- use one graph as the shared source of truth
+- prefer one agent to discover context and other agents to execute against that narrowed scope
+- avoid expanding the same task through MCP, `pack`, and `prompt` at the same time unless you are explicitly comparing them
+- do not treat benchmark wins as guaranteed on every repo or every session
+
+## Choose the right surface first
+
+| Surface | Use it when | Avoid it when |
+|---|---|---|
+| Installed agent rules (`graphify-ts <agent> install`) | You want the agent to keep checking the graph automatically during normal work | You only need a one-off exported prompt |
+| MCP tools | The agent supports MCP and can ask follow-up questions inside the same session | You need a static handoff to another CLI or a saved prompt artifact |
+| `graphify-ts pack` | You want a compact task-specific context bundle before broad search or before dispatching workers | You need provider-specific prompt formatting |
+| `graphify-ts prompt` | You need a provider-ready compiled prompt for a non-MCP CLI or proof workflow | The agent already has a live MCP connection and session state |
+
+## Recommended workflow by agent
+
+### Claude Code
+
+Use `graphify-ts claude install` when Claude is your primary interactive coding agent. Claude works best as an MCP-first agent:
+
+1. `graphify-ts generate .`
+2. `graphify-ts claude install`
+3. Ask the codebase question normally and let Claude use MCP tools like `retrieve`, `impact`, `relevant_files`, or `implementation_checklist`.
+
+Use `pack` only when you want to hand the narrowed context to another agent or when you want a deterministic snapshot before parallel work.
+
+### Codex CLI
+
+Use `graphify-ts codex install` when Codex is participating in broad repo work. Codex should stay context-pack-first:
+
+1. `graphify-ts generate .`
+2. `graphify-ts pack "<task>" --task explain`
+3. Start Codex with the installed AGENTS.md + hook guidance
+4. Open only the files or risks identified by the pack before broad shell search or worker dispatch
+
+Use `prompt` only if you need a one-shot provider-formatted prompt instead of Codex's installed rules.
+
+### GitHub Copilot CLI
+
+Use `graphify-ts copilot install` when Copilot CLI is your shell-facing agent. Prefer the MCP path for explain, review, and impact questions so Copilot can query the graph directly instead of repeatedly reading files.
+
+Use `pack` when you want to freeze the current scope before handing the task to another tool or another agent.
+
+### Cursor
+
+Use `graphify-ts cursor install` when Cursor is the editing surface and you want graph-backed navigation inside the IDE. Cursor works well as the implementation/editor agent while another agent handles broader discovery.
+
+If you already know the scope from Claude or Codex, hand Cursor the narrowed file list or `pack` output instead of making Cursor rediscover the repo from scratch.
+
+### Gemini
+
+Use `graphify-ts gemini install` if you want Gemini CLI to query the graph through MCP. Use `graphify-ts prompt ... --provider gemini` when you want a provider-ready prompt for one-shot runs, proof workflows, or environments where MCP is not available.
+
+For Gemini, `prompt` is the better fit when you care more about a stable exported prompt than live tool use.
+
+## Avoid repeated context expansion
+
+The most common waste pattern is making several agents rediscover the same task independently. Prefer this order:
+
+1. Build or refresh the graph once: `graphify-ts generate .`
+2. Pick one discovery surface:
+   - MCP for interactive graph-backed sessions
+   - `pack` for compact task handoff
+   - `prompt` for provider-ready export
+3. Reuse that narrowed scope across agents instead of starting from raw search again
+
+Practical rules:
+
+- Do not run `pack`, then ask an MCP-connected agent to rediscover the same task from scratch unless the pack is clearly insufficient.
+- Do not use `compare` or `review-compare` as routine task entrypoints; they are proof workflows.
+- Refresh the graph after structural code changes before sending the same task to another agent.
+- Let one agent own broad discovery. Other agents should receive file lists, task framing, or compact graph context.
+- If the graph tools are unavailable or stale, read `graphify-out/GRAPH_REPORT.md` before falling back to raw file exploration.
+
+## Task examples
+
+### Explain
+
+**Best default:** Claude Code, Copilot CLI, Cursor, or Gemini over MCP
+
+```bash
+graphify-ts generate .
+graphify-ts claude install
+```
+
+Then ask: “How does auth work?”
+
+**Codex variant**
+
+```bash
+graphify-ts generate .
+graphify-ts pack "How does auth work?" --task explain
+graphify-ts codex install
+```
+
+Use the pack to decide what Codex should open first.
+
+### Review
+
+Use graph-backed review surfaces first:
+
+```bash
+graphify-ts generate .
+graphify-ts review-compare graphify-out/graph.json --exec 'cat {prompt_file} | claude -p' --yes
+```
+
+For live review work, prefer `pr_impact` / review-oriented MCP tools when the agent supports MCP. If a second agent needs the same review scope, hand it the compact review context instead of re-running diff discovery.
+
+### Impact
+
+Use the graph directly for blast radius:
+
+```bash
+graphify-ts generate .
+graphify-ts pack "What breaks if I change AuthService.login?" --task impact
+```
+
+For MCP-capable agents, ask the impact question normally and let the agent use `impact` or `risk_map`. For non-MCP handoffs, use the impact pack as the shared artifact.
+
+### Implementation
+
+Use a lead-agent / worker-agent split:
+
+1. Lead agent compiles scope with MCP or `pack`
+2. Lead agent identifies files, risks, and validation steps
+3. Worker agents edit only within that narrowed scope
+
+Example:
+
+```bash
+graphify-ts generate .
+graphify-ts pack "Implement password-reset audit logging" --task explain
+```
+
+Good follow-up flow:
+
+- Claude or Copilot: identify files and tests
+- Codex: parallelize only after the pack identifies likely edit surfaces
+- Cursor: perform the edits in the narrowed files
+
+## Conservative claims
+
+Safe guidance:
+
+- graphify-ts can reduce repeated repo discovery across multiple local agents
+- MCP is best for live interactive workflows
+- `pack` is best for compact task handoff
+- `prompt` is best for provider-ready export
+
+Unsafe guidance:
+
+- claiming universal token savings for every agent or repo
+- telling every user to always prefer `prompt` over MCP
+- encouraging several agents to rediscover the same broad task independently


### PR DESCRIPTION
## Summary
- add a conservative agent orchestration guide for Claude Code, Codex, Copilot, Cursor, and Gemini
- explain when to use installed rules, MCP, `pack`, and `prompt`
- add guidance for avoiding repeated context expansion and link the new guide from the README

Closes #175

## Testing
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for orchestrating multiple AI agents (Claude Code, Codex, Copilot, Cursor, Gemini) with decision frameworks, recommended workflows, and best practices for context management across different agent surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/193)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->