### PR TITLE
[P0][MCP] Add strict install profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Changed
 
 - **MCP context-pack duplicate suppression**: identical `context_pack` explain calls within one MCP stdio session now reuse the prior payload when graph version and relevant options match, expose cache hit/miss metadata, and automatically miss again after `graph.json` changes.
+- **Strict MCP install profile**: `claude`, `cursor`, `copilot`, and `gemini` installs now accept `--profile strict`, keep the lean core MCP tool surface, and rewrite generated guidance toward one `context_pack` first with diagnostics-driven expansion instead of broad exploration.
 
 ## [0.22.8] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -115,16 +115,18 @@ graphify-ts produces local context packs that any modern coding agent can consum
 
 | Agent | Connection | Install command |
 |---|---|---|
-| Claude Code | MCP via `.mcp.json` | `graphify-ts claude install` |
-| Cursor | MCP via `.cursor/mcp.json` | `graphify-ts cursor install` |
-| GitHub Copilot CLI | MCP via `.vscode/mcp.json` | `graphify-ts copilot install` |
-| Gemini CLI | MCP server | `graphify-ts gemini install` |
+| Claude Code | MCP via `.mcp.json` | `graphify-ts claude <install|uninstall> [--profile core|full|strict]` |
+| Cursor | MCP via `.cursor/mcp.json` | `graphify-ts cursor <install|uninstall> [--profile core|full|strict]` |
+| GitHub Copilot CLI | MCP via `.vscode/mcp.json` | `graphify-ts copilot <install|uninstall> [--profile core|full|strict]` |
+| Gemini CLI | MCP server | `graphify-ts gemini <install|uninstall> [--profile core|full|strict]` |
 | Aider | AGENTS.md context-pack-first profile | `graphify-ts aider install` |
 | OpenCode | AGENTS.md + `.opencode/plugins/graphify-ts.js` + MCP via `opencode.json` / `opencode.jsonc` | `graphify-ts opencode install` |
 | Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `graphify-ts codex install` |
 | Windsurf / others | Pipe `graphify-ts prompt` output | `graphify-ts prompt "..." --provider claude` |
 
 These are local installers that write project instructions and, when the platform supports it, local MCP config or plugin files that point at the graphify-ts subprocess. No code is uploaded.
+
+For Claude, Cursor, Copilot, and Gemini, `--profile strict` keeps the lean core MCP tool surface but rewrites the generated guidance into a compact flow: call `context_pack` once for the task before broader exploration, answer from the pack when coverage is complete, expand only when diagnostics show missing evidence, and avoid raw file search unless the pack is insufficient.
 
 Aider and OpenCode are intentionally context-pack-first: run `graphify-ts generate .`, install the profile, and start broad codebase work with `graphify-ts pack "<task>" --task explain` before raw file search. `graphify-ts aider install` writes an AGENTS.md profile only; remove it with `graphify-ts aider uninstall`. `graphify-ts opencode install` writes the AGENTS.md profile, `.opencode/plugins/graphify-ts.js`, and the graphify MCP entry in `opencode.json` or `opencode.jsonc`; remove only graphify-ts-owned content with `graphify-ts opencode uninstall`. Manual verification does not require either agent binary: inspect the generated files after install, then confirm uninstall removes only the graphify-ts entries.
 
@@ -136,7 +138,7 @@ For practical multi-agent workflows across Claude Code, Codex, Copilot, Cursor, 
 
 ## MCP tools
 
-These six MCP tools handle the most common agent workflows in the default **core** profile. The full surface is 25 tools, opt-in via `GRAPHIFY_TOOL_PROFILE=full` or `--profile full` on install.
+These six MCP tools handle the most common agent workflows in the default **core** profile. The full surface is 25 tools, opt-in via `GRAPHIFY_TOOL_PROFILE=full` or `--profile full` on install. `--profile strict` still uses the lean core tool surface, but changes the installed guidance so the agent starts with one `context_pack` call and expands only when the pack diagnostics say evidence is missing.
 
 | Tool | When the agent uses it |
 |---|---|

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -386,10 +386,10 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
     '    uninstall            remove graphify hook sections',
     '    status               show whether graphify hooks are installed',
     '  aider <install|uninstall>   manage local AGENTS.md rules',
-    '  claude <install|uninstall> [--profile core|full]  manage local CLAUDE.md graphify rules',
-    '  cursor <install|uninstall> [--profile core|full]  manage local Cursor graphify rules',
-    '  gemini <install|uninstall>  manage local GEMINI.md rules and Gemini CLI hook config',
-    '  copilot <install|uninstall> [--profile core|full] install or remove the GitHub Copilot skill',
+    '  claude <install|uninstall> [--profile core|full|strict]  manage local CLAUDE.md graphify rules',
+    '  cursor <install|uninstall> [--profile core|full|strict]  manage local Cursor graphify rules',
+    '  gemini <install|uninstall> [--profile core|full|strict]  manage local GEMINI.md rules and Gemini CLI hook config',
+    '  copilot <install|uninstall> [--profile core|full|strict] install or remove the GitHub Copilot skill',
     '  codex <install|uninstall>   manage local AGENTS.md + Codex hook rules',
     '  opencode <install|uninstall> manage local AGENTS.md + OpenCode plugin/MCP rules',
     '  claw <install|uninstall>    manage local AGENTS.md rules',
