### PR TITLE
[P2][Examples] Add small sample TypeScript workspace for demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
+- **Small sample TypeScript workspace**: adds `examples/sample-workspace/` plus a short tutorial and checked-in prompt examples so new users can run `generate` and `pack` against a compact TypeScript demo without needing a private repo or the larger benchmark demo corpus.
 - **Agent orchestration guide**: adds `docs/integrations/agent-orchestration.md` with conservative multi-agent workflows for Claude Code, Codex, Copilot, Cursor, and Gemini, including when to use installed rules, MCP, `pack`, and `prompt`, plus guidance for avoiding repeated context expansion.
 - **Codex CLI integration profile**: `graphify-ts codex install` now writes Codex-specific context-pack-first AGENTS.md guidance, registers a Codex hook reminder, documents uninstall behavior, and includes generated-text/config tests without requiring Codex during automated runs.
 - **Interactive CLI update notices**: interactive `graphify-ts` runs now check npm for newer releases using a cached user-level registry lookup, print a short upgrade hint when a newer version exists, and stay silent for `--help`, `--version`, `--json`, CI, and explicitly disabled runs (`GRAPHIFY_DISABLE_UPDATE_NOTIFIER=1`).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ graphify-ts pack "how does auth work?" --task explain          # compact CLI con
 graphify-ts prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
 ```
 
+Want a tiny reproducible workspace for local demos? Start with [`examples/sample-workspace/`](examples/sample-workspace/) and the [sample workspace tutorial](docs/tutorials/sample-workspace.md).
+
 ---
 
 ## What graphify-ts is

--- a/docs/tutorials/sample-workspace.md
+++ b/docs/tutorials/sample-workspace.md
@@ -1,0 +1,30 @@
+# Sample workspace tutorial
+
+Use `examples/sample-workspace/` when you want a fast, reproducible TypeScript workspace for demos without the larger benchmark-oriented `examples/demo-repo/`.
+
+## Generate the graph
+
+```bash
+npm run build
+graphify-ts generate examples/sample-workspace --no-html
+```
+
+This creates `examples/sample-workspace/graphify-out/graph.json`.
+
+## Run a compact pack query
+
+```bash
+graphify-ts pack "how does password reset request enqueue the reset email" \
+  --graph examples/sample-workspace/graphify-out/graph.json \
+  --task explain
+```
+
+That prompt should surface the route → service → queue-like job flow around password reset email delivery.
+
+## Prompt examples
+
+The sample workspace ships checked-in prompt examples in [`examples/sample-workspace/prompt-examples.json`](../../examples/sample-workspace/prompt-examples.json):
+
+- how does password reset request enqueue the reset email
+- where is reset token persisted before the email job runs
+- what updates the password after a reset token is verified

--- a/docs/tutorials/sample-workspace.md
+++ b/docs/tutorials/sample-workspace.md
@@ -5,7 +5,7 @@ Use `examples/sample-workspace/` when you want a fast, reproducible TypeScript w
 ## Generate the graph
 
 ```bash
-npm run build
+npm run build # run from the repository root to build graphify-ts locally
 graphify-ts generate examples/sample-workspace --no-html
 ```
 

--- a/examples/sample-workspace/README.md
+++ b/examples/sample-workspace/README.md
@@ -1,0 +1,22 @@
+# Password Reset Demo Workspace
+
+This sample workspace is intentionally smaller than `examples/demo-repo/`. It is meant for quick local demos, screenshots, and first-run experiments when you want a believable TypeScript codebase without a large benchmark corpus.
+
+The flow is compact but realistic:
+
+- `src/routes/account-routes.ts` models route-style entrypoints
+- `src/services/password-reset-service.ts` coordinates the business logic
+- `src/jobs/reset-email-job.ts` stands in for a queue/worker boundary
+- `src/persistence/user-repository.ts` stores and updates reset state
+- `src/notifications/email-gateway.ts` simulates the external email side
+
+Try it locally:
+
+```bash
+graphify-ts generate examples/sample-workspace --no-html
+graphify-ts pack "how does password reset request enqueue the reset email" \
+  --graph examples/sample-workspace/graphify-out/graph.json \
+  --task explain
+```
+
+Prompt examples live in [`prompt-examples.json`](./prompt-examples.json).

--- a/examples/sample-workspace/package.json
+++ b/examples/sample-workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sample-password-reset-workspace",
+  "private": true,
+  "type": "module"
+}

--- a/examples/sample-workspace/prompt-examples.json
+++ b/examples/sample-workspace/prompt-examples.json
@@ -1,0 +1,26 @@
+[
+  {
+    "question": "how does password reset request enqueue the reset email",
+    "expected_labels": [
+      "PasswordResetService",
+      ".requestPasswordReset()",
+      "enqueueResetEmailJob()"
+    ]
+  },
+  {
+    "question": "where is reset token persisted before the email job runs",
+    "expected_labels": [
+      "UserRepository",
+      "saveResetToken()",
+      "password-reset-service.ts"
+    ]
+  },
+  {
+    "question": "what updates the password after a reset token is verified",
+    "expected_labels": [
+      ".completePasswordReset()",
+      "updatePasswordHash()",
+      "UserRepository"
+    ]
+  }
+]

--- a/examples/sample-workspace/src/app.ts
+++ b/examples/sample-workspace/src/app.ts
@@ -1,0 +1,19 @@
+import { sendPasswordResetEmail } from './notifications/email-gateway.js'
+import { userRepository } from './persistence/user-repository.js'
+import { createAccountRoutes } from './routes/account-routes.js'
+import { createPasswordResetService } from './services/password-reset-service.js'
+
+const passwordResetService = createPasswordResetService({
+  userRepository,
+  sendPasswordResetEmail,
+})
+
+export const accountRoutes = createAccountRoutes(passwordResetService)
+
+export function requestPasswordReset(email: string) {
+  return accountRoutes.requestPasswordReset(email)
+}
+
+export function completePasswordReset(token: string, passwordHash: string) {
+  return accountRoutes.completePasswordReset(token, passwordHash)
+}

--- a/examples/sample-workspace/src/jobs/reset-email-job.ts
+++ b/examples/sample-workspace/src/jobs/reset-email-job.ts
@@ -1,0 +1,14 @@
+export interface ResetEmailJob {
+  email: string
+  token: string
+  sendPasswordResetEmail: (email: string, resetLink: string) => { delivered: boolean; channel: 'email' }
+}
+
+export function enqueueResetEmailJob(job: ResetEmailJob) {
+  return processResetEmailJob(job)
+}
+
+export function processResetEmailJob(job: ResetEmailJob) {
+  const resetLink = `https://example.test/reset?token=${job.token}`
+  return job.sendPasswordResetEmail(job.email, resetLink)
+}

--- a/examples/sample-workspace/src/notifications/email-gateway.ts
+++ b/examples/sample-workspace/src/notifications/email-gateway.ts
@@ -1,0 +1,6 @@
+export function sendPasswordResetEmail(email: string, resetLink: string) {
+  return {
+    delivered: email.length > 0 && resetLink.length > 0,
+    channel: 'email' as const,
+  }
+}

--- a/examples/sample-workspace/src/persistence/user-repository.ts
+++ b/examples/sample-workspace/src/persistence/user-repository.ts
@@ -1,0 +1,40 @@
+export interface UserRecord {
+  id: string
+  email: string
+  passwordHash: string
+  resetToken?: string
+}
+
+export class UserRepository {
+  private readonly users = new Map<string, UserRecord>([
+    ['u-1', { id: 'u-1', email: 'sam@example.test', passwordHash: 'hash:v1' }],
+    ['u-2', { id: 'u-2', email: 'lee@example.test', passwordHash: 'hash:v1' }],
+  ])
+
+  findUserByEmail(email: string): UserRecord | undefined {
+    return [...this.users.values()].find((user) => user.email === email)
+  }
+
+  findUserByResetToken(token: string): UserRecord | undefined {
+    return [...this.users.values()].find((user) => user.resetToken === token)
+  }
+
+  saveResetToken(userId: string, token: string): void {
+    const user = this.users.get(userId)
+    if (!user) {
+      return
+    }
+    user.resetToken = token
+  }
+
+  updatePasswordHash(userId: string, passwordHash: string): void {
+    const user = this.users.get(userId)
+    if (!user) {
+      return
+    }
+    user.passwordHash = passwordHash
+    delete user.resetToken
+  }
+}
+
+export const userRepository = new UserRepository()

--- a/examples/sample-workspace/src/routes/account-routes.ts
+++ b/examples/sample-workspace/src/routes/account-routes.ts
@@ -1,0 +1,15 @@
+export interface PasswordResetPort {
+  requestPasswordReset(email: string): { queued: boolean; token: string | null }
+  completePasswordReset(token: string, passwordHash: string): boolean
+}
+
+export function createAccountRoutes(passwordReset: PasswordResetPort) {
+  return {
+    requestPasswordReset(email: string) {
+      return passwordReset.requestPasswordReset(email)
+    },
+    completePasswordReset(token: string, passwordHash: string) {
+      return passwordReset.completePasswordReset(token, passwordHash)
+    },
+  }
+}

--- a/examples/sample-workspace/src/routes/account-routes.ts
+++ b/examples/sample-workspace/src/routes/account-routes.ts
@@ -1,5 +1,5 @@
 export interface PasswordResetPort {
-  requestPasswordReset(email: string): { queued: boolean; token: string | null }
+  requestPasswordReset(email: string): { queued: boolean }
   completePasswordReset(token: string, passwordHash: string): boolean
 }
 

--- a/examples/sample-workspace/src/services/password-reset-service.ts
+++ b/examples/sample-workspace/src/services/password-reset-service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import { enqueueResetEmailJob } from '../jobs/reset-email-job.js'
 import type { UserRepository } from '../persistence/user-repository.js'
 import { recordAuditEvent } from '../shared/audit-log.js'
@@ -10,13 +12,13 @@ export interface PasswordResetDependencies {
 export class PasswordResetService {
   constructor(private readonly dependencies: PasswordResetDependencies) {}
 
-  requestPasswordReset(email: string): { queued: boolean; token: string | null } {
+  requestPasswordReset(email: string): { queued: boolean } {
     const user = this.dependencies.userRepository.findUserByEmail(email)
     if (!user) {
-      return { queued: false, token: null }
+      return { queued: false }
     }
 
-    const token = `reset-${user.id}`
+    const token = randomUUID()
     this.dependencies.userRepository.saveResetToken(user.id, token)
     enqueueResetEmailJob({
       email: user.email,
@@ -25,7 +27,7 @@ export class PasswordResetService {
     })
     recordAuditEvent('password-reset-requested', user.id)
 
-    return { queued: true, token }
+    return { queued: true }
   }
 
   completePasswordReset(token: string, passwordHash: string): boolean {

--- a/examples/sample-workspace/src/services/password-reset-service.ts
+++ b/examples/sample-workspace/src/services/password-reset-service.ts
@@ -15,7 +15,7 @@ export class PasswordResetService {
   requestPasswordReset(email: string): { queued: boolean } {
     const user = this.dependencies.userRepository.findUserByEmail(email)
     if (!user) {
-      return { queued: false }
+      return { queued: true }
     }
 
     const token = randomUUID()

--- a/examples/sample-workspace/src/services/password-reset-service.ts
+++ b/examples/sample-workspace/src/services/password-reset-service.ts
@@ -1,0 +1,45 @@
+import { enqueueResetEmailJob } from '../jobs/reset-email-job.js'
+import type { UserRepository } from '../persistence/user-repository.js'
+import { recordAuditEvent } from '../shared/audit-log.js'
+
+export interface PasswordResetDependencies {
+  userRepository: UserRepository
+  sendPasswordResetEmail: (email: string, resetLink: string) => { delivered: boolean; channel: 'email' }
+}
+
+export class PasswordResetService {
+  constructor(private readonly dependencies: PasswordResetDependencies) {}
+
+  requestPasswordReset(email: string): { queued: boolean; token: string | null } {
+    const user = this.dependencies.userRepository.findUserByEmail(email)
+    if (!user) {
+      return { queued: false, token: null }
+    }
+
+    const token = `reset-${user.id}`
+    this.dependencies.userRepository.saveResetToken(user.id, token)
+    enqueueResetEmailJob({
+      email: user.email,
+      token,
+      sendPasswordResetEmail: this.dependencies.sendPasswordResetEmail,
+    })
+    recordAuditEvent('password-reset-requested', user.id)
+
+    return { queued: true, token }
+  }
+
+  completePasswordReset(token: string, passwordHash: string): boolean {
+    const user = this.dependencies.userRepository.findUserByResetToken(token)
+    if (!user) {
+      return false
+    }
+
+    this.dependencies.userRepository.updatePasswordHash(user.id, passwordHash)
+    recordAuditEvent('password-reset-completed', user.id)
+    return true
+  }
+}
+
+export function createPasswordResetService(dependencies: PasswordResetDependencies): PasswordResetService {
+  return new PasswordResetService(dependencies)
+}

--- a/examples/sample-workspace/src/shared/audit-log.ts
+++ b/examples/sample-workspace/src/shared/audit-log.ts
@@ -1,0 +1,3 @@
+export function recordAuditEvent(eventName: string, userId: string): string {
+  return `${eventName}:${userId}`
+}

--- a/examples/sample-workspace/tsconfig.json
+++ b/examples/sample-workspace/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/unit/sample-workspace.test.ts
+++ b/tests/unit/sample-workspace.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from 'vitest'
 
 import { generateGraph } from '../../src/infrastructure/generate.js'
 import { runContextPackCommand } from '../../src/infrastructure/context-pack-command.js'
+import { UserRepository } from '../../examples/sample-workspace/src/persistence/user-repository.js'
+import { createPasswordResetService } from '../../examples/sample-workspace/src/services/password-reset-service.js'
 
 interface PromptExample {
   question: string
@@ -82,9 +84,27 @@ describe('examples/sample-workspace', () => {
     const tutorial = readFileSync(resolve('docs/tutorials/sample-workspace.md'), 'utf8')
     const readme = readFileSync(resolve('README.md'), 'utf8')
 
+    if (tutorial.includes('npm run build')) {
+      expect(tutorial.toLowerCase()).toContain('repository root')
+    }
     expect(tutorial).toContain('graphify-ts generate examples/sample-workspace')
     expect(tutorial).toContain('graphify-ts pack')
     expect(tutorial).toContain('prompt-examples.json')
     expect(readme).toContain('examples/sample-workspace')
+  })
+
+  it('does not return the password reset token to the caller', () => {
+    const userRepository = new UserRepository()
+    const passwordResetService = createPasswordResetService({
+      userRepository,
+      sendPasswordResetEmail: () => ({ delivered: true, channel: 'email' }),
+    })
+
+    const result = passwordResetService.requestPasswordReset('sam@example.test')
+    const user = userRepository.findUserByEmail('sam@example.test')
+
+    expect(result).toEqual({ queued: true })
+    expect(user?.resetToken).toBeTruthy()
+    expect(user?.resetToken).not.toBe('reset-u-1')
   })
 })

--- a/tests/unit/sample-workspace.test.ts
+++ b/tests/unit/sample-workspace.test.ts
@@ -1,0 +1,90 @@
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+import { generateGraph } from '../../src/infrastructure/generate.js'
+import { runContextPackCommand } from '../../src/infrastructure/context-pack-command.js'
+
+interface PromptExample {
+  question: string
+  expected_labels: string[]
+}
+
+function withTempDir<T>(callback: (tempDir: string) => T | Promise<T>): T | Promise<T> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'graphify-ts-sample-workspace-'))
+  const finalize = () => rmSync(tempDir, { recursive: true, force: true })
+  try {
+    const result = callback(tempDir)
+    if (result && typeof (result as Promise<T>).then === 'function') {
+      return (result as Promise<T>).finally(finalize)
+    }
+    finalize()
+    return result
+  } catch (error) {
+    finalize()
+    throw error
+  }
+}
+
+function copySampleWorkspace(tempDir: string): string {
+  const sourceRoot = resolve('examples/sample-workspace')
+  const targetRoot = join(tempDir, 'sample-workspace')
+  cpSync(sourceRoot, targetRoot, {
+    recursive: true,
+    filter: (source) => {
+      const relativePath = relative(sourceRoot, source)
+      return relativePath !== 'graphify-out' && !relativePath.startsWith(`graphify-out${sep}`)
+    },
+  })
+  return targetRoot
+}
+
+describe('examples/sample-workspace', () => {
+  it('ships a small sample workspace that can generate a graph and answer a pack prompt', async () => {
+    expect(existsSync(resolve('examples/sample-workspace'))).toBe(true)
+    expect(existsSync(resolve('examples/sample-workspace/prompt-examples.json'))).toBe(true)
+
+    await withTempDir(async (tempDir) => {
+      const sampleRoot = copySampleWorkspace(tempDir)
+      const promptExamples = JSON.parse(
+        readFileSync(join(sampleRoot, 'prompt-examples.json'), 'utf8'),
+      ) as PromptExample[]
+      const firstPrompt = promptExamples[0]
+
+      expect(firstPrompt).toBeDefined()
+      const result = generateGraph(sampleRoot, { noHtml: true })
+      const graphPath = join(sampleRoot, 'graphify-out', 'graph.json')
+      const packOutput = await runContextPackCommand({
+        prompt: firstPrompt?.question ?? '',
+        budget: 1800,
+        task: 'explain',
+        graphPath,
+      })
+      const pack = JSON.parse(packOutput) as {
+        pack: {
+          matched_nodes: Array<{ label: string }>
+        }
+      }
+
+      expect(result.nodeCount).toBeGreaterThan(0)
+      expect(existsSync(graphPath)).toBe(true)
+      expect(pack.pack.matched_nodes.length).toBeGreaterThan(0)
+      expect(
+        (firstPrompt?.expected_labels ?? []).some((label) =>
+          pack.pack.matched_nodes.some((node) => node.label === label)),
+      ).toBe(true)
+    })
+  })
+
+  it('documents how to generate and pack against the sample workspace', () => {
+    const tutorial = readFileSync(resolve('docs/tutorials/sample-workspace.md'), 'utf8')
+    const readme = readFileSync(resolve('README.md'), 'utf8')
+
+    expect(tutorial).toContain('graphify-ts generate examples/sample-workspace')
+    expect(tutorial).toContain('graphify-ts pack')
+    expect(tutorial).toContain('prompt-examples.json')
+    expect(readme).toContain('examples/sample-workspace')
+  })
+})

--- a/tests/unit/sample-workspace.test.ts
+++ b/tests/unit/sample-workspace.test.ts
@@ -107,4 +107,19 @@ describe('examples/sample-workspace', () => {
     expect(user?.resetToken).toBeTruthy()
     expect(user?.resetToken).not.toBe('reset-u-1')
   })
+
+  it('returns the same queued response for unknown email addresses', () => {
+    const userRepository = new UserRepository()
+    const passwordResetService = createPasswordResetService({
+      userRepository,
+      sendPasswordResetEmail: () => ({ delivered: true, channel: 'email' }),
+    })
+
+    const existingUserResult = passwordResetService.requestPasswordReset('sam@example.test')
+    const unknownUserResult = passwordResetService.requestPasswordReset('missing@example.test')
+
+    expect(existingUserResult).toEqual({ queued: true })
+    expect(unknownUserResult).toEqual({ queued: true })
+    expect(userRepository.findUserByEmail('missing@example.test')).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- add a compact TypeScript sample workspace for quick local demos
- add a short tutorial plus checked-in prompt examples for `generate` and `pack`
- add regression coverage proving the sample workspace can generate a graph and answer a pack prompt

Closes #187

## Testing
- npm run typecheck
- npm run build
- npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a tutorial, README updates, and quickstart links showing how to run a tiny sample workspace with the CLI generate/pack flow and included prompt examples.

* **New Features**
  * Added a lightweight TypeScript sample demonstrating a full password-reset flow (request, enqueue/email job, token persistence, completion) and checked-in prompt examples for queries.

* **Tests**
  * Added unit tests validating end-to-end password-reset behavior and CLI generation/pack integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/194)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->