### PR TITLE
feat: add native-agent compare suite summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Native-agent compare suite summary**: multi-question `compare --baseline-mode native_agent` runs now roll up wins/losses for input tokens, turns, and latency, report mean/median input-token reduction, and highlight the best win and worst regression prompt in the terminal summary.
+
 ## [0.22.9] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ PR-review proof on a real diff: prompt tokens 63,024 → **8,690** (**7.25× few
 
 Latest runtime-pack refinement: **runtime-generation prompts stay compact** by following the strongest backend runtime path and suppressing sibling routes, script/migration noise, and shared-hub fan-out on broad backend-generation questions.
 
-Single-prompt backend benchmark snapshot: in one real GoValidate `compare --baseline-mode native_agent` run for `"Explain how idea report is getting generated"`, graphify-ts reduced Anthropic-reported input tokens from **1,653,307** to **498,280** (~**69.9%** lower). Details and caveats: [`docs/benchmarks/2026-05-12-govalidate-report-generation/`](docs/benchmarks/2026-05-12-govalidate-report-generation/).
+Single-prompt backend benchmark snapshot: in one real GoValidate `compare --baseline-mode native_agent` run for `"Explain how idea report is getting generated"`, graphify-ts reduced Anthropic-reported input tokens from **1,653,307** to **498,280** (~**69.9%** lower). Multi-question native-agent compare runs now also roll up suite wins/losses for input tokens, turns, and latency, report mean/median input-token reduction, and highlight the best win and worst regression prompt. Details and caveats: [`docs/benchmarks/2026-05-12-govalidate-report-generation/`](docs/benchmarks/2026-05-12-govalidate-report-generation/).
 
 [Reproduce them](docs/benchmarks/2026-04-30-govalidate/verify.sh) with one shell script against the committed evidence files.
 

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -36,7 +36,7 @@ node dist/src/cli/bin.js compare "How does login create a session?" \
   --yes
 ```
 
-If you switch to `--baseline-mode native_agent`, prefer a structured Anthropic runner such as `cat {prompt_file} | claude -p --output-format json`. Plain-text Claude runs still save paired answers, but the report cannot compute Anthropic-billed reductions without the trailing JSON usage block.
+If you switch to `--baseline-mode native_agent`, prefer a structured Anthropic runner such as `cat {prompt_file} | claude -p --output-format json`. Plain-text Claude runs still save paired answers, but the report cannot compute Anthropic-billed reductions without the trailing JSON usage block. Multi-question native-agent runs also emit suite-level wins/losses for input tokens, turns, and latency, plus mean/median input-token reduction and best/worst prompt outcomes in the terminal summary.
 
 Gemini-safe installed-CLI invocation:
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1614,6 +1614,123 @@ function formatDirectionalDelta(
   return ` (${Number((graphify / baseline).toFixed(2))}x ${increasedLabel})`
 }
 
+type NativeAgentComparableReport = NativeAgentCompareReport & {
+  baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>
+  graphify: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>
+}
+
+interface NativeAgentSuiteChange {
+  question: string
+  percentReduction: number
+}
+
+function isComparableNativeAgentReport(report: NativeAgentCompareReport): report is NativeAgentComparableReport {
+  return report.baseline.kind === 'succeeded' && report.graphify.kind === 'succeeded'
+}
+
+function computeReductionPercent(baseline: number, graphify: number): number | null {
+  if (baseline <= 0 || graphify <= 0) {
+    return null
+  }
+  return Number((((baseline - graphify) / baseline) * 100).toFixed(1))
+}
+
+function formatPercent(value: number): string {
+  return Number(value.toFixed(1)).toString()
+}
+
+function formatCount(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) {
+    return null
+  }
+  return values.reduce((total, value) => total + value, 0) / values.length
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null
+  }
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? null
+  }
+  const left = sorted[middle - 1]
+  const right = sorted[middle]
+  if (left === undefined || right === undefined) {
+    return null
+  }
+  return (left + right) / 2
+}
+
+function nativeAgentSuiteChanges(
+  reports: readonly NativeAgentComparableReport[],
+  metric: (report: NativeAgentComparableReport) => { baseline: number; graphify: number },
+): NativeAgentSuiteChange[] {
+  return reports.flatMap((report) => {
+    const values = metric(report)
+    const percentReduction = computeReductionPercent(values.baseline, values.graphify)
+    return percentReduction === null ? [] : [{ question: report.question, percentReduction }]
+  })
+}
+
+function bestWin(changes: readonly NativeAgentSuiteChange[]): NativeAgentSuiteChange | null {
+  const wins = changes.filter((change) => change.percentReduction > 0)
+  if (wins.length === 0) {
+    return null
+  }
+  return wins.reduce((best, change) => (change.percentReduction > best.percentReduction ? change : best))
+}
+
+function worstRegression(changes: readonly NativeAgentSuiteChange[]): NativeAgentSuiteChange | null {
+  const losses = changes.filter((change) => change.percentReduction < 0)
+  if (losses.length === 0) {
+    return null
+  }
+  return losses.reduce((worst, change) => (change.percentReduction < worst.percentReduction ? change : worst))
+}
+
+function formatSuiteOutcome(change: NativeAgentSuiteChange | null, decreasedLabel: string, increasedLabel: string): string {
+  if (change === null) {
+    return 'none'
+  }
+  const amount = formatPercent(Math.abs(change.percentReduction))
+  const direction = change.percentReduction > 0 ? decreasedLabel : increasedLabel
+  return `"${change.question}" (${amount}% ${direction})`
+}
+
+function formatNativeAgentSuiteMetricLine(
+  label: string,
+  changes: readonly NativeAgentSuiteChange[],
+  decreasedLabel: string,
+  increasedLabel: string,
+  includeMeanMedian = false,
+): string {
+  const wins = changes.filter((change) => change.percentReduction > 0).length
+  const losses = changes.filter((change) => change.percentReduction < 0).length
+  const parts = [
+    `- Suite ${label}: ${formatCount(wins, 'win', 'wins')} · ${formatCount(losses, 'loss', 'losses')}`,
+  ]
+
+  if (includeMeanMedian) {
+    const reductions = changes.map((change) => change.percentReduction)
+    const meanReduction = mean(reductions)
+    const medianReduction = median(reductions)
+    if (meanReduction !== null && medianReduction !== null) {
+      parts.push(`mean reduction ${formatPercent(meanReduction)}%`)
+      parts.push(`median reduction ${formatPercent(medianReduction)}%`)
+    }
+  }
+
+  parts.push(`best win: ${formatSuiteOutcome(bestWin(changes), decreasedLabel, increasedLabel)}`)
+  parts.push(`worst regression: ${formatSuiteOutcome(worstRegression(changes), decreasedLabel, increasedLabel)}`)
+  return parts.join(' · ')
+}
+
 function isNativeAgentRunFailure(run: NativeAgentRunStatus): boolean {
   return run.kind === 'runner_error'
 }
@@ -1884,6 +2001,39 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
     `[graphify compare] completed ${result.reports.length} native_agent question(s)`,
     `- Output: ${result.output_root}`,
   ]
+  const comparableReports = result.reports.filter(isComparableNativeAgentReport)
+  if (comparableReports.length > 1) {
+    lines.push(
+      formatNativeAgentSuiteMetricLine(
+        'input_tokens (Anthropic-reported)',
+        nativeAgentSuiteChanges(comparableReports, (report) => ({
+          baseline: report.baseline.total_input_tokens_anthropic_exact,
+          graphify: report.graphify.total_input_tokens_anthropic_exact,
+        })),
+        'less',
+        'more',
+        true,
+      ),
+      formatNativeAgentSuiteMetricLine(
+        'num_turns',
+        nativeAgentSuiteChanges(comparableReports, (report) => ({
+          baseline: report.baseline.num_turns,
+          graphify: report.graphify.num_turns,
+        })),
+        'fewer',
+        'more',
+      ),
+      formatNativeAgentSuiteMetricLine(
+        'latency',
+        nativeAgentSuiteChanges(comparableReports, (report) => ({
+          baseline: report.baseline.duration_ms,
+          graphify: report.graphify.duration_ms,
+        })),
+        'faster',
+        'slower',
+      ),
+    )
+  }
   for (const report of result.reports) {
     if (isNativeAgentRunFailure(report.baseline) || isNativeAgentRunFailure(report.graphify)) {
       lines.push(`- "${report.question}" → runner error (see ${portablePath(report.paths.report)})`)

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1709,12 +1709,16 @@ function formatNativeAgentSuiteMetricLine(
   decreasedLabel: string,
   increasedLabel: string,
   includeMeanMedian = false,
+  totalQuestionCount = changes.length,
 ): string {
   const wins = changes.filter((change) => change.percentReduction > 0).length
   const losses = changes.filter((change) => change.percentReduction < 0).length
   const parts = [
     `- Suite ${label}: ${formatCount(wins, 'win', 'wins')} · ${formatCount(losses, 'loss', 'losses')}`,
   ]
+  if (changes.length !== totalQuestionCount) {
+    parts.push(`${changes.length}/${totalQuestionCount} comparable`)
+  }
 
   if (includeMeanMedian) {
     const reductions = changes.map((change) => change.percentReduction)
@@ -2001,6 +2005,7 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
     `[graphify compare] completed ${result.reports.length} native_agent question(s)`,
     `- Output: ${result.output_root}`,
   ]
+  const totalQuestionCount = result.reports.length
   const comparableReports = result.reports.filter(isComparableNativeAgentReport)
   if (comparableReports.length > 1) {
     lines.push(
@@ -2013,6 +2018,7 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
         'less',
         'more',
         true,
+        totalQuestionCount,
       ),
       formatNativeAgentSuiteMetricLine(
         'num_turns',
@@ -2022,6 +2028,8 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
         })),
         'fewer',
         'more',
+        false,
+        totalQuestionCount,
       ),
       formatNativeAgentSuiteMetricLine(
         'latency',
@@ -2031,6 +2039,8 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
         })),
         'faster',
         'slower',
+        false,
+        totalQuestionCount,
       ),
     )
   }

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -167,6 +167,16 @@ function buildSummaryResult(overrides: {
   }
 }
 
+type SummaryOverrides = Parameters<typeof buildSummaryResult>[0]
+
+function buildSuiteSummaryResult(overridesList: SummaryOverrides[]): NativeAgentCompareResult {
+  return {
+    graph_path: '/tmp/project/graphify-out/graph.json',
+    output_root: '/tmp/project/graphify-out/compare/2026-05-12T00-00-00Z',
+    reports: overridesList.map((overrides) => buildSummaryResult(overrides).reports[0]!),
+  }
+}
+
 describe('parseAnthropicResultEvent', () => {
   it('parses a single non-stream JSON object from stdout', () => {
     const stdout = `${JSON.stringify(BASELINE_USAGE_PAYLOAD)}\n`
@@ -493,5 +503,83 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).not.toContain('0.33x fewer')
     expect(summary).not.toContain('0.33x faster')
     expect(summary).not.toContain('0.33x less')
+  })
+
+  it('summarizes all-win native_agent suites with aggregate win counts and reductions', () => {
+    const summary = formatNativeAgentCompareSummary(buildSuiteSummaryResult([
+      {
+        question: 'win a',
+        baselineTurns: 9,
+        graphifyTurns: 3,
+        baselineDurationMs: 9000,
+        graphifyDurationMs: 3000,
+        baselineInputTokens: 900,
+        graphifyInputTokens: 300,
+        reductions: {
+          num_turns: 3,
+          duration_ms: 3,
+          input_tokens: 3,
+          cost_usd: 1,
+        },
+      },
+      {
+        question: 'win b',
+        baselineTurns: 8,
+        graphifyTurns: 2,
+        baselineDurationMs: 8000,
+        graphifyDurationMs: 2000,
+        baselineInputTokens: 800,
+        graphifyInputTokens: 200,
+        reductions: {
+          num_turns: 4,
+          duration_ms: 4,
+          input_tokens: 4,
+          cost_usd: 1,
+        },
+      },
+    ]))
+
+    expect(summary).toContain('Suite input_tokens (Anthropic-reported): 2 wins · 0 losses · mean reduction 70.8% · median reduction 70.8% · best win: "win b" (75% less) · worst regression: none')
+    expect(summary).toContain('Suite num_turns: 2 wins · 0 losses · best win: "win b" (75% fewer) · worst regression: none')
+    expect(summary).toContain('Suite latency: 2 wins · 0 losses · best win: "win b" (75% faster) · worst regression: none')
+  })
+
+  it('summarizes mixed native_agent suites with wins, losses, and regressions', () => {
+    const summary = formatNativeAgentCompareSummary(buildSuiteSummaryResult([
+      {
+        question: 'win case',
+        baselineTurns: 10,
+        graphifyTurns: 5,
+        baselineDurationMs: 10000,
+        graphifyDurationMs: 5000,
+        baselineInputTokens: 1000,
+        graphifyInputTokens: 500,
+        reductions: {
+          num_turns: 2,
+          duration_ms: 2,
+          input_tokens: 2,
+          cost_usd: 1,
+        },
+      },
+      {
+        question: 'loss case',
+        baselineTurns: 4,
+        graphifyTurns: 6,
+        baselineDurationMs: 4000,
+        graphifyDurationMs: 6000,
+        baselineInputTokens: 400,
+        graphifyInputTokens: 500,
+        reductions: {
+          num_turns: 0.67,
+          duration_ms: 0.67,
+          input_tokens: 0.8,
+          cost_usd: 1,
+        },
+      },
+    ]))
+
+    expect(summary).toContain('Suite input_tokens (Anthropic-reported): 1 win · 1 loss · mean reduction 12.5% · median reduction 12.5% · best win: "win case" (50% less) · worst regression: "loss case" (25% more)')
+    expect(summary).toContain('Suite num_turns: 1 win · 1 loss · best win: "win case" (50% fewer) · worst regression: "loss case" (50% more)')
+    expect(summary).toContain('Suite latency: 1 win · 1 loss · best win: "win case" (50% faster) · worst regression: "loss case" (50% slower)')
   })
 })

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -582,4 +582,72 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).toContain('Suite num_turns: 1 win · 1 loss · best win: "win case" (50% fewer) · worst regression: "loss case" (50% more)')
     expect(summary).toContain('Suite latency: 1 win · 1 loss · best win: "win case" (50% faster) · worst regression: "loss case" (50% slower)')
   })
+
+  it('calls out the comparable-question denominator when answer-only runs are excluded from suite aggregates', () => {
+    const result = buildSuiteSummaryResult([
+      {
+        question: 'win a',
+        baselineTurns: 9,
+        graphifyTurns: 3,
+        baselineDurationMs: 9000,
+        graphifyDurationMs: 3000,
+        baselineInputTokens: 900,
+        graphifyInputTokens: 300,
+        reductions: {
+          num_turns: 3,
+          duration_ms: 3,
+          input_tokens: 3,
+          cost_usd: 1,
+        },
+      },
+      {
+        question: 'win b',
+        baselineTurns: 8,
+        graphifyTurns: 2,
+        baselineDurationMs: 8000,
+        graphifyDurationMs: 2000,
+        baselineInputTokens: 800,
+        graphifyInputTokens: 200,
+        reductions: {
+          num_turns: 4,
+          duration_ms: 4,
+          input_tokens: 4,
+          cost_usd: 1,
+        },
+      },
+      {
+        question: 'answer only',
+        baselineTurns: 5,
+        graphifyTurns: 5,
+        baselineDurationMs: 5000,
+        graphifyDurationMs: 5000,
+        baselineInputTokens: 500,
+        graphifyInputTokens: 500,
+        reductions: {
+          num_turns: 1,
+          duration_ms: 1,
+          input_tokens: 1,
+          cost_usd: 1,
+        },
+      },
+    ])
+    result.reports[2] = {
+      ...result.reports[2]!,
+      graphify: {
+        kind: 'answer_only',
+        evidence: null,
+        exit_code: 0,
+        stderr: null,
+        result_path: '/tmp/project/answer-only.txt',
+      },
+      reductions: null,
+    }
+
+    const summary = formatNativeAgentCompareSummary(result)
+
+    expect(summary).toContain('Suite input_tokens (Anthropic-reported): 2 wins · 0 losses · 2/3 comparable · mean reduction 70.8% · median reduction 70.8% · best win: "win b" (75% less) · worst regression: none')
+    expect(summary).toContain('Suite num_turns: 2 wins · 0 losses · 2/3 comparable · best win: "win b" (75% fewer) · worst regression: none')
+    expect(summary).toContain('Suite latency: 2 wins · 0 losses · 2/3 comparable · best win: "win b" (75% faster) · worst regression: none')
+    expect(summary).toContain('"answer only" → answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed')
+  })
 })


### PR DESCRIPTION
## Summary
- add suite-level native_agent compare rollups for input tokens, turns, and latency
- report mean and median input-token reduction plus best win and worst regression prompts
- cover the new output in tests and document it in the README, proof workflow docs, and changelog

## Testing
- npm run test:run -- tests/unit/compare-native-agent.test.ts
- npm run typecheck
- npm run build
- npm run test:run

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-question native-agent comparisons now show suite-level rollups in terminal: aggregated wins/losses, mean/median input-token reduction, turns/latency stats, comparable-counts, and best/worst prompt highlights.

* **Documentation**
  * Clarified measured-results and proof-workflow guidance, including JSON output recommendation for native-agent runs and explanation of suite-level metrics.

* **Tests**
  * Added unit tests covering suite-level aggregation and reporting behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->