@@ -876,7 +876,7 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (options.action === 'install' && !existsSync('graphify-out/graph.json')) {
         io.log("Warning: graphify-out/graph.json not found. Run 'graphify-ts generate .' first, then re-run this command.")
       }
-      io.log(options.action === 'install' ? dependencies.geminiInstall('.') : dependencies.geminiUninstall('.'))
+      io.log(options.action === 'install' ? dependencies.geminiInstall('.', options.profile ? { profile: options.profile } : {}) : dependencies.geminiUninstall('.'))
       return 0
     }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -2,7 +2,7 @@ import { isAbsolute, resolve } from 'node:path'
 
 import type { ContextPackRetrievalStrategy, ContextPackTaskKind } from '../contracts/context-pack.js'
 import { validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
-import { type InstallPlatform, isInstallPlatform, type McpToolProfile, isMcpToolProfile } from '../infrastructure/install.js'
+import { type InstallPlatform, isInstallPlatform, type InstallProfile, isInstallProfile } from '../infrastructure/install.js'
 
 export class UsageError extends Error {
   constructor(message: string) {
@@ -165,10 +165,10 @@ export interface InstallCliOptions {
 
 export interface PlatformActionCliOptions {
   action: 'install' | 'uninstall'
-  profile?: McpToolProfile
+  profile?: InstallProfile
 }
 
-const PROFILE_AWARE_PLATFORM_COMMANDS = new Set(['claude', 'cursor', 'copilot'])
+const PROFILE_AWARE_PLATFORM_COMMANDS = new Set(['claude', 'cursor', 'copilot', 'gemini'])
 
 const MAX_CLI_SOURCE_NODES = 50
 const MAX_CLI_LABEL_LENGTH = 512
@@ -1572,7 +1572,7 @@ export function parsePlatformActionArgs(command: string, args: string[]): Platfo
   const action = args[0]
   const profileAware = PROFILE_AWARE_PLATFORM_COMMANDS.has(command)
   const usage = profileAware
-    ? `Usage: graphify-ts ${command} <install|uninstall> [--profile core|full]`
+    ? `Usage: graphify-ts ${command} <install|uninstall> [--profile core|full|strict]`
     : `Usage: graphify-ts ${command} <install|uninstall>`
   if (action !== 'install' && action !== 'uninstall') {
     throw new UsageError(usage)
@@ -1585,7 +1585,7 @@ export function parsePlatformActionArgs(command: string, args: string[]): Platfo
     throw new UsageError(usage)
   }
 
-  let profile: McpToolProfile | undefined
+  let profile: InstallProfile | undefined
   for (let index = 1; index < args.length; index += 1) {
     const argument = args[index]
     if (!argument) {
@@ -1597,8 +1597,8 @@ export function parsePlatformActionArgs(command: string, args: string[]): Platfo
 
     if (argument === '--profile') {
       const value = requireNonEmptyValue('--profile', args[index + 1])
-      if (!isMcpToolProfile(value)) {
-        throw new UsageError('error: --profile must be one of core, full')
+      if (!isInstallProfile(value)) {
+        throw new UsageError('error: --profile must be one of core, full, strict')
       }
       profile = value
       index += 1
@@ -1608,8 +1608,8 @@ export function parsePlatformActionArgs(command: string, args: string[]): Platfo
     if (argument.startsWith('--profile=')) {
       const [, value] = argument.split('=', 2)
       const normalizedValue = requireNonEmptyValue('--profile', value)
-      if (!isMcpToolProfile(normalizedValue)) {
-        throw new UsageError('error: --profile must be one of core, full')
+      if (!isInstallProfile(normalizedValue)) {
+        throw new UsageError('error: --profile must be one of core, full, strict')
       }
       profile = normalizedValue
       continue

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -19,6 +19,8 @@ export type AgentPlatform = (typeof AGENT_PLATFORMS)[number]
 export const MCP_TOOL_PROFILES = ['core', 'full'] as const
 
 export type McpToolProfile = (typeof MCP_TOOL_PROFILES)[number]
+export const INSTALL_PROFILES = [...MCP_TOOL_PROFILES, 'strict'] as const
+export type InstallProfile = (typeof INSTALL_PROFILES)[number]
 
 interface InstallPlatformConfig {
   skillFile: string
@@ -33,8 +35,10 @@ interface InstallSkillOptions {
 }
 
 interface McpInstallOptions {
-  profile?: McpToolProfile
+  profile?: InstallProfile
 }
+
+type GeminiInstallOptions = InstallSkillOptions & McpInstallOptions
 
 const SKILL_SLUG = 'graphify-ts'
 const SKILL_COMMAND = '/graphify-ts'
@@ -158,6 +162,9 @@ const MCP_ROUTING_GUIDANCE =
 const RETRIEVE_FIRST_MESSAGE =
   `STOP. This project has a graphify-ts knowledge graph. ${MCP_ROUTING_GUIDANCE} Graphify answers most codebase questions in 1 focused MCP call instead of 5–10 sequential file reads (3x fewer turns, ~2.8x faster on a real production codebase). Do not use Glob, Grep, Bash, Read, or Agent tools first. Only fall back to raw file tools if the graph tools cannot answer the question or the MCP server is unavailable.`
 
+const STRICT_CONTEXT_PACK_MESSAGE =
+  'STOP. This project has a graphify-ts knowledge graph. Use strict compact MCP mode: call context_pack once for the task before broader exploration, answer from the pack when coverage is complete, only expand with context_expand or focused graph tools when diagnostics show missing evidence, and avoid raw file search unless the pack is insufficient.'
+
 const CODEX_CONTEXT_PACK_FIRST_MESSAGE =
   `STOP. This project has a graphify-ts knowledge graph. Follow the Codex context-pack-first workflow: run graphify-ts pack "<task or question>" --task explain before broad Bash search, raw file reads, or spawning workers. Use --task review, --task debug, or --task impact when that better matches the work. If MCP graph tools are available, use retrieve, relevant_files, feature_map, risk_map, implementation_checklist, or impact to refine the pack. Only fall back to raw file tools when the context pack or graph tools are missing, stale, or insufficient; read graphify-out/GRAPH_REPORT.md before expanding manually.`
 
@@ -240,6 +247,16 @@ IMPORTANT: This project has a graphify-ts knowledge graph. You MUST follow these
 2. **Do NOT use Glob, Grep, Bash, Read, or dispatch Agent/Explore subagents first** for codebase questions.
 3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read graphify-out/GRAPH_REPORT.md first.
 4. **Do NOT dispatch Explore or research agents** for codebase questions — the knowledge graph already has the structural context they would spend tokens discovering.
+`
+
+const STRICT_CLAUDE_MD_SECTION = `${SECTION_MARKER}
+
+IMPORTANT: This project has a graphify-ts knowledge graph. You MUST follow these strict compact MCP rules:
+
+1. **Call \`context_pack\` once for the task before broader exploration.**
+2. **Answer from the pack when coverage is complete.**
+3. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
+4. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`graphify-out/GRAPH_REPORT.md\` first.
 `
 
 const AGENTS_MD_SECTION = `${SECTION_MARKER}
@@ -359,6 +376,16 @@ IMPORTANT: This project has a graphify-ts knowledge graph. You MUST follow these
 3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read graphify-out/GRAPH_REPORT.md first.
 `
 
+const STRICT_GEMINI_MD_SECTION = `${SECTION_MARKER}
+
+IMPORTANT: This project has a graphify-ts knowledge graph. Use strict compact MCP guidance:
+
+1. **Call \`context_pack\` once for the task before broader exploration.**
+2. **Answer from the pack when coverage is complete.**
+3. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
+4. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`graphify-out/GRAPH_REPORT.md\` first.
+`
+
 const SKILL_REGISTRATION_MARKER = '- **graphify-ts**'
 const LOCAL_SKILL_ASSET_DIRECTORY = join('assets', 'skills')
 const CLI_BIN_NAME = 'graphify-ts'
@@ -408,6 +435,68 @@ IMPORTANT: This project has a graphify-ts knowledge graph.
 2. **Do NOT search the codebase with other tools first** for codebase questions.
 3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read graphify-out/GRAPH_REPORT.md first.
 `
+
+const STRICT_CURSOR_RULE = `---
+description: graphify-ts strict compact MCP mode — use one context pack before broader exploration
+alwaysApply: true
+---
+
+IMPORTANT: This project has a graphify-ts knowledge graph. Use strict compact MCP guidance:
+
+1. **Call \`context_pack\` once for the task before broader exploration.**
+2. **Answer from the pack when coverage is complete.**
+3. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
+4. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`graphify-out/GRAPH_REPORT.md\` first.
+`
+
+function claudeMdSection(profile?: InstallProfile): string {
+  return profile === 'strict' ? STRICT_CLAUDE_MD_SECTION : CLAUDE_MD_SECTION
+}
+
+function geminiMdSection(profile?: InstallProfile): string {
+  return profile === 'strict' ? STRICT_GEMINI_MD_SECTION : GEMINI_MD_SECTION
+}
+
+function cursorRule(profile?: InstallProfile): string {
+  return profile === 'strict' ? STRICT_CURSOR_RULE : CURSOR_RULE
+}
+
+function settingsHook(profile?: InstallProfile): Record<string, unknown> {
+  return {
+    matcher: 'Glob|Grep|Bash|Agent|Read',
+    hooks: [
+      {
+        type: 'command',
+        command: hookCommand(
+          JSON.stringify({
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              additionalContext: profile === 'strict' ? STRICT_CONTEXT_PACK_MESSAGE : RETRIEVE_FIRST_MESSAGE,
+            },
+          }),
+        ),
+      },
+    ],
+  }
+}
+
+function geminiHook(profile?: InstallProfile): Record<string, unknown> {
+  return {
+    matcher: 'read_file|list_directory|search_for_pattern',
+    hooks: [
+      {
+        type: 'command',
+        command: hookCommandWithFallback(
+          JSON.stringify({
+            decision: 'allow',
+            additionalContext: profile === 'strict' ? STRICT_CONTEXT_PACK_MESSAGE : RETRIEVE_FIRST_MESSAGE,
+          }),
+          JSON.stringify({ decision: 'allow' }),
+        ),
+      },
+    ],
+  }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -1337,8 +1426,9 @@ function installMcpServer(
   // defaults first, then the existing entry on top so user values win.
   const existingServer = existed ? (mcpServers[SKILL_SLUG] as Record<string, unknown>) : null
   const existingEnv = existingServer && isRecord(existingServer.env) ? (existingServer.env as Record<string, string>) : {}
+  const envProfile: McpToolProfile = options.profile === 'full' ? 'full' : 'core'
   const env: Record<string, string> = options.profile
-    ? { ...existingEnv, GRAPHIFY_TOOL_PROFILE: options.profile }
+    ? { ...existingEnv, GRAPHIFY_TOOL_PROFILE: envProfile }
     : { GRAPHIFY_TOOL_PROFILE: 'core', ...existingEnv }
   const serverConfig = isVscode
     ? { type: 'stdio', command: npxCommand, args: npxArgs, env }
@@ -1381,7 +1471,7 @@ function uninstallMcpServer(projectDir: string, target: McpConfigTarget): string
   return `${MCP_CONFIG_PATHS[target]} -> MCP server removed`
 }
 
-function installClaudeHook(projectDir: string): string {
+function installClaudeHook(projectDir: string, profile?: InstallProfile): string {
   const settingsPath = join(projectDir, '.claude', 'settings.json')
   const settings = readJsonObject(settingsPath)
   const hooks = ensureRecord(settings, 'hooks')
@@ -1389,12 +1479,12 @@ function installClaudeHook(projectDir: string): string {
 
   const existingIndex = preToolUse.findIndex((hook) => isRecord(hook) && JSON.stringify(hook).includes('graphify-out'))
   if (existingIndex >= 0) {
-    preToolUse[existingIndex] = SETTINGS_HOOK
+    preToolUse[existingIndex] = settingsHook(profile)
     writeJson(settingsPath, settings)
     return '.claude/settings.json -> hook updated'
   }
 
-  preToolUse.push(SETTINGS_HOOK)
+  preToolUse.push(settingsHook(profile))
   writeJson(settingsPath, settings)
   return '.claude/settings.json -> PreToolUse hook registered'
 }
@@ -1419,17 +1509,25 @@ function uninstallClaudeHook(projectDir: string): string | undefined {
   return '.claude/settings.json -> PreToolUse hook removed'
 }
 
-function installGeminiHook(projectDir: string): string {
+function installGeminiHook(projectDir: string, profile?: InstallProfile): string {
   const settingsPath = join(projectDir, '.gemini', 'settings.json')
   const settings = readJsonObject(settingsPath)
   const hooks = ensureRecord(settings, 'hooks')
   const beforeTool = ensureArray(hooks, 'BeforeTool')
+  const nextHook = geminiHook(profile)
+  const existingIndex = beforeTool.findIndex((hook) => JSON.stringify(hook).includes('graphify-out'))
 
-  if (beforeTool.some((hook) => JSON.stringify(hook).includes('graphify-out'))) {
-    return '.gemini/settings.json -> BeforeTool hook already registered (no change)'
+  if (existingIndex >= 0) {
+    if (JSON.stringify(beforeTool[existingIndex]) === JSON.stringify(nextHook)) {
+      return '.gemini/settings.json -> BeforeTool hook already registered (no change)'
+    }
+
+    beforeTool[existingIndex] = nextHook
+    writeJson(settingsPath, settings)
+    return '.gemini/settings.json -> BeforeTool hook updated'
   }
 
-  beforeTool.push(GEMINI_HOOK)
+  beforeTool.push(nextHook)
   writeJson(settingsPath, settings)
   return '.gemini/settings.json -> BeforeTool hook registered'
 }
@@ -1667,6 +1765,10 @@ export function isMcpToolProfile(value: string): value is McpToolProfile {
   return MCP_TOOL_PROFILES.includes(value as McpToolProfile)
 }
 
+export function isInstallProfile(value: string): value is InstallProfile {
+  return INSTALL_PROFILES.includes(value as InstallProfile)
+}
+
 export function installSkill(platform: SkillInstallPlatform, options: InstallSkillOptions = {}): string {
   const homeDir = resolve(options.homeDir ?? homedir())
   const packageRoot = resolve(options.packageRoot ?? findPackageRoot())
@@ -1703,10 +1805,14 @@ export function uninstallSkill(platform: SkillInstallPlatform, options: Pick<Ins
   return messages.join('\n')
 }
 
-export function geminiInstall(projectDir = '.', options: InstallSkillOptions = {}): string {
+export function geminiInstall(projectDir = '.', options: GeminiInstallOptions = {}): string {
   const resolvedProjectDir = resolve(projectDir)
-  const messages = [installSkill('gemini', options), writeSection(join(resolvedProjectDir, 'GEMINI.md'), GEMINI_MD_SECTION), installGeminiHook(resolvedProjectDir)]
-  messages.push('', 'Gemini CLI will now check the knowledge graph before answering', 'codebase questions and rebuild it after code changes.')
+  const messages = [installSkill('gemini', options), writeSection(join(resolvedProjectDir, 'GEMINI.md'), geminiMdSection(options.profile)), installGeminiHook(resolvedProjectDir, options.profile)]
+  if (options.profile === 'strict') {
+    messages.push('', 'Gemini CLI will now use the graphify strict compact MCP profile:', 'call context_pack once, answer from the pack when coverage is complete, and expand only when diagnostics show missing evidence.')
+  } else {
+    messages.push('', 'Gemini CLI will now check the knowledge graph before answering', 'codebase questions and rebuild it after code changes.')
+  }
   return messages.join('\n')
 }
 
@@ -1726,7 +1832,11 @@ export function geminiUninstall(projectDir = '.', options: Pick<InstallSkillOpti
 }
 
 export function installCopilotMcp(projectDir = '.', options: McpInstallOptions = {}): string {
-  return installMcpServer(resolve(projectDir), 'copilot', process.platform, options)
+  const message = installMcpServer(resolve(projectDir), 'copilot', process.platform, options)
+  if (options.profile === 'strict') {
+    return `${message}\n\nGitHub Copilot will now use the graphify strict compact MCP profile: call context_pack once, answer from the pack when coverage is complete, and expand only when diagnostics show missing evidence.`
+  }
+  return message
 }
 
 export function uninstallCopilotMcp(projectDir = '.'): string {
@@ -1739,15 +1849,24 @@ export function cursorInstall(projectDir = '.', options: McpInstallOptions = {})
   ensureParentDirectory(rulePath)
 
   const messages: string[] = []
+  const ruleContent = cursorRule(options.profile)
 
   if (existsSync(rulePath)) {
-    messages.push(`graphify-ts Cursor rule already exists at ${rulePath} (no change)`)
+    if (readFileSync(rulePath, 'utf8') === ruleContent) {
+      messages.push(`graphify-ts Cursor rule already exists at ${rulePath} (no change)`)
+    } else {
+      writeFileSync(rulePath, ruleContent, 'utf8')
+      messages.push(`graphify-ts Cursor rule updated at ${rulePath}`)
+    }
   } else {
-    writeFileSync(rulePath, CURSOR_RULE, 'utf8')
+    writeFileSync(rulePath, ruleContent, 'utf8')
     messages.push(`graphify-ts Cursor rule written to ${rulePath}`)
   }
 
   messages.push(installMcpServer(resolvedProjectDir, 'cursor', process.platform, options))
+  if (options.profile === 'strict') {
+    messages.push('', 'Cursor will now use the graphify strict compact MCP profile before broader exploration.')
+  }
   return messages.join('\n')
 }
 
@@ -1774,11 +1893,15 @@ export function cursorUninstall(projectDir = '.'): string {
 export function claudeInstall(projectDir = '.', options: McpInstallOptions = {}): string {
   const resolvedProjectDir = resolve(projectDir)
   const messages = [
-    writeSection(join(resolvedProjectDir, 'CLAUDE.md'), CLAUDE_MD_SECTION),
-    installClaudeHook(resolvedProjectDir),
+    writeSection(join(resolvedProjectDir, 'CLAUDE.md'), claudeMdSection(options.profile)),
+    installClaudeHook(resolvedProjectDir, options.profile),
     installMcpServer(resolvedProjectDir, 'claude', process.platform, options),
   ]
-  messages.push('', 'Claude Code will now start with the matching graphify MCP tool', 'BEFORE searching raw files for any codebase question.')
+  if (options.profile === 'strict') {
+    messages.push('', 'Claude Code will now use the graphify strict compact MCP profile:', 'call context_pack once, answer from the pack when coverage is complete, and expand only when diagnostics show missing evidence.')
+  } else {
+    messages.push('', 'Claude Code will now start with the matching graphify MCP tool', 'BEFORE searching raw files for any codebase question.')
+  }
   return messages.join('\n')
 }
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -737,13 +737,15 @@ describe('cli parser', () => {
 
     expect(parsePlatformActionArgs('claude', ['install'])).toEqual({ action: 'install' })
     expect(parsePlatformActionArgs('claude', ['install', '--profile', 'full'])).toEqual({ action: 'install', profile: 'full' })
+    expect(parsePlatformActionArgs('claude', ['install', '--profile', 'strict'])).toEqual({ action: 'install', profile: 'strict' })
     expect(parsePlatformActionArgs('aider', ['install'])).toEqual({ action: 'install' })
     expect(parsePlatformActionArgs('gemini', ['install'])).toEqual({ action: 'install' })
+    expect(parsePlatformActionArgs('gemini', ['install', '--profile', 'strict'])).toEqual({ action: 'install', profile: 'strict' })
     expect(parsePlatformActionArgs('copilot', ['uninstall'])).toEqual({ action: 'uninstall' })
     expect(parsePlatformActionArgs('cursor', ['uninstall'])).toEqual({ action: 'uninstall' })
     expect(parsePlatformActionArgs('codex', ['uninstall'])).toEqual({ action: 'uninstall' })
-    expect(() => parsePlatformActionArgs('claude', ['install', '--profile', 'wide'])).toThrow('error: --profile must be one of core, full')
-    expect(() => parsePlatformActionArgs('claude', ['uninstall', '--profile', 'full'])).toThrow('Usage: graphify-ts claude <install|uninstall> [--profile core|full]')
+    expect(() => parsePlatformActionArgs('claude', ['install', '--profile', 'wide'])).toThrow('error: --profile must be one of core, full, strict')
+    expect(() => parsePlatformActionArgs('claude', ['uninstall', '--profile', 'full'])).toThrow('Usage: graphify-ts claude <install|uninstall> [--profile core|full|strict]')
     expect(() => parsePlatformActionArgs('trae', [])).toThrow('Usage: graphify-ts trae <install|uninstall>')
   })
 })
@@ -875,10 +877,10 @@ describe('cli main', () => {
     expect(help).toContain('hook <action>')
     expect(help).toContain('install [--platform P]')
     expect(help).toContain('aider <install|uninstall>')
-    expect(help).toContain('claude <install|uninstall> [--profile core|full]')
-    expect(help).toContain('cursor <install|uninstall> [--profile core|full]')
-    expect(help).toContain('gemini <install|uninstall>')
-    expect(help).toContain('copilot <install|uninstall> [--profile core|full]')
+    expect(help).toContain('claude <install|uninstall> [--profile core|full|strict]')
+    expect(help).toContain('cursor <install|uninstall> [--profile core|full|strict]')
+    expect(help).toContain('gemini <install|uninstall> [--profile core|full|strict]')
+    expect(help).toContain('copilot <install|uninstall> [--profile core|full|strict]')
     expect(help).toContain('codex <install|uninstall>')
     expect(help).toContain('opencode <install|uninstall>')
   })
@@ -1606,24 +1608,28 @@ describe('cli main', () => {
     expect(logs).toContain('opencode local rules installed')
   })
 
-  it('passes the requested MCP profile into claude, cursor, and copilot installs', async () => {
+  it('passes the requested install profile into claude, cursor, gemini, and copilot installs', async () => {
     const { io } = createIo()
     const dependencies = createDependencies()
-    const claudeInstall = vi.fn().mockReturnValue('claude full install')
-    const cursorInstall = vi.fn().mockReturnValue('cursor full install')
-    const installCopilotMcp = vi.fn().mockReturnValue('copilot full install')
+    const claudeInstall = vi.fn().mockReturnValue('claude strict install')
+    const cursorInstall = vi.fn().mockReturnValue('cursor strict install')
+    const geminiInstall = vi.fn().mockReturnValue('gemini strict install')
+    const installCopilotMcp = vi.fn().mockReturnValue('copilot strict install')
 
     dependencies.claudeInstall = claudeInstall as unknown as CliDependencies['claudeInstall']
     dependencies.cursorInstall = cursorInstall as unknown as CliDependencies['cursorInstall']
+    dependencies.geminiInstall = geminiInstall as unknown as CliDependencies['geminiInstall']
     dependencies.installCopilotMcp = installCopilotMcp as unknown as CliDependencies['installCopilotMcp']
 
-    await expect(executeCli(['claude', 'install', '--profile', 'full'], io, dependencies)).resolves.toBe(0)
-    await expect(executeCli(['cursor', 'install', '--profile', 'full'], io, dependencies)).resolves.toBe(0)
-    await expect(executeCli(['copilot', 'install', '--profile', 'full'], io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['claude', 'install', '--profile', 'strict'], io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['cursor', 'install', '--profile', 'strict'], io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['gemini', 'install', '--profile', 'strict'], io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['copilot', 'install', '--profile', 'strict'], io, dependencies)).resolves.toBe(0)
 
-    expect(claudeInstall).toHaveBeenCalledWith('.', { profile: 'full' })
-    expect(cursorInstall).toHaveBeenCalledWith('.', { profile: 'full' })
-    expect(installCopilotMcp).toHaveBeenCalledWith('.', { profile: 'full' })
+    expect(claudeInstall).toHaveBeenCalledWith('.', { profile: 'strict' })
+    expect(cursorInstall).toHaveBeenCalledWith('.', { profile: 'strict' })
+    expect(geminiInstall).toHaveBeenCalledWith('.', { profile: 'strict' })
+    expect(installCopilotMcp).toHaveBeenCalledWith('.', { profile: 'strict' })
   })
 
   it('removes the Copilot MCP config during copilot uninstall', async () => {

--- a/tests/unit/install-docs.test.ts
+++ b/tests/unit/install-docs.test.ts
@@ -16,4 +16,15 @@ describe('install documentation', () => {
     expect(readme).toContain('graphify-ts aider uninstall')
     expect(readme).toContain('graphify-ts opencode uninstall')
   })
+
+  it('documents the strict MCP install profile for claude, cursor, copilot, and gemini', () => {
+    const readme = readFileSync(resolve('README.md'), 'utf8')
+
+    expect(readme).toContain('claude <install|uninstall> [--profile core|full|strict]')
+    expect(readme).toContain('cursor <install|uninstall> [--profile core|full|strict]')
+    expect(readme).toContain('copilot <install|uninstall> [--profile core|full|strict]')
+    expect(readme).toContain('gemini <install|uninstall> [--profile core|full|strict]')
+    expect(readme).toContain('`--profile strict` keeps the lean core MCP tool surface')
+    expect(readme).toContain('call `context_pack` once for the task before broader exploration')
+  })
 })

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -310,6 +310,21 @@ describe('install helpers', () => {
     })
   })
 
+  it('writes strict Gemini guidance for compact context-pack-first usage', () => {
+    withTempDir((projectDir) => {
+      const installGeminiWithProfile = geminiInstall as (projectDir?: string, options?: { profile?: 'core' | 'full' | 'strict' }) => string
+      const installMessage = installGeminiWithProfile(projectDir, { profile: 'strict' })
+
+      const geminiMd = readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')
+
+      expect(geminiMd).toContain('Call `context_pack` once for the task before broader exploration.')
+      expect(geminiMd).toContain('Answer from the pack when coverage is complete.')
+      expect(geminiMd).toContain('Only expand with graph/search tools when diagnostics show missing evidence.')
+      expect(geminiMd).toContain('Avoid raw file search unless the pack is insufficient.')
+      expect(installMessage).toContain('strict compact MCP profile')
+    })
+  })
+
   it('keeps Gemini project instructions and hooks idempotent across repeated installs', () => {
     withBundledPackageRoot((packageRoot) => {
       withTempDir((homeDir) => {
@@ -326,6 +341,22 @@ describe('install helpers', () => {
           expect(countOccurrences(firstSettings, 'graphify-out')).toBeGreaterThan(0)
         })
       })
+    })
+  })
+
+  it('updates an existing Gemini hook when switching to the strict profile', () => {
+    withTempDir((projectDir) => {
+      geminiInstall(projectDir)
+
+      const installGeminiWithProfile = geminiInstall as (projectDir?: string, options?: { profile?: 'core' | 'full' | 'strict' }) => string
+      installGeminiWithProfile(projectDir, { profile: 'strict' })
+
+      const settings = readFileSync(join(projectDir, '.gemini', 'settings.json'), 'utf8')
+      const decodedHookPayload = decodeHookPayloads(settings)
+
+      expect(decodedHookPayload).toContain('strict compact MCP mode')
+      expect(decodedHookPayload).toContain('call context_pack once for the task before broader exploration')
+      expect(decodedHookPayload).not.toContain('Graphify answers most codebase questions in 1 focused MCP call')
     })
   })
 
@@ -423,6 +454,29 @@ describe('install helpers', () => {
     })
   })
 
+  it('writes strict Claude guidance while keeping the MCP env on the lean core tool profile', () => {
+    withTempDir((projectDir) => {
+      const installClaudeWithProfile = claudeInstall as (projectDir?: string, options?: { profile?: 'core' | 'full' | 'strict' }) => string
+      const installMessage = installClaudeWithProfile(projectDir, { profile: 'strict' })
+
+      const claudeMd = readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')
+      const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.mcp.json'), 'utf8')) as {
+        mcpServers?: {
+          'graphify-ts'?: {
+            env?: Record<string, string>
+          }
+        }
+      }
+
+      expect(mcpConfig.mcpServers?.['graphify-ts']?.env?.GRAPHIFY_TOOL_PROFILE).toBe('core')
+      expect(claudeMd).toContain('Call `context_pack` once for the task before broader exploration.')
+      expect(claudeMd).toContain('Answer from the pack when coverage is complete.')
+      expect(claudeMd).toContain('Only expand with graph/search tools when diagnostics show missing evidence.')
+      expect(claudeMd).toContain('Avoid raw file search unless the pack is insufficient.')
+      expect(installMessage).toContain('strict compact MCP profile')
+    })
+  })
+
   it('writes GRAPHIFY_TOOL_PROFILE=core in the generated Cursor .cursor/mcp.json env block', () => {
     withTempDir((projectDir) => {
       cursorInstall(projectDir)
@@ -436,6 +490,42 @@ describe('install helpers', () => {
       }
 
       expect(mcpConfig.mcpServers?.['graphify-ts']?.env?.GRAPHIFY_TOOL_PROFILE).toBe('core')
+    })
+  })
+
+  it('writes strict Cursor guidance while keeping the MCP env on the lean core tool profile', () => {
+    withTempDir((projectDir) => {
+      const installCursorWithProfile = cursorInstall as (projectDir?: string, options?: { profile?: 'core' | 'full' | 'strict' }) => string
+      const installMessage = installCursorWithProfile(projectDir, { profile: 'strict' })
+
+      const rule = readFileSync(join(projectDir, '.cursor', 'rules', 'graphify-ts.mdc'), 'utf8')
+      const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.cursor', 'mcp.json'), 'utf8')) as {
+        mcpServers?: {
+          'graphify-ts'?: {
+            env?: Record<string, string>
+          }
+        }
+      }
+
+      expect(mcpConfig.mcpServers?.['graphify-ts']?.env?.GRAPHIFY_TOOL_PROFILE).toBe('core')
+      expect(rule).toContain('Call `context_pack` once for the task before broader exploration.')
+      expect(rule).toContain('Answer from the pack when coverage is complete.')
+      expect(rule).toContain('Only expand with graph/search tools when diagnostics show missing evidence.')
+      expect(rule).toContain('Avoid raw file search unless the pack is insufficient.')
+      expect(installMessage).toContain('strict compact MCP profile')
+    })
+  })
+
+  it('updates an existing Cursor rule when switching to the strict profile', () => {
+    withTempDir((projectDir) => {
+      cursorInstall(projectDir)
+
+      const installCursorWithProfile = cursorInstall as (projectDir?: string, options?: { profile?: 'core' | 'full' | 'strict' }) => string
+      installCursorWithProfile(projectDir, { profile: 'strict' })
+
+      const rule = readFileSync(join(projectDir, '.cursor', 'rules', 'graphify-ts.mdc'), 'utf8')
+      expect(rule).toContain('Call `context_pack` once for the task before broader exploration.')
+      expect(rule).not.toContain('start with the graph tool that matches the question')
     })
   })
 
@@ -491,6 +581,26 @@ describe('install helpers', () => {
       }
 
       expect(mcpConfig.servers?.['graphify-ts']?.env?.GRAPHIFY_TOOL_PROFILE).toBe('full')
+    })
+  })
+
+  it('writes strict Copilot guidance while keeping the MCP env on the lean core tool profile', () => {
+    withTempDir((projectDir) => {
+      const installCopilotWithProfile = installCopilotMcp as (projectDir?: string, options?: { profile?: 'core' | 'full' | 'strict' }) => string
+      const installMessage = installCopilotWithProfile(projectDir, { profile: 'strict' })
+
+      const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.vscode', 'mcp.json'), 'utf8')) as {
+        servers?: {
+          'graphify-ts'?: {
+            env?: Record<string, string>
+          }
+        }
+      }
+
+      expect(mcpConfig.servers?.['graphify-ts']?.env?.GRAPHIFY_TOOL_PROFILE).toBe('core')
+      expect(installMessage).toContain('strict compact MCP profile')
+      expect(installMessage).toContain('call context_pack once')
+      expect(installMessage).toContain('expand only when diagnostics show missing evidence')
     })
   })
 


### PR DESCRIPTION
## Summary
- add a strict install profile for Claude, Cursor, Copilot, and Gemini while keeping the runtime MCP env on the lean core tool surface
- generate strict compact guidance, hooks, and rules that start with one context_pack call and only expand when diagnostics show missing evidence
- cover the new profile with CLI/install/docs regressions, including Cursor and Gemini upgrade-path tests when switching profiles

Closes #159.

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--profile strict` option for MCP installations in Claude Code, Cursor, GitHub Copilot, and Gemini, enabling a lean core tool surface with context-pack-first guidance.

* **Documentation**
  * Updated installation guides to document the new strict profile option and its behavior across supported AI tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/201)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->