### PR TITLE
feat: add cache-aware native-agent compare accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Changed
 
 - **Native-agent compare suite summary**: multi-question `compare --baseline-mode native_agent` runs now roll up comparable-question wins/losses for input tokens, turns, and latency, report mean/median input-token reduction, surface comparable-question counts when some runs are excluded from the aggregate, and highlight the best win and worst regression prompt in the terminal summary.
+- **Native-agent cache-aware compare accounting**: `compare --baseline-mode native_agent` now persists derived total/uncached/cached Anthropic input-token fields alongside the raw provider `usage` block, and the terminal summary breaks out uncached/cache creation/cache read lines when cache activity is present.
 
 ## [0.22.9] - 2026-05-16
 

--- a/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
+++ b/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
@@ -34,6 +34,14 @@ This is the exact compare summary captured for the run:
     provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs
 ```
 
+Current `compare --baseline-mode native_agent` reports keep the raw Anthropic `usage` block and also persist derived token-accounting fields for each run:
+
+- `total_input_tokens_anthropic_exact` = `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`
+- `uncached_input_tokens_anthropic_exact` = `input_tokens + cache_creation_input_tokens`
+- `cached_input_tokens_anthropic_exact` = `cache_read_input_tokens`
+
+The terminal summary only prints the extra uncached/cache lines when at least one run reported non-zero cache activity, so zero-cache runs stay compact while cached runs make the cold-vs-reused split explicit.
+
 ## Commands
 
 `0.22.7` is the version used for this benchmark. Future versions may improve or regress; do not read this as “install 0.22.7 forever.”
@@ -100,7 +108,7 @@ The script recomputes the saved-token, saved-turn, and latency deltas directly f
 - This is a **single prompt / single project** benchmark.
 - Native-agent behavior is stochastic; reruns can vary.
 - Claude MCP/tool usage can change turn count and token totals.
-- Anthropic provider-reported tokens include cache creation/read details; `compare` records provider/runtime proof for both runs.
+- Anthropic provider-reported tokens include cache creation/read details; `compare` records the raw provider `usage` block plus derived total/uncached/cached input-token fields for both runs.
 - This benchmark does **not** prove universal token reduction.
 - More benchmark cases are needed across prompts, repositories, and task types.
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1515,7 +1515,18 @@ export interface AnthropicResultEvent {
 }
 
 export type NativeAgentRunStatus =
-  | { kind: 'succeeded'; model: string | null; usage: AnthropicUsageBlock; total_input_tokens_anthropic_exact: number; total_cost_usd: number | null; num_turns: number; duration_ms: number; result_path: string }
+  | {
+      kind: 'succeeded'
+      model: string | null
+      usage: AnthropicUsageBlock
+      total_input_tokens_anthropic_exact: number
+      uncached_input_tokens_anthropic_exact: number
+      cached_input_tokens_anthropic_exact: number
+      total_cost_usd: number | null
+      num_turns: number
+      duration_ms: number
+      result_path: string
+    }
   | { kind: 'answer_only'; evidence: string | null; exit_code: number; stderr: string | null; result_path: string }
   | { kind: 'runner_error'; evidence: string | null; exit_code: number | null; stderr: string | null }
 
@@ -1881,6 +1892,14 @@ function totalAnthropicInputTokens(usage: AnthropicUsageBlock): number {
   return usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
 }
 
+function uncachedAnthropicInputTokens(usage: AnthropicUsageBlock): number {
+  return usage.input_tokens + usage.cache_creation_input_tokens
+}
+
+function cachedAnthropicInputTokens(usage: AnthropicUsageBlock): number {
+  return usage.cache_read_input_tokens
+}
+
 export async function executeNativeAgentCompare(
   input: GenerateCompareArtifactsInput,
   dependencies: ExecuteNativeAgentCompareDependencies = {},
@@ -1975,6 +1994,8 @@ export async function executeNativeAgentCompare(
             model: event.model,
             usage: event.usage,
             total_input_tokens_anthropic_exact: totalAnthropicInputTokens(event.usage),
+            uncached_input_tokens_anthropic_exact: uncachedAnthropicInputTokens(event.usage),
+            cached_input_tokens_anthropic_exact: cachedAnthropicInputTokens(event.usage),
             total_cost_usd: event.total_cost_usd,
             num_turns: event.num_turns,
             duration_ms: event.duration_ms,
@@ -2048,6 +2069,8 @@ export async function executeNativeAgentCompare(
           model: event.model,
           usage: event.usage,
           total_input_tokens_anthropic_exact: totalAnthropicInputTokens(event.usage),
+          uncached_input_tokens_anthropic_exact: uncachedAnthropicInputTokens(event.usage),
+          cached_input_tokens_anthropic_exact: cachedAnthropicInputTokens(event.usage),
           total_cost_usd: event.total_cost_usd,
           num_turns: event.num_turns,
           duration_ms: event.duration_ms,
@@ -2210,13 +2233,26 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       continue
     }
 
+    const hasCacheActivity =
+      baseline.usage.cache_creation_input_tokens > 0 ||
+      baseline.cached_input_tokens_anthropic_exact > 0 ||
+      graphify.usage.cache_creation_input_tokens > 0 ||
+      graphify.cached_input_tokens_anthropic_exact > 0
+
     lines.push(
       `- "${report.question}"`,
       `    num_turns: baseline ${baseline.num_turns} → graphify ${graphify.num_turns}${formatDirectionalDelta(baseline.num_turns, graphify.num_turns, 'fewer', 'more')}`,
       `    latency:   baseline ${baseline.duration_ms}ms → graphify ${graphify.duration_ms}ms${formatDirectionalDelta(baseline.duration_ms, graphify.duration_ms, 'faster', 'slower')}`,
       `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → graphify ${graphify.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, graphify.total_input_tokens_anthropic_exact, 'less', 'more')}`,
-      `    provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs`,
     )
+    if (hasCacheActivity) {
+      lines.push(
+        `    uncached_input_tokens (Anthropic-reported): baseline ${baseline.uncached_input_tokens_anthropic_exact} → graphify ${graphify.uncached_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.uncached_input_tokens_anthropic_exact, graphify.uncached_input_tokens_anthropic_exact, 'less', 'more')}`,
+        `    cache_creation_input_tokens (Anthropic-reported): baseline ${baseline.usage.cache_creation_input_tokens} → graphify ${graphify.usage.cache_creation_input_tokens}${formatDirectionalDelta(baseline.usage.cache_creation_input_tokens, graphify.usage.cache_creation_input_tokens, 'less', 'more')}`,
+        `    cache_read_input_tokens (Anthropic-reported): baseline ${baseline.usage.cache_read_input_tokens} → graphify ${graphify.usage.cache_read_input_tokens}${formatDirectionalDelta(baseline.usage.cache_read_input_tokens, graphify.usage.cache_read_input_tokens, 'less', 'more')}`,
+      )
+    }
+    lines.push(`    provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs`)
   }
   return lines.join('\n')
 }

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -113,6 +113,8 @@ function buildSummaryResult(overrides: {
             output_tokens: 100,
           },
           total_input_tokens_anthropic_exact: overrides.baselineInputTokens,
+          uncached_input_tokens_anthropic_exact: overrides.baselineInputTokens,
+          cached_input_tokens_anthropic_exact: 0,
           total_cost_usd: 1,
           num_turns: overrides.baselineTurns,
           duration_ms: overrides.baselineDurationMs,
@@ -128,6 +130,8 @@ function buildSummaryResult(overrides: {
             output_tokens: 100,
           },
           total_input_tokens_anthropic_exact: overrides.graphifyInputTokens,
+          uncached_input_tokens_anthropic_exact: overrides.graphifyInputTokens,
+          cached_input_tokens_anthropic_exact: 0,
           total_cost_usd: 1,
           num_turns: overrides.graphifyTurns,
           duration_ms: overrides.graphifyDurationMs,
@@ -245,6 +249,21 @@ describe('executeNativeAgentCompare', () => {
       expect(report.graphify.usage).toEqual(GRAPHIFY_USAGE_PAYLOAD.usage)
       expect(report.graphify.num_turns).toBe(3)
       expect(report.graphify.total_cost_usd).toBe(0.7)
+
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as {
+        baseline: Record<string, unknown>
+        graphify: Record<string, unknown>
+      }
+      expect(savedReport.baseline).toEqual(expect.objectContaining({
+        total_input_tokens_anthropic_exact: 615190,
+        uncached_input_tokens_anthropic_exact: 40662,
+        cached_input_tokens_anthropic_exact: 574528,
+      }))
+      expect(savedReport.graphify).toEqual(expect.objectContaining({
+        total_input_tokens_anthropic_exact: 233508,
+        uncached_input_tokens_anthropic_exact: 92846,
+        cached_input_tokens_anthropic_exact: 140662,
+      }))
 
       // Reductions match the spec table (3x turns, 2.6x input, 2.77x duration).
       expect(report.reductions).not.toBeNull()
@@ -460,7 +479,7 @@ describe('executeNativeAgentCompare', () => {
 
 describe('formatNativeAgentCompareSummary', () => {
   it('describes wins as fewer, less, and faster', () => {
-    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+    const result = buildSummaryResult({
       question: 'win case',
       baselineTurns: 9,
       graphifyTurns: 3,
@@ -474,11 +493,36 @@ describe('formatNativeAgentCompareSummary', () => {
         input_tokens: 3,
         cost_usd: 1,
       },
-    }))
+    })
+    const report = result.reports[0]
+    if (!report || report.baseline.kind !== 'succeeded' || report.graphify.kind !== 'succeeded') {
+      throw new Error('summary fixture should produce succeeded runs')
+    }
+    report.baseline.usage = {
+      input_tokens: 600,
+      cache_creation_input_tokens: 200,
+      cache_read_input_tokens: 100,
+      output_tokens: 100,
+    }
+    report.baseline.uncached_input_tokens_anthropic_exact = 800
+    report.baseline.cached_input_tokens_anthropic_exact = 100
+    report.graphify.usage = {
+      input_tokens: 150,
+      cache_creation_input_tokens: 100,
+      cache_read_input_tokens: 50,
+      output_tokens: 100,
+    }
+    report.graphify.uncached_input_tokens_anthropic_exact = 250
+    report.graphify.cached_input_tokens_anthropic_exact = 50
+
+    const summary = formatNativeAgentCompareSummary(result)
 
     expect(summary).toContain('num_turns: baseline 9 → graphify 3 (3x fewer)')
     expect(summary).toContain('latency:   baseline 9000ms → graphify 3000ms (3x faster)')
     expect(summary).toContain('input_tokens (Anthropic-reported): baseline 900 → graphify 300 (3x less)')
+    expect(summary).toContain('uncached_input_tokens (Anthropic-reported): baseline 800 → graphify 250 (3.2x less)')
+    expect(summary).toContain('cache_creation_input_tokens (Anthropic-reported): baseline 200 → graphify 100 (2x less)')
+    expect(summary).toContain('cache_read_input_tokens (Anthropic-reported): baseline 100 → graphify 50 (2x less)')
   })
 
   it('describes regressions as more and slower instead of fewer and faster', () => {
@@ -504,6 +548,28 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).not.toContain('0.33x fewer')
     expect(summary).not.toContain('0.33x faster')
     expect(summary).not.toContain('0.33x less')
+  })
+
+  it('omits cache-detail lines when neither run reported cache activity', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'no cache case',
+      baselineTurns: 9,
+      graphifyTurns: 3,
+      baselineDurationMs: 9000,
+      graphifyDurationMs: 3000,
+      baselineInputTokens: 900,
+      graphifyInputTokens: 300,
+      reductions: {
+        num_turns: 3,
+        duration_ms: 3,
+        input_tokens: 3,
+        cost_usd: 1,
+      },
+    }))
+
+    expect(summary).not.toContain('uncached_input_tokens (Anthropic-reported)')
+    expect(summary).not.toContain('cache_creation_input_tokens (Anthropic-reported)')
+    expect(summary).not.toContain('cache_read_input_tokens (Anthropic-reported)')
   })
 
   it('summarizes all-win native_agent suites with aggregate win counts and reductions', () => {


### PR DESCRIPTION
## Summary
- persist derived total, uncached, and cached Anthropic input-token fields for native-agent compare runs
- show uncached, cache creation, and cache read token lines in native-agent summaries when cache activity is present
- document the token-accounting interpretation in the benchmark note and changelog

## Testing
- npm run test:run -- tests/unit/compare-native-agent.test.ts
- npm run typecheck
- npm run build
- npm run test:run

Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced native-agent compare reporting with cache-aware token accounting, displaying uncached vs cached input-token breakdown when cache activity is detected.
  * Improved aggregate comparison statistics showing mean/median token improvements and highlighting best/worst performance outcomes.

* **Documentation**
  * Clarified native-agent compare behavior and token accounting methodology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->