### PR TITLE
feat: add pack-only compare mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Pack-only compare mode**: `graphify-ts compare --baseline-mode pack_only` now compares one bounded raw-context baseline prompt against one compiled graphify pack, persists the compact pack audit fields in `report.json`, and keeps `native_agent` as the provider-reported runtime benchmark path.
+
 ## [0.22.9] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ graphify-ts pack "why does auth fail?" --task explain --retrieval-strategy slice
 graphify-ts prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
 graphify-ts review-compare graphify-out/graph.json --exec '...' --yes  # PR review benchmark
 graphify-ts compare "How does auth work?" --exec '...' --yes           # general benchmark
+graphify-ts compare "How does auth work?" --baseline-mode pack_only --exec '...' --yes  # bounded raw context vs compiled graphify pack
 graphify-ts time-travel main HEAD --view risk   # what changed between two refs
 graphify-ts federate frontend/graph.json backend/graph.json  # multi-repo merge
 graphify-ts --help                              # full surface

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -36,6 +36,8 @@ node dist/src/cli/bin.js compare "How does login create a session?" \
   --yes
 ```
 
+If you want to isolate the context-compiler claim without MCP/tool-call behavior, switch to `--baseline-mode pack_only`. That mode compares one bounded raw-context baseline prompt against one compiled graphify pack and persists the compact pack audit fields (`token_count`, matched nodes, relationships, coverage, and selection diagnostics) in `report.json`.
+
 If you switch to `--baseline-mode native_agent`, prefer a structured Anthropic runner such as `cat {prompt_file} | claude -p --output-format json`. Plain-text Claude runs still save paired answers, but the report cannot compute Anthropic-billed reductions without the trailing JSON usage block.
 
 Gemini-safe installed-CLI invocation:

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -371,7 +371,7 @@ export function formatHelp(binaryName = 'graphify-ts'): string {
     '    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}',
     '    --questions PATH      load questions from a JSON file instead of a positional question',
     '    --output-dir DIR      compare output directory (default graphify-out/compare)',
-    '    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
+    '    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled graphify pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
     '    --yes                 skip confirmation before running the paid prompt comparison',
     '    --limit N             cap processed prompts/questions for the comparison run',
     '  review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff',

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -90,7 +90,7 @@ export interface CompareCliOptions {
   execTemplate: string
   questionsPath: string | null
   outputDir: string
-  baselineMode: 'full' | 'bounded' | 'native_agent'
+  baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent'
   yes: boolean
   limit: number | null
 }
@@ -263,12 +263,12 @@ function parseQueryRankBy(value: string): QueryRankBy {
   throw new UsageError('error: --rank-by must be one of relevance, degree')
 }
 
-function parseCompareBaselineMode(value: string): 'full' | 'bounded' | 'native_agent' {
+function parseCompareBaselineMode(value: string): 'full' | 'bounded' | 'pack_only' | 'native_agent' {
   const normalized = value.trim().toLowerCase()
-  if (normalized === 'full' || normalized === 'bounded' || normalized === 'native_agent') {
+  if (normalized === 'full' || normalized === 'bounded' || normalized === 'pack_only' || normalized === 'native_agent') {
     return normalized
   }
-  throw new UsageError('error: --baseline-mode must be one of full, bounded, native_agent')
+  throw new UsageError('error: --baseline-mode must be one of full, bounded, pack_only, native_agent')
 }
 
 function parseTimeTravelView(value: string): 'summary' | 'risk' | 'drift' | 'timeline' {
@@ -901,7 +901,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   let execTemplate = ''
   let questionsPath: string | null = null
   let outputDir = 'graphify-out/compare'
-  let baselineMode: 'full' | 'bounded' | 'native_agent' = 'full'
+  let baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent' = 'full'
   let yes = false
   let limit: number | null = null
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -9,12 +9,12 @@ import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIO
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
 import { parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner.js'
-import { retrieveContext, tokenizeLabel, type RetrieveResult } from '../runtime/retrieve.js'
+import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 
-export type CompareBaselineMode = 'full' | 'bounded' | 'native_agent'
+export type CompareBaselineMode = 'full' | 'bounded' | 'pack_only' | 'native_agent'
 export type CompareRunMode = 'baseline' | 'graphify'
 export type CompareRunStatus = 'not_run' | 'succeeded' | 'failed' | 'context_overflow'
 export type CompareFailureReason = 'prompt_too_long' | 'runner_error' | 'exec_error'
@@ -86,6 +86,12 @@ export interface ComparePromptTokenEstimator {
 
 export type ComparePromptUsage = PromptRunnerUsage
 
+export interface CompareReportPack extends CompactRetrieveResult {
+  claims?: NonNullable<RetrieveResult['claims']>
+  coverage?: NonNullable<RetrieveResult['coverage']>
+  selection_diagnostics?: NonNullable<RetrieveResult['selection_diagnostics']>
+}
+
 export interface ComparePromptReport {
   question: string
   graph_path: string
@@ -142,6 +148,7 @@ export interface ComparePromptReport {
     graphify: string | null
   }
   provider_proof?: ComparePromptProviderProof
+  pack?: CompareReportPack
   paths: ComparePromptArtifactPaths
 }
 
@@ -492,6 +499,16 @@ function formatGraphifyContextSections(retrieval: RetrieveResult): ContextPrompt
         }]
       : []),
   ]
+}
+
+function compareReportPackFromRetrieveResult(retrieval: RetrieveResult): CompareReportPack {
+  const compact = compactRetrieveResult(retrieval)
+  return {
+    ...compact,
+    ...(retrieval.claims ? { claims: retrieval.claims } : {}),
+    ...(retrieval.coverage ? { coverage: retrieval.coverage } : {}),
+    ...(retrieval.selection_diagnostics ? { selection_diagnostics: retrieval.selection_diagnostics } : {}),
+  }
 }
 
 function computeReductionRatio(baselinePromptTokens: number, graphifyPromptTokens: number): number {
@@ -884,7 +901,7 @@ function deriveBaselineCorpusText(graphPath: string, graph: KnowledgeGraph): str
 export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): ComparePromptPack {
   const corpusText = input.corpusText.trim()
   const corpusBody =
-    input.mode === 'bounded'
+    input.mode === 'bounded' || input.mode === 'pack_only'
       ? buildBoundedCorpusExcerpt(input.question, input.graph, corpusText, input.maxTokens ?? DEFAULT_BOUNDED_BASELINE_TOKENS)
       : corpusText
   const builtPrompt = buildBaselinePromptArtifact(input.question, input.graph, corpusBody, input.mode, input.session)
@@ -968,6 +985,8 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
   const outputDir = validateGraphOutputPath(input.outputDir)
   const now = input.now ?? new Date()
   const outputRoot = createCompareOutputRoot(outputDir, now)
+  const projectRoot = realpathSync(inferProjectRootFromGraphPath(graphPath))
+  const retrievalBudget = input.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET
   let baselineSession: ContextSessionState | undefined
   let graphifySession: ContextSessionState | undefined
 
@@ -975,17 +994,6 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
     const questionOutputDir = questions.length === 1 ? outputRoot : join(outputRoot, `question-${String(index + 1).padStart(3, '0')}`)
     mkdirSync(questionOutputDir, { recursive: true })
 
-    const baselinePrompt = buildBaselinePromptPack({
-      question,
-      graph,
-      corpusText,
-      mode: input.baselineMode,
-      ...(input.baselineMaxTokens !== undefined ? { maxTokens: input.baselineMaxTokens } : {}),
-      ...(baselineSession ? { session: baselineSession } : {}),
-    })
-    baselineSession = baselinePrompt.session_state
-    const projectRoot = realpathSync(inferProjectRootFromGraphPath(graphPath))
-    const retrievalBudget = input.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET
     const retrieval = retrieveCompareContext(graph, question, retrievalBudget, projectRoot)
     const graphifyPrompt = buildGraphifyPromptPack({
       question,
@@ -993,6 +1001,20 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
       ...(graphifySession ? { session: graphifySession } : {}),
     })
     graphifySession = graphifyPrompt.session_state
+    const comparePack = input.baselineMode === 'pack_only' ? compareReportPackFromRetrieveResult(retrieval) : undefined
+    const baselineMaxTokens =
+      input.baselineMode === 'pack_only'
+        ? graphifyPrompt.token_count
+        : input.baselineMaxTokens
+    const baselinePrompt = buildBaselinePromptPack({
+      question,
+      graph,
+      corpusText,
+      mode: input.baselineMode,
+      ...(baselineMaxTokens !== undefined ? { maxTokens: baselineMaxTokens } : {}),
+      ...(baselineSession ? { session: baselineSession } : {}),
+    })
+    baselineSession = baselinePrompt.session_state
 
     const paths: ComparePromptArtifactPaths = {
       output_dir: questionOutputDir,
@@ -1069,6 +1091,7 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
         baseline: null,
         graphify: null,
       },
+      ...(comparePack ? { pack: comparePack } : {}),
       paths,
     }
 
@@ -1284,7 +1307,7 @@ export function formatCompareSummary(result: GenerateCompareArtifactsResult): st
   // (not a real agent's behavior) so reduction_ratio is a synthetic estimate;
   // append an explicit disclosure line. native_agent mode is preferred for shipping.
   const baselineModes = new Set<CompareBaselineMode>(result.reports.map((report) => report.baseline_mode))
-  const usesSyntheticBaseline = baselineModes.has('full') || baselineModes.has('bounded')
+  const usesSyntheticBaseline = baselineModes.has('full') || baselineModes.has('bounded') || baselineModes.has('pack_only')
 
   const lines = [
     `[graphify compare] completed ${result.reports.length} question(s)`,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -467,6 +467,27 @@ describe('cli parser', () => {
     })
   })
 
+  it('parses compare args with pack_only baseline mode', () => {
+    expect(
+      parseCompareArgs([
+        'how does login work',
+        '--exec',
+        'claude -p "$(cat {prompt_file})"',
+        '--baseline-mode',
+        'pack_only',
+      ]),
+    ).toEqual({
+      question: 'how does login work',
+      graphPath: 'graphify-out/graph.json',
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      questionsPath: null,
+      outputDir: resolve('graphify-out/compare'),
+      baselineMode: 'pack_only',
+      yes: false,
+      limit: null,
+    })
+  })
+
   it('rejects invalid compare args', () => {
     expect(() => parseCompareArgs(['how does login work'])).toThrow('error: --exec is required')
     expect(() => parseCompareArgs(['how does login work', '--questions', 'benchmark-questions.json', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow(
@@ -875,7 +896,7 @@ describe('cli main', () => {
     expect(help).toContain('    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}')
     expect(help).toContain('    --questions PATH      load questions from a JSON file instead of a positional question')
     expect(help).toContain('    --output-dir DIR      compare output directory (default graphify-out/compare)')
-    expect(help).toContain('    --baseline-mode MODE  full | bounded | native_agent (default full; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)')
+    expect(help).toContain('    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled graphify pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)')
     expect(help).toContain('    --yes                 skip confirmation before running the paid prompt comparison')
     expect(help).toContain('    --limit N             cap processed prompts/questions for the comparison run')
     expect(help).toContain('review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff')

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -544,6 +544,56 @@ describe('compare runtime', () => {
     expect(estimateQueryTokens(boundedPack.prompt)).toBeLessThanOrEqual(120)
   })
 
+  it('builds pack_only compare artifacts with a bounded baseline and persisted pack metadata', () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+
+    const result = generateCompareArtifacts({
+      graphPath,
+      question: 'how does login create a session',
+      outputDir: COMPARE_OUTPUT_ROOT,
+      execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+      baselineMode: 'pack_only',
+      now: new Date('2026-04-24T19:30:00.000Z'),
+    })
+
+    const report = result.reports[0]!
+    const baselinePrompt = readFileSync(report.paths.baseline_prompt, 'utf8')
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+    const savedPack = savedReport.pack as Record<string, unknown>
+
+    expect(report.baseline_mode).toBe('pack_only')
+    expect(baselinePrompt).toContain('[bounded baseline excerpt]')
+    expect(report.baseline_prompt_tokens).toBeLessThanOrEqual(report.graphify_prompt_tokens)
+    expect(savedReport.baseline_mode).toBe('pack_only')
+    expect(savedPack.token_count).toEqual(expect.any(Number))
+    expect(savedPack.matched_nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'authenticateUser',
+        }),
+      ]),
+    )
+    expect(savedPack.relationships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          relation: 'calls',
+        }),
+      ]),
+    )
+    expect(savedPack.coverage).toEqual(
+      expect.objectContaining({
+        entries: expect.any(Array),
+      }),
+    )
+    expect(savedPack.selection_diagnostics).toEqual(
+      expect.objectContaining({
+        selection_strategy: 'value-per-token',
+      }),
+    )
+  })
+
   it('rejects bounded baseline budgets below the prompt floor', () => {
     const graph = makeGraph()
     const corpusText = makeCorpusText()


### PR DESCRIPTION
## Summary
- add `compare --baseline-mode pack_only` to compare a bounded raw-context baseline against one compiled graphify pack
- persist pack audit fields in compare reports and cover the new mode with CLI/runtime tests
- update compare help text, README, proof workflows, and changelog

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "pack_only" baseline mode for `graphify-ts compare --baseline-mode pack_only`, enabling A/B comparison between a bounded raw-context baseline and a compiled graphify pack with persisted audit metrics in `report.json`.

* **Documentation**
  * Updated CLI help text, README, and workflow documentation with examples and guidance for the new pack_only comparison mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->