### PR TITLE
[P1][MCP] Cache repeated explain context_pack calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to the TypeScript package will be documented in this file.
 - **Release checklist page**: adds `docs/release.md` with a repeatable maintainer checklist covering version bumps, changelog updates, verification commands, package dry-runs, CLI smoke checks, and post-release verification.
 - **Public roadmap page**: adds `docs/roadmap.md` with contributor-facing P0/P1/P2 tracks, issue links, label explanations, and a README pointer back to the main roadmap tracker.
 
+### Changed
+
+- **MCP context-pack duplicate suppression**: identical `context_pack` explain calls within one MCP stdio session now reuse the prior payload when graph version and relevant options match, expose cache hit/miss metadata, and automatically miss again after `graph.json` changes.
+
 ## [0.22.8] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ These six MCP tools handle the most common agent workflows in the default **core
 
 Full-profile additions: `context_pack`, `context_expand`, `context_prompt`, `context_session_reset`, `risk_map`, `implementation_checklist`, `relevant_files`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `get_neighbors`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`. Full reference: [examples/mcp-tool-examples.md](examples/mcp-tool-examples.md).
 
+Within one MCP stdio session, identical `context_pack` requests for `task=explain` are reused automatically when the graph version and relevant prompt/options match. The cache is memory-only, skips delta-session packs, and invalidates itself when `graph.json` changes.
+
 ---
 
 ## Common commands

--- a/src/runtime/stdio-server.ts
+++ b/src/runtime/stdio-server.ts
@@ -49,6 +49,7 @@ const MAX_STDIO_RESOURCE_BYTES = 5_000_000
 const MAX_STDIO_DIFF_ITEMS = 100
 const MAX_RESOURCE_SUBSCRIPTIONS = 16
 const MAX_CONTEXT_PROMPT_SESSIONS = 256
+const MAX_CONTEXT_PACK_CACHE_ENTRIES = 256
 const graphCache = new Map<string, { mtimeMs: number; graph: ReturnType<typeof loadGraph> }>()
 const MAX_COMPLETION_VALUES = 25
 const MAX_LOG_NOTIFICATION_CHARS = 10_000
@@ -59,11 +60,13 @@ type McpLogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical
  *  Used by the context_pack delta surface (#81) so subsequent calls return
  *  only nodes the agent hasn't already received. */
 type ContextPackNodeIdStore = Map<string, Set<string>>
+type ContextPackCacheStore = Map<string, string>
 
 interface StdioSessionState extends ResourceSessionState {
   logLevel: McpLogLevel
   contextPromptSessions?: Map<string, ContextSessionState>
   contextPackHandles?: Map<string, unknown>
+  contextPackCache?: ContextPackCacheStore
   /** Slice #81 — per-delta-session node ids already shipped. */
   contextPackNodeIds?: ContextPackNodeIdStore
 }
@@ -98,6 +101,7 @@ function createSessionState(): StdioSessionState {
     resourceListSignature: null,
     contextPromptSessions: new Map<string, ContextSessionState>(),
     contextPackHandles: new Map<string, unknown>(),
+    contextPackCache: new Map<string, string>(),
     contextPackNodeIds: new Map<string, Set<string>>(),
   }
 }
@@ -179,6 +183,14 @@ function ensureContextPackHandles(state: StdioSessionState): Map<string, unknown
   }
 
   return state.contextPackHandles
+}
+
+function ensureContextPackCache(state: StdioSessionState): ContextPackCacheStore {
+  if (!state.contextPackCache) {
+    state.contextPackCache = new Map<string, string>()
+  }
+
+  return state.contextPackCache
 }
 
 function ensureContextPackNodeIds(state: StdioSessionState): ContextPackNodeIdStore {
@@ -643,19 +655,31 @@ export function handleStdioRequest(
            },
            clearContextPackNodeIds: (sessionId) => ensureContextPackNodeIds(sessionState).delete(sessionId),
            getContextPackHandle: (handleId) => ensureContextPackHandles(sessionState).get(handleId),
-           setContextPackHandle: (handleId, expansion) => {
-             const handles = ensureContextPackHandles(sessionState)
-             if (!handles.has(handleId) && handles.size >= MAX_CONTEXT_PROMPT_SESSIONS) {
-               const oldestHandleId = handles.keys().next().value as string | undefined
-               if (oldestHandleId !== undefined) {
+            setContextPackHandle: (handleId, expansion) => {
+              const handles = ensureContextPackHandles(sessionState)
+              if (!handles.has(handleId) && handles.size >= MAX_CONTEXT_PROMPT_SESSIONS) {
+                const oldestHandleId = handles.keys().next().value as string | undefined
+                if (oldestHandleId !== undefined) {
                  handles.delete(oldestHandleId)
                }
-             }
-             handles.set(handleId, expansion)
-           },
-           readStoredCommunityLabels,
-          jsonrpcInvalidParams: JSONRPC_INVALID_PARAMS,
-          jsonrpcServerError: JSONRPC_SERVER_ERROR,
+              }
+              handles.set(handleId, expansion)
+            },
+            getContextPackCache: (cacheKey) => ensureContextPackCache(sessionState).get(cacheKey),
+            setContextPackCache: (cacheKey, payloadText) => {
+              const cache = ensureContextPackCache(sessionState)
+              if (!cache.has(cacheKey) && cache.size >= MAX_CONTEXT_PACK_CACHE_ENTRIES) {
+                const oldestKey = cache.keys().next().value as string | undefined
+                if (oldestKey !== undefined) {
+                  cache.delete(oldestKey)
+                }
+              }
+              cache.set(cacheKey, payloadText)
+            },
+            clearContextPackCache: (cacheKey) => ensureContextPackCache(sessionState).delete(cacheKey),
+            readStoredCommunityLabels,
+           jsonrpcInvalidParams: JSONRPC_INVALID_PARAMS,
+           jsonrpcServerError: JSONRPC_SERVER_ERROR,
           maxStdioTextLength: MAX_STDIO_TEXT_LENGTH,
           maxStdioHops: MAX_STDIO_HOPS,
           maxStdioTokenBudget: MAX_STDIO_TOKEN_BUDGET,

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -35,6 +35,7 @@ import { applyContextPackResolution, type ContextPackResolution } from '../conte
 import { riskMap } from '../risk-map.js'
 import { buildTaskContextPlan } from '../task-context-planner.js'
 import type { TimeTravelView } from '../time-travel.js'
+import { graphFreshnessMetadata } from '../freshness.js'
 import {
   communitiesFromGraph,
   getCommunity,
@@ -75,6 +76,9 @@ interface ToolHelpers {
   clearContextPromptSession(sessionId: string): boolean
   getContextPackHandle(handleId: string): unknown
   setContextPackHandle(handleId: string, expansion: unknown): void
+  getContextPackCache(cacheKey: string): string | undefined
+  setContextPackCache(cacheKey: string, payloadText: string): void
+  clearContextPackCache(cacheKey: string): boolean
   /** Slice #81 — returns node ids already shipped to this delta session. */
   getContextPackNodeIds(sessionId: string): string[]
   /** Slice #81 — records additional node ids shipped to a delta session. */
@@ -105,6 +109,11 @@ interface StoredContextPackHandle {
   task: 'explain' | 'review' | 'impact'
   task_intent: TaskContextPlan['evidence']['recipe_id']
   follow_up: ContextPackExpandableFollowUp
+}
+
+interface ContextPackCacheEnvelope {
+  status: 'hit' | 'miss'
+  graph_version: string
 }
 
 function isStoredContextPackHandle(value: unknown): value is StoredContextPackHandle {
@@ -146,6 +155,50 @@ function parseRetrievalStrategyParam(
     return raw
   }
   return 'invalid'
+}
+
+function parseContextPackResolution(raw: string | null): ContextPackResolution {
+  return raw === 'summary'
+    || raw === 'mixed'
+    || raw === 'signature'
+    || raw === 'sketch'
+    ? raw
+    : 'detail'
+}
+
+function buildContextPackCacheKey(input: {
+  graphPath: string
+  graphVersion: string
+  prompt: string
+  task: 'explain'
+  budget: number
+  retrievalLevel: 0 | 1 | 2 | 3 | 4 | 5 | null
+  retrievalStrategy: ContextPackRetrievalStrategy | null
+  resolution: ContextPackResolution
+  verbose: boolean
+}): string {
+  return JSON.stringify({
+    graph_path: input.graphPath,
+    graph_version: input.graphVersion,
+    tool: 'context_pack',
+    prompt: input.prompt,
+    task: input.task,
+    budget: input.budget,
+    retrieval_level: input.retrievalLevel,
+    retrieval_strategy: input.retrievalStrategy,
+    resolution: input.resolution,
+    verbose: input.verbose,
+  })
+}
+
+function withContextPackCache<T extends Record<string, unknown>>(
+  payload: T,
+  cache: ContextPackCacheEnvelope,
+): T & { cache: ContextPackCacheEnvelope } {
+  return {
+    ...payload,
+    cache,
+  }
 }
 
 function emptyCoverage(): ContextPackCoverage {
@@ -864,6 +917,45 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_strategy is not supported for task=review')
       }
 
+      const contextPackLevelOverride = helpers.numberParamAlias(toolArguments, ['retrieval_level', 'retrievalLevel'], { min: 0, max: 5 })
+      if ((Object.hasOwn(toolArguments, 'retrieval_level') || Object.hasOwn(toolArguments, 'retrievalLevel')) && contextPackLevelOverride === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_level must be an integer between 0 and 5')
+      }
+      const contextPackLevelTyped = contextPackLevelOverride === null ? null : (contextPackLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)
+      const resolution = parseContextPackResolution(earlyResolutionParam)
+      const includeSelectionDiagnostics = toolArguments.verbose === true
+      const deltaSessionId = helpers.stringParamAlias(toolArguments, ['delta_session_id', 'deltaSessionId'])
+      const cacheGraphVersion = !deltaSessionId && task === 'explain'
+        ? graphFreshnessMetadata(graphPath).graphVersion
+        : null
+      const cacheKey = cacheGraphVersion
+        ? buildContextPackCacheKey({
+            graphPath,
+            graphVersion: cacheGraphVersion,
+            prompt,
+            task: 'explain',
+            budget: resolvedBudget,
+            retrievalLevel: contextPackLevelTyped ?? null,
+            retrievalStrategy: contextPackStrategy,
+            resolution,
+            verbose: includeSelectionDiagnostics,
+          })
+        : null
+      if (cacheKey) {
+        const cachedPayloadText = helpers.getContextPackCache(cacheKey)
+        if (cachedPayloadText) {
+          try {
+            const cachedPayload = JSON.parse(cachedPayloadText) as Record<string, unknown>
+            return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackCache(cachedPayload, {
+              status: 'hit',
+              graph_version: cacheGraphVersion!,
+            }))))
+          } catch {
+            helpers.clearContextPackCache(cacheKey)
+          }
+        }
+      }
+
       if (task === 'review') {
         const graphDir = dirname(validateGraphPath(graphPath))
         const projectRoot = dirname(graphDir)
@@ -882,18 +974,14 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           changed_paths: prResult.changed_files,
           focus_paths: [...prResult.review_context.supporting_paths, ...prResult.review_context.test_paths],
         })
-        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        const payload = {
           ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, plan),
           pack: compactPack,
           ...reviewMetadata,
-        })))
+        }
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(payload)))
       }
 
-      const contextPackLevelOverride = helpers.numberParamAlias(toolArguments, ['retrieval_level', 'retrievalLevel'], { min: 0, max: 5 })
-      if ((Object.hasOwn(toolArguments, 'retrieval_level') || Object.hasOwn(toolArguments, 'retrievalLevel')) && contextPackLevelOverride === null) {
-        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_level must be an integer between 0 and 5')
-      }
-      const contextPackLevelTyped = contextPackLevelOverride === null ? null : (contextPackLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)
       const retrieval = retrieveContext(graph, {
         question: prompt,
         budget: resolvedBudget,
@@ -926,7 +1014,6 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const fullPack = contextPackFromRetrieveResult(retrieval)
       const compactPack = compactRetrieveResult(retrieval)
       const metadata = contextMetadata(retrieval)
-      const includeSelectionDiagnostics = toolArguments.verbose === true
       storeExpandableHandles(prompt, task, initialPlan.evidence.recipe_id, metadata.expandable, helpers)
       // Slice #78: emit context-pack quality diagnostics so callers can
       // detect bad runs (missing required evidence, zero claims, weak
@@ -938,17 +1025,9 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       // 'mixed' keeps top-N most relevant nodes in detail; 'signature'
       // keeps declaration shape; 'sketch' emits graph-derived behavior /
       // dependency compression when relationship data exists.
-      const resolutionParam = helpers.stringParam(toolArguments, 'resolution')
-      const resolution: ContextPackResolution =
-        resolutionParam === 'summary'
-          || resolutionParam === 'mixed'
-          || resolutionParam === 'signature'
-          || resolutionParam === 'sketch'
-          ? resolutionParam
-          : 'detail'
-      const applyResolutionToNodes = <T>(
-        nodes: T[],
-        relationships?: readonly ContextPackRelationship[],
+       const applyResolutionToNodes = <T>(
+         nodes: T[],
+         relationships?: readonly ContextPackRelationship[],
       ): {
         nodes: T[]
         bytes_saved: number
@@ -987,7 +1066,6 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       // delta + referenced_ids, and record the new ids for the next call.
       // The session store is per-MCP-process (in-memory) so two parallel
       // agents using the same id naturally diverge — that's intentional.
-      const deltaSessionId = helpers.stringParamAlias(toolArguments, ['delta_session_id', 'deltaSessionId'])
       if (deltaSessionId) {
         const previouslySent = helpers.getContextPackNodeIds(deltaSessionId)
         const deltaResult = computeDeltaContextPack(fullPack, previouslySent)
@@ -1023,7 +1101,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         })))
       }
       const resolvedNodes = applyResolutionToNodes(compactPack.matched_nodes, compactPack.relationships)
-      return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+      const basePayload = {
         ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
         resolution,
         pack: {
@@ -1038,7 +1116,16 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           ? { selection_diagnostics: fullPack.selection_diagnostics }
           : {}),
         ...metadata,
-      })))
+      }
+      if (!cacheKey || !cacheGraphVersion) {
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(basePayload)))
+      }
+      const payloadText = JSON.stringify(withContextPackCache(basePayload, {
+        status: 'miss',
+        graph_version: cacheGraphVersion,
+      }))
+      helpers.setContextPackCache(cacheKey, payloadText)
+      return helpers.ok(id, helpers.textToolResult(payloadText))
     }
     case 'context_pack_session_reset': {
       const sessionId = helpers.stringParamAlias(toolArguments, ['delta_session_id', 'deltaSessionId', 'session_id', 'sessionId'])

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -116,6 +116,13 @@ interface ContextPackCacheEnvelope {
   graph_version: string
 }
 
+interface CachedExplainContextPackPayload extends Record<string, unknown> {
+  task: 'explain'
+  prompt: string
+  task_intent: TaskContextPlan['evidence']['recipe_id']
+  expandable: ContextPackExpandableRef[]
+}
+
 function isStoredContextPackHandle(value: unknown): value is StoredContextPackHandle {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return false
@@ -155,6 +162,71 @@ function parseRetrievalStrategyParam(
     return raw
   }
   return 'invalid'
+}
+
+function isContextPackEvidenceClass(value: unknown): value is ContextPackEvidenceClass {
+  return value === 'primary'
+    || value === 'supporting'
+    || value === 'structural'
+    || value === 'change'
+    || value === 'impact'
+}
+
+function isContextPackTaskKind(value: unknown): value is 'explain' | 'review' | 'impact' {
+  return value === 'explain' || value === 'review' || value === 'impact'
+}
+
+function isExpandableSourceRange(value: unknown): value is ContextPackExpandableFollowUp['focus_ranges'][number] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.source_file === 'string'
+    && typeof candidate.start_line === 'number'
+    && Number.isInteger(candidate.start_line)
+    && typeof candidate.end_line === 'number'
+    && Number.isInteger(candidate.end_line)
+}
+
+function isContextPackExpandableFollowUp(value: unknown): value is ContextPackExpandableFollowUp {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+  return candidate.kind === 'context_pack'
+    && isContextPackTaskKind(candidate.task_kind)
+    && isContextPackEvidenceClass(candidate.evidence_class)
+    && Array.isArray(candidate.focus_files)
+    && candidate.focus_files.every((entry) => typeof entry === 'string')
+    && Array.isArray(candidate.focus_ranges)
+    && candidate.focus_ranges.every((entry) => isExpandableSourceRange(entry))
+}
+
+function isContextPackExpandableRef(value: unknown): value is ContextPackExpandableRef {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+  return candidate.kind === 'nodes'
+    && typeof candidate.handle_id === 'string'
+    && isContextPackEvidenceClass(candidate.evidence_class)
+    && typeof candidate.count === 'number'
+    && Number.isInteger(candidate.count)
+    && candidate.count >= 0
+    && Array.isArray(candidate.preview)
+    && isContextPackExpandableFollowUp(candidate.follow_up)
+}
+
+function isCachedExplainContextPackPayload(value: unknown): value is CachedExplainContextPackPayload {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const candidate = value as Record<string, unknown>
+  return candidate.task === 'explain'
+    && typeof candidate.prompt === 'string'
+    && typeof candidate.task_intent === 'string'
+    && Array.isArray(candidate.expandable)
+    && candidate.expandable.every((entry) => isContextPackExpandableRef(entry))
 }
 
 function parseContextPackResolution(raw: string | null): ContextPackResolution {
@@ -945,7 +1017,17 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         const cachedPayloadText = helpers.getContextPackCache(cacheKey)
         if (cachedPayloadText) {
           try {
-            const cachedPayload = JSON.parse(cachedPayloadText) as Record<string, unknown>
+            const cachedPayload = JSON.parse(cachedPayloadText)
+            if (!isCachedExplainContextPackPayload(cachedPayload)) {
+              throw new Error('Malformed cached explain context_pack payload')
+            }
+            storeExpandableHandles(
+              cachedPayload.prompt,
+              'explain',
+              cachedPayload.task_intent,
+              cachedPayload.expandable,
+              helpers,
+            )
             return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackCache(cachedPayload, {
               status: 'hit',
               graph_version: cacheGraphVersion!,

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -1147,6 +1147,77 @@ describe('stdio runtime', () => {
     }
   })
 
+  it('rehydrates cached explain context_pack expandable handles before returning a cache hit', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPackHandles: new Map<string, unknown>(),
+      }
+
+      const first = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 1,
+          },
+        },
+      }, sessionState))
+
+      const firstPayload = JSON.parse((first?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      expect(firstPayload.expandable).toEqual(expect.arrayContaining([
+        expect.objectContaining({ handle_id: expect.any(String) }),
+      ]))
+      sessionState.contextPackHandles.clear()
+
+      const second = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 1,
+          },
+        },
+      }, sessionState))
+
+      const secondPayload = JSON.parse((second?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const expanded = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'context_expand',
+          arguments: {
+            handle_id: secondPayload.expandable[0].handle_id,
+          },
+        },
+      }, sessionState))
+
+      const expandedPayload = JSON.parse((expanded?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(firstPayload.expandable[0].handle_id).toBe(secondPayload.expandable[0].handle_id)
+      expect(secondPayload.cache).toEqual(expect.objectContaining({ status: 'hit' }))
+      expect(expandedPayload).toEqual(expect.objectContaining({
+        handle_id: secondPayload.expandable[0].handle_id,
+        pack: expect.objectContaining({
+          matched_nodes: expect.any(Array),
+        }),
+      }))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('invalidates cached context_pack responses after graph.json changes', async () => {
     const root = createGraphFixtureRoot()
     try {
@@ -1278,6 +1349,55 @@ describe('stdio runtime', () => {
             resolution: 'detail',
             verbose: false,
           }), '{'],
+        ]),
+      }
+
+      const response = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const payload = JSON.parse((response?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(payload.cache).toEqual(expect.objectContaining({ status: 'miss' }))
+      expect(payload.pack).toEqual(expect.objectContaining({
+        matched_nodes: expect.any(Array),
+      }))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to a fresh explain context_pack response when a cached entry has the wrong shape', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPackCache: new Map<string, string>([
+          [JSON.stringify({
+            graph_path: graphPath,
+            graph_version: graphFreshnessMetadata(graphPath).graphVersion,
+            tool: 'context_pack',
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+            retrieval_level: null,
+            retrieval_strategy: null,
+            resolution: 'detail',
+            verbose: false,
+          }), JSON.stringify({ task: 'explain', prompt: 'How does AuthService reach Transport?' })],
         ]),
       }
 

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -7,6 +7,7 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { handleStdioRequest, serveGraphStdio } from '../../src/runtime/stdio-server.js'
+import { graphFreshnessMetadata } from '../../src/runtime/freshness.js'
 
 function createGraphFixtureRoot(): string {
   const parentDir = resolve('graphify-out', 'test-runtime')
@@ -1090,6 +1091,215 @@ describe('stdio runtime', () => {
       })
       expect(resetPromptPayload.compiled.session_state.revision).toBe(1)
       expect(resetPromptPayload.compiled.reused_context_tokens).toBe(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('marks identical context_pack requests as cached within the same MCP session', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+      }
+
+      const first = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const second = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const firstPayload = JSON.parse((first?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const secondPayload = JSON.parse((second?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(firstPayload.cache).toEqual(expect.objectContaining({ status: 'miss' }))
+      expect(secondPayload.cache).toEqual(expect.objectContaining({
+        status: 'hit',
+        graph_version: firstPayload.cache.graph_version,
+      }))
+      expect(secondPayload.pack).toEqual(firstPayload.pack)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('invalidates cached context_pack responses after graph.json changes', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+      }
+
+      const first = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const graph = JSON.parse(readFileSync(graphPath, 'utf8')) as {
+        nodes: Array<Record<string, unknown>>
+      }
+      graph.nodes.push({
+        id: 'fresh-cache-node',
+        label: 'FreshCacheNode',
+        source_file: '/workspace/src/cache.ts',
+        line_number: 1,
+        node_kind: 'function',
+        file_type: 'code',
+        community: 0,
+      })
+      writeFileSync(graphPath, JSON.stringify(graph), 'utf8')
+
+      const second = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const firstPayload = JSON.parse((first?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const secondPayload = JSON.parse((second?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(firstPayload.cache).toEqual(expect.objectContaining({ status: 'miss' }))
+      expect(secondPayload.cache).toEqual(expect.objectContaining({ status: 'miss' }))
+      expect(secondPayload.cache.graph_version).not.toBe(firstPayload.cache.graph_version)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not cache review context_pack requests', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+      }
+
+      const first = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'Review the current changes',
+            task: 'review',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const second = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'Review the current changes',
+            task: 'review',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const firstPayload = JSON.parse((first?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      const secondPayload = JSON.parse((second?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(firstPayload).not.toHaveProperty('cache')
+      expect(secondPayload).not.toHaveProperty('cache')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to a fresh explain context_pack response when a cached entry is malformed', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPackCache: new Map<string, string>([
+          [JSON.stringify({
+            graph_path: graphPath,
+            graph_version: graphFreshnessMetadata(graphPath).graphVersion,
+            tool: 'context_pack',
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+            retrieval_level: null,
+            retrieval_strategy: null,
+            resolution: 'detail',
+            verbose: false,
+          }), '{'],
+        ]),
+      }
+
+      const response = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            budget: 150,
+          },
+        },
+      }, sessionState))
+
+      const payload = JSON.parse((response?.result as { content: Array<{ text: string }> }).content[0]!.text)
+
+      expect(payload.cache).toEqual(expect.objectContaining({ status: 'miss' }))
+      expect(payload.pack).toEqual(expect.objectContaining({
+        matched_nodes: expect.any(Array),
+      }))
     } finally {
       rmSync(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- add a session-scoped cache for repeated `context_pack` explain requests in the MCP stdio runtime
- key cache hits by graph path/version plus explain-mode options, and fall back cleanly when a cached entry is malformed
- document the explain-only cache behavior and add stdio regressions for hit/miss, graph refresh, and non-cached review flows

Closes #161

## Verification
- npm run typecheck
- npm run build
- npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-session caching for identical context-pack explain requests to improve performance; includes hit/miss metadata and auto-invalidation when the graph changes.

* **Documentation**
  * Updated MCP tools docs describing the in-session context-pack caching behavior and its effects.

* **Tests**
  * Added unit tests covering cache hit/miss behavior, invalidation, and resilience to malformed cache entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/199)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->