### PR TITLE
feat: add GoValidate pack-quality gates

### DIFF
--- a/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
+++ b/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
@@ -85,6 +85,11 @@ coverage: primary/supporting/structural/implementation/structure covered
 diagnostics: none
 ```
 
+Exact labels used for that gate:
+
+- required runtime path labels: `IdeaReportController`, `GenerateIdeaReportService`
+- forbidden sibling/script/share labels: `IdeaReportSharePage`, `GenerateIdeaReportScript`
+
 Why this matters: a 3.32x input-token reduction is not persuasive if the compiled pack still expands to the full budget. Here the pack stayed compact **and** preserved the required runtime path.
 
 ## Reproducing from this directory

--- a/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
+++ b/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
@@ -71,7 +71,21 @@ If you want a machine-readable copy of the pack output for archival, redirect th
 
 The compare win only became credible after the runtime pack stopped filling the full 4000-token budget and returned a compact runtime slice instead of near-whole-backend noise.
 
-The `v0.22.7` pack quality gate for this prompt was:
+Pack quality is necessary but not sufficient for answer quality: a small pack can still miss the runtime path and produce a worse answer. The win here is only worth publishing because the saved pack stayed compact **and** preserved the report-generation route that the answer needed.
+
+The shared gate definition now lives in:
+
+- `docs/benchmarks/govalidate-suite/quality-gates.json`
+- `docs/benchmarks/govalidate-suite/verify-pack-quality.js`
+
+For this prompt, the shared `docs-artifact` gate encodes the same runtime-path requirements and ceilings that were checked for the `v0.22.7` run:
+
+Exact labels used for that gate:
+
+- required runtime path labels: `IdeaReportController`, `GenerateIdeaReportService`
+- forbidden sibling/script/share labels: `IdeaReportSharePage`, `GenerateIdeaReportScript`
+
+Observed report pack for this saved benchmark:
 
 ```text
 token_count: 1456
@@ -85,12 +99,14 @@ coverage: primary/supporting/structural/implementation/structure covered
 diagnostics: none
 ```
 
-Exact labels used for that gate:
+Run the shared verifier against a saved compare report with:
 
-- required runtime path labels: `IdeaReportController`, `GenerateIdeaReportService`
-- forbidden sibling/script/share labels: `IdeaReportSharePage`, `GenerateIdeaReportScript`
-
-Why this matters: a 3.32x input-token reduction is not persuasive if the compiled pack still expands to the full budget. Here the pack stayed compact **and** preserved the required runtime path.
+```bash
+node docs/benchmarks/govalidate-suite/verify-pack-quality.js \
+  --report docs/benchmarks/2026-05-12-govalidate-report-generation/report.json \
+  --config docs/benchmarks/govalidate-suite/quality-gates.json \
+  --gate docs-artifact
+```
 
 ## Reproducing from this directory
 
@@ -100,7 +116,7 @@ Drop the `report.json` from:
 graphify-out/compare/2026-05-12T19-18-26/report.json
 ```
 
-into this directory, then run:
+into this directory, then run the shared verifier command above and:
 
 ```bash
 bash docs/benchmarks/2026-05-12-govalidate-report-generation/verify.sh

--- a/docs/benchmarks/govalidate-suite/README.md
+++ b/docs/benchmarks/govalidate-suite/README.md
@@ -1,0 +1,28 @@
+# GoValidate shared benchmark quality gates
+
+This directory holds the shared pack-quality gates for committed GoValidate benchmark artifacts.
+
+## Files
+
+- `quality-gates.json` — named gate definitions plus the prompt text they apply to
+- `verify-pack-quality.js` — deterministic verifier for persisted `graphify-ts compare` reports
+
+## Usage
+
+By gate name:
+
+```bash
+node docs/benchmarks/govalidate-suite/verify-pack-quality.js \
+  --report path/to/report.json \
+  --gate docs-artifact
+```
+
+By prompt text:
+
+```bash
+node docs/benchmarks/govalidate-suite/verify-pack-quality.js \
+  --report path/to/report.json \
+  --prompt "Explain how idea report is getting generated"
+```
+
+The verifier reads `report.pack`, checks normalized matched-node labels against the required/forbidden lists, enforces the numeric ceilings, prints a deterministic pass/fail summary, and exits non-zero on malformed input or any gate failure. Label matching lowercases and strips non-alphanumeric characters, so gate labels must still contain at least one alphanumeric character after normalization.

--- a/docs/benchmarks/govalidate-suite/quality-gates.json
+++ b/docs/benchmarks/govalidate-suite/quality-gates.json
@@ -1,0 +1,16 @@
+{
+  "docs-artifact": {
+    "prompt": "Explain how idea report is getting generated",
+    "required_labels": [
+      "IdeaReportController",
+      "GenerateIdeaReportService"
+    ],
+    "forbidden_labels": [
+      "IdeaReportSharePage",
+      "GenerateIdeaReportScript"
+    ],
+    "max_pack_tokens": 1456,
+    "max_matched_nodes": 38,
+    "max_relationships": 57
+  }
+}

--- a/docs/benchmarks/govalidate-suite/verify-pack-quality.js
+++ b/docs/benchmarks/govalidate-suite/verify-pack-quality.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function usage() {
+  return [
+    'Usage:',
+    '  node docs/benchmarks/govalidate-suite/verify-pack-quality.js --report <report.json> (--gate <name> | --prompt <text>) [--config <quality-gates.json>]',
+  ].join('\n')
+}
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}
+
+function parseArgs(argv) {
+  const args = { report: null, gate: null, prompt: null, config: null }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const value = argv[index + 1]
+
+    if (arg === '--report') {
+      args.report = value ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--gate') {
+      args.gate = value ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--prompt') {
+      args.prompt = value ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--config') {
+      args.config = value ?? null
+      index += 1
+      continue
+    }
+    fail(`Unknown argument: ${arg}\n${usage()}`)
+  }
+
+  if (!args.report) {
+    fail(`Missing required --report argument.\n${usage()}`)
+  }
+  if ((args.gate ? 1 : 0) + (args.prompt ? 1 : 0) !== 1) {
+    fail(`Pass exactly one of --gate or --prompt.\n${usage()}`)
+  }
+
+  return args
+}
+
+function readJsonFile(path, label) {
+  let raw
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (error) {
+    fail(`Failed to read ${label}: ${path}\n${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    fail(`Failed to parse ${label}: ${path}\n${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function normalizeLabel(label) {
+  return label.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function validateGateDefinition(gateName, gate) {
+  if (gate === null || typeof gate !== 'object' || Array.isArray(gate)) {
+    fail(`Malformed gate definition for ${gateName}: expected an object`)
+  }
+
+  const requiredLabels = gate.required_labels
+  const forbiddenLabels = gate.forbidden_labels
+  const maxPackTokens = gate.max_pack_tokens
+  const maxMatchedNodes = gate.max_matched_nodes
+  const maxRelationships = gate.max_relationships
+
+  if (!Array.isArray(requiredLabels) || requiredLabels.length === 0 || requiredLabels.some((label) => typeof label !== 'string' || label.trim() === '')) {
+    fail(`Malformed gate definition for ${gateName}: required_labels must be a non-empty string array`)
+  }
+  if (!Array.isArray(forbiddenLabels) || forbiddenLabels.some((label) => typeof label !== 'string' || label.trim() === '')) {
+    fail(`Malformed gate definition for ${gateName}: forbidden_labels must be a string array`)
+  }
+  if ([...requiredLabels, ...forbiddenLabels].some((label) => normalizeLabel(label).length === 0)) {
+    fail(`Malformed gate definition for ${gateName}: labels must contain at least one alphanumeric character after normalization`)
+  }
+  if (!Number.isFinite(maxPackTokens) || maxPackTokens <= 0) {
+    fail(`Malformed gate definition for ${gateName}: max_pack_tokens must be a positive number`)
+  }
+  if (!Number.isInteger(maxMatchedNodes) || maxMatchedNodes <= 0) {
+    fail(`Malformed gate definition for ${gateName}: max_matched_nodes must be a positive integer`)
+  }
+  if (!Number.isInteger(maxRelationships) || maxRelationships < 0) {
+    fail(`Malformed gate definition for ${gateName}: max_relationships must be a non-negative integer`)
+  }
+  if ('prompt' in gate && (typeof gate.prompt !== 'string' || gate.prompt.trim() === '')) {
+    fail(`Malformed gate definition for ${gateName}: prompt must be a non-empty string when provided`)
+  }
+
+  return {
+    prompt: typeof gate.prompt === 'string' ? gate.prompt : null,
+    required_labels: requiredLabels,
+    forbidden_labels: forbiddenLabels,
+    max_pack_tokens: maxPackTokens,
+    max_matched_nodes: maxMatchedNodes,
+    max_relationships: maxRelationships,
+  }
+}
+
+function loadGateConfig(configPath) {
+  const parsed = readJsonFile(configPath, 'gate config')
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail(`Malformed gate config: expected a JSON object at ${configPath}`)
+  }
+
+  const entries = Object.entries(parsed)
+  if (entries.length === 0) {
+    fail(`Malformed gate config: expected at least one gate entry in ${configPath}`)
+  }
+
+  return new Map(entries.map(([gateName, gate]) => [gateName, validateGateDefinition(gateName, gate)]))
+}
+
+function resolveGate(gates, selector) {
+  if (selector.gate) {
+    const gate = gates.get(selector.gate)
+    if (!gate) {
+      fail(`Unknown gate: ${selector.gate}`)
+    }
+    return { gateName: selector.gate, gate }
+  }
+
+  const matches = [...gates.entries()].filter(([gateName, gate]) => gateName === selector.prompt || gate.prompt === selector.prompt)
+  if (matches.length === 0) {
+    fail(`No gate matches prompt: ${selector.prompt}`)
+  }
+  if (matches.length > 1) {
+    fail(`Prompt matches multiple gates: ${selector.prompt}`)
+  }
+
+  const [gateName, gate] = matches[0]
+  return { gateName, gate }
+}
+
+function validateReport(reportPath) {
+  const report = readJsonFile(reportPath, 'compare report')
+  if (report === null || typeof report !== 'object' || Array.isArray(report)) {
+    fail(`Malformed compare report: expected an object at ${reportPath}`)
+  }
+  if (report.pack === null || typeof report.pack !== 'object' || Array.isArray(report.pack)) {
+    fail(`Malformed compare report: missing object report.pack in ${reportPath}`)
+  }
+
+  const { pack } = report
+  if (!Number.isFinite(pack.token_count)) {
+    fail(`Malformed compare report: pack.token_count must be a finite number`)
+  }
+  if (!Array.isArray(pack.matched_nodes)) {
+    fail(`Malformed compare report: pack.matched_nodes must be an array`)
+  }
+  if (!Array.isArray(pack.relationships)) {
+    fail(`Malformed compare report: pack.relationships must be an array`)
+  }
+  for (const [index, node] of pack.matched_nodes.entries()) {
+    if (node === null || typeof node !== 'object' || Array.isArray(node) || typeof node.label !== 'string' || node.label.trim() === '') {
+      fail(`Malformed compare report: pack.matched_nodes[${index}] must be an object with a non-empty label`)
+    }
+  }
+
+  return report
+}
+
+function verifyPackQuality(gateName, gate, report) {
+  const normalizedLabels = new Set(
+    report.pack.matched_nodes
+      .map((node) => normalizeLabel(node.label))
+      .filter((label) => label.length > 0),
+  )
+
+  const missingRequired = gate.required_labels.filter((label) => !normalizedLabels.has(normalizeLabel(label)))
+  const forbiddenPresent = gate.forbidden_labels.filter((label) => normalizedLabels.has(normalizeLabel(label)))
+  const failures = []
+
+  if (missingRequired.length > 0) {
+    failures.push(`missing required labels: ${missingRequired.join(', ')}`)
+  }
+  if (forbiddenPresent.length > 0) {
+    failures.push(`forbidden labels present: ${forbiddenPresent.join(', ')}`)
+  }
+  if (report.pack.token_count > gate.max_pack_tokens) {
+    failures.push(`pack.token_count ${report.pack.token_count} exceeds max_pack_tokens ${gate.max_pack_tokens}`)
+  }
+  if (report.pack.matched_nodes.length > gate.max_matched_nodes) {
+    failures.push(`pack.matched_nodes count ${report.pack.matched_nodes.length} exceeds max_matched_nodes ${gate.max_matched_nodes}`)
+  }
+  if (report.pack.relationships.length > gate.max_relationships) {
+    failures.push(`pack.relationships count ${report.pack.relationships.length} exceeds max_relationships ${gate.max_relationships}`)
+  }
+
+  const lines = [
+    `${gateName} ${failures.length === 0 ? 'PASS' : 'FAIL'}`,
+    `prompt: ${gate.prompt ?? report.pack.question ?? report.question ?? '(unknown)'}`,
+  ]
+
+  if (failures.length === 0) {
+    lines.push(`required labels present: ${gate.required_labels.join(', ')}`)
+    lines.push('forbidden labels present: none')
+    lines.push(`pack.token_count ${report.pack.token_count} <= max_pack_tokens ${gate.max_pack_tokens}`)
+    lines.push(`pack.matched_nodes count ${report.pack.matched_nodes.length} <= max_matched_nodes ${gate.max_matched_nodes}`)
+    lines.push(`pack.relationships count ${report.pack.relationships.length} <= max_relationships ${gate.max_relationships}`)
+  } else {
+    lines.push(...failures)
+  }
+
+  return { ok: failures.length === 0, output: lines.join('\n') }
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const args = parseArgs(process.argv.slice(2))
+const configPath = args.config && isAbsolute(args.config)
+  ? resolve(args.config)
+  : resolve(scriptDir, args.config ?? 'quality-gates.json')
+const reportPath = resolve(args.report)
+const gates = loadGateConfig(configPath)
+const { gateName, gate } = resolveGate(gates, args)
+const report = validateReport(reportPath)
+const result = verifyPackQuality(gateName, gate, report)
+
+if (result.ok) {
+  console.log(result.output)
+  process.exit(0)
+}
+
+console.error(result.output)
+process.exit(1)

--- a/docs/benchmarks/govalidate-suite/verify-pack-quality.js
+++ b/docs/benchmarks/govalidate-suite/verify-pack-quality.js
@@ -104,12 +104,12 @@ function validateGateDefinition(gateName, gate) {
   if (!Number.isInteger(maxRelationships) || maxRelationships < 0) {
     fail(`Malformed gate definition for ${gateName}: max_relationships must be a non-negative integer`)
   }
-  if ('prompt' in gate && (typeof gate.prompt !== 'string' || gate.prompt.trim() === '')) {
-    fail(`Malformed gate definition for ${gateName}: prompt must be a non-empty string when provided`)
+  if (typeof gate.prompt !== 'string' || gate.prompt.trim() === '') {
+    fail(`Malformed gate definition for ${gateName}: prompt must be a non-empty string`)
   }
 
   return {
-    prompt: typeof gate.prompt === 'string' ? gate.prompt : null,
+    prompt: gate.prompt.trim(),
     required_labels: requiredLabels,
     forbidden_labels: forbiddenLabels,
     max_pack_tokens: maxPackTokens,
@@ -163,8 +163,8 @@ function validateReport(reportPath) {
   }
 
   const { pack } = report
-  if (!Number.isFinite(pack.token_count)) {
-    fail(`Malformed compare report: pack.token_count must be a finite number`)
+  if (!Number.isInteger(pack.token_count) || pack.token_count < 0) {
+    fail(`Malformed compare report: pack.token_count must be a non-negative integer`)
   }
   if (!Array.isArray(pack.matched_nodes)) {
     fail(`Malformed compare report: pack.matched_nodes must be an array`)

--- a/docs/benchmarks/govalidate-suite/verify-pack-quality.js
+++ b/docs/benchmarks/govalidate-suite/verify-pack-quality.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs'
-import { dirname, isAbsolute, resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 function usage() {
@@ -228,9 +228,7 @@ function verifyPackQuality(gateName, gate, report) {
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const args = parseArgs(process.argv.slice(2))
-const configPath = args.config && isAbsolute(args.config)
-  ? resolve(args.config)
-  : resolve(scriptDir, args.config ?? 'quality-gates.json')
+const configPath = args.config ? resolve(args.config) : resolve(scriptDir, 'quality-gates.json')
 const reportPath = resolve(args.report)
 const gates = loadGateConfig(configPath)
 const { gateName, gate } = resolveGate(gates, args)

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -8,8 +8,10 @@ import type { CompareReportPack } from '../../src/infrastructure/compare.js'
 
 const ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-04-30-govalidate')
 const REVIEW_ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-05-02-govalidate-pr-review')
+const REPORT_GENERATION_ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-05-12-govalidate-report-generation')
 const BENCHMARK_STYLESHEET = resolve('docs', 'benchmarks', 'styles.css')
 const PACK_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'verify-pack-quality.js')
+const PACK_GATE_CONFIG_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'quality-gates.json')
 
 interface PackQualityGateDefinition {
   required_labels: string[]
@@ -276,6 +278,20 @@ describe('public benchmark artifact (2026-05-02 govalidate pr review)', () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('verbose_prompt_tokens')
     expect(result.stdout).toContain('compact_prompt_tokens')
+  })
+})
+
+describe('public benchmark artifact (2026-05-12 govalidate report generation)', () => {
+  const readme = readFileSync(resolve(REPORT_GENERATION_ARTIFACT_DIR, 'README.md'), 'utf8')
+
+  it('README explains that pack quality is necessary but not sufficient for answer quality', () => {
+    const lower = readme.toLowerCase()
+    expect(lower).toContain('pack quality is necessary but not sufficient for answer quality')
+  })
+
+  it('README points readers to the shared suite verifier and gate config', () => {
+    expect(readme).toContain(relative(process.cwd(), PACK_VERIFIER_PATH))
+    expect(readme).toContain(relative(process.cwd(), PACK_GATE_CONFIG_PATH))
   })
 })
 

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -63,6 +63,9 @@ function buildRelationships(
   matchedNodes: CompareReportPack['matched_nodes'],
 ): CompareReportPack['relationships'] {
   const labels = matchedNodes.map(({ label }) => label)
+  if (labels.length === 0) {
+    return []
+  }
 
   return Array.from({ length: totalCount }, (_, index) => ({
     from: labels[index % labels.length]!,
@@ -277,6 +280,10 @@ describe('public benchmark artifact (2026-05-02 govalidate pr review)', () => {
 })
 
 describe('shared GoValidate pack-quality verifier contract', () => {
+  it('builds no relationships when a fixture has no matched nodes', () => {
+    expect(buildRelationships(3, [])).toEqual([])
+  })
+
   it('accepts docs-artifact packs that satisfy required labels and pack ceilings', () => {
     const result = runPackVerifier('pass', buildPackFixture())
     const output = combinedOutput(result)

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -1,12 +1,148 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
+
+import type { CompareReportPack } from '../../src/infrastructure/compare.js'
 
 const ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-04-30-govalidate')
 const REVIEW_ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-05-02-govalidate-pr-review')
 const BENCHMARK_STYLESHEET = resolve('docs', 'benchmarks', 'styles.css')
+const PACK_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'verify-pack-quality.js')
+
+interface PackQualityGateDefinition {
+  required_labels: string[]
+  forbidden_labels: string[]
+  max_pack_tokens: number
+  max_matched_nodes: number
+  max_relationships: number
+}
+
+const DOCS_ARTIFACT_GATE: PackQualityGateDefinition = {
+  required_labels: ['IdeaReportController', 'GenerateIdeaReportService'],
+  forbidden_labels: ['IdeaReportSharePage', 'GenerateIdeaReportScript'],
+  max_pack_tokens: 1_456,
+  max_matched_nodes: 38,
+  max_relationships: 57,
+}
+
+function buildMatchedNodes(totalCount: number, labels: readonly string[]): CompareReportPack['matched_nodes'] {
+  const nodes: CompareReportPack['matched_nodes'] = labels.map(
+    (label, index): CompareReportPack['matched_nodes'][number] => ({
+      label,
+      source_file: `src/runtime/report-${index + 1}.ts`,
+      line_number: index + 1,
+      snippet: `// ${label}`,
+      match_score: totalCount - index,
+      relevance_band: index === 0 ? 'direct' : 'related',
+      community: 1,
+      file_type: 'code',
+    }),
+  )
+
+  while (nodes.length < totalCount) {
+    const index = nodes.length + 1
+    nodes.push({
+      label: `SupportingReportNode${index}`,
+      source_file: `src/runtime/supporting-${index}.ts`,
+      line_number: index,
+      snippet: `// SupportingReportNode${index}`,
+      match_score: totalCount - index,
+      relevance_band: 'peripheral',
+      community: 1,
+      file_type: 'code',
+    })
+  }
+
+  return nodes
+}
+
+function buildRelationships(
+  totalCount: number,
+  matchedNodes: CompareReportPack['matched_nodes'],
+): CompareReportPack['relationships'] {
+  const labels = matchedNodes.map(({ label }) => label)
+
+  return Array.from({ length: totalCount }, (_, index) => ({
+    from: labels[index % labels.length]!,
+    to: labels[(index + 1) % labels.length]!,
+    relation: 'calls',
+  }))
+}
+
+function buildPackFixture(overrides: Partial<Pick<CompareReportPack, 'token_count' | 'matched_nodes' | 'relationships'>> = {}): CompareReportPack {
+  const matched_nodes = overrides.matched_nodes
+    ?? buildMatchedNodes(DOCS_ARTIFACT_GATE.max_matched_nodes, DOCS_ARTIFACT_GATE.required_labels)
+  const relationships = overrides.relationships ?? buildRelationships(DOCS_ARTIFACT_GATE.max_relationships, matched_nodes)
+
+  return {
+    question: 'Explain how idea report is getting generated',
+    token_count: DOCS_ARTIFACT_GATE.max_pack_tokens,
+    matched_nodes,
+    relationships,
+    community_context: [{ id: 1, label: 'Report Generation', node_count: 38 }],
+    graph_signals: { god_nodes: [], bridge_nodes: [] },
+    retrieval_strategy: 'default',
+    ...overrides,
+  }
+}
+
+function writeCompareStyleReport(reportPath: string, pack: CompareReportPack): void {
+  writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        question: pack.question,
+        graph_path: 'graphify-out/graph.json',
+        baseline_mode: 'pack_only',
+        pack,
+        paths: {
+          output_dir: '.',
+          baseline_prompt: 'baseline-prompt.txt',
+          graphify_prompt: 'graphify-prompt.txt',
+          report: 'report.json',
+          share_safe_report: 'report.share-safe.json',
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+function runPackVerifier(
+  testName: string,
+  pack: CompareReportPack,
+  gateConfig: Record<string, PackQualityGateDefinition> = { 'docs-artifact': DOCS_ARTIFACT_GATE },
+): ReturnType<typeof spawnSync> {
+  const fixtureRoot = join(
+    process.cwd(),
+    'graphify-out',
+    'benchmark-artifact-pack-quality',
+    `${testName}-${process.pid}-${Date.now()}`,
+  )
+  const reportPath = join(fixtureRoot, 'report.json')
+  const configPath = join(fixtureRoot, 'quality-gates.json')
+  mkdirSync(fixtureRoot, { recursive: true })
+  writeCompareStyleReport(reportPath, pack)
+  writeFileSync(configPath, `${JSON.stringify(gateConfig, null, 2)}\n`, 'utf8')
+
+  try {
+    return spawnSync(
+      process.execPath,
+      [PACK_VERIFIER_PATH, '--gate', 'docs-artifact', '--config', configPath, '--report', reportPath],
+      { encoding: 'utf8' },
+    )
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+}
+
+function combinedOutput(result: ReturnType<typeof spawnSync>): string {
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+}
 
 describe('public benchmark artifact (2026-04-30 govalidate)', () => {
   const baseline = JSON.parse(readFileSync(resolve(ARTIFACT_DIR, 'baseline-session.json'), 'utf8')) as {
@@ -131,6 +267,59 @@ describe('public benchmark artifact (2026-05-02 govalidate pr review)', () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('verbose_prompt_tokens')
     expect(result.stdout).toContain('compact_prompt_tokens')
+  })
+})
+
+describe('shared GoValidate pack-quality verifier contract', () => {
+  it('accepts docs-artifact packs that satisfy required labels and pack ceilings', () => {
+    const result = runPackVerifier('pass', buildPackFixture())
+    const output = combinedOutput(result)
+
+    expect(result.status).toBe(0)
+    expect(output).toContain('docs-artifact')
+    expect(output).toContain('PASS')
+  })
+
+  it('fails docs-artifact packs with a useful per-gate summary when any pack gate is violated', () => {
+    const matched_nodes = buildMatchedNodes(
+      DOCS_ARTIFACT_GATE.max_matched_nodes + 1,
+      ['IdeaReportController', 'IdeaReportSharePage'],
+    )
+    const result = runPackVerifier(
+      'fail',
+      buildPackFixture({
+        token_count: DOCS_ARTIFACT_GATE.max_pack_tokens + 1,
+        matched_nodes,
+        relationships: buildRelationships(DOCS_ARTIFACT_GATE.max_relationships + 1, matched_nodes),
+      }),
+    )
+    const output = combinedOutput(result)
+
+    expect(result.status).not.toBe(0)
+    expect(output).toContain('docs-artifact')
+    expect(output).toContain('missing required labels: GenerateIdeaReportService')
+    expect(output).toContain('forbidden labels present: IdeaReportSharePage')
+    expect(output).toContain('pack.token_count 1457 exceeds max_pack_tokens 1456')
+    expect(output).toContain('pack.matched_nodes count 39 exceeds max_matched_nodes 38')
+    expect(output).toContain('pack.relationships count 58 exceeds max_relationships 57')
+  })
+
+  it('rejects gate configs whose labels normalize to empty strings', () => {
+    const result = runPackVerifier(
+      'invalid-label-config',
+      buildPackFixture(),
+      {
+        'docs-artifact': {
+          ...DOCS_ARTIFACT_GATE,
+          required_labels: ['---'],
+        },
+      },
+    )
+    const output = combinedOutput(result)
+
+    expect(result.status).not.toBe(0)
+    expect(output).toContain('Malformed gate definition for docs-artifact')
+    expect(output).toContain('labels must contain at least one alphanumeric character after normalization')
   })
 })
 

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -14,6 +14,7 @@ const PACK_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 've
 const PACK_GATE_CONFIG_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'quality-gates.json')
 
 interface PackQualityGateDefinition {
+  prompt: string
   required_labels: string[]
   forbidden_labels: string[]
   max_pack_tokens: number
@@ -22,6 +23,7 @@ interface PackQualityGateDefinition {
 }
 
 const DOCS_ARTIFACT_GATE: PackQualityGateDefinition = {
+  prompt: 'Explain how idea report is getting generated',
   required_labels: ['IdeaReportController', 'GenerateIdeaReportService'],
   forbidden_labels: ['IdeaReportSharePage', 'GenerateIdeaReportScript'],
   max_pack_tokens: 1_456,
@@ -121,7 +123,7 @@ function runPackVerifier(
   testName: string,
   pack: CompareReportPack,
   options: {
-    gateConfig?: Record<string, PackQualityGateDefinition>
+    gateConfig?: Record<string, unknown>
     relativeConfigPath?: boolean
     relativeReportPath?: boolean
   } = {},
@@ -153,6 +155,10 @@ function runPackVerifier(
 
 function combinedOutput(result: ReturnType<typeof spawnSync>): string {
   return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+}
+
+function toPosixPath(path: string): string {
+  return path.replaceAll('\\', '/')
 }
 
 describe('public benchmark artifact (2026-04-30 govalidate)', () => {
@@ -290,8 +296,8 @@ describe('public benchmark artifact (2026-05-12 govalidate report generation)', 
   })
 
   it('README points readers to the shared suite verifier and gate config', () => {
-    expect(readme).toContain(relative(process.cwd(), PACK_VERIFIER_PATH))
-    expect(readme).toContain(relative(process.cwd(), PACK_GATE_CONFIG_PATH))
+    expect(readme).toContain(toPosixPath(relative(process.cwd(), PACK_VERIFIER_PATH)))
+    expect(readme).toContain(toPosixPath(relative(process.cwd(), PACK_GATE_CONFIG_PATH)))
   })
 })
 
@@ -331,6 +337,43 @@ describe('shared GoValidate pack-quality verifier contract', () => {
     expect(output).toContain('pack.token_count 1457 exceeds max_pack_tokens 1456')
     expect(output).toContain('pack.matched_nodes count 39 exceeds max_matched_nodes 38')
     expect(output).toContain('pack.relationships count 58 exceeds max_relationships 57')
+  })
+
+  it('rejects gate configs that omit prompt even when selected by gate name', () => {
+    const result = runPackVerifier('missing-prompt', buildPackFixture(), {
+      gateConfig: {
+        'docs-artifact': {
+          required_labels: DOCS_ARTIFACT_GATE.required_labels,
+          forbidden_labels: DOCS_ARTIFACT_GATE.forbidden_labels,
+          max_pack_tokens: DOCS_ARTIFACT_GATE.max_pack_tokens,
+          max_matched_nodes: DOCS_ARTIFACT_GATE.max_matched_nodes,
+          max_relationships: DOCS_ARTIFACT_GATE.max_relationships,
+        },
+      },
+    })
+
+    expect(result.status).not.toBe(0)
+    expect(combinedOutput(result)).toContain('Malformed gate definition for docs-artifact: prompt must be a non-empty string')
+  })
+
+  it('rejects compare reports with fractional token counts', () => {
+    const result = runPackVerifier(
+      'fractional-token-count',
+      buildPackFixture({ token_count: 1456.5 }),
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(combinedOutput(result)).toContain('Malformed compare report: pack.token_count must be a non-negative integer')
+  })
+
+  it('rejects compare reports with negative token counts', () => {
+    const result = runPackVerifier(
+      'negative-token-count',
+      buildPackFixture({ token_count: -1 }),
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(combinedOutput(result)).toContain('Malformed compare report: pack.token_count must be a non-negative integer')
   })
 
   it('resolves relative --config paths from the current working directory like --report', () => {

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -115,7 +115,11 @@ function writeCompareStyleReport(reportPath: string, pack: CompareReportPack): v
 function runPackVerifier(
   testName: string,
   pack: CompareReportPack,
-  gateConfig: Record<string, PackQualityGateDefinition> = { 'docs-artifact': DOCS_ARTIFACT_GATE },
+  options: {
+    gateConfig?: Record<string, PackQualityGateDefinition>
+    relativeConfigPath?: boolean
+    relativeReportPath?: boolean
+  } = {},
 ): ReturnType<typeof spawnSync> {
   const fixtureRoot = join(
     process.cwd(),
@@ -125,14 +129,16 @@ function runPackVerifier(
   )
   const reportPath = join(fixtureRoot, 'report.json')
   const configPath = join(fixtureRoot, 'quality-gates.json')
+  const reportArg = options.relativeReportPath ? relative(process.cwd(), reportPath) : reportPath
+  const configArg = options.relativeConfigPath ? relative(process.cwd(), configPath) : configPath
   mkdirSync(fixtureRoot, { recursive: true })
   writeCompareStyleReport(reportPath, pack)
-  writeFileSync(configPath, `${JSON.stringify(gateConfig, null, 2)}\n`, 'utf8')
+  writeFileSync(configPath, `${JSON.stringify(options.gateConfig ?? { 'docs-artifact': DOCS_ARTIFACT_GATE }, null, 2)}\n`, 'utf8')
 
   try {
     return spawnSync(
       process.execPath,
-      [PACK_VERIFIER_PATH, '--gate', 'docs-artifact', '--config', configPath, '--report', reportPath],
+      [PACK_VERIFIER_PATH, '--gate', 'docs-artifact', '--config', configArg, '--report', reportArg],
       { encoding: 'utf8' },
     )
   } finally {
@@ -304,14 +310,28 @@ describe('shared GoValidate pack-quality verifier contract', () => {
     expect(output).toContain('pack.relationships count 58 exceeds max_relationships 57')
   })
 
+  it('resolves relative --config paths from the current working directory like --report', () => {
+    const result = runPackVerifier('relative-config-path', buildPackFixture(), {
+      relativeConfigPath: true,
+      relativeReportPath: true,
+    })
+    const output = combinedOutput(result)
+
+    expect(result.status).toBe(0)
+    expect(output).toContain('docs-artifact')
+    expect(output).toContain('PASS')
+  })
+
   it('rejects gate configs whose labels normalize to empty strings', () => {
     const result = runPackVerifier(
       'invalid-label-config',
       buildPackFixture(),
       {
-        'docs-artifact': {
-          ...DOCS_ARTIFACT_GATE,
-          required_labels: ['---'],
+        gateConfig: {
+          'docs-artifact': {
+            ...DOCS_ARTIFACT_GATE,
+            required_labels: ['---'],
+          },
         },
       },
     )

--- a/tests/unit/benchmark-quality.test.ts
+++ b/tests/unit/benchmark-quality.test.ts
@@ -68,6 +68,15 @@ function buildFrameworkSupportGraph(): KnowledgeGraph {
 
 const RUNNER_GRAPH_PATH = join(process.cwd(), 'graphify-out', 'graph.json')
 const RUNNER_OUTPUT_DIR = join(process.cwd(), 'graphify-out', 'benchmark-quality-test-output')
+const SHARED_PACK_QUALITY_GATES_PATH = join(process.cwd(), 'docs', 'benchmarks', 'govalidate-suite', 'quality-gates.json')
+
+interface SharedPackQualityGate {
+  required_labels: string[]
+  forbidden_labels: string[]
+  max_pack_tokens: number
+  max_matched_nodes: number
+  max_relationships: number
+}
 
 function resetRunnerOutputDir(): void {
   rmSync(RUNNER_OUTPUT_DIR, { recursive: true, force: true })
@@ -489,5 +498,26 @@ describe('retrieval quality benchmark', () => {
     expect(report.avg_recall).toBeGreaterThanOrEqual(0.9)
     expect(report.avg_snippet_coverage).toBe(1)
     expect(report.mrr).toBeGreaterThanOrEqual(0.95)
+  })
+})
+
+describe('shared GoValidate pack-quality gate config', () => {
+  it('defines explicit label allow/deny lists and pack ceilings for each shared gate entry', () => {
+    const gateConfig = JSON.parse(readFileSync(SHARED_PACK_QUALITY_GATES_PATH, 'utf8')) as Record<string, SharedPackQualityGate>
+    const entries = Object.entries(gateConfig)
+
+    expect(entries.length).toBeGreaterThan(0)
+
+    for (const [gateName, gate] of entries) {
+      expect(gateName.length).toBeGreaterThan(0)
+      expect(gate.required_labels.length).toBeGreaterThan(0)
+      expect(Array.isArray(gate.forbidden_labels)).toBe(true)
+      expect(Number.isFinite(gate.max_pack_tokens)).toBe(true)
+      expect(gate.max_pack_tokens).toBeGreaterThan(0)
+      expect(Number.isInteger(gate.max_matched_nodes)).toBe(true)
+      expect(gate.max_matched_nodes).toBeGreaterThan(0)
+      expect(Number.isInteger(gate.max_relationships)).toBe(true)
+      expect(gate.max_relationships).toBeGreaterThanOrEqual(0)
+    }
   })
 })

--- a/tests/unit/benchmark-quality.test.ts
+++ b/tests/unit/benchmark-quality.test.ts
@@ -71,6 +71,7 @@ const RUNNER_OUTPUT_DIR = join(process.cwd(), 'graphify-out', 'benchmark-quality
 const SHARED_PACK_QUALITY_GATES_PATH = join(process.cwd(), 'docs', 'benchmarks', 'govalidate-suite', 'quality-gates.json')
 
 interface SharedPackQualityGate {
+  prompt: string
   required_labels: string[]
   forbidden_labels: string[]
   max_pack_tokens: number
@@ -510,6 +511,8 @@ describe('shared GoValidate pack-quality gate config', () => {
 
     for (const [gateName, gate] of entries) {
       expect(gateName.length).toBeGreaterThan(0)
+      expect(typeof gate.prompt).toBe('string')
+      expect(gate.prompt.trim().length).toBeGreaterThan(0)
       expect(gate.required_labels.length).toBeGreaterThan(0)
       expect(Array.isArray(gate.forbidden_labels)).toBe(true)
       expect(Number.isFinite(gate.max_pack_tokens)).toBe(true)


### PR DESCRIPTION
Closes #157

## Summary
- add a shared `docs/benchmarks/govalidate-suite/` directory with deterministic pack-quality gates and a no-model verifier
- cover the verifier contract and gate schema with benchmark artifact and quality tests
- update the 2026-05-12 GoValidate benchmark note to use the shared gate flow and verifier command

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI verifier to validate benchmark reports against configurable quality gates.
  * Introduced a predefined "docs-artifact" gate with required/forbidden label checks and numeric limits.

* **Documentation**
  * Added and updated guides describing quality-gate usage, verifier commands, and reproducibility steps.

* **Tests**
  * Added unit and contract tests covering valid/invalid reports, malformed configs, and gate enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->