### PR TITLE
Add share-safe proof report artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Added
 
 - **Pack-only compare mode**: `graphify-ts compare --baseline-mode pack_only` now compares one bounded raw-context baseline prompt against one compiled graphify pack, persists the compact pack audit fields in `report.json`, and keeps `native_agent` as the provider-reported runtime benchmark path.
+- **Share-safe proof reports**: `compare`, `benchmark`, and `review-compare` now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
 
 ## [0.22.9] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Added
 
 - **Pack-only compare mode**: `graphify-ts compare --baseline-mode pack_only` now compares one bounded raw-context baseline prompt against one compiled graphify pack, persists the compact pack audit fields in `report.json`, and keeps `native_agent` as the provider-reported runtime benchmark path.
-- **Share-safe proof reports**: `compare`, `benchmark`, and `review-compare` now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
+- **Share-safe proof reports**: `compare`, `review-compare`, and runner-backed `benchmark --exec ...` executions now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
 
 ## [0.22.9] - 2026-05-16
 

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -61,7 +61,7 @@ What gets saved under `graphify-out/compare/<timestamp>/`:
 
 When Gemini emits structured JSON with `usageMetadata`, `compare` captures real reported input and total tokens in `report.json` and the terminal summary. If the runner only returns answer text or malformed JSON, `compare` falls back to labeled local `cl100k_base` prompt estimates instead.
 
-`report.json` keeps the real local artifact paths. `report.share-safe.json` preserves the compare metrics with stable placeholders for sharing, while the prompt and answer text files remain local-only artifacts. That makes the companion report safe to publish for path hygiene, but it still does not promise perfect redaction of every possible project detail.
+`report.json` keeps the real local artifact paths. `report.share-safe.json` preserves the compare metrics with stable placeholders for sharing, including sanitized placeholder paths to the prompt/answer artifacts; only the prompt and answer file contents remain local. That makes the companion report safe to publish for path hygiene, but it still does not promise perfect redaction of every possible project detail.
 
 Recent report versions also add a **provider/runtime proof** block so you can see whether a reduction is backed by provider-reported input/cache/total-token numbers or by local estimate + session-reuse accounting. Use this when you need customer-facing proof or your own apples-to-apples answer comparison.
 
@@ -88,7 +88,7 @@ What gets saved under `graphify-out/review-compare/<timestamp>/`:
 
 Use this when the question is not "graphify vs. naive baseline", but "did compact review mode make the PR-review prompt materially smaller while keeping the same review surface shape?" The report includes prompt-token deltas, payload-token deltas, run statuses, elapsed times for both modes, and a provider/runtime proof block that makes it explicit when review-compare is using local estimate + session-reuse accounting rather than provider-billed usage.
 
-As with `compare` and `benchmark`, the prompt and answer files stay local, while `report.share-safe.json` keeps the review metrics with stable placeholders so you can share evidence without publishing your exact local artifact paths.
+As with `compare` and `benchmark`, the prompt and answer file contents stay local, while `report.share-safe.json` keeps the review metrics plus sanitized placeholder paths to those artifacts so you can share evidence without publishing your exact local artifact paths.
 
 ## 4. Production and multi-repo proof
 

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -25,6 +25,8 @@ Expected signals on the checked-in demo:
 
 This is still the most reproducible question-set proof path because the corpus, labels, and expected signals are checked in here. It now runs through your configured terminal runner, so use `--yes` for CI/non-interactive runs and expect model-token usage unless your runner is purely local.
 
+`benchmark` keeps the per-run prompt/answer files and full `report.json` as local artifacts. It also writes a companion `report.share-safe.json` with stable placeholders so you can publish token and coverage metrics without exposing real local artifact paths. Treat that share-safe report as publishing evidence, not as a guarantee that every possible project detail has been fully redacted.
+
 ## 2. Same-question, same-model A/B proof
 
 `compare` is the real showcase path. It builds one baseline prompt and one graph-guided prompt for the same question, runs both through your own terminal model command, and saves the artifact bundle.
@@ -55,8 +57,11 @@ What gets saved under `graphify-out/compare/<timestamp>/`:
 - `baseline-answer.txt`
 - `graphify-answer.txt`
 - `report.json`
+- `report.share-safe.json`
 
 When Gemini emits structured JSON with `usageMetadata`, `compare` captures real reported input and total tokens in `report.json` and the terminal summary. If the runner only returns answer text or malformed JSON, `compare` falls back to labeled local `cl100k_base` prompt estimates instead.
+
+`report.json` keeps the real local artifact paths. `report.share-safe.json` preserves the compare metrics with stable placeholders for sharing, while the prompt and answer text files remain local-only artifacts. That makes the companion report safe to publish for path hygiene, but it still does not promise perfect redaction of every possible project detail.
 
 Recent report versions also add a **provider/runtime proof** block so you can see whether a reduction is backed by provider-reported input/cache/total-token numbers or by local estimate + session-reuse accounting. Use this when you need customer-facing proof or your own apples-to-apples answer comparison.
 
@@ -79,8 +84,11 @@ What gets saved under `graphify-out/review-compare/<timestamp>/`:
 - `verbose-answer.txt`
 - `compact-answer.txt`
 - `report.json`
+- `report.share-safe.json`
 
 Use this when the question is not "graphify vs. naive baseline", but "did compact review mode make the PR-review prompt materially smaller while keeping the same review surface shape?" The report includes prompt-token deltas, payload-token deltas, run statuses, elapsed times for both modes, and a provider/runtime proof block that makes it explicit when review-compare is using local estimate + session-reuse accounting rather than provider-billed usage.
+
+As with `compare` and `benchmark`, the prompt and answer files stay local, while `report.share-safe.json` keeps the review metrics with stable placeholders so you can share evidence without publishing your exact local artifact paths.
 
 ## 4. Production and multi-repo proof
 

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -25,7 +25,7 @@ Expected signals on the checked-in demo:
 
 This is still the most reproducible question-set proof path because the corpus, labels, and expected signals are checked in here. It now runs through your configured terminal runner, so use `--yes` for CI/non-interactive runs and expect model-token usage unless your runner is purely local.
 
-`benchmark` keeps the per-run prompt/answer files and full `report.json` as local artifacts. It also writes a companion `report.share-safe.json` with stable placeholders so you can publish token and coverage metrics without exposing real local artifact paths. Treat that share-safe report as publishing evidence, not as a guarantee that every possible project detail has been fully redacted.
+Runner-backed `benchmark` executions (`--exec ...`) keep the per-run prompt/answer files and full `report.json` as local artifacts. That path also writes a companion `report.share-safe.json` with stable placeholders, preserving the per-run usage/proof fields plus sanitized artifact paths for sharing without exposing real local paths. The benchmark-wide coverage/evidence totals still live in the aggregate benchmark result and terminal summary rather than inside each per-run share-safe file. Treat that share-safe report as publishing evidence, not as a guarantee that every possible project detail has been fully redacted.
 
 ## 2. Same-question, same-model A/B proof
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -56,7 +56,7 @@ This does **not** measure model quality. It is a safe local smoke check that pro
 - `generate` should write `examples/sample-workspace/graphify-out/graph.json`
 - `pack` should print a compact JSON payload with matched nodes from the password reset flow
 - `prompt` should print a provider-ready prompt payload
-- `compare` should create an artifact directory under `graphify-out/compare/` containing prompt and answer files plus `report.json`
+- `compare` should create an artifact directory under `graphify-out/compare/` containing prompt and answer files plus both `report.json` and `report.share-safe.json`
 
 ## Troubleshooting
 

--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -6,6 +6,7 @@ import { KnowledgeGraph } from '../../contracts/graph.js'
 import type { ContextSessionState } from '../../contracts/context-session.js'
 import { type RetrieveResult, retrieveContext } from '../../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR } from '../../runtime/serve.js'
+import { toShareSafeArtifactPath } from '../../shared/share-safe-artifacts.js'
 import { validateGraphOutputPath } from '../../shared/security.js'
 import { buildGraphifyPromptPack, expandCompareExecTemplate } from '../compare.js'
 import { parsePromptRunnerOutput, type PromptRunnerUsage } from '../prompt-runner.js'
@@ -247,24 +248,43 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
     session_state: promptPack.session_state,
   }
 
+  const localReport = {
+    question: options.question,
+    prompt_tokens_estimated: run.prompt_tokens_estimated,
+    query_tokens: run.query_tokens,
+    effective_query_tokens: run.effective_query_tokens,
+    reused_context_tokens: run.reused_context_tokens,
+    total_tokens: run.total_tokens,
+    prompt_token_source: run.prompt_token_source,
+    usage: run.usage,
+    elapsed_ms: run.elapsed_ms,
+    prompt_token_estimator: QUERY_TOKEN_ESTIMATOR,
+    artifacts: {
+      prompt: portablePath(artifacts.prompt),
+      answer: portablePath(artifacts.answer),
+      report: portablePath(artifacts.report),
+    },
+  }
+  const shareSafeRoots = {
+    artifactRoot: outputRoot,
+    projectRoot: inferProjectRootFromGraphPath(options.graphPath),
+  }
+  const shareSafeReportPath = join(outputRoot, 'report.share-safe.json')
+
   writeFileSync(
     artifacts.report,
+    `${JSON.stringify(localReport, null, 2)}\n`,
+    'utf8',
+  )
+  writeFileSync(
+    shareSafeReportPath,
     `${JSON.stringify(
       {
-        question: options.question,
-          prompt_tokens_estimated: run.prompt_tokens_estimated,
-          query_tokens: run.query_tokens,
-          effective_query_tokens: run.effective_query_tokens,
-          reused_context_tokens: run.reused_context_tokens,
-          total_tokens: run.total_tokens,
-          prompt_token_source: run.prompt_token_source,
-        usage: run.usage,
-        elapsed_ms: run.elapsed_ms,
-        prompt_token_estimator: QUERY_TOKEN_ESTIMATOR,
+        ...localReport,
         artifacts: {
-          prompt: portablePath(artifacts.prompt),
-          answer: portablePath(artifacts.answer),
-          report: portablePath(artifacts.report),
+          prompt: toShareSafeArtifactPath(artifacts.prompt, shareSafeRoots),
+          answer: toShareSafeArtifactPath(artifacts.answer, shareSafeRoots),
+          report: toShareSafeArtifactPath(shareSafeReportPath, shareSafeRoots),
         },
       },
       null,

--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -23,6 +23,7 @@ export interface BenchmarkPromptArtifacts {
   prompt: string
   answer: string
   report: string
+  share_safe_report: string
 }
 
 export interface BenchmarkPromptExecution {
@@ -206,6 +207,7 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
     prompt: join(outputRoot, 'graphify-prompt.txt'),
     answer: join(outputRoot, 'graphify-answer.txt'),
     report: join(outputRoot, 'report.json'),
+    share_safe_report: join(outputRoot, 'report.share-safe.json'),
   }
   writeFileSync(artifacts.prompt, promptPack.session_payload, 'utf8')
 
@@ -263,28 +265,28 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
       prompt: portablePath(artifacts.prompt),
       answer: portablePath(artifacts.answer),
       report: portablePath(artifacts.report),
+      share_safe_report: portablePath(artifacts.share_safe_report),
     },
   }
   const shareSafeRoots = {
     artifactRoot: outputRoot,
     projectRoot: inferProjectRootFromGraphPath(options.graphPath),
   }
-  const shareSafeReportPath = join(outputRoot, 'report.share-safe.json')
-
   writeFileSync(
     artifacts.report,
     `${JSON.stringify(localReport, null, 2)}\n`,
     'utf8',
   )
   writeFileSync(
-    shareSafeReportPath,
+    artifacts.share_safe_report,
     `${JSON.stringify(
       {
         ...localReport,
         artifacts: {
           prompt: toShareSafeArtifactPath(artifacts.prompt, shareSafeRoots),
           answer: toShareSafeArtifactPath(artifacts.answer, shareSafeRoots),
-          report: toShareSafeArtifactPath(shareSafeReportPath, shareSafeRoots),
+          report: toShareSafeArtifactPath(artifacts.report, shareSafeRoots),
+          share_safe_report: toShareSafeArtifactPath(artifacts.share_safe_report, shareSafeRoots),
         },
       },
       null,

--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -250,6 +250,11 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
     session_state: promptPack.session_state,
   }
 
+  const localReportArtifacts = {
+    prompt: portablePath(artifacts.prompt),
+    answer: portablePath(artifacts.answer),
+    report: portablePath(artifacts.report),
+  }
   const localReport = {
     question: options.question,
     prompt_tokens_estimated: run.prompt_tokens_estimated,
@@ -261,12 +266,7 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
     usage: run.usage,
     elapsed_ms: run.elapsed_ms,
     prompt_token_estimator: QUERY_TOKEN_ESTIMATOR,
-    artifacts: {
-      prompt: portablePath(artifacts.prompt),
-      answer: portablePath(artifacts.answer),
-      report: portablePath(artifacts.report),
-      share_safe_report: portablePath(artifacts.share_safe_report),
-    },
+    artifacts: localReportArtifacts,
   }
   const shareSafeRoots = {
     artifactRoot: outputRoot,
@@ -279,16 +279,17 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
   )
   writeFileSync(
     artifacts.share_safe_report,
-    `${JSON.stringify(
-      {
-        ...localReport,
-        artifacts: {
-          prompt: toShareSafeArtifactPath(artifacts.prompt, shareSafeRoots),
-          answer: toShareSafeArtifactPath(artifacts.answer, shareSafeRoots),
-          report: toShareSafeArtifactPath(artifacts.report, shareSafeRoots),
-          share_safe_report: toShareSafeArtifactPath(artifacts.share_safe_report, shareSafeRoots),
+      `${JSON.stringify(
+        {
+          ...localReport,
+          share_safe_report: true,
+          artifacts: {
+            ...Object.fromEntries(
+              Object.entries(localReportArtifacts).map(([key, path]) => [key, toShareSafeArtifactPath(path, shareSafeRoots)]),
+            ),
+            share_safe_report: toShareSafeArtifactPath(artifacts.share_safe_report, shareSafeRoots),
+          },
         },
-      },
       null,
       2,
     )}\n`,

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -324,7 +324,30 @@ function compareShareSafePathRoots(path: readonly string[], roots: ShareSafePath
   return [roots.projectRoot, roots.artifactRoot]
 }
 
+function isCompareArtifactRootField(path: readonly string[]): boolean {
+  const parentKey = path[path.length - 2]
+  return parentKey === 'paths' || parentKey === 'answer_paths'
+}
+
+function compareExternalPathFallback(path: string): string {
+  const normalizedPath = path.replaceAll('\\', '/')
+  const lastSegment = normalizedPath.split('/').pop()
+  return lastSegment && lastSegment.length > 0 ? lastSegment : '<external-path>'
+}
+
 function sanitizeCompareShareSafePath(value: string, roots: ShareSafePathRoots, path: readonly string[]): string {
+  if (isCompareArtifactRootField(path)) {
+    if (isAbsolutePathLike(value)) {
+      return isPathWithinRoot(resolve(value), roots.artifactRoot)
+        ? toShareSafeArtifactPath(value, roots)
+        : compareExternalPathFallback(value)
+    }
+
+    return isPathWithinRoot(resolve(roots.artifactRoot, value), roots.artifactRoot)
+      ? value
+      : compareExternalPathFallback(value)
+  }
+
   if (isAbsolutePathLike(value)) {
     return toShareSafeArtifactPath(value, roots)
   }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -12,6 +12,7 @@ import { parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
+import { toShareSafeArtifactPath } from '../shared/share-safe-artifacts.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 
 export type CompareBaselineMode = 'full' | 'bounded' | 'pack_only' | 'native_agent'
@@ -65,6 +66,7 @@ export interface ComparePromptArtifactPaths {
   baseline_prompt: string
   graphify_prompt: string
   report: string
+  share_safe_report: string
 }
 
 export interface CompareAnswerArtifactPaths {
@@ -269,26 +271,49 @@ export function expandCompareExecTemplate(
 }
 
 function writeCompareReport(report: ComparePromptReport): void {
+  const shareSafeRoots = {
+    artifactRoot: report.paths.output_dir,
+    projectRoot: inferProjectRootFromGraphPath(report.graph_path),
+  }
+  const serializedReport = {
+    ...report,
+    graph_path: portablePath(report.graph_path),
+    answer_paths: {
+      baseline: portablePath(report.answer_paths.baseline),
+      graphify: portablePath(report.answer_paths.graphify),
+    },
+    paths: {
+      output_dir: portablePath(report.paths.output_dir),
+      baseline_prompt: portablePath(report.paths.baseline_prompt),
+      graphify_prompt: portablePath(report.paths.graphify_prompt),
+      report: portablePath(report.paths.report),
+      share_safe_report: portablePath(report.paths.share_safe_report),
+    },
+  }
+  const shareSafeReport = {
+    ...report,
+    graph_path: toShareSafeArtifactPath(report.graph_path, shareSafeRoots),
+    answer_paths: {
+      baseline: toShareSafeArtifactPath(report.answer_paths.baseline, shareSafeRoots),
+      graphify: toShareSafeArtifactPath(report.answer_paths.graphify, shareSafeRoots),
+    },
+    paths: {
+      output_dir: toShareSafeArtifactPath(report.paths.output_dir, shareSafeRoots),
+      baseline_prompt: toShareSafeArtifactPath(report.paths.baseline_prompt, shareSafeRoots),
+      graphify_prompt: toShareSafeArtifactPath(report.paths.graphify_prompt, shareSafeRoots),
+      report: toShareSafeArtifactPath(report.paths.share_safe_report, shareSafeRoots),
+      share_safe_report: toShareSafeArtifactPath(report.paths.share_safe_report, shareSafeRoots),
+    },
+  }
+
   writeFileSync(
     report.paths.report,
-    `${JSON.stringify(
-      {
-        ...report,
-        graph_path: portablePath(report.graph_path),
-        answer_paths: {
-          baseline: portablePath(report.answer_paths.baseline),
-          graphify: portablePath(report.answer_paths.graphify),
-        },
-        paths: {
-          output_dir: portablePath(report.paths.output_dir),
-          baseline_prompt: portablePath(report.paths.baseline_prompt),
-          graphify_prompt: portablePath(report.paths.graphify_prompt),
-          report: portablePath(report.paths.report),
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(serializedReport, null, 2)}\n`,
+    'utf8',
+  )
+  writeFileSync(
+    report.paths.share_safe_report,
+    `${JSON.stringify(shareSafeReport, null, 2)}\n`,
     'utf8',
   )
 }
@@ -1021,6 +1046,7 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
       baseline_prompt: join(questionOutputDir, 'baseline-prompt.txt'),
       graphify_prompt: join(questionOutputDir, 'graphify-prompt.txt'),
       report: join(questionOutputDir, 'report.json'),
+      share_safe_report: join(questionOutputDir, 'report.share-safe.json'),
     }
     const answerPaths: CompareAnswerArtifactPaths = {
       baseline: answerFilePath(questionOutputDir, 'baseline'),

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -374,6 +374,7 @@ function shouldSanitizeCompareShareSafePath(path: readonly string[]): boolean {
 
   return (
     key === 'graph_path' ||
+    key === 'result_path' ||
     key === 'source_file' ||
     key === 'focus_files' ||
     parentKey === 'paths' ||
@@ -1555,6 +1556,7 @@ export interface NativeAgentCompareReport {
   paths: {
     output_dir: string
     report: string
+    share_safe_report: string
     baseline_answer: string
     graphify_answer: string
     prompt_file: string
@@ -1785,6 +1787,7 @@ export async function executeNativeAgentCompare(
     const baselineAnswerPath = answerFilePath(questionDir, 'baseline')
     const graphifyAnswerPath = answerFilePath(questionDir, 'graphify')
     const reportPath = join(questionDir, 'report.json')
+    const shareSafeReportPath = join(questionDir, 'report.share-safe.json')
 
     const reportShell: NativeAgentCompareReport = {
       baseline_mode: 'native_agent',
@@ -1818,6 +1821,7 @@ export async function executeNativeAgentCompare(
       paths: {
         output_dir: questionDir,
         report: reportPath,
+        share_safe_report: shareSafeReportPath,
         baseline_answer: baselineAnswerPath,
         graphify_answer: graphifyAnswerPath,
         prompt_file: promptFile,
@@ -1994,23 +1998,32 @@ export async function executeNativeAgentCompare(
 }
 
 function writeNativeAgentReport(report: NativeAgentCompareReport): void {
+  const shareSafeRoots = {
+    artifactRoot: report.paths.output_dir,
+    projectRoot: inferProjectRootFromGraphPath(report.graph_path),
+  }
+  const serializedReport = {
+    ...report,
+    graph_path: portablePath(report.graph_path),
+    paths: {
+      output_dir: portablePath(report.paths.output_dir),
+      report: portablePath(report.paths.report),
+      share_safe_report: portablePath(report.paths.share_safe_report),
+      baseline_answer: portablePath(report.paths.baseline_answer),
+      graphify_answer: portablePath(report.paths.graphify_answer),
+      prompt_file: portablePath(report.paths.prompt_file),
+    },
+  }
+  const shareSafeReport = sanitizeCompareShareSafeValue(report, shareSafeRoots)
+
   writeFileSync(
     report.paths.report,
-    `${JSON.stringify(
-      {
-        ...report,
-        graph_path: portablePath(report.graph_path),
-        paths: {
-          output_dir: portablePath(report.paths.output_dir),
-          report: portablePath(report.paths.report),
-          baseline_answer: portablePath(report.paths.baseline_answer),
-          graphify_answer: portablePath(report.paths.graphify_answer),
-          prompt_file: portablePath(report.paths.prompt_file),
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(serializedReport, null, 2)}\n`,
+    'utf8',
+  )
+  writeFileSync(
+    report.paths.share_safe_report,
+    `${JSON.stringify(shareSafeReport, null, 2)}\n`,
     'utf8',
   )
 }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -301,7 +301,7 @@ function writeCompareReport(report: ComparePromptReport): void {
       output_dir: toShareSafeArtifactPath(report.paths.output_dir, shareSafeRoots),
       baseline_prompt: toShareSafeArtifactPath(report.paths.baseline_prompt, shareSafeRoots),
       graphify_prompt: toShareSafeArtifactPath(report.paths.graphify_prompt, shareSafeRoots),
-      report: toShareSafeArtifactPath(report.paths.share_safe_report, shareSafeRoots),
+      report: toShareSafeArtifactPath(report.paths.report, shareSafeRoots),
       share_safe_report: toShareSafeArtifactPath(report.paths.share_safe_report, shareSafeRoots),
     },
   }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -12,7 +12,7 @@ import { parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
-import { toShareSafeArtifactPath } from '../shared/share-safe-artifacts.js'
+import { sanitizeShareSafeText, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 
 export type CompareBaselineMode = 'full' | 'bounded' | 'pack_only' | 'native_agent'
@@ -290,21 +290,7 @@ function writeCompareReport(report: ComparePromptReport): void {
       share_safe_report: portablePath(report.paths.share_safe_report),
     },
   }
-  const shareSafeReport = {
-    ...report,
-    graph_path: toShareSafeArtifactPath(report.graph_path, shareSafeRoots),
-    answer_paths: {
-      baseline: toShareSafeArtifactPath(report.answer_paths.baseline, shareSafeRoots),
-      graphify: toShareSafeArtifactPath(report.answer_paths.graphify, shareSafeRoots),
-    },
-    paths: {
-      output_dir: toShareSafeArtifactPath(report.paths.output_dir, shareSafeRoots),
-      baseline_prompt: toShareSafeArtifactPath(report.paths.baseline_prompt, shareSafeRoots),
-      graphify_prompt: toShareSafeArtifactPath(report.paths.graphify_prompt, shareSafeRoots),
-      report: toShareSafeArtifactPath(report.paths.report, shareSafeRoots),
-      share_safe_report: toShareSafeArtifactPath(report.paths.share_safe_report, shareSafeRoots),
-    },
-  }
+  const shareSafeReport = sanitizeCompareShareSafeValue(report, shareSafeRoots)
 
   writeFileSync(
     report.paths.report,
@@ -316,6 +302,24 @@ function writeCompareReport(report: ComparePromptReport): void {
     `${JSON.stringify(shareSafeReport, null, 2)}\n`,
     'utf8',
   )
+}
+
+function sanitizeCompareShareSafeValue(value: unknown, roots: ShareSafePathRoots): unknown {
+  if (typeof value === 'string') {
+    return sanitizeShareSafeText(value, roots)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeCompareShareSafeValue(entry, roots))
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, sanitizeCompareShareSafeValue(entry, roots)]),
+    )
+  }
+
+  return value
 }
 
 async function defaultComparePromptRunner(execution: ComparePromptExecution): Promise<ComparePromptRunnerResult> {

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -309,8 +309,35 @@ function isAbsolutePathLike(value: string): boolean {
   return normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)
 }
 
-function sanitizeCompareShareSafePath(value: string, roots: ShareSafePathRoots): string {
-  return isAbsolutePathLike(value) ? toShareSafeArtifactPath(value, roots) : value
+function compareShareSafePathRoots(path: readonly string[], roots: ShareSafePathRoots): string[] {
+  const key = path[path.length - 1]
+  const parentKey = path[path.length - 2]
+
+  if (parentKey === 'paths' || parentKey === 'answer_paths') {
+    return [roots.artifactRoot]
+  }
+
+  if (key === 'graph_path' || key === 'source_file' || key === 'focus_files') {
+    return [roots.projectRoot]
+  }
+
+  return [roots.projectRoot, roots.artifactRoot]
+}
+
+function sanitizeCompareShareSafePath(value: string, roots: ShareSafePathRoots, path: readonly string[]): string {
+  if (isAbsolutePathLike(value)) {
+    return toShareSafeArtifactPath(value, roots)
+  }
+
+  const candidateRoots = compareShareSafePathRoots(path, roots)
+  for (const root of candidateRoots) {
+    if (isPathWithinRoot(resolve(root, value), root)) {
+      return value
+    }
+  }
+
+  const fallbackRoot = candidateRoots[0] ?? roots.projectRoot
+  return toShareSafeArtifactPath(resolve(fallbackRoot, value), roots)
 }
 
 function shouldSanitizeCompareShareSafeText(path: readonly string[]): boolean {
@@ -337,7 +364,7 @@ function sanitizeCompareShareSafeValue(value: unknown, roots: ShareSafePathRoots
       return sanitizeShareSafeText(value, roots)
     }
     if (shouldSanitizeCompareShareSafePath(path)) {
-      return sanitizeCompareShareSafePath(value, roots)
+      return sanitizeCompareShareSafePath(value, roots, path)
     }
     return value
   }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -12,7 +12,7 @@ import { parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
-import { sanitizeShareSafeText, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
+import { sanitizeShareSafeText, toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 
 export type CompareBaselineMode = 'full' | 'bounded' | 'pack_only' | 'native_agent'
@@ -304,18 +304,51 @@ function writeCompareReport(report: ComparePromptReport): void {
   )
 }
 
-function sanitizeCompareShareSafeValue(value: unknown, roots: ShareSafePathRoots): unknown {
+function isAbsolutePathLike(value: string): boolean {
+  const normalized = value.replaceAll('\\', '/')
+  return normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)
+}
+
+function sanitizeCompareShareSafePath(value: string, roots: ShareSafePathRoots): string {
+  return isAbsolutePathLike(value) ? toShareSafeArtifactPath(value, roots) : value
+}
+
+function shouldSanitizeCompareShareSafeText(path: readonly string[]): boolean {
+  const rootKey = path[0]
+  return rootKey === 'stderr' || rootKey === 'evidence'
+}
+
+function shouldSanitizeCompareShareSafePath(path: readonly string[]): boolean {
+  const key = path[path.length - 1]
+  const parentKey = path[path.length - 2]
+
+  return (
+    key === 'graph_path' ||
+    key === 'source_file' ||
+    key === 'focus_files' ||
+    parentKey === 'paths' ||
+    parentKey === 'answer_paths'
+  )
+}
+
+function sanitizeCompareShareSafeValue(value: unknown, roots: ShareSafePathRoots, path: string[] = []): unknown {
   if (typeof value === 'string') {
-    return sanitizeShareSafeText(value, roots)
+    if (shouldSanitizeCompareShareSafeText(path)) {
+      return sanitizeShareSafeText(value, roots)
+    }
+    if (shouldSanitizeCompareShareSafePath(path)) {
+      return sanitizeCompareShareSafePath(value, roots)
+    }
+    return value
   }
 
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeCompareShareSafeValue(entry, roots))
+    return value.map((entry) => sanitizeCompareShareSafeValue(entry, roots, path))
   }
 
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [key, sanitizeCompareShareSafeValue(entry, roots)]),
+      Object.entries(value).map(([key, entry]) => [key, sanitizeCompareShareSafeValue(entry, roots, [...path, key])]),
     )
   }
 

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -154,13 +154,19 @@ function rewriteReviewComparePaths(
   }
 }
 
+function redactCredentialLikeText(text: string): string {
+  return text
+    .replaceAll(/\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS)[A-Z0-9_]*)=([^\s]+)/gi, '$1=[REDACTED]')
+    .replaceAll(/(Bearer)\s+[^\s]+/gi, '$1 [REDACTED]')
+}
+
 function rewriteShareSafeStderr(
   stderr: Record<ReviewCompareMode, string | null>,
   roots: ShareSafePathRoots,
 ): Record<ReviewCompareMode, string | null> {
   return {
-    verbose: stderr.verbose === null ? null : sanitizeShareSafeText(stderr.verbose, roots),
-    compact: stderr.compact === null ? null : sanitizeShareSafeText(stderr.compact, roots),
+    verbose: stderr.verbose === null ? null : sanitizeShareSafeText(redactCredentialLikeText(stderr.verbose), roots),
+    compact: stderr.compact === null ? null : sanitizeShareSafeText(redactCredentialLikeText(stderr.compact), roots),
   }
 }
 

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -5,6 +5,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 
 import { analyzePrImpact, compactPrImpactResult } from '../runtime/pr-impact.js'
 import { estimateQueryTokens, loadGraph } from '../runtime/serve.js'
+import { toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
 import { findNearestExistingAncestor, validateGraphPath } from '../shared/security.js'
 import { buildContextPrompt } from './context-prompt.js'
 
@@ -16,6 +17,7 @@ export interface ReviewComparePromptArtifactPaths {
   verbose_prompt: string
   compact_prompt: string
   report: string
+  share_safe_report: string
 }
 
 export interface ReviewCompareAnswerArtifactPaths {
@@ -126,6 +128,26 @@ function timestampDirectoryName(date: Date): string {
 
 function portablePath(path: string): string {
   return relative(process.cwd(), path) || '.'
+}
+
+function rewriteAnswerPaths(paths: ReviewCompareAnswerArtifactPaths, roots: ShareSafePathRoots): ReviewCompareAnswerArtifactPaths {
+  return {
+    verbose: toShareSafeArtifactPath(paths.verbose, roots),
+    compact: toShareSafeArtifactPath(paths.compact, roots),
+  }
+}
+
+function rewriteReviewComparePaths(
+  paths: ReviewComparePromptArtifactPaths,
+  roots: ShareSafePathRoots,
+): ReviewComparePromptArtifactPaths {
+  return {
+    output_dir: toShareSafeArtifactPath(paths.output_dir, roots),
+    verbose_prompt: toShareSafeArtifactPath(paths.verbose_prompt, roots),
+    compact_prompt: toShareSafeArtifactPath(paths.compact_prompt, roots),
+    report: toShareSafeArtifactPath(paths.report, roots),
+    share_safe_report: toShareSafeArtifactPath(paths.share_safe_report, roots),
+  }
 }
 
 function inferProjectRootFromGraphPath(graphPath: string): string {
@@ -316,26 +338,40 @@ function renderReviewPrompt(payload: unknown, mode: ReviewCompareMode): ReturnTy
 }
 
 function writeReport(report: ReviewCompareReport): void {
+  const roots = {
+    artifactRoot: report.paths.output_dir,
+    projectRoot: inferProjectRootFromGraphPath(report.graph_path),
+  }
+  const serializedReport = {
+    ...report,
+    graph_path: portablePath(report.graph_path),
+    answer_paths: {
+      verbose: portablePath(report.answer_paths.verbose),
+      compact: portablePath(report.answer_paths.compact),
+    },
+    paths: {
+      output_dir: portablePath(report.paths.output_dir),
+      verbose_prompt: portablePath(report.paths.verbose_prompt),
+      compact_prompt: portablePath(report.paths.compact_prompt),
+      report: portablePath(report.paths.report),
+      share_safe_report: portablePath(report.paths.share_safe_report),
+    },
+  }
+  const shareSafeReport = {
+    ...report,
+    graph_path: toShareSafeArtifactPath(report.graph_path, roots),
+    answer_paths: rewriteAnswerPaths(report.answer_paths, roots),
+    paths: rewriteReviewComparePaths(report.paths, roots),
+  }
+
   writeFileSync(
     report.paths.report,
-    `${JSON.stringify(
-      {
-        ...report,
-        graph_path: portablePath(report.graph_path),
-        answer_paths: {
-          verbose: portablePath(report.answer_paths.verbose),
-          compact: portablePath(report.answer_paths.compact),
-        },
-        paths: {
-          output_dir: portablePath(report.paths.output_dir),
-          verbose_prompt: portablePath(report.paths.verbose_prompt),
-          compact_prompt: portablePath(report.paths.compact_prompt),
-          report: portablePath(report.paths.report),
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(serializedReport, null, 2)}\n`,
+    'utf8',
+  )
+  writeFileSync(
+    report.paths.share_safe_report,
+    `${JSON.stringify(shareSafeReport, null, 2)}\n`,
     'utf8',
   )
 }
@@ -364,6 +400,7 @@ export function generateReviewCompareArtifacts(input: ReviewCompareInput): Revie
     verbose_prompt: join(outputRoot, 'verbose-prompt.txt'),
     compact_prompt: join(outputRoot, 'compact-prompt.txt'),
     report: join(outputRoot, 'report.json'),
+    share_safe_report: join(outputRoot, 'report.share-safe.json'),
   }
   const answerPaths: ReviewCompareAnswerArtifactPaths = {
     verbose: answerFilePath(outputRoot, 'verbose'),

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -5,7 +5,11 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 
 import { analyzePrImpact, compactPrImpactResult } from '../runtime/pr-impact.js'
 import { estimateQueryTokens, loadGraph } from '../runtime/serve.js'
-import { toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
+import {
+  sanitizeShareSafeText,
+  toShareSafeArtifactPath,
+  type ShareSafePathRoots,
+} from '../shared/share-safe-artifacts.js'
 import { findNearestExistingAncestor, validateGraphPath } from '../shared/security.js'
 import { buildContextPrompt } from './context-prompt.js'
 
@@ -147,6 +151,16 @@ function rewriteReviewComparePaths(
     compact_prompt: toShareSafeArtifactPath(paths.compact_prompt, roots),
     report: toShareSafeArtifactPath(paths.report, roots),
     share_safe_report: toShareSafeArtifactPath(paths.share_safe_report, roots),
+  }
+}
+
+function rewriteShareSafeStderr(
+  stderr: Record<ReviewCompareMode, string | null>,
+  roots: ShareSafePathRoots,
+): Record<ReviewCompareMode, string | null> {
+  return {
+    verbose: stderr.verbose === null ? null : sanitizeShareSafeText(stderr.verbose, roots),
+    compact: stderr.compact === null ? null : sanitizeShareSafeText(stderr.compact, roots),
   }
 }
 
@@ -361,6 +375,7 @@ function writeReport(report: ReviewCompareReport): void {
     ...report,
     graph_path: toShareSafeArtifactPath(report.graph_path, roots),
     answer_paths: rewriteAnswerPaths(report.answer_paths, roots),
+    stderr: rewriteShareSafeStderr(report.stderr, roots),
     paths: rewriteReviewComparePaths(report.paths, roots),
   }
 

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -346,7 +346,7 @@ function looksLikeLiteralSchemeSuffix(suffix: string): boolean {
   const firstLooksShareLike =
     WINDOWS_SHARE_SEGMENT_HINTS.has(firstSegment) ||
     firstSegment.endsWith('$') ||
-    /^[A-Z][A-Za-z0-9_$-]*$/.test(rawFirstSegment)
+    (/^[A-Z][A-Za-z0-9_$-]*$/.test(rawFirstSegment) && /\d/.test(hostHint))
   if (firstLooksShareLike) {
     return false
   }
@@ -360,6 +360,9 @@ function looksLikeLiteralSchemeSuffix(suffix: string): boolean {
   const lastExtension = lastExtensionIndex >= 0 ? lastSegment.slice(lastExtensionIndex + 1).toLowerCase() : ''
   if (URL_PATH_SEGMENT_HINTS.has(firstSegment) || URL_ASSET_EXTENSIONS.has(lastExtension)) {
     return true
+  }
+  if (hostHint === 'eng' && pathSegments.length >= 2) {
+    return false
   }
 
   if (!lastSegment.includes('.')) {

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -1,0 +1,33 @@
+import { basename, relative, resolve, sep } from 'node:path'
+
+export interface ShareSafePathRoots {
+  artifactRoot: string
+  projectRoot: string
+}
+
+function sameResolvedPath(path: string, root: string): boolean {
+  return resolve(path) === resolve(root)
+}
+
+function isWithinRoot(path: string, root: string): boolean {
+  const resolvedRoot = resolve(root)
+  const resolvedPath = resolve(path)
+  const rootPrefix = resolvedRoot.endsWith(sep) ? resolvedRoot : `${resolvedRoot}${sep}`
+  return resolvedPath.startsWith(rootPrefix)
+}
+
+function toPortableShareSafeSuffix(path: string): string {
+  return path.split(sep).join('/')
+}
+
+export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots): string {
+  if (sameResolvedPath(path, roots.artifactRoot)) return '<artifact-root>'
+  if (isWithinRoot(path, roots.artifactRoot)) {
+    return `<artifact-root>/${toPortableShareSafeSuffix(relative(roots.artifactRoot, path))}`
+  }
+  if (sameResolvedPath(path, roots.projectRoot)) return '<project-root>'
+  if (isWithinRoot(path, roots.projectRoot)) {
+    return `<project-root>/${toPortableShareSafeSuffix(relative(roots.projectRoot, path))}`
+  }
+  return basename(path)
+}

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs'
-import { basename, relative, resolve, sep } from 'node:path'
+import { relative, resolve, sep } from 'node:path'
 
 export interface ShareSafePathRoots {
   artifactRoot: string
@@ -95,16 +95,22 @@ function splitTrailingPathPunctuation(token: string): { path: string; suffix: st
   }
 }
 
+function externalPathFallback(path: string): string {
+  const normalizedPath = path.replaceAll('\\', '/')
+  const lastSegment = normalizedPath.split('/').pop()
+  return lastSegment && lastSegment.length > 0 ? lastSegment : '<external-path>'
+}
+
 export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots): string {
   const rewrittenPath = toShareSafeRootedPath(path, roots)
   if (rewrittenPath !== null) return rewrittenPath
-  return basename(path)
+  return externalPathFallback(path)
 }
 
 export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): string {
   return text.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
     const { path, suffix } = splitTrailingPathPunctuation(token)
     const rewrittenPath = toShareSafeRootedPath(path, roots)
-    return rewrittenPath === null ? token : `${rewrittenPath}${suffix}`
+    return rewrittenPath === null ? `${externalPathFallback(path)}${suffix}` : `${rewrittenPath}${suffix}`
   })
 }

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -6,8 +6,14 @@ export interface ShareSafePathRoots {
   projectRoot: string
 }
 
-const ABSOLUTE_PATH_TOKEN_PATTERN = /(?:[A-Za-z]:[\\/]|\/)[^\s"'`<>]+/g
+const URL_TOKEN_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'`<>]+/gi
+const PATH_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+(?: [^\s"'<>\\/]+)*`
+const ABSOLUTE_PATH_TOKEN_PATTERN = new RegExp(
+  String.raw`(?:[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
+  'g',
+)
 const TRAILING_PATH_PUNCTUATION = new Set([',', '.', ':', ';', ')', ']', '}'])
+const URL_PLACEHOLDER_PREFIX = '__GRAPHIFY_SHARE_SAFE_URL__'
 
 function sameResolvedPath(path: string, root: string): boolean {
   return resolve(path) === resolve(root)
@@ -108,9 +114,20 @@ export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots)
 }
 
 export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): string {
-  return text.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
+  const urls: string[] = []
+  const protectedText = text.replace(URL_TOKEN_PATTERN, (url) => {
+    const placeholder = `${URL_PLACEHOLDER_PREFIX}${urls.length}__`
+    urls.push(url)
+    return placeholder
+  })
+
+  const sanitizedText = protectedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
     const { path, suffix } = splitTrailingPathPunctuation(token)
     const rewrittenPath = toShareSafeRootedPath(path, roots)
     return rewrittenPath === null ? `${externalPathFallback(path)}${suffix}` : `${rewrittenPath}${suffix}`
+  })
+
+  return sanitizedText.replace(new RegExp(`${URL_PLACEHOLDER_PREFIX}(\\d+)__`, 'g'), (_placeholder, index) => {
+    return urls[Number(index)] ?? ''
   })
 }

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -8,12 +8,13 @@ export interface ShareSafePathRoots {
 
 const URL_TOKEN_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'`<>]+/gi
 const PATH_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+(?: [^\s"'<>\\/]+)*`
+const RELATIVE_TRAVERSAL_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+`
 const ABSOLUTE_PATH_TOKEN_PATTERN = new RegExp(
-  String.raw`(?:[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
+  String.raw`(?<!<artifact-root>)(?<!<project-root>)(?:[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
   'g',
 )
 const RELATIVE_TRAVERSAL_TOKEN_PATTERN = new RegExp(
-  String.raw`(?:\.\.[\\/]+)+(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?`,
+  String.raw`(?:\.\.[\\/]+)+(?:${RELATIVE_TRAVERSAL_SEGMENT_PATTERN}(?:[\\/]+${RELATIVE_TRAVERSAL_SEGMENT_PATTERN})*)?`,
   'g',
 )
 const TRAILING_PATH_PUNCTUATION = new Set([',', '.', ':', ';', ')', ']', '}'])
@@ -111,6 +112,20 @@ function externalPathFallback(path: string): string {
   return lastSegment && lastSegment.length > 0 ? lastSegment : '<external-path>'
 }
 
+function isWithinShareSafeRootedToken(text: string, offset: number): boolean {
+  const boundary = Math.max(
+    text.lastIndexOf(' ', offset - 1),
+    text.lastIndexOf('\n', offset - 1),
+    text.lastIndexOf('\r', offset - 1),
+    text.lastIndexOf('\t', offset - 1),
+    text.lastIndexOf('"', offset - 1),
+    text.lastIndexOf("'", offset - 1),
+    text.lastIndexOf('`', offset - 1),
+  )
+  const tokenPrefix = text.slice(boundary + 1, offset)
+  return tokenPrefix.includes('<artifact-root>') || tokenPrefix.includes('<project-root>')
+}
+
 export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots): string {
   const rewrittenPath = toShareSafeRootedPath(path, roots)
   if (rewrittenPath !== null) return rewrittenPath
@@ -141,7 +156,10 @@ export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): 
     return `${sanitizeRelativeTraversalPath(path, roots)}${suffix}`
   })
 
-  const sanitizedText = traversalSanitizedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
+  const sanitizedText = traversalSanitizedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token, offset, source) => {
+    if (isWithinShareSafeRootedToken(source, offset)) {
+      return token
+    }
     const { path, suffix } = splitTrailingPathPunctuation(token)
     const rewrittenPath = toShareSafeRootedPath(path, roots)
     return rewrittenPath === null ? `${externalPathFallback(path)}${suffix}` : `${rewrittenPath}${suffix}`

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -8,7 +8,7 @@ export interface ShareSafePathRoots {
 
 const URL_TOKEN_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'`<>]+/gi
 const PATH_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+(?: [^\s"'<>\\/]+)*`
-const RELATIVE_TRAVERSAL_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+`
+const RELATIVE_TRAVERSAL_SEGMENT_PATTERN = PATH_SEGMENT_PATTERN
 const ABSOLUTE_PATH_TOKEN_PATTERN = new RegExp(
   String.raw`(?<!<artifact-root>)(?<!<project-root>)(?:[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
   'g',
@@ -114,7 +114,6 @@ function externalPathFallback(path: string): string {
 
 function isWithinShareSafeRootedToken(text: string, offset: number): boolean {
   const boundary = Math.max(
-    text.lastIndexOf(' ', offset - 1),
     text.lastIndexOf('\n', offset - 1),
     text.lastIndexOf('\r', offset - 1),
     text.lastIndexOf('\t', offset - 1),
@@ -123,7 +122,9 @@ function isWithinShareSafeRootedToken(text: string, offset: number): boolean {
     text.lastIndexOf('`', offset - 1),
   )
   const tokenPrefix = text.slice(boundary + 1, offset)
-  return tokenPrefix.includes('<artifact-root>') || tokenPrefix.includes('<project-root>')
+  const placeholderIndex = Math.max(tokenPrefix.lastIndexOf('<artifact-root>'), tokenPrefix.lastIndexOf('<project-root>'))
+  if (placeholderIndex < 0) return false
+  return /^<(?:artifact-root|project-root)>(?:\/[^"'`<>\r\n\t]*)?$/.test(tokenPrefix.slice(placeholderIndex))
 }
 
 export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots): string {
@@ -132,7 +133,7 @@ export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots)
   return externalPathFallback(path)
 }
 
-function sanitizeRelativeTraversalPath(path: string, roots: ShareSafePathRoots): string {
+function resolveRelativeTraversalPath(path: string, roots: ShareSafePathRoots): string | null {
   for (const candidate of [resolve(roots.projectRoot, path), resolve(roots.artifactRoot, path)]) {
     if (!existsSync(candidate)) continue
 
@@ -140,7 +141,36 @@ function sanitizeRelativeTraversalPath(path: string, roots: ShareSafePathRoots):
     if (rewrittenPath !== null) return rewrittenPath
   }
 
+  return null
+}
+
+function sanitizeRelativeTraversalPath(path: string, roots: ShareSafePathRoots): string {
+  const rewrittenPath = resolveRelativeTraversalPath(path, roots)
+  if (rewrittenPath !== null) return rewrittenPath
   return externalPathFallback(path)
+}
+
+function sanitizeRelativeTraversalToken(token: string, roots: ShareSafePathRoots): string {
+  const { path, suffix } = splitTrailingPathPunctuation(token)
+  const rewrittenPath = resolveRelativeTraversalPath(path, roots)
+  if (rewrittenPath !== null) return `${rewrittenPath}${suffix}`
+
+  let matchedPrefix = ''
+  let matchedRewrite: string | null = null
+  for (let index = 0; index < path.length; index += 1) {
+    if (path[index] !== ' ') continue
+    const candidatePath = path.slice(0, index)
+    const candidateRewrite = resolveRelativeTraversalPath(candidatePath, roots)
+    if (candidateRewrite === null) continue
+    matchedPrefix = candidatePath
+    matchedRewrite = candidateRewrite
+  }
+
+  if (matchedRewrite !== null) {
+    return `${matchedRewrite}${path.slice(matchedPrefix.length)}${suffix}`
+  }
+
+  return `${sanitizeRelativeTraversalPath(path, roots)}${suffix}`
 }
 
 export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): string {
@@ -151,10 +181,9 @@ export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): 
     return placeholder
   })
 
-  const traversalSanitizedText = protectedText.replace(RELATIVE_TRAVERSAL_TOKEN_PATTERN, (token) => {
-    const { path, suffix } = splitTrailingPathPunctuation(token)
-    return `${sanitizeRelativeTraversalPath(path, roots)}${suffix}`
-  })
+  const traversalSanitizedText = protectedText.replace(RELATIVE_TRAVERSAL_TOKEN_PATTERN, (token) =>
+    sanitizeRelativeTraversalToken(token, roots),
+  )
 
   const sanitizedText = traversalSanitizedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token, offset, source) => {
     if (isWithinShareSafeRootedToken(source, offset)) {

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -1,9 +1,13 @@
+import { realpathSync } from 'node:fs'
 import { basename, relative, resolve, sep } from 'node:path'
 
 export interface ShareSafePathRoots {
   artifactRoot: string
   projectRoot: string
 }
+
+const ABSOLUTE_PATH_TOKEN_PATTERN = /(?:[A-Za-z]:[\\/]|\/)[^\s"'`<>]+/g
+const TRAILING_PATH_PUNCTUATION = new Set([',', '.', ':', ';', ')', ']', '}'])
 
 function sameResolvedPath(path: string, root: string): boolean {
   return resolve(path) === resolve(root)
@@ -20,14 +24,87 @@ function toPortableShareSafeSuffix(path: string): string {
   return path.split(sep).join('/')
 }
 
+function addPathAlias(path: string, aliases: Set<string>): void {
+  aliases.add(resolve(path))
+  if (path.startsWith('/private/')) {
+    aliases.add(path.slice('/private'.length))
+  } else if (path.startsWith('/var/')) {
+    aliases.add(`/private${path}`)
+  }
+
+  try {
+    const realPath = realpathSync(path)
+    aliases.add(realPath)
+    if (realPath.startsWith('/private/')) {
+      aliases.add(realPath.slice('/private'.length))
+    } else if (realPath.startsWith('/var/')) {
+      aliases.add(`/private${realPath}`)
+    }
+  } catch {
+    // Ignore paths that do not exist when building aliases.
+  }
+}
+
+function rootAliases(root: string): string[] {
+  const aliases = new Set<string>()
+  addPathAlias(root, aliases)
+  return [...aliases].sort((left, right) => right.length - left.length)
+}
+
+function replaceRootPrefix(path: string, root: string, placeholder: '<artifact-root>' | '<project-root>'): string | null {
+  if (path === root) {
+    return placeholder
+  }
+
+  const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`
+  if (!path.startsWith(rootPrefix)) {
+    return null
+  }
+
+  return `${placeholder}/${toPortableShareSafeSuffix(path.slice(rootPrefix.length))}`
+}
+
+function toShareSafeRootedPath(path: string, roots: ShareSafePathRoots): string | null {
+  if (sameResolvedPath(path, roots.artifactRoot) || isWithinRoot(path, roots.artifactRoot)) {
+    return replaceRootPrefix(resolve(path), resolve(roots.artifactRoot), '<artifact-root>') ?? '<artifact-root>'
+  }
+  for (const alias of rootAliases(roots.artifactRoot)) {
+    const replaced = replaceRootPrefix(path, alias, '<artifact-root>')
+    if (replaced !== null) return replaced
+  }
+
+  if (sameResolvedPath(path, roots.projectRoot) || isWithinRoot(path, roots.projectRoot)) {
+    return replaceRootPrefix(resolve(path), resolve(roots.projectRoot), '<project-root>') ?? '<project-root>'
+  }
+  for (const alias of rootAliases(roots.projectRoot)) {
+    const replaced = replaceRootPrefix(path, alias, '<project-root>')
+    if (replaced !== null) return replaced
+  }
+
+  return null
+}
+
+function splitTrailingPathPunctuation(token: string): { path: string; suffix: string } {
+  let end = token.length
+  while (end > 0 && TRAILING_PATH_PUNCTUATION.has(token[end - 1] ?? '')) {
+    end -= 1
+  }
+  return {
+    path: token.slice(0, end),
+    suffix: token.slice(end),
+  }
+}
+
 export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots): string {
-  if (sameResolvedPath(path, roots.artifactRoot)) return '<artifact-root>'
-  if (isWithinRoot(path, roots.artifactRoot)) {
-    return `<artifact-root>/${toPortableShareSafeSuffix(relative(roots.artifactRoot, path))}`
-  }
-  if (sameResolvedPath(path, roots.projectRoot)) return '<project-root>'
-  if (isWithinRoot(path, roots.projectRoot)) {
-    return `<project-root>/${toPortableShareSafeSuffix(relative(roots.projectRoot, path))}`
-  }
+  const rewrittenPath = toShareSafeRootedPath(path, roots)
+  if (rewrittenPath !== null) return rewrittenPath
   return basename(path)
+}
+
+export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): string {
+  return text.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
+    const { path, suffix } = splitTrailingPathPunctuation(token)
+    const rewrittenPath = toShareSafeRootedPath(path, roots)
+    return rewrittenPath === null ? token : `${rewrittenPath}${suffix}`
+  })
 }

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import { relative, resolve, sep } from 'node:path'
 
 export interface ShareSafePathRoots {
@@ -10,6 +10,10 @@ const URL_TOKEN_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'`<>]+/gi
 const PATH_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+(?: [^\s"'<>\\/]+)*`
 const ABSOLUTE_PATH_TOKEN_PATTERN = new RegExp(
   String.raw`(?:[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
+  'g',
+)
+const RELATIVE_TRAVERSAL_TOKEN_PATTERN = new RegExp(
+  String.raw`(?:\.\.[\\/]+)+(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?`,
   'g',
 )
 const TRAILING_PATH_PUNCTUATION = new Set([',', '.', ':', ';', ')', ']', '}'])
@@ -113,6 +117,17 @@ export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots)
   return externalPathFallback(path)
 }
 
+function sanitizeRelativeTraversalPath(path: string, roots: ShareSafePathRoots): string {
+  for (const candidate of [resolve(roots.projectRoot, path), resolve(roots.artifactRoot, path)]) {
+    if (!existsSync(candidate)) continue
+
+    const rewrittenPath = toShareSafeRootedPath(candidate, roots)
+    if (rewrittenPath !== null) return rewrittenPath
+  }
+
+  return externalPathFallback(path)
+}
+
 export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): string {
   const urls: string[] = []
   const protectedText = text.replace(URL_TOKEN_PATTERN, (url) => {
@@ -121,7 +136,12 @@ export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): 
     return placeholder
   })
 
-  const sanitizedText = protectedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
+  const traversalSanitizedText = protectedText.replace(RELATIVE_TRAVERSAL_TOKEN_PATTERN, (token) => {
+    const { path, suffix } = splitTrailingPathPunctuation(token)
+    return `${sanitizeRelativeTraversalPath(path, roots)}${suffix}`
+  })
+
+  const sanitizedText = traversalSanitizedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token) => {
     const { path, suffix } = splitTrailingPathPunctuation(token)
     const rewrittenPath = toShareSafeRootedPath(path, roots)
     return rewrittenPath === null ? `${externalPathFallback(path)}${suffix}` : `${rewrittenPath}${suffix}`

--- a/src/shared/share-safe-artifacts.ts
+++ b/src/shared/share-safe-artifacts.ts
@@ -6,11 +6,31 @@ export interface ShareSafePathRoots {
   projectRoot: string
 }
 
-const URL_TOKEN_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'`<>]+/gi
+const URL_TOKEN_PATTERN = /(?<![A-Za-z0-9+./-])[a-z][a-z0-9+.-]*:\/\/[^\s"'`<>]+/gi
+const FILE_URL_TOKEN_PATTERN = /file:\/\/[^\s"'`<>]+/gi
+const ROOTED_LITERAL_SCHEME_SUFFIX_PATTERN = /(?:<artifact-root>|<project-root>)[^\n\r\t"'`<]*?:\/\/[^\s"'`<>]+/g
+const PROTOCOL_RELATIVE_URL_TOKEN_PATTERN = /(?<!:)\/\/[^\s"'`<>]+/g
 const PATH_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/]+(?: [^\s"'<>\\/]+)*`
-const RELATIVE_TRAVERSAL_SEGMENT_PATTERN = PATH_SEGMENT_PATTERN
+const ATTACHED_PATH_SEGMENT_PATTERN = String.raw`[^\s"'<>\\/,;:]+(?: [^\s"'<>\\/,;:]+)*`
+const RELATIVE_TRAVERSAL_SEGMENT_PATTERN = ATTACHED_PATH_SEGMENT_PATTERN
+const WINDOWS_DRIVE_PATH_PATTERN = String.raw`[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?`
+const WINDOWS_UNC_PATH_PATTERN = String.raw`\\\\${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})+`
+const ATTACHED_WINDOWS_DRIVE_PATH_PATTERN = String.raw`[A-Za-z]:[\\/](?:${ATTACHED_PATH_SEGMENT_PATTERN}(?:[\\/]+${ATTACHED_PATH_SEGMENT_PATTERN})*)?`
+const ATTACHED_WINDOWS_UNC_PATH_PATTERN = String.raw`\\\\${ATTACHED_PATH_SEGMENT_PATTERN}(?:[\\/]+${ATTACHED_PATH_SEGMENT_PATTERN})+`
 const ABSOLUTE_PATH_TOKEN_PATTERN = new RegExp(
-  String.raw`(?<!<artifact-root>)(?<!<project-root>)(?:[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
+  String.raw`(?<!<artifact-root>)(?<!<project-root>)(?:${WINDOWS_DRIVE_PATH_PATTERN}|${WINDOWS_UNC_PATH_PATTERN}|\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
+  'g',
+)
+const PUNCTUATION_ATTACHED_WINDOWS_PATH_PATTERN = new RegExp(
+  String.raw`([,:;])(${ATTACHED_WINDOWS_DRIVE_PATH_PATTERN}|${ATTACHED_WINDOWS_UNC_PATH_PATTERN})`,
+  'g',
+)
+const PUNCTUATION_ATTACHED_UNIX_PATH_PATTERN = new RegExp(
+  String.raw`(?<!\b[A-Za-z])([,:;])(\/(?:${ATTACHED_PATH_SEGMENT_PATTERN}(?:[\\/]+${ATTACHED_PATH_SEGMENT_PATTERN})*)?)`,
+  'g',
+)
+const RESTARTED_ABSOLUTE_PATH_PATTERN = new RegExp(
+  String.raw`(?:\/\/(?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?|\/[A-Za-z]:[\\/](?:${PATH_SEGMENT_PATTERN}(?:[\\/]+${PATH_SEGMENT_PATTERN})*)?)`,
   'g',
 )
 const RELATIVE_TRAVERSAL_TOKEN_PATTERN = new RegExp(
@@ -18,6 +38,10 @@ const RELATIVE_TRAVERSAL_TOKEN_PATTERN = new RegExp(
   'g',
 )
 const TRAILING_PATH_PUNCTUATION = new Set([',', '.', ':', ';', ')', ']', '}'])
+const WINDOWS_SHARE_SEGMENT_HINTS = new Set(['share', 'shares', 'users', 'homes', 'public', 'private', 'admin$', 'ipc$', 'print$'])
+const SHARE_HOST_HINTS = new Set(['server', 'servers', 'file', 'files', 'nas', 'smb', 'share', 'storage', 'internal', 'intranet', 'corp'])
+const URL_PATH_SEGMENT_HINTS = new Set(['assets', 'static', 'scripts', 'styles', 'images', 'img', 'fonts', 'media', 'docs', 'doc', 'api', 'blog'])
+const URL_ASSET_EXTENSIONS = new Set(['js', 'mjs', 'cjs', 'css', 'map', 'json', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'woff', 'woff2', 'ttf', 'eot', 'html', 'htm', 'pdf', 'xml'])
 const URL_PLACEHOLDER_PREFIX = '__GRAPHIFY_SHARE_SAFE_URL__'
 
 function sameResolvedPath(path: string, root: string): boolean {
@@ -112,19 +136,142 @@ function externalPathFallback(path: string): string {
   return lastSegment && lastSegment.length > 0 ? lastSegment : '<external-path>'
 }
 
-function isWithinShareSafeRootedToken(text: string, offset: number): boolean {
-  const boundary = Math.max(
-    text.lastIndexOf('\n', offset - 1),
-    text.lastIndexOf('\r', offset - 1),
-    text.lastIndexOf('\t', offset - 1),
-    text.lastIndexOf('"', offset - 1),
-    text.lastIndexOf("'", offset - 1),
-    text.lastIndexOf('`', offset - 1),
+function candidatePathPrefixEnds(path: string): number[] {
+  const ends = new Set<number>([path.length])
+  for (let index = 0; index < path.length; index += 1) {
+    const char = path[index]
+    if (char === ' ' || TRAILING_PATH_PUNCTUATION.has(char ?? '')) {
+      ends.add(index)
+    }
+    if (char === ':' && (path[index + 1] === '/' || /^[A-Za-z]:[\\/]/.test(path.slice(index + 1)))) {
+      ends.add(index)
+    }
+    if ((char === '/' || char === '\\') && (path[index + 1] === char || /^[A-Za-z]:[\\/]/.test(path.slice(index + 1)))) {
+      ends.add(index)
+    }
+  }
+  return [...ends].sort((left, right) => right - left)
+}
+
+function findBestResolvedPrefix(
+  path: string,
+  resolvePrefix: (candidate: string) => string | null,
+): { prefix: string; rewrite: string } | null {
+  for (const end of candidatePathPrefixEnds(path)) {
+    const candidate = path.slice(0, end)
+    const rewrite = resolvePrefix(candidate)
+    if (rewrite !== null) {
+      return { prefix: candidate, rewrite }
+    }
+  }
+  return null
+}
+
+function resolveShareSafePlaceholderPrefix(
+  path: string,
+  root: string,
+  placeholder: '<artifact-root>' | '<project-root>',
+): string | null {
+  if (!path.startsWith('/')) {
+    return null
+  }
+
+  const normalizedPath = path.replaceAll('\\', '/')
+  if (
+    normalizedPath.includes('//') ||
+    /\/[A-Za-z]:\//.test(normalizedPath) ||
+    /:(?:\/|[A-Za-z]:\/)/.test(normalizedPath)
+  ) {
+    return null
+  }
+
+  const resolvedPath = resolve(root, path.slice(1))
+  const rewrittenPath = replaceRootPrefix(resolvedPath, resolve(root), placeholder)
+  if (rewrittenPath === null) {
+    return null
+  }
+
+  if (existsSync(resolvedPath) || !path.includes(' ') || looksLikeShareSafeMissingPath(path)) {
+    return rewrittenPath
+  }
+
+  return null
+}
+
+function looksLikeShareSafeMissingPath(path: string): boolean {
+  if (!path.startsWith('/')) {
+    return false
+  }
+
+  const normalizedPath = path.slice(1).replaceAll('\\', '/')
+  if (!normalizedPath.includes('/')) {
+    return false
+  }
+
+  for (let index = 0; index < path.length; index += 1) {
+    if (path[index] !== ' ') {
+      continue
+    }
+
+    const nextSeparator = path.slice(index + 1).search(/[\\/]/)
+    const nextSeparatorIndex = nextSeparator < 0 ? -1 : index + 1 + nextSeparator
+
+    if (nextSeparatorIndex >= 0) {
+      const segmentBeforeSeparator = path.slice(index + 1, nextSeparatorIndex)
+      if (
+        segmentBeforeSeparator.trim().length === 0 ||
+        segmentBeforeSeparator.endsWith(' ') ||
+        [...TRAILING_PATH_PUNCTUATION].some((punctuation) => segmentBeforeSeparator.includes(punctuation))
+      ) {
+        return false
+      }
+      continue
+    }
+
+    const segmentAfterSpace = path.slice(index + 1)
+    if (segmentAfterSpace.length === 0) {
+      return false
+    }
+
+    if (!segmentAfterSpace.includes('.')) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function shareSafeRootedTokenEnd(text: string, offset: number, roots: ShareSafePathRoots): number | null {
+  const artifactIndex = text.lastIndexOf('<artifact-root>', offset)
+  const projectIndex = text.lastIndexOf('<project-root>', offset)
+  const placeholderIndex = Math.max(artifactIndex, projectIndex)
+  if (placeholderIndex < 0) {
+    return null
+  }
+
+  const placeholder = artifactIndex > projectIndex ? '<artifact-root>' : '<project-root>'
+  const root = placeholder === '<artifact-root>' ? roots.artifactRoot : roots.projectRoot
+  const start = placeholderIndex + placeholder.length
+  const hardBoundaryIndexes = [
+    text.indexOf('\n', start),
+    text.indexOf('\r', start),
+    text.indexOf('\t', start),
+    text.indexOf('"', start),
+    text.indexOf("'", start),
+    text.indexOf('`', start),
+    text.indexOf('<', start),
+  ].filter((index) => index >= 0)
+  const hardBoundary = hardBoundaryIndexes.length === 0 ? text.length : Math.min(...hardBoundaryIndexes)
+  const pathTail = text.slice(start, hardBoundary)
+  const bestPrefix = findBestResolvedPrefix(pathTail, (candidate) =>
+    resolveShareSafePlaceholderPrefix(candidate, root, placeholder),
   )
-  const tokenPrefix = text.slice(boundary + 1, offset)
-  const placeholderIndex = Math.max(tokenPrefix.lastIndexOf('<artifact-root>'), tokenPrefix.lastIndexOf('<project-root>'))
-  if (placeholderIndex < 0) return false
-  return /^<(?:artifact-root|project-root)>(?:\/[^"'`<>\r\n\t]*)?$/.test(tokenPrefix.slice(placeholderIndex))
+  if (bestPrefix === null) {
+    return null
+  }
+
+  const tokenEnd = start + bestPrefix.prefix.length
+  return offset >= start && offset < tokenEnd ? tokenEnd : null
 }
 
 export function toShareSafeArtifactPath(path: string, roots: ShareSafePathRoots): string {
@@ -152,30 +299,101 @@ function sanitizeRelativeTraversalPath(path: string, roots: ShareSafePathRoots):
 
 function sanitizeRelativeTraversalToken(token: string, roots: ShareSafePathRoots): string {
   const { path, suffix } = splitTrailingPathPunctuation(token)
-  const rewrittenPath = resolveRelativeTraversalPath(path, roots)
-  if (rewrittenPath !== null) return `${rewrittenPath}${suffix}`
-
-  let matchedPrefix = ''
-  let matchedRewrite: string | null = null
-  for (let index = 0; index < path.length; index += 1) {
-    if (path[index] !== ' ') continue
-    const candidatePath = path.slice(0, index)
-    const candidateRewrite = resolveRelativeTraversalPath(candidatePath, roots)
-    if (candidateRewrite === null) continue
-    matchedPrefix = candidatePath
-    matchedRewrite = candidateRewrite
-  }
-
-  if (matchedRewrite !== null) {
-    return `${matchedRewrite}${path.slice(matchedPrefix.length)}${suffix}`
+  const bestPrefix = findBestResolvedPrefix(path, (candidate) => resolveRelativeTraversalPath(candidate, roots))
+  if (bestPrefix !== null) {
+    const trailingText = `${path.slice(bestPrefix.prefix.length)}${suffix}`
+    return trailingText.length === 0 ? bestPrefix.rewrite : `${bestPrefix.rewrite}${sanitizeShareSafeText(trailingText, roots)}`
   }
 
   return `${sanitizeRelativeTraversalPath(path, roots)}${suffix}`
 }
 
+function sanitizeFileUrl(url: string, roots: ShareSafePathRoots): string {
+  let path = url.slice('file://'.length)
+  if (path.startsWith('localhost/')) {
+    path = path.slice('localhost'.length)
+  }
+  if (path.startsWith('/') && /^[A-Za-z]:[\\/]/.test(path.slice(1))) {
+    path = path.slice(1)
+  }
+  return `file://${toShareSafeArtifactPath(path, roots)}`
+}
+
+function looksLikeProtocolRelativeUrl(path: string): boolean {
+  if (!path.startsWith('//')) {
+    return false
+  }
+
+  return looksLikeLiteralSchemeSuffix(path.slice(2))
+}
+
+function looksLikeLiteralSchemeSuffix(suffix: string): boolean {
+  const slashIndex = suffix.indexOf('/')
+  const host = slashIndex >= 0 ? suffix.slice(0, slashIndex) : suffix
+  if (!(host === 'localhost' || host.includes('.') || /^[^/]+:\d+$/.test(host))) {
+    return false
+  }
+  const hostHint = host.split(/[.:]/, 1)[0]?.toLowerCase() ?? ''
+  if (SHARE_HOST_HINTS.has(hostHint)) {
+    return false
+  }
+
+  const pathSegments = (slashIndex >= 0 ? suffix.slice(slashIndex + 1) : '')
+    .split('/')
+    .filter((segment) => segment.length > 0)
+  const rawFirstSegment = pathSegments[0] ?? ''
+  const firstSegment = pathSegments[0]?.toLowerCase() ?? ''
+  const firstLooksShareLike =
+    WINDOWS_SHARE_SEGMENT_HINTS.has(firstSegment) ||
+    firstSegment.endsWith('$') ||
+    /^[A-Z][A-Za-z0-9_$-]*$/.test(rawFirstSegment)
+  if (firstLooksShareLike) {
+    return false
+  }
+
+  if (pathSegments.length <= 1) {
+    return true
+  }
+
+  const lastSegment = pathSegments[pathSegments.length - 1] ?? ''
+  const lastExtensionIndex = lastSegment.lastIndexOf('.')
+  const lastExtension = lastExtensionIndex >= 0 ? lastSegment.slice(lastExtensionIndex + 1).toLowerCase() : ''
+  if (URL_PATH_SEGMENT_HINTS.has(firstSegment) || URL_ASSET_EXTENSIONS.has(lastExtension)) {
+    return true
+  }
+
+  if (!lastSegment.includes('.')) {
+    return pathSegments.length >= 2
+  }
+  return false
+}
+
 export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): string {
   const urls: string[] = []
-  const protectedText = text.replace(URL_TOKEN_PATTERN, (url) => {
+  const fileProtectedText = text.replace(FILE_URL_TOKEN_PATTERN, (url) => {
+    const placeholder = `${URL_PLACEHOLDER_PREFIX}${urls.length}__`
+    urls.push(sanitizeFileUrl(url, roots))
+    return placeholder
+  })
+  const rootedSuffixProtectedText = fileProtectedText.replace(ROOTED_LITERAL_SCHEME_SUFFIX_PATTERN, (value) => {
+    const schemeIndex = value.indexOf('://')
+    const suffix = schemeIndex >= 0 ? value.slice(schemeIndex + 3) : ''
+    if (!looksLikeLiteralSchemeSuffix(suffix)) {
+      return value
+    }
+    const placeholder = `${URL_PLACEHOLDER_PREFIX}${urls.length}__`
+    urls.push(value)
+    return placeholder
+  })
+  const schemeProtectedText = rootedSuffixProtectedText.replace(URL_TOKEN_PATTERN, (url) => {
+    const placeholder = `${URL_PLACEHOLDER_PREFIX}${urls.length}__`
+    urls.push(url)
+    return placeholder
+  })
+  const protectedText = schemeProtectedText.replace(PROTOCOL_RELATIVE_URL_TOKEN_PATTERN, (url) => {
+    if (!looksLikeProtocolRelativeUrl(url)) {
+      return url
+    }
     const placeholder = `${URL_PLACEHOLDER_PREFIX}${urls.length}__`
     urls.push(url)
     return placeholder
@@ -184,10 +402,40 @@ export function sanitizeShareSafeText(text: string, roots: ShareSafePathRoots): 
   const traversalSanitizedText = protectedText.replace(RELATIVE_TRAVERSAL_TOKEN_PATTERN, (token) =>
     sanitizeRelativeTraversalToken(token, roots),
   )
+  const unixSanitizedText = traversalSanitizedText.replace(
+    PUNCTUATION_ATTACHED_UNIX_PATH_PATTERN,
+    (_match, punctuation: string, path: string) => `${punctuation}${toShareSafeArtifactPath(path, roots)}`,
+  )
+  const windowsSanitizedText = unixSanitizedText.replace(
+    PUNCTUATION_ATTACHED_WINDOWS_PATH_PATTERN,
+    (_match, punctuation: string, path: string) => `${punctuation}${toShareSafeArtifactPath(path, roots)}`,
+  )
+  const restartedPathSanitizedText = windowsSanitizedText.replace(
+    RESTARTED_ABSOLUTE_PATH_PATTERN,
+    (match) => (looksLikeProtocolRelativeUrl(match) ? match : `/${toShareSafeArtifactPath(match.slice(1), roots)}`),
+  )
 
-  const sanitizedText = traversalSanitizedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token, offset, source) => {
-    if (isWithinShareSafeRootedToken(source, offset)) {
-      return token
+  const sanitizedText = restartedPathSanitizedText.replace(ABSOLUTE_PATH_TOKEN_PATTERN, (token, offset, source) => {
+    const rootedTokenEnd = shareSafeRootedTokenEnd(source, offset, roots)
+    if (rootedTokenEnd !== null) {
+      const protectedLength = rootedTokenEnd - offset
+      let protectedPrefix = token.slice(0, protectedLength)
+      let trailingSuffix = token.slice(protectedLength)
+      if (trailingSuffix.startsWith('://') && looksLikeLiteralSchemeSuffix(trailingSuffix.slice(3))) {
+        return `${protectedPrefix}${trailingSuffix}`
+      }
+      if (protectedPrefix.endsWith(':') && looksLikeProtocolRelativeUrl(trailingSuffix)) {
+        return `${protectedPrefix}${trailingSuffix}`
+      }
+      if (/^[\\/]/.test(trailingSuffix) && /[A-Za-z]:$/.test(protectedPrefix)) {
+        protectedPrefix = protectedPrefix.slice(0, -2)
+        trailingSuffix = `${token.slice(protectedLength - 2, protectedLength)}${trailingSuffix}`
+      }
+      if (trailingSuffix.startsWith('//') || /^\/[A-Za-z]:[\\/]/.test(trailingSuffix)) {
+        protectedPrefix = `${protectedPrefix}/`
+        trailingSuffix = trailingSuffix.slice(1)
+      }
+      return trailingSuffix.length === 0 ? protectedPrefix : `${protectedPrefix}${sanitizeShareSafeText(trailingSuffix, roots)}`
     }
     const { path, suffix } = splitTrailingPathPunctuation(token)
     const rewrittenPath = toShareSafeRootedPath(path, roots)

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -544,7 +544,15 @@ describe('runBenchmark', () => {
 
       const run = benchmark.per_question[0]
       expect(run?.artifacts).toBeDefined()
-      const shareSafePath = join(dirname(run!.artifacts!.report), 'report.share-safe.json')
+      expect(run?.artifacts).toEqual(
+        expect.objectContaining({
+          prompt: executions[0]!.promptFile,
+          answer: executions[0]!.outputFile,
+          report: join(dirname(executions[0]!.promptFile), 'report.json'),
+          share_safe_report: join(dirname(executions[0]!.promptFile), 'report.share-safe.json'),
+        }),
+      )
+      const shareSafePath = run!.artifacts!.share_safe_report
       const shareSafeReport = JSON.parse(readFileSync(shareSafePath, 'utf8')) as Record<string, unknown>
 
       expect(shareSafeReport).toEqual(
@@ -553,7 +561,8 @@ describe('runBenchmark', () => {
           artifacts: expect.objectContaining({
             prompt: '<artifact-root>/graphify-prompt.txt',
             answer: '<artifact-root>/graphify-answer.txt',
-            report: '<artifact-root>/report.share-safe.json',
+            report: '<artifact-root>/report.json',
+            share_safe_report: '<artifact-root>/report.share-safe.json',
           }),
         }),
       )

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { join, relative, sep } from 'node:path'
+import { dirname, join, relative, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 
 import { describe, expect, test, vi } from 'vitest'
@@ -541,6 +541,22 @@ describe('runBenchmark', () => {
       expect(readFileSync(executions[1]!.promptFile, 'utf8')).not.toContain('Retrieved graph context:')
       expect(readFileSync(executions[0]!.outputFile, 'utf8')).toBe('Answer for how does authentication work\n')
       expect(readFileSync(executions[1]!.outputFile, 'utf8')).toBe('Answer for what is the main entry point\n')
+
+      const run = benchmark.per_question[0]
+      expect(run?.artifacts).toBeDefined()
+      const shareSafePath = join(dirname(run!.artifacts!.report), 'report.share-safe.json')
+      const shareSafeReport = JSON.parse(readFileSync(shareSafePath, 'utf8')) as Record<string, unknown>
+
+      expect(shareSafeReport).toEqual(
+        expect.objectContaining({
+          question: 'how does authentication work',
+          artifacts: expect.objectContaining({
+            prompt: '<artifact-root>/graphify-prompt.txt',
+            answer: '<artifact-root>/graphify-answer.txt',
+            report: '<artifact-root>/report.share-safe.json',
+          }),
+        }),
+      )
 
       expect(benchmark.matched_question_count).toBe(2)
       expect(benchmark.unmatched_questions).toEqual(['xyzzy plugh zorkmid'])

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -552,12 +552,25 @@ describe('runBenchmark', () => {
           share_safe_report: join(dirname(executions[0]!.promptFile), 'report.share-safe.json'),
         }),
       )
+      const localReport = JSON.parse(readFileSync(run!.artifacts!.report, 'utf8')) as Record<string, unknown>
       const shareSafePath = run!.artifacts!.share_safe_report
       const shareSafeReport = JSON.parse(readFileSync(shareSafePath, 'utf8')) as Record<string, unknown>
 
+      expect(localReport).toEqual(
+        expect.objectContaining({
+          question: 'how does authentication work',
+          artifacts: {
+            prompt: relative(process.cwd(), executions[0]!.promptFile),
+            answer: relative(process.cwd(), executions[0]!.outputFile),
+            report: relative(process.cwd(), run!.artifacts!.report),
+          },
+        }),
+      )
+      expect((localReport.artifacts as Record<string, unknown>)?.share_safe_report).toBeUndefined()
       expect(shareSafeReport).toEqual(
         expect.objectContaining({
           question: 'how does authentication work',
+          share_safe_report: true,
           artifacts: expect.objectContaining({
             prompt: '<artifact-root>/graphify-prompt.txt',
             answer: '<artifact-root>/graphify-answer.txt',

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -158,6 +158,7 @@ function buildSummaryResult(overrides: {
         paths: {
           output_dir: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z',
           report: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/report.json',
+          share_safe_report: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/report.share-safe.json',
           baseline_answer: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/baseline.md',
           graphify_answer: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/graphify.md',
           prompt_file: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z/prompt.txt',

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -2148,6 +2148,24 @@ describe('compare runtime', () => {
     ).toBe('//example.com/api/v1/users')
     expect(
       sanitizeShareSafeText(
+        '//api.example.com/v1/users',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//api.example.com/v1/users')
+    expect(
+      sanitizeShareSafeText(
+        '//eng.example.com/api/v1/users',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//eng.example.com/api/v1/users')
+    expect(
+      sanitizeShareSafeText(
+        '//example.com/API/v1/users',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//example.com/API/v1/users')
+    expect(
+      sanitizeShareSafeText(
         'See //example.com/blog/2026/launch for details',
         { artifactRoot, projectRoot },
       ),
@@ -2178,6 +2196,18 @@ describe('compare runtime', () => {
     ).toBe('<project-root>/safe://example.com/docs/getting-started')
     expect(
       sanitizeShareSafeText(
+        '<project-root>/safe://api.example.com/v1/users',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe://api.example.com/v1/users')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://eng.example.com/api/v1/users',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe://eng.example.com/api/v1/users')
+    expect(
+      sanitizeShareSafeText(
         '<project-root>/src/auth.ts://github.com/openai/gpt-5',
         { artifactRoot, projectRoot },
       ),
@@ -2194,6 +2224,12 @@ describe('compare runtime', () => {
         { artifactRoot, projectRoot },
       ),
     ).toBe('//cdn.example.com/assets/app.js')
+    expect(
+      sanitizeShareSafeText(
+        '//img.example.com/a/b',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//img.example.com/a/b')
     expect(
       sanitizeShareSafeText(
         '<project-root>/safe://cdn.example.com/assets/app.js',
@@ -2238,6 +2274,12 @@ describe('compare runtime', () => {
     ).toBe('secret.txt')
     expect(
       sanitizeShareSafeText(
+        '//printer01.example.com/Engineering/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret')
+    expect(
+      sanitizeShareSafeText(
         '//server.example.com/engineering/secret',
         { artifactRoot, projectRoot },
       ),
@@ -2245,6 +2287,12 @@ describe('compare runtime', () => {
     expect(
       sanitizeShareSafeText(
         '//corp.example.com/alice/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret')
+    expect(
+      sanitizeShareSafeText(
+        '//eng.example.com/alice/secret',
         { artifactRoot, projectRoot },
       ),
     ).toBe('secret')
@@ -2275,6 +2323,12 @@ describe('compare runtime', () => {
     expect(
       sanitizeShareSafeText(
         '<project-root>/safe://corp.example.com/alice/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe:<external-path>secret')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://eng.example.com/alice/secret',
         { artifactRoot, projectRoot },
       ),
     ).toBe('<project-root>/safe:<external-path>secret')

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -695,10 +695,14 @@ describe('compare runtime', () => {
     expect(existsSync(report!.paths.baseline_prompt)).toBe(true)
     expect(existsSync(report!.paths.graphify_prompt)).toBe(true)
     expect(existsSync(report!.paths.report)).toBe(true)
+    expect(report?.paths.share_safe_report).toBe(join(report!.paths.output_dir, 'report.share-safe.json'))
+    expect(existsSync(report!.paths.share_safe_report)).toBe(true)
 
     const baselinePrompt = readFileSync(report!.paths.baseline_prompt, 'utf8')
     const graphifyPrompt = readFileSync(report!.paths.graphify_prompt, 'utf8')
     const savedReport = JSON.parse(readFileSync(report!.paths.report, 'utf8')) as Record<string, unknown>
+    const shareSafePath = join(report!.paths.output_dir, 'report.share-safe.json')
+    const shareSafeReport = JSON.parse(readFileSync(shareSafePath, 'utf8')) as Record<string, unknown>
 
     expect(baselinePrompt).toContain('Question:\nhow does login create a session')
     expect(baselinePrompt).toContain('return new SessionManager().createSession(credentials.userId)')
@@ -729,11 +733,22 @@ describe('compare runtime', () => {
           baseline_prompt: join('graphify-out', 'compare', 'test-runtime', '2026-04-24T19-30-00', 'baseline-prompt.txt'),
           graphify_prompt: join('graphify-out', 'compare', 'test-runtime', '2026-04-24T19-30-00', 'graphify-prompt.txt'),
           report: join('graphify-out', 'compare', 'test-runtime', '2026-04-24T19-30-00', 'report.json'),
+          share_safe_report: join('graphify-out', 'compare', 'test-runtime', '2026-04-24T19-30-00', 'report.share-safe.json'),
         },
+      }),
+    )
+    expect(shareSafeReport).toEqual(
+      expect.objectContaining({
+        graph_path: '<project-root>/graphify-out/graph.json',
+        paths: expect.objectContaining({
+          output_dir: '<artifact-root>',
+          report: '<artifact-root>/report.share-safe.json',
+        }),
       }),
     )
     expect(JSON.stringify(savedReport)).not.toContain('super-secret')
     expect(JSON.stringify(savedReport)).not.toContain(execTemplate)
+    expect(JSON.stringify(shareSafeReport)).not.toContain(report!.paths.output_dir)
   })
 
   it('runs compare prompts sequentially and saves answer artifacts', async () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 
 import { strToU8, zipSync } from 'fflate'
 import { vi } from 'vitest'
@@ -1898,6 +1898,76 @@ describe('compare runtime', () => {
         }),
       }),
     )
+  })
+
+  it('sanitizes escaped artifact-root answer path traversals without reclassifying them under the project root', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'src', 'secret.ts')
+    writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
+    const graphPath = writeGraphFixture(graph)
+    const outputTimestamp = '2026-04-24T19-30-00'
+    const questionOutputDir = join(COMPARE_OUTPUT_ROOT, outputTimestamp)
+    const escapedAnswerPath = relative(questionOutputDir, secretPath)
+    const originalCwd = process.cwd()
+
+    vi.resetModules()
+    vi.doMock('node:path', async () => {
+      const actual = await vi.importActual<typeof import('node:path')>('node:path')
+      return {
+        ...actual,
+        join: (...args: string[]) => {
+          if (args[0] === questionOutputDir && args[1] === 'baseline-answer.txt') {
+            return escapedAnswerPath
+          }
+          return actual.join(...args)
+        },
+      }
+    })
+
+    try {
+      const { executeCompareRuns: executeCompareRunsWithForgedAnswerPath } = await import('../../src/infrastructure/compare.js')
+      const result = await executeCompareRunsWithForgedAnswerPath(
+        {
+          graphPath,
+          question: 'how does login create a session',
+          outputDir: COMPARE_OUTPUT_ROOT,
+          execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+          baselineMode: 'full',
+          now: new Date('2026-04-24T19:30:00.000Z'),
+        },
+        {
+          runner: async (execution) => {
+            process.chdir(questionOutputDir)
+            return {
+              exitCode: 0,
+              stdout: `${execution.mode} answer\n`,
+              stderr: '',
+              elapsedMs: 3,
+            }
+          },
+        },
+      )
+
+      const report = result.reports[0]!
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as {
+        answer_paths: {
+          baseline: string
+          graphify: string
+        }
+      }
+
+      expect(report.answer_paths.baseline).toBe(escapedAnswerPath)
+      expect((savedReport.answer_paths as { baseline: string }).baseline).toBe(escapedAnswerPath)
+      expect(shareSafeReport.answer_paths.baseline).toBe('secret.ts')
+      expect(shareSafeReport.answer_paths.baseline).not.toBe('<project-root>/src/secret.ts')
+      expect(JSON.stringify(shareSafeReport)).not.toContain('<project-root>/src/secret.ts')
+    } finally {
+      process.chdir(originalCwd)
+      vi.doUnmock('node:path')
+      vi.resetModules()
+    }
   })
 
   it('loads graphify snippets when compare runs from outside the inferred project root', () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1743,6 +1743,7 @@ describe('compare runtime', () => {
     ).resolves.toContain('no Anthropic usage block')
 
     const report = JSON.parse(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'report.json'), 'utf8')) as Record<string, unknown>
+    const shareSafeReport = JSON.parse(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'report.share-safe.json'), 'utf8')) as Record<string, unknown>
     expect(report).toEqual(
       expect.objectContaining({
         baseline: expect.objectContaining({
@@ -1756,6 +1757,28 @@ describe('compare runtime', () => {
         reductions: null,
       }),
     )
+    expect(shareSafeReport).toEqual(
+      expect.objectContaining({
+        graph_path: '<project-root>/graphify-out/graph.json',
+        paths: expect.objectContaining({
+          output_dir: '<artifact-root>',
+          report: '<artifact-root>/report.json',
+          share_safe_report: '<artifact-root>/report.share-safe.json',
+          baseline_answer: '<artifact-root>/baseline-answer.txt',
+          graphify_answer: '<artifact-root>/graphify-answer.txt',
+          prompt_file: '<artifact-root>/native_agent-prompt.txt',
+        }),
+        baseline: expect.objectContaining({
+          kind: 'answer_only',
+          result_path: '<artifact-root>/baseline-answer.txt',
+        }),
+        graphify: expect.objectContaining({
+          kind: 'answer_only',
+          result_path: '<artifact-root>/graphify-answer.txt',
+        }),
+      }),
+    )
+    expect(JSON.stringify(shareSafeReport)).not.toContain(PROJECT_FIXTURE_ROOT)
     expect(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'baseline-answer.txt'), 'utf8')).toBe('baseline answer\n')
     expect(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'graphify-answer.txt'), 'utf8')).toBe('graphify answer\n')
   })
@@ -1886,14 +1909,18 @@ describe('compare runtime', () => {
     const report = result.reports[0]!
     const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
     const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+    const savedReportEvidence = (savedReport.evidence as Record<string, string | null>).baseline
+    const savedReportStderr = (savedReport.stderr as Record<string, string | null>).graphify
     const shareSafeEvidence = (shareSafeReport.evidence as Record<string, string | null>).baseline
     const shareSafeStderr = (shareSafeReport.stderr as Record<string, string | null>).graphify
 
     expect(report.evidence.baseline).toContain(`${overflowPath} for details`)
     expect(report.stderr.graphify).toContain(`${overflowPath} for details`)
-    expect(JSON.stringify(savedReport)).toContain(`${overflowPath} for details`)
+    expect(savedReportEvidence).toContain(`${overflowPath} for details`)
+    expect(savedReportStderr).toContain(`${overflowPath} for details`)
 
-    expect(JSON.stringify(shareSafeReport)).not.toContain(overflowPath)
+    expect(shareSafeEvidence).not.toContain(overflowPath)
+    expect(shareSafeStderr).not.toContain(overflowPath)
     expect(shareSafeEvidence).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
     expect(shareSafeStderr).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
     expect(shareSafeEvidence).toContain(`${expectedShareSafeSecretPath} for details`)

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1848,9 +1848,14 @@ describe('compare runtime', () => {
   it('sanitizes share-safe compare stderr and evidence paths without changing the local report', async () => {
     const graph = makeGraph()
     writeProjectFiles()
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'src', 'secret.ts')
+    writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
     const graphPath = writeGraphFixture(graph)
-    const overflowPath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'overflow.log')
-    const execErrorPath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'runner-error.log')
+    const outputTimestamp = '2026-04-24T19-30-00'
+    const questionOutputDir = join(COMPARE_OUTPUT_ROOT, outputTimestamp)
+    const overflowPath = relative(questionOutputDir, secretPath)
+    const execErrorTargetPath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'runner-error.log')
+    const execErrorPath = relative(PROJECT_FIXTURE_ROOT, execErrorTargetPath)
 
     const result = await executeCompareRuns(
       {
@@ -1880,6 +1885,8 @@ describe('compare runtime', () => {
     const report = result.reports[0]!
     const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
     const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+    const shareSafeEvidence = (shareSafeReport.evidence as Record<string, string | null>).baseline
+    const shareSafeStderr = (shareSafeReport.stderr as Record<string, string | null>).graphify
 
     expect(report.evidence.baseline).toContain(overflowPath)
     expect(report.stderr.graphify).toContain(execErrorPath)
@@ -1888,10 +1895,12 @@ describe('compare runtime', () => {
 
     expect(JSON.stringify(shareSafeReport)).not.toContain(overflowPath)
     expect(JSON.stringify(shareSafeReport)).not.toContain(execErrorPath)
+    expect(shareSafeEvidence).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
+    expect(shareSafeStderr).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
     expect(shareSafeReport).toEqual(
       expect.objectContaining({
         evidence: expect.objectContaining({
-          baseline: expect.stringContaining('overflow.log'),
+          baseline: expect.stringContaining('secret.ts'),
         }),
         stderr: expect.objectContaining({
           graphify: expect.stringContaining('runner-error.log'),

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -596,7 +596,7 @@ describe('compare runtime', () => {
     )
   })
 
-  it('sanitizes pack_only source_file paths in share-safe compare reports', () => {
+  it('preserves repo-relative pack_only source_file paths while sanitizing absolute ones in share-safe compare reports', () => {
     const graph = makeGraph()
     writeProjectFiles()
     const graphPath = writeGraphFixture(graph)
@@ -632,6 +632,10 @@ describe('compare runtime', () => {
             label: 'authenticateUser',
             source_file: outsideSourcePath,
           }),
+          expect.objectContaining({
+            label: 'SessionManager',
+            source_file: 'src/session.ts',
+          }),
         ]),
       )
       expect(shareSafePack.matched_nodes).toEqual(
@@ -639,6 +643,10 @@ describe('compare runtime', () => {
           expect.objectContaining({
             label: 'authenticateUser',
             source_file: 'auth.ts',
+          }),
+          expect.objectContaining({
+            label: 'SessionManager',
+            source_file: 'src/session.ts',
           }),
         ]),
       )

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1854,8 +1854,7 @@ describe('compare runtime', () => {
     const outputTimestamp = '2026-04-24T19-30-00'
     const questionOutputDir = join(COMPARE_OUTPUT_ROOT, outputTimestamp)
     const overflowPath = relative(questionOutputDir, secretPath)
-    const execErrorTargetPath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'runner-error.log')
-    const execErrorPath = relative(PROJECT_FIXTURE_ROOT, execErrorTargetPath)
+    const expectedShareSafeSecretPath = '<project-root>/src/secret.ts'
 
     const result = await executeCompareRuns(
       {
@@ -1871,13 +1870,13 @@ describe('compare runtime', () => {
           if (execution.mode === 'baseline') {
             return {
               exitCode: 1,
-              stdout: `Prompt is too long while loading ${overflowPath}\n`,
+              stdout: `Prompt is too long while loading ${overflowPath} for details\n`,
               stderr: '',
               elapsedMs: 3,
             }
           }
 
-          throw new Error(`Runner crashed while reading ${execErrorPath}`)
+          throw new Error(`Runner crashed while reading ${overflowPath} for details`)
         },
       },
     )
@@ -1888,22 +1887,22 @@ describe('compare runtime', () => {
     const shareSafeEvidence = (shareSafeReport.evidence as Record<string, string | null>).baseline
     const shareSafeStderr = (shareSafeReport.stderr as Record<string, string | null>).graphify
 
-    expect(report.evidence.baseline).toContain(overflowPath)
-    expect(report.stderr.graphify).toContain(execErrorPath)
-    expect(JSON.stringify(savedReport)).toContain(overflowPath)
-    expect(JSON.stringify(savedReport)).toContain(execErrorPath)
+    expect(report.evidence.baseline).toContain(`${overflowPath} for details`)
+    expect(report.stderr.graphify).toContain(`${overflowPath} for details`)
+    expect(JSON.stringify(savedReport)).toContain(`${overflowPath} for details`)
 
     expect(JSON.stringify(shareSafeReport)).not.toContain(overflowPath)
-    expect(JSON.stringify(shareSafeReport)).not.toContain(execErrorPath)
     expect(shareSafeEvidence).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
     expect(shareSafeStderr).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
+    expect(shareSafeEvidence).toContain(`${expectedShareSafeSecretPath} for details`)
+    expect(shareSafeStderr).toContain(`${expectedShareSafeSecretPath} for details`)
     expect(shareSafeReport).toEqual(
       expect.objectContaining({
         evidence: expect.objectContaining({
-          baseline: expect.stringContaining('secret.ts'),
+          baseline: expect.stringContaining(`${expectedShareSafeSecretPath} for details`),
         }),
         stderr: expect.objectContaining({
-          graphify: expect.stringContaining('runner-error.log'),
+          graphify: expect.stringContaining(`${expectedShareSafeSecretPath} for details`),
         }),
       }),
     )

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1848,13 +1848,14 @@ describe('compare runtime', () => {
   it('sanitizes share-safe compare stderr and evidence paths without changing the local report', async () => {
     const graph = makeGraph()
     writeProjectFiles()
-    const secretPath = join(PROJECT_FIXTURE_ROOT, 'src', 'secret.ts')
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'Quarterly Reports', 'review notes.txt')
+    mkdirSync(dirname(secretPath), { recursive: true })
     writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
     const graphPath = writeGraphFixture(graph)
     const outputTimestamp = '2026-04-24T19-30-00'
     const questionOutputDir = join(COMPARE_OUTPUT_ROOT, outputTimestamp)
     const overflowPath = relative(questionOutputDir, secretPath)
-    const expectedShareSafeSecretPath = '<project-root>/src/secret.ts'
+    const expectedShareSafeSecretPath = '<project-root>/Quarterly Reports/review notes.txt'
 
     const result = await executeCompareRuns(
       {
@@ -1896,6 +1897,8 @@ describe('compare runtime', () => {
     expect(shareSafeStderr).not.toMatch(/\.\.[\\/A-Za-z0-9_-]/)
     expect(shareSafeEvidence).toContain(`${expectedShareSafeSecretPath} for details`)
     expect(shareSafeStderr).toContain(`${expectedShareSafeSecretPath} for details`)
+    expect(shareSafeEvidence).toContain('for details')
+    expect(shareSafeStderr).toContain('for details')
     expect(shareSafeReport).toEqual(
       expect.objectContaining({
         evidence: expect.objectContaining({

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -742,7 +742,8 @@ describe('compare runtime', () => {
         graph_path: '<project-root>/graphify-out/graph.json',
         paths: expect.objectContaining({
           output_dir: '<artifact-root>',
-          report: '<artifact-root>/report.share-safe.json',
+          report: '<artifact-root>/report.json',
+          share_safe_report: '<artifact-root>/report.share-safe.json',
         }),
       }),
     )

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -656,6 +656,58 @@ describe('compare runtime', () => {
     }
   })
 
+  it('sanitizes outside-root relative traversal source_file paths in share-safe compare reports', () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const outsideTraversalPath = '../../vault/private/auth.ts'
+    const originalRetrieveContext = retrieveRuntime.retrieveContext
+    const retrieveSpy = vi.spyOn(retrieveRuntime, 'retrieveContext').mockImplementation((inputGraph, options) => ({
+      ...originalRetrieveContext(inputGraph, options),
+      matched_nodes: originalRetrieveContext(inputGraph, options).matched_nodes.map((node) =>
+        node.label === 'authenticateUser' ? { ...node, source_file: outsideTraversalPath } : node,
+      ),
+    }))
+
+    try {
+      const result = generateCompareArtifacts({
+        graphPath,
+        question: 'how does login create a session',
+        corpusText: makeCorpusText(),
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+        baselineMode: 'pack_only',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      })
+
+      const report = result.reports[0]!
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+      const savedPack = savedReport.pack as { matched_nodes: Array<{ label: string; source_file: string }> }
+      const shareSafePack = shareSafeReport.pack as { matched_nodes: Array<{ label: string; source_file: string }> }
+
+      expect(savedPack.matched_nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'authenticateUser',
+            source_file: outsideTraversalPath,
+          }),
+        ]),
+      )
+      expect(shareSafePack.matched_nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'authenticateUser',
+            source_file: 'auth.ts',
+          }),
+        ]),
+      )
+      expect(JSON.stringify(shareSafeReport)).not.toContain(outsideTraversalPath)
+    } finally {
+      retrieveSpy.mockRestore()
+    }
+  })
+
   it('rejects bounded baseline budgets below the prompt floor', () => {
     const graph = makeGraph()
     const corpusText = makeCorpusText()

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -22,6 +22,7 @@ import * as retrieveRuntime from '../../src/runtime/retrieve.js'
 import { retrieveContext } from '../../src/runtime/retrieve.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 import { MAX_TEXT_BYTES } from '../../src/shared/security.js'
+import { sanitizeShareSafeText } from '../../src/shared/share-safe-artifacts.js'
 
 const PROJECT_FIXTURE_ROOT = resolve('graphify-out', 'test-runtime', 'compare-runtime-project')
 const GRAPH_FIXTURE_ROOT = join(PROJECT_FIXTURE_ROOT, 'graphify-out')
@@ -1909,6 +1910,404 @@ describe('compare runtime', () => {
         }),
       }),
     )
+  })
+
+  it('continues redacting later absolute paths after spaced share-safe placeholders', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'Quarterly Reports', 'review notes.txt')
+
+    mkdirSync(dirname(secretPath), { recursive: true })
+    mkdirSync(artifactRoot, { recursive: true })
+    writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
+
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/Quarterly Reports/review notes.txt and /etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt and passwd')
+  })
+
+  it('preserves spaced share-safe placeholders even when the referenced file does not exist', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+
+    mkdirSync(artifactRoot, { recursive: true })
+
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/Quarterly Reports/missing notes.txt and /etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/missing notes.txt and passwd')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/Quarterly Reports/missing notes.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/missing notes.txt')
+  })
+
+  it('does not let dotted prose inside a spaced placeholder hide later absolute paths', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+
+    mkdirSync(artifactRoot, { recursive: true })
+
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/foo v1.2 beta.3 /etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/foo v1.2 beta.3 passwd')
+  })
+
+  it('preserves non-existent spaced placeholder directories without hiding later absolute paths', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+
+    mkdirSync(artifactRoot, { recursive: true })
+
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/dir with space/subdir and /etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/dir with space/subdir and passwd')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/dir with space/subdir',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/dir with space/subdir')
+  })
+
+  it('keeps redacting punctuation-attached absolute paths after spaced placeholders', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'Quarterly Reports', 'review notes.txt')
+
+    mkdirSync(dirname(secretPath), { recursive: true })
+    mkdirSync(artifactRoot, { recursive: true })
+    writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
+
+    const traversalPath = relative(artifactRoot, secretPath)
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/dir with space,/etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/dir with space,passwd')
+    expect(
+      sanitizeShareSafeText(
+        `${traversalPath},/etc/passwd`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt,passwd')
+  })
+
+  it('keeps redacting punctuation-attached Windows absolute paths after protected prefixes', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'Quarterly Reports', 'review notes.txt')
+    const uncWindowsPath = String.raw`\\server\share\secret.txt`
+
+    mkdirSync(dirname(secretPath), { recursive: true })
+    mkdirSync(artifactRoot, { recursive: true })
+    writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
+
+    const traversalPath = relative(artifactRoot, secretPath)
+    const windowsSlashPath = 'C:/Windows/system32/drivers/etc/hosts'
+    const windowsBackslashPath = 'C:\\Windows\\system32\\drivers\\etc\\hosts'
+    const spacedWindowsPath = 'C:/Users/Alice/My Secrets/secret.txt'
+
+    expect(
+      sanitizeShareSafeText(
+        `<project-root>/Quarterly Reports/review notes.txt,${windowsSlashPath}`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt,hosts')
+    expect(
+      sanitizeShareSafeText(
+        `<project-root>/Quarterly Reports/review notes.txt,${windowsBackslashPath}`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt,hosts')
+    expect(
+      sanitizeShareSafeText(
+        `${traversalPath},${windowsSlashPath}`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt,hosts')
+    expect(
+      sanitizeShareSafeText(
+        `<project-root>/Quarterly Reports,${spacedWindowsPath}`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports,secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        `<project-root>/Quarterly Reports/review notes.txt,${uncWindowsPath}`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt,secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        `before ${uncWindowsPath} after`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('before secret.txt after')
+    expect(
+      sanitizeShareSafeText(
+        'x,C:/Windows/notepad.exe,C:/Windows/system.ini',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('x,notepad.exe,system.ini')
+  })
+
+  it('keeps redacting separator-restarted absolute paths after protected prefixes', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+
+    mkdirSync(artifactRoot, { recursive: true })
+
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/foo//etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/foo/passwd')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/foo/C:/Users/alice/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/foo/secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/dir with space/subdir:/Users/alice/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/dir with space/subdir:secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/missing notes:/etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/missing notes:passwd')
+  })
+
+  it('preserves punctuation-delimited prose after sanitizing traversal paths with spaces', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+    const secretPath = join(PROJECT_FIXTURE_ROOT, 'Quarterly Reports', 'review notes.txt')
+
+    mkdirSync(dirname(secretPath), { recursive: true })
+    mkdirSync(artifactRoot, { recursive: true })
+    writeFileSync(secretPath, 'export const secret = true\n', 'utf8')
+
+    const traversalPath = relative(artifactRoot, secretPath)
+    expect(
+      sanitizeShareSafeText(
+        `${traversalPath}: details`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt: details')
+    expect(
+      sanitizeShareSafeText(
+        `${traversalPath}:${traversalPath}`,
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt:<project-root>/Quarterly Reports/review notes.txt')
+  })
+
+  it('preserves protocol-relative URLs while still sanitizing double-slash paths', () => {
+    const projectRoot = PROJECT_FIXTURE_ROOT
+    const artifactRoot = join(COMPARE_OUTPUT_ROOT, 'placeholder-run')
+
+    mkdirSync(artifactRoot, { recursive: true })
+
+    expect(
+      sanitizeShareSafeText(
+        '//example.com/foo',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//example.com/foo')
+    expect(
+      sanitizeShareSafeText(
+        'See //example.com/foo for docs',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('See //example.com/foo for docs')
+    expect(
+      sanitizeShareSafeText(
+        '//example.com/api/v1/users',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//example.com/api/v1/users')
+    expect(
+      sanitizeShareSafeText(
+        'See //example.com/blog/2026/launch for details',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('See //example.com/blog/2026/launch for details')
+    expect(
+      sanitizeShareSafeText(
+        '//example.com/docs/getting-started',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//example.com/docs/getting-started')
+    expect(
+      sanitizeShareSafeText(
+        '//github.com/openai/gpt-5',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//github.com/openai/gpt-5')
+    expect(
+      sanitizeShareSafeText(
+        'See //example.com/foo/bar for docs',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('See //example.com/foo/bar for docs')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://example.com/docs/getting-started',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe://example.com/docs/getting-started')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/src/auth.ts://github.com/openai/gpt-5',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/src/auth.ts://github.com/openai/gpt-5')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://example.com/foo/bar',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe://example.com/foo/bar')
+    expect(
+      sanitizeShareSafeText(
+        '//cdn.example.com/assets/app.js',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('//cdn.example.com/assets/app.js')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://cdn.example.com/assets/app.js',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe://cdn.example.com/assets/app.js')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/Quarterly Reports/review notes.txt://example.com/foo',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/Quarterly Reports/review notes.txt://example.com/foo')
+    expect(
+      sanitizeShareSafeText(
+        'foo.bar://example.com/a/b',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('foo.bar://example.com/a/b')
+    expect(
+      sanitizeShareSafeText(
+        '//server/share/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '//server.example.com/share/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '//server.example.com/share/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret')
+    expect(
+      sanitizeShareSafeText(
+        '//server.example.com/Engineering/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '//server.example.com/engineering/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret')
+    expect(
+      sanitizeShareSafeText(
+        '//corp.example.com/alice/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('secret')
+    expect(
+      sanitizeShareSafeText(
+        '//server.example.com/Engineering',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('Engineering')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/foo//server.example.com/share/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/foo/secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/foo//server.example.com/share/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/foo/secret')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/foo//server.example.com/Engineering/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/foo/secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://corp.example.com/alice/secret',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe:<external-path>secret')
+    expect(
+      sanitizeShareSafeText(
+        'See //server.example.com/Engineering for access',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('See Engineering for access')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe:<external-path>passwd')
+    expect(
+      sanitizeShareSafeText(
+        '<project-root>/safe://C:/Users/alice/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('<project-root>/safe:<external-path>secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        'see file:///etc/passwd and file:///C:/Users/alice/Documents/secret.txt',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('see file://passwd and file://secret.txt')
+    expect(
+      sanitizeShareSafeText(
+        'See.file:///etc/passwd',
+        { artifactRoot, projectRoot },
+      ),
+    ).toBe('See.file://passwd')
   })
 
   it('sanitizes escaped artifact-root answer path traversals without reclassifying them under the project root', async () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync 
 import { dirname, join, resolve } from 'node:path'
 
 import { strToU8, zipSync } from 'fflate'
+import { vi } from 'vitest'
 
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import {
@@ -17,6 +18,7 @@ import {
 import { parsePromptRunnerOutput } from '../../src/infrastructure/prompt-runner.js'
 import { saveManifest } from '../../src/pipeline/manifest.js'
 import { toJson } from '../../src/pipeline/export.js'
+import * as retrieveRuntime from '../../src/runtime/retrieve.js'
 import { retrieveContext } from '../../src/runtime/retrieve.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 import { MAX_TEXT_BYTES } from '../../src/shared/security.js'
@@ -592,6 +594,58 @@ describe('compare runtime', () => {
         selection_strategy: 'value-per-token',
       }),
     )
+  })
+
+  it('sanitizes pack_only source_file paths in share-safe compare reports', () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const outsideSourcePath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'auth.ts')
+    const originalRetrieveContext = retrieveRuntime.retrieveContext
+    const retrieveSpy = vi.spyOn(retrieveRuntime, 'retrieveContext').mockImplementation((inputGraph, options) => ({
+      ...originalRetrieveContext(inputGraph, options),
+      matched_nodes: originalRetrieveContext(inputGraph, options).matched_nodes.map((node) =>
+        node.label === 'authenticateUser' ? { ...node, source_file: outsideSourcePath } : node,
+      ),
+    }))
+
+    try {
+      const result = generateCompareArtifacts({
+        graphPath,
+        question: 'how does login create a session',
+        corpusText: makeCorpusText(),
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+        baselineMode: 'pack_only',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      })
+
+      const report = result.reports[0]!
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+      const savedPack = savedReport.pack as { matched_nodes: Array<{ label: string; source_file: string }> }
+      const shareSafePack = shareSafeReport.pack as { matched_nodes: Array<{ label: string; source_file: string }> }
+
+      expect(savedPack.matched_nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'authenticateUser',
+            source_file: outsideSourcePath,
+          }),
+        ]),
+      )
+      expect(shareSafePack.matched_nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'authenticateUser',
+            source_file: 'auth.ts',
+          }),
+        ]),
+      )
+      expect(JSON.stringify(shareSafeReport)).not.toContain(outsideSourcePath)
+    } finally {
+      retrieveSpy.mockRestore()
+    }
   })
 
   it('rejects bounded baseline budgets below the prompt floor', () => {
@@ -1729,6 +1783,61 @@ describe('compare runtime', () => {
     expect(savedReport).toContain('stderr omitted for safety')
     expect(savedReport).not.toContain('super-secret')
     expect(savedReport).not.toContain('abc123')
+  })
+
+  it('sanitizes share-safe compare stderr and evidence paths without changing the local report', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const overflowPath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'overflow.log')
+    const execErrorPath = resolve(PROJECT_FIXTURE_ROOT, '..', '..', '..', 'vault', 'private', 'runner-error.log')
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => {
+          if (execution.mode === 'baseline') {
+            return {
+              exitCode: 1,
+              stdout: `Prompt is too long while loading ${overflowPath}\n`,
+              stderr: '',
+              elapsedMs: 3,
+            }
+          }
+
+          throw new Error(`Runner crashed while reading ${execErrorPath}`)
+        },
+      },
+    )
+
+    const report = result.reports[0]!
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+    const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+
+    expect(report.evidence.baseline).toContain(overflowPath)
+    expect(report.stderr.graphify).toContain(execErrorPath)
+    expect(JSON.stringify(savedReport)).toContain(overflowPath)
+    expect(JSON.stringify(savedReport)).toContain(execErrorPath)
+
+    expect(JSON.stringify(shareSafeReport)).not.toContain(overflowPath)
+    expect(JSON.stringify(shareSafeReport)).not.toContain(execErrorPath)
+    expect(shareSafeReport).toEqual(
+      expect.objectContaining({
+        evidence: expect.objectContaining({
+          baseline: expect.stringContaining('overflow.log'),
+        }),
+        stderr: expect.objectContaining({
+          graphify: expect.stringContaining('runner-error.log'),
+        }),
+      }),
+    )
   })
 
   it('loads graphify snippets when compare runs from outside the inferred project root', () => {

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -210,6 +210,42 @@ describe('review compare', () => {
     expect(readFileSync(result.report.paths.compact_prompt, 'utf8')).toContain('"review_context"')
   })
 
+  it('writes a companion share-safe report without changing the local report contract', () => {
+    const root = createRepo()
+    repoRoots.push(root)
+
+    const result = generateReviewCompareArtifacts({
+      graphPath: join(root, 'graphify-out', 'graph.json'),
+      outputDir: join(root, 'graphify-out', 'review-compare'),
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      now: new Date('2026-05-01T21:00:00.000Z'),
+    })
+
+    const localReport = JSON.parse(readFileSync(result.report.paths.report, 'utf8')) as Record<string, unknown>
+    const shareSafePath = join(result.report.paths.output_dir, 'report.share-safe.json')
+    const shareSafeReport = JSON.parse(readFileSync(shareSafePath, 'utf8')) as Record<string, unknown>
+
+    expect(localReport).toEqual(
+      expect.objectContaining({
+        graph_path: expect.stringContaining('graphify-out/graph.json'),
+        paths: expect.objectContaining({
+          report: expect.stringContaining('report.json'),
+        }),
+      }),
+    )
+    expect(shareSafeReport).toEqual(
+      expect.objectContaining({
+        graph_path: '<project-root>/graphify-out/graph.json',
+        paths: expect.objectContaining({
+          output_dir: '<artifact-root>',
+          report: '<artifact-root>/report.json',
+          share_safe_report: '<artifact-root>/report.share-safe.json',
+        }),
+      }),
+    )
+    expect(JSON.stringify(shareSafeReport)).not.toContain(root)
+  })
+
   it('sanitizes path-derived node ids in persisted review prompts', () => {
     const root = createRepo({ pathLikeNodeIds: true })
     repoRoots.push(root)

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -309,6 +309,7 @@ describe('review compare', () => {
   it('redacts local artifact paths from share-safe stderr on failed runs', async () => {
     const root = createRepo()
     repoRoots.push(root)
+    const externalAbsolutePath = process.platform === 'win32' ? 'C:\\Users\\alice\\.ssh\\config' : '/Users/alice/.ssh/config'
 
     const result = await executeReviewCompareRuns(
       {
@@ -326,6 +327,7 @@ describe('review compare', () => {
             `output=${execution.outputFile}`,
             `graph=${join(root, 'graphify-out', 'graph.json')}`,
             `project=${root}`,
+            `external=${externalAbsolutePath}`,
           ].join('\n'),
           elapsedMs: execution.mode === 'verbose' ? 15 : 9,
         }),
@@ -333,17 +335,22 @@ describe('review compare', () => {
     )
 
     const localReport = JSON.parse(readFileSync(result.report.paths.report, 'utf8')) as ReviewCompareReport
-    const shareSafeReport = JSON.parse(readFileSync(result.report.paths.share_safe_report, 'utf8')) as ReviewCompareReport
+    const shareSafeRaw = readFileSync(result.report.paths.share_safe_report, 'utf8')
+    const shareSafeReport = JSON.parse(shareSafeRaw) as ReviewCompareReport
 
     expect(localReport.stderr.verbose).toContain(`prompt=${result.report.paths.verbose_prompt}`)
     expect(localReport.stderr.verbose).toContain(`output=${result.report.answer_paths.verbose}`)
     expect(localReport.stderr.verbose).toContain(`graph=${join(root, 'graphify-out', 'graph.json')}`)
     expect(localReport.stderr.verbose).toContain(`project=${root}`)
+    expect(localReport.stderr.verbose).toContain(`external=${externalAbsolutePath}`)
 
     expect(shareSafeReport.stderr.verbose).toContain('prompt=<artifact-root>/verbose-prompt.txt')
     expect(shareSafeReport.stderr.verbose).toContain('output=<artifact-root>/verbose-answer.txt')
     expect(shareSafeReport.stderr.verbose).toContain('graph=<project-root>/graphify-out/graph.json')
     expect(shareSafeReport.stderr.verbose).toContain('project=<project-root>')
+    expect(shareSafeReport.stderr.verbose).toContain(`external=${basename(externalAbsolutePath)}`)
     expect(shareSafeReport.stderr.verbose).not.toContain(root)
+    expect(shareSafeReport.stderr.verbose).not.toContain(externalAbsolutePath)
+    expect(shareSafeRaw).not.toContain(externalAbsolutePath)
   })
 })

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -13,6 +13,10 @@ import {
 } from '../../src/infrastructure/review-compare.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 
+function normalizePortablePath(path: string): string {
+  return path.replaceAll('\\', '/')
+}
+
 function createRepo(options: { pathLikeNodeIds?: boolean; pathWithSpaces?: boolean } = {}): string {
   const repoPrefix = options.pathWithSpaces ? 'graphify ts review compare repo-' : 'graphify-ts-review-compare-'
   const root = mkdtempSync(join(tmpdir(), repoPrefix))
@@ -227,14 +231,8 @@ describe('review compare', () => {
     const shareSafePath = join(result.report.paths.output_dir, 'report.share-safe.json')
     const shareSafeReport = JSON.parse(readFileSync(shareSafePath, 'utf8')) as Record<string, unknown>
 
-    expect(localReport).toEqual(
-      expect.objectContaining({
-        graph_path: expect.stringContaining('graphify-out/graph.json'),
-        paths: expect.objectContaining({
-          report: expect.stringContaining('report.json'),
-        }),
-      }),
-    )
+    expect(normalizePortablePath(String(localReport.graph_path))).toContain('graphify-out/graph.json')
+    expect((localReport.paths as Record<string, unknown>).report).toEqual(expect.stringContaining('report.json'))
     expect(shareSafeReport).toEqual(
       expect.objectContaining({
         graph_path: '<project-root>/graphify-out/graph.json',
@@ -332,6 +330,8 @@ describe('review compare', () => {
             `graph=${join(root, 'graphify-out', 'graph.json')}`,
             `project=${root}`,
             `external=${externalAbsolutePath}`,
+            'OPENAI_API_KEY=super-secret',
+            'Authorization: Bearer abc123',
             `url=${diagnosticUrl}`,
           ].join('\n'),
           elapsedMs: execution.mode === 'verbose' ? 15 : 9,
@@ -348,12 +348,18 @@ describe('review compare', () => {
     expect(localReport.stderr.verbose).toContain(`graph=${join(root, 'graphify-out', 'graph.json')}`)
     expect(localReport.stderr.verbose).toContain(`project=${root}`)
     expect(localReport.stderr.verbose).toContain(`external=${externalAbsolutePath}`)
+    expect(localReport.stderr.verbose).toContain('OPENAI_API_KEY=super-secret')
+    expect(localReport.stderr.verbose).toContain('Authorization: Bearer abc123')
 
     expect(shareSafeReport.stderr.verbose).toContain('prompt=<artifact-root>/verbose-prompt.txt')
     expect(shareSafeReport.stderr.verbose).toContain('output=<artifact-root>/verbose-answer.txt')
     expect(shareSafeReport.stderr.verbose).toContain('graph=<project-root>/graphify-out/graph.json')
     expect(shareSafeReport.stderr.verbose).toContain('project=<project-root>')
     expect(shareSafeReport.stderr.verbose).toContain(`external=${basename(externalAbsolutePath)}`)
+    expect(shareSafeReport.stderr.verbose).toContain('OPENAI_API_KEY=[REDACTED]')
+    expect(shareSafeReport.stderr.verbose).toContain('Authorization: Bearer [REDACTED]')
+    expect(shareSafeReport.stderr.verbose).not.toContain('super-secret')
+    expect(shareSafeReport.stderr.verbose).not.toContain('abc123')
     expect(shareSafeReport.stderr.verbose).toContain(`url=${diagnosticUrl}`)
     expect(shareSafeReport.stderr.verbose).not.toContain(root)
     expect(shareSafeReport.stderr.verbose).not.toContain(externalAbsolutePath)

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -9,6 +9,7 @@ import {
   executeReviewCompareRuns,
   formatReviewCompareSummary,
   generateReviewCompareArtifacts,
+  type ReviewCompareReport,
 } from '../../src/infrastructure/review-compare.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 
@@ -303,5 +304,46 @@ describe('review compare', () => {
       compact: 9,
     })
     expect(formatReviewCompareSummary(result)).toContain('Prompt tokens')
+  })
+
+  it('redacts local artifact paths from share-safe stderr on failed runs', async () => {
+    const root = createRepo()
+    repoRoots.push(root)
+
+    const result = await executeReviewCompareRuns(
+      {
+        graphPath: join(root, 'graphify-out', 'graph.json'),
+        outputDir: join(root, 'graphify-out', 'review-compare'),
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        now: new Date('2026-05-01T21:00:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: 1,
+          stdout: '',
+          stderr: [
+            `prompt=${execution.promptFile}`,
+            `output=${execution.outputFile}`,
+            `graph=${join(root, 'graphify-out', 'graph.json')}`,
+            `project=${root}`,
+          ].join('\n'),
+          elapsedMs: execution.mode === 'verbose' ? 15 : 9,
+        }),
+      },
+    )
+
+    const localReport = JSON.parse(readFileSync(result.report.paths.report, 'utf8')) as ReviewCompareReport
+    const shareSafeReport = JSON.parse(readFileSync(result.report.paths.share_safe_report, 'utf8')) as ReviewCompareReport
+
+    expect(localReport.stderr.verbose).toContain(`prompt=${result.report.paths.verbose_prompt}`)
+    expect(localReport.stderr.verbose).toContain(`output=${result.report.answer_paths.verbose}`)
+    expect(localReport.stderr.verbose).toContain(`graph=${join(root, 'graphify-out', 'graph.json')}`)
+    expect(localReport.stderr.verbose).toContain(`project=${root}`)
+
+    expect(shareSafeReport.stderr.verbose).toContain('prompt=<artifact-root>/verbose-prompt.txt')
+    expect(shareSafeReport.stderr.verbose).toContain('output=<artifact-root>/verbose-answer.txt')
+    expect(shareSafeReport.stderr.verbose).toContain('graph=<project-root>/graphify-out/graph.json')
+    expect(shareSafeReport.stderr.verbose).toContain('project=<project-root>')
+    expect(shareSafeReport.stderr.verbose).not.toContain(root)
   })
 })

--- a/tests/unit/review-compare.test.ts
+++ b/tests/unit/review-compare.test.ts
@@ -13,8 +13,9 @@ import {
 } from '../../src/infrastructure/review-compare.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 
-function createRepo(options: { pathLikeNodeIds?: boolean } = {}): string {
-  const root = mkdtempSync(join(tmpdir(), 'graphify-ts-review-compare-'))
+function createRepo(options: { pathLikeNodeIds?: boolean; pathWithSpaces?: boolean } = {}): string {
+  const repoPrefix = options.pathWithSpaces ? 'graphify ts review compare repo-' : 'graphify-ts-review-compare-'
+  const root = mkdtempSync(join(tmpdir(), repoPrefix))
   mkdirSync(join(root, 'src'), { recursive: true })
   mkdirSync(join(root, 'tests'), { recursive: true })
   mkdirSync(join(root, 'graphify-out'), { recursive: true })
@@ -307,14 +308,17 @@ describe('review compare', () => {
   })
 
   it('redacts local artifact paths from share-safe stderr on failed runs', async () => {
-    const root = createRepo()
+    const root = createRepo({ pathWithSpaces: true })
     repoRoots.push(root)
-    const externalAbsolutePath = process.platform === 'win32' ? 'C:\\Users\\alice\\.ssh\\config' : '/Users/alice/.ssh/config'
+    const externalAbsolutePath = process.platform === 'win32'
+      ? 'C:\\Users\\alice\\Desktop\\Quarterly Reports\\review notes.txt'
+      : '/Users/alice/Desktop/Quarterly Reports/review notes.txt'
+    const diagnosticUrl = 'https://example.com/errors/review-compare?path=/docs/reference'
 
     const result = await executeReviewCompareRuns(
       {
         graphPath: join(root, 'graphify-out', 'graph.json'),
-        outputDir: join(root, 'graphify-out', 'review-compare'),
+        outputDir: join(root, 'graphify-out', 'review compare'),
         execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
         now: new Date('2026-05-01T21:00:00.000Z'),
       },
@@ -328,6 +332,7 @@ describe('review compare', () => {
             `graph=${join(root, 'graphify-out', 'graph.json')}`,
             `project=${root}`,
             `external=${externalAbsolutePath}`,
+            `url=${diagnosticUrl}`,
           ].join('\n'),
           elapsedMs: execution.mode === 'verbose' ? 15 : 9,
         }),
@@ -349,6 +354,7 @@ describe('review compare', () => {
     expect(shareSafeReport.stderr.verbose).toContain('graph=<project-root>/graphify-out/graph.json')
     expect(shareSafeReport.stderr.verbose).toContain('project=<project-root>')
     expect(shareSafeReport.stderr.verbose).toContain(`external=${basename(externalAbsolutePath)}`)
+    expect(shareSafeReport.stderr.verbose).toContain(`url=${diagnosticUrl}`)
     expect(shareSafeReport.stderr.verbose).not.toContain(root)
     expect(shareSafeReport.stderr.verbose).not.toContain(externalAbsolutePath)
     expect(shareSafeRaw).not.toContain(externalAbsolutePath)


### PR DESCRIPTION
## Summary
- add companion `report.share-safe.json` artifacts for compare, review-compare, and runner-backed benchmark flows
- centralize share-safe path and text sanitization for artifact reports and harden redaction across traversal, UNC, protocol-relative URL, rooted `://`, and `file://` edge cases
- update docs/changelog and expand regression coverage for share-safe artifact behavior

Closes #189

## Testing
- npm run typecheck
- npm run build
- npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `report.share-safe.json` output for compare, review-compare, and benchmark --exec runs: sanitized, placeholder-based paths for safe sharing while keeping full local `report.json`.
  * Added a share-safe sanitization utility to rewrite/redact paths and URL-like tokens for shareable reports.

* **Documentation**
  * Updated guides and tutorials to describe share-safe reporting behavior.

* **Tests**
  * Expanded unit tests to cover share-safe report generation and sanitization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->