### PR TITLE
[P2][Docs] Add end-to-end tutorial with a small sample app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the TypeScript package will be documented in this file.
 - **Contributor issue templates**: contributor docs now link the public roadmap and GitHub issue forms cover docs, benchmark, and research/design requests with explicit private-data and reproducibility expectations.
 - **Release checklist page**: adds `docs/release.md` with a repeatable maintainer checklist covering version bumps, changelog updates, verification commands, package dry-runs, CLI smoke checks, and post-release verification.
 - **Public roadmap page**: adds `docs/roadmap.md` with contributor-facing P0/P1/P2 tracks, issue links, label explanations, and a README pointer back to the main roadmap tracker.
+- **End-to-end getting started tutorial**: adds `docs/tutorials/getting-started.md` with a local-first sample-workspace walkthrough covering install, graph generation, `pack`, `prompt`, and a safe `compare` smoke check without requiring paid model usage.
 
 ## [0.22.8] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ graphify-ts prompt "how does auth work?" --provider claude     # provider-ready 
 
 Want a tiny reproducible workspace for local demos? Start with [`examples/sample-workspace/`](examples/sample-workspace/) and the [sample workspace tutorial](docs/tutorials/sample-workspace.md).
 
+Want a broader local-first walkthrough that also covers install, `prompt`, and a safe `compare` smoke check? Use the [end-to-end getting started tutorial](docs/tutorials/getting-started.md).
+
 ---
 
 ## What graphify-ts is

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,72 @@
+# End-to-end getting started tutorial
+
+Use this walkthrough when you want to evaluate `graphify-ts` end to end without a private repository or paid model calls. It uses the checked-in `examples/sample-workspace/` demo so every step stays local and reproducible.
+
+## 1. Install graphify-ts
+
+```bash
+npm install -g @mohammednagy/graphify-ts
+```
+
+If you are working from this repository instead of a published npm install, run `npm run build` from the repository root first so the local CLI is up to date.
+
+## 2. Generate a graph for the sample workspace
+
+```bash
+graphify-ts generate examples/sample-workspace --no-html
+```
+
+This creates `examples/sample-workspace/graphify-out/graph.json`.
+
+## 3. Build a compact pack
+
+```bash
+graphify-ts pack "how does password reset request enqueue the reset email" \
+  --graph examples/sample-workspace/graphify-out/graph.json \
+  --task explain
+```
+
+This is the fastest way to confirm the route → service → job flow is represented in the graph.
+
+## 4. Compile a provider-ready prompt
+
+```bash
+graphify-ts prompt "where is reset token persisted before the email job runs" \
+  --provider claude \
+  --graph examples/sample-workspace/graphify-out/graph.json
+```
+
+`prompt` only compiles the prompt payload. It does **not** call Claude or spend paid model tokens by itself.
+
+## 5. Run a safe compare smoke check
+
+If you want to exercise `compare` without calling a paid model, use a local echo-style runner:
+
+```bash
+graphify-ts compare "how does password reset request enqueue the reset email" \
+  --graph examples/sample-workspace/graphify-out/graph.json \
+  --exec 'cat {prompt_file}' \
+  --yes
+```
+
+This does **not** measure model quality. It is a safe local smoke check that proves `compare` can build both prompts and save the artifact bundle without requiring a hosted model. Real model-backed compare runs are optional.
+
+## Expected output
+
+- `generate` should write `examples/sample-workspace/graphify-out/graph.json`
+- `pack` should print a compact JSON payload with matched nodes from the password reset flow
+- `prompt` should print a provider-ready prompt payload
+- `compare` should create an artifact directory under `graphify-out/compare/` containing prompt and answer files plus `report.json`
+
+## Troubleshooting
+
+- **`graphify-ts: command not found`**: make sure the global npm install succeeded, or run from a local repo checkout after `npm run build`.
+- **`graph.json` missing**: rerun `graphify-ts generate examples/sample-workspace --no-html` before `pack`, `prompt`, or `compare`.
+- **`compare` looks noisy**: the `cat {prompt_file}` runner is only a local smoke check. Use a real terminal model runner later if you want meaningful answer comparisons.
+- **Need more questions?** Start with `examples/sample-workspace/prompt-examples.json`.
+
+## Optional next steps
+
+- Replace the local compare runner with your real CLI model command from [`docs/proof-workflows.md`](../proof-workflows.md).
+- Install one of the agent profiles from the README after the sample graph is generated.
+- Move from `examples/sample-workspace/` to your own workspace and rerun the same `generate` → `pack` → `prompt` flow.

--- a/tests/unit/getting-started-docs.test.ts
+++ b/tests/unit/getting-started-docs.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+describe('getting started tutorial', () => {
+  it('documents an end-to-end sample workspace walkthrough', () => {
+    const tutorial = readFileSync(resolve('docs/tutorials/getting-started.md'), 'utf8')
+    const readme = readFileSync(resolve('README.md'), 'utf8')
+
+    expect(tutorial).toContain('npm install -g @mohammednagy/graphify-ts')
+    expect(tutorial).toContain('graphify-ts generate examples/sample-workspace --no-html')
+    expect(tutorial).toContain('graphify-ts pack')
+    expect(tutorial).toContain('graphify-ts prompt')
+    expect(tutorial).toContain('graphify-ts compare')
+    expect(tutorial).toContain('--exec')
+    expect(tutorial).toContain('--yes')
+    expect(tutorial.toLowerCase()).toContain('expected output')
+    expect(tutorial.toLowerCase()).toContain('troubleshooting')
+    expect(tutorial.toLowerCase()).toContain('optional')
+    expect(tutorial).toContain('examples/sample-workspace')
+    expect(readme).toContain('docs/tutorials/getting-started.md')
+  })
+})


### PR DESCRIPTION
## Summary
- add docs/tutorials/getting-started.md with a local-first sample-workspace walkthrough
- cover install, generate, pack, prompt, and a safe compare smoke check without paid model usage
- link the new tutorial from the README and lock it with a docs regression test

Closes #186

## Verification
- npm run typecheck
- npm run build
- npm run test:run -- tests/unit/sample-workspace.test.ts tests/unit/getting-started-docs.test.ts
- npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive getting started tutorial with a local, reproducible workflow covering installation, graph generation, pack creation, prompt compilation, and safe comparison testing
  * Updated README Quickstart section with reference to the new tutorial

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/198)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->