### PR TITLE
feat: add compare MCP trace metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 - **Native-agent compare suite summary**: multi-question `compare --baseline-mode native_agent` runs now roll up comparable-question wins/losses for input tokens, turns, and latency, report mean/median input-token reduction, surface comparable-question counts when some runs are excluded from the aggregate, and highlight the best win and worst regression prompt in the terminal summary.
 - **Native-agent cache-aware compare accounting**: `compare --baseline-mode native_agent` now persists derived total/uncached/cached Anthropic input-token fields alongside the raw provider `usage` block, and the terminal summary breaks out uncached/cache creation/cache read lines when cache activity is present.
+- **Compact compare trace summaries**: compare summaries now add a single `Graphify trace:` line when `report.json` includes `graphify_trace`, and the benchmark docs clarify that the persisted field stores only compact, share-safe metadata (counts, tool names, per-turn summaries).
 
 ## [0.22.9] - 2026-05-16
 

--- a/docs/benchmarks/govalidate-suite/README.md
+++ b/docs/benchmarks/govalidate-suite/README.md
@@ -26,3 +26,7 @@ node docs/benchmarks/govalidate-suite/verify-pack-quality.js \
 ```
 
 The verifier reads `report.pack`, checks normalized matched-node labels against the required/forbidden lists, enforces the numeric ceilings, prints a deterministic pass/fail summary, and exits non-zero on malformed input or any gate failure. Label matching lowercases and strips non-alphanumeric characters, so gate labels must still contain at least one alphanumeric character after normalization.
+
+## Compare report metadata
+
+`graphify-ts compare` reports may also include a `graphify_trace` object when the graphify-side runner emits structured Claude-style tool-use messages. The field is intentionally compact and safe: it stores only aggregate counts, tool names, and per-turn tool summaries for the graphify run. It does **not** persist raw tool inputs, prompts, or full trace payloads. Terminal compare summaries surface the same data as one short `Graphify trace:` line instead of dumping the trace body.

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -714,8 +714,8 @@ function parseTraceToolName(value: unknown): string | null {
 }
 
 function parseTraceTurnNumber(value: unknown, fallbackTurn: number): number {
-  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
-    return Math.trunc(value)
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value
   }
   return fallbackTurn
 }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1510,6 +1510,30 @@ function formatCompareProviderProof(result: GenerateCompareArtifactsResult): str
   return `mixed provider-reported usage (${providerReportedRuns}/${totalRuns} prompt runs) with local estimate fallback`
 }
 
+function formatCompareGraphifyTraceSummary(result: GenerateCompareArtifactsResult): string | null {
+  const traces = result.reports.flatMap((report) => (report.graphify_trace ? [report.graphify_trace] : []))
+  if (traces.length === 0) {
+    return null
+  }
+
+  const toolCallsByName = new Map<string, number>()
+  const totalToolCalls = traces.reduce((total, trace) => {
+    for (const [toolName, count] of Object.entries(trace.tool_calls_by_name)) {
+      toolCallsByName.set(toolName, (toolCallsByName.get(toolName) ?? 0) + count)
+    }
+    return total + trace.tool_call_count
+  }, 0)
+  const totalTurns = traces.reduce((total, trace) => total + trace.per_turn.length, 0)
+  const topTools = [...toolCallsByName.entries()]
+    .sort((leftEntry, rightEntry) => rightEntry[1] - leftEntry[1] || leftEntry[0].localeCompare(rightEntry[0]))
+    .slice(0, 3)
+    .map(([toolName, count]) => `${toolName}×${count}`)
+  const traceCoverage = traces.length === result.reports.length ? '' : ` · traces for ${traces.length}/${result.reports.length} graphify runs`
+  const topToolsSummary = topTools.length > 0 ? ` · top tools: ${topTools.join(', ')}` : ''
+
+  return `Graphify trace: ${totalToolCalls} tool call${totalToolCalls === 1 ? '' : 's'} across ${totalTurns} turn${totalTurns === 1 ? '' : 's'}${traceCoverage}${topToolsSummary}`
+}
+
 export function formatCompareSummary(result: GenerateCompareArtifactsResult): string {
   const baselineTokens = sumPromptTokens(result.reports, 'baseline')
   const graphifyTokens = sumPromptTokens(result.reports, 'graphify')
@@ -1562,6 +1586,10 @@ export function formatCompareSummary(result: GenerateCompareArtifactsResult): st
   }
   lines.push(`- Reused context tokens: baseline ${baselineReusedTokens} · graphify ${graphifyReusedTokens}`)
   lines.push(`- Provider/runtime proof: ${formatCompareProviderProof(result)}`)
+  const graphifyTraceSummary = formatCompareGraphifyTraceSummary(result)
+  if (graphifyTraceSummary !== null) {
+    lines.push(`- ${graphifyTraceSummary}`)
+  }
 
   return lines.join('\n')
 }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -8,7 +8,7 @@ import { buildContextPrompt, type ContextPromptStableSection } from './context-p
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
-import { parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner.js'
+import { parsePromptRunnerJsonRecord, parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner.js'
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
@@ -94,6 +94,20 @@ export interface CompareReportPack extends CompactRetrieveResult {
   selection_diagnostics?: NonNullable<RetrieveResult['selection_diagnostics']>
 }
 
+export interface CompareGraphifyTraceTurnSummary {
+  turn: number
+  tool_call_count: number
+  tools: string[]
+}
+
+export interface CompareGraphifyTrace {
+  source: 'claude_messages_tool_use'
+  summary: string
+  tool_call_count: number
+  tool_calls_by_name: Record<string, number>
+  per_turn: CompareGraphifyTraceTurnSummary[]
+}
+
 export interface ComparePromptReport {
   question: string
   graph_path: string
@@ -150,6 +164,7 @@ export interface ComparePromptReport {
     graphify: string | null
   }
   provider_proof?: ComparePromptProviderProof
+  graphify_trace?: CompareGraphifyTrace
   pack?: CompareReportPack
   paths: ComparePromptArtifactPaths
 }
@@ -683,6 +698,95 @@ function comparePromptTokenSource(usage: ComparePromptUsage | null): CompareProm
 
 function compareProviderForUsage(usage: ComparePromptUsage | null): 'claude' | 'gemini' | null {
   return usage?.provider ?? null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function parseTraceToolName(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmedValue = value.trim()
+  return trimmedValue.length > 0 ? trimmedValue : null
+}
+
+function parseTraceTurnNumber(value: unknown, fallbackTurn: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value)
+  }
+  return fallbackTurn
+}
+
+function extractGraphifyTrace(stdout: string): CompareGraphifyTrace | undefined {
+  const payload = parsePromptRunnerJsonRecord(stdout)
+  if (payload === null || !Array.isArray(payload.messages)) {
+    return undefined
+  }
+
+  const toolCallsByName: Record<string, number> = {}
+  const perTurnIndex = new Map<number, CompareGraphifyTraceTurnSummary>()
+  const turnOrder: number[] = []
+  let fallbackTurn = 1
+  let totalToolCalls = 0
+
+  for (const message of payload.messages) {
+    if (!isRecord(message) || message.role !== 'assistant' || !Array.isArray(message.content)) {
+      continue
+    }
+
+    const tools: string[] = []
+    for (const contentPart of message.content) {
+      if (!isRecord(contentPart) || contentPart.type !== 'tool_use') {
+        continue
+      }
+
+      const toolName = parseTraceToolName(contentPart.name)
+      if (toolName === null) {
+        continue
+      }
+
+      tools.push(toolName)
+      toolCallsByName[toolName] = (toolCallsByName[toolName] ?? 0) + 1
+      totalToolCalls += 1
+    }
+
+    if (tools.length === 0) {
+      continue
+    }
+
+    const turn = parseTraceTurnNumber(message.turn, fallbackTurn)
+    fallbackTurn = Math.max(fallbackTurn, turn + 1)
+    const existingTurn = perTurnIndex.get(turn)
+    if (existingTurn) {
+      existingTurn.tool_call_count += tools.length
+      existingTurn.tools.push(...tools)
+      continue
+    }
+
+    perTurnIndex.set(turn, {
+      turn,
+      tool_call_count: tools.length,
+      tools,
+    })
+    turnOrder.push(turn)
+  }
+
+  if (totalToolCalls === 0) {
+    return undefined
+  }
+
+  return {
+    source: 'claude_messages_tool_use',
+    summary: `${totalToolCalls} tool calls across ${turnOrder.length} turns`,
+    tool_call_count: totalToolCalls,
+    tool_calls_by_name: Object.fromEntries(
+      Object.entries(toolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
+    ),
+    per_turn: turnOrder.map((turn) => perTurnIndex.get(turn)!),
+  }
 }
 
 function buildCompareProviderProofEntry(
@@ -1277,6 +1381,14 @@ export async function executeCompareRuns(
         report.failure_reason[execution.mode] =
           executionResult.exitCode === 0 ? null : contextOverflowEvidence !== null ? 'prompt_too_long' : 'runner_error'
         report.evidence[execution.mode] = contextOverflowEvidence
+        if (execution.mode === 'graphify') {
+          const graphifyTrace = executionResult.exitCode === 0 ? extractGraphifyTrace(executionResult.stdout) : undefined
+          if (graphifyTrace) {
+            report.graphify_trace = graphifyTrace
+          } else {
+            delete report.graphify_trace
+          }
+        }
       } catch (error) {
         ensureCompareAnswerFile(execution.outputFile, '')
         report.usage[execution.mode] = null
@@ -1288,6 +1400,9 @@ export async function executeCompareRuns(
         report.stderr[execution.mode] = sanitizeCompareStderr(errorMessage)
         report.failure_reason[execution.mode] = contextOverflowEvidence !== null ? 'prompt_too_long' : 'exec_error'
         report.evidence[execution.mode] = contextOverflowEvidence
+        if (execution.mode === 'graphify') {
+          delete report.graphify_trace
+        }
       }
 
       syncComparePromptMetrics(report)

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -728,7 +728,6 @@ function extractGraphifyTrace(stdout: string): CompareGraphifyTrace | undefined 
 
   const toolCallsByName: Record<string, number> = {}
   const perTurnIndex = new Map<number, CompareGraphifyTraceTurnSummary>()
-  const turnOrder: number[] = []
   let fallbackTurn = 1
   let totalToolCalls = 0
 
@@ -771,21 +770,22 @@ function extractGraphifyTrace(stdout: string): CompareGraphifyTrace | undefined 
       tool_call_count: tools.length,
       tools,
     })
-    turnOrder.push(turn)
   }
 
   if (totalToolCalls === 0) {
     return undefined
   }
 
+  const sortedTurns = [...perTurnIndex.keys()].sort((leftTurn, rightTurn) => leftTurn - rightTurn)
+
   return {
     source: 'claude_messages_tool_use',
-    summary: `${totalToolCalls} tool calls across ${turnOrder.length} turns`,
+    summary: `${totalToolCalls} tool calls across ${sortedTurns.length} turns`,
     tool_call_count: totalToolCalls,
     tool_calls_by_name: Object.fromEntries(
       Object.entries(toolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
     ),
-    per_turn: turnOrder.map((turn) => perTurnIndex.get(turn)!),
+    per_turn: sortedTurns.map((turn) => perTurnIndex.get(turn)!),
   }
 }
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1352,6 +1352,7 @@ export async function executeCompareRuns(
     ]
 
     for (const execution of executions) {
+      let graphifyTrace: CompareGraphifyTrace | undefined
       try {
         validateCompareExecTemplate(input.execTemplate)
         const command = expandCompareExecTemplate(input.execTemplate, {
@@ -1365,6 +1366,9 @@ export async function executeCompareRuns(
           question: report.question,
           command,
         })
+        if (execution.mode === 'graphify') {
+          graphifyTrace = extractGraphifyTrace(executionResult.stdout)
+        }
         const parsedOutput = parsePromptRunnerOutput(executionResult.stdout)
         ensureCompareAnswerFile(
           execution.outputFile,
@@ -1382,7 +1386,6 @@ export async function executeCompareRuns(
           executionResult.exitCode === 0 ? null : contextOverflowEvidence !== null ? 'prompt_too_long' : 'runner_error'
         report.evidence[execution.mode] = contextOverflowEvidence
         if (execution.mode === 'graphify') {
-          const graphifyTrace = executionResult.exitCode === 0 ? extractGraphifyTrace(executionResult.stdout) : undefined
           if (graphifyTrace) {
             report.graphify_trace = graphifyTrace
           } else {
@@ -1401,7 +1404,11 @@ export async function executeCompareRuns(
         report.failure_reason[execution.mode] = contextOverflowEvidence !== null ? 'prompt_too_long' : 'exec_error'
         report.evidence[execution.mode] = contextOverflowEvidence
         if (execution.mode === 'graphify') {
-          delete report.graphify_trace
+          if (graphifyTrace) {
+            report.graphify_trace = graphifyTrace
+          } else {
+            delete report.graphify_trace
+          }
         }
       }
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1404,11 +1404,7 @@ export async function executeCompareRuns(
         report.failure_reason[execution.mode] = contextOverflowEvidence !== null ? 'prompt_too_long' : 'exec_error'
         report.evidence[execution.mode] = contextOverflowEvidence
         if (execution.mode === 'graphify') {
-          if (graphifyTrace) {
-            report.graphify_trace = graphifyTrace
-          } else {
-            delete report.graphify_trace
-          }
+          delete report.graphify_trace
         }
       }
 

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1314,25 +1314,41 @@ describe('compare runtime', () => {
       {
         runner: async (execution) => ({
           exitCode: 0,
-          stdout: JSON.stringify({
-            type: 'result',
-            subtype: 'success',
-            result: `${execution.mode} answer\n`,
-            usage:
-              execution.mode === 'baseline'
-                ? {
+          stdout:
+            execution.mode === 'baseline'
+              ? JSON.stringify({
+                  type: 'result',
+                  subtype: 'success',
+                  result: `${execution.mode} answer\n`,
+                  usage: {
                     input_tokens: 1200,
                     output_tokens: 90,
                     cache_creation_input_tokens: 100,
                     cache_read_input_tokens: 20,
-                  }
-                : {
+                  },
+                })
+              : makeClaudeStructuredCompareStdout({
+                  result: 'graphify answer\n',
+                  usage: {
                     input_tokens: 400,
                     output_tokens: 70,
                     cache_creation_input_tokens: 0,
                     cache_read_input_tokens: 10,
                   },
-          }),
+                  assistant_turns: [
+                    {
+                      turn: 1,
+                      content: [
+                        { type: 'tool_use', name: 'retrieve', input: { question: 'login session flow' } },
+                        { type: 'tool_use', name: 'mcp__graphify-ts__impact', input: { label: 'SessionManager' } },
+                      ],
+                    },
+                    {
+                      turn: 2,
+                      content: [{ type: 'tool_use', name: 'retrieve', input: { question: 'session follow-up' } }],
+                    },
+                  ],
+                }),
           stderr: '',
           elapsedMs: execution.mode === 'baseline' ? 11 : 17,
         }),
@@ -1396,6 +1412,9 @@ describe('compare runtime', () => {
     expect(formatCompareSummary(result)).toContain('Effective input tokens (cache-adjusted): baseline 1300 · graphify 400')
     expect(formatCompareSummary(result)).toContain('Total tokens (Claude reported): baseline 1410 · graphify 480')
     expect(formatCompareSummary(result)).toContain('Provider/runtime proof: Claude reported input, cache, and total tokens for 2/2 prompt runs')
+    expect(formatCompareSummary(result)).toContain(
+      'Graphify trace: 3 tool calls across 2 turns · top tools: retrieve×2, mcp__graphify-ts__impact×1',
+    )
   })
 
   it('does not write structured stdout JSON into answer artifacts when usage is present without answer text', async () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1169,6 +1169,81 @@ describe('compare runtime', () => {
     )
   })
 
+  it('falls back to sequential turn numbers when structured messages use fractional turns', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: 0,
+          stdout:
+            execution.mode === 'baseline'
+              ? makeClaudeStructuredCompareStdout({
+                  result: 'baseline answer\n',
+                  usage: {
+                    input_tokens: 1200,
+                    output_tokens: 90,
+                    cache_creation_input_tokens: 100,
+                    cache_read_input_tokens: 20,
+                  },
+                })
+              : makeClaudeStructuredCompareStdout({
+                  result: 'graphify answer\n',
+                  usage: {
+                    input_tokens: 400,
+                    output_tokens: 70,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 10,
+                  },
+                  assistant_turns: [
+                    {
+                      turn: 1,
+                      content: [{ type: 'tool_use', name: 'retrieve', input: { question: 'initial lookup' } }],
+                    },
+                    {
+                      turn: 1.9,
+                      content: [{ type: 'tool_use', name: 'mcp__graphify-ts__impact', input: { label: 'SessionManager' } }],
+                    },
+                  ],
+                }),
+          stderr: '',
+          elapsedMs: execution.mode === 'baseline' ? 11 : 17,
+        }),
+      },
+    )
+
+    const report = result.reports[0]!
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+    const graphifyTrace = savedReport.graphify_trace as Record<string, unknown> | undefined
+
+    expect(graphifyTrace).toEqual(
+      expect.objectContaining({
+        per_turn: [
+          expect.objectContaining({
+            turn: 1,
+            tool_call_count: 1,
+            tools: ['retrieve'],
+          }),
+          expect.objectContaining({
+            turn: 2,
+            tool_call_count: 1,
+            tools: ['mcp__graphify-ts__impact'],
+          }),
+        ],
+      }),
+    )
+  })
+
   it('preserves compact graphify trace metadata when graphify exits non-zero with structured stdout', async () => {
     const graph = makeGraph()
     writeProjectFiles()

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -263,6 +263,44 @@ function writeManifestFixture(
   return manifestPath
 }
 
+function makeClaudeStructuredCompareStdout(options: {
+  result: string
+  usage?: {
+    input_tokens: number
+    output_tokens: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
+  }
+  assistant_turns?: Array<{
+    turn: number
+    content: Array<Record<string, unknown>>
+  }>
+}): string {
+  return JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    result: options.result,
+    ...(options.usage
+      ? {
+          usage: {
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            ...options.usage,
+          },
+        }
+      : {}),
+    ...(options.assistant_turns
+      ? {
+          messages: options.assistant_turns.map((turn) => ({
+            role: 'assistant',
+            turn: turn.turn,
+            content: turn.content,
+          })),
+        }
+      : {}),
+  })
+}
+
 beforeEach(() => {
   rmSync(PROJECT_FIXTURE_ROOT, { recursive: true, force: true })
   rmSync(GRAPH_FIXTURE_ROOT, { recursive: true, force: true })
@@ -951,6 +989,147 @@ describe('compare runtime', () => {
         },
       }),
     )
+  })
+
+  it('persists compact graphify trace metadata in report.json without raw tool payload content', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const privateQuestionPayload = 'PRIVATE_QUESTION_PAYLOAD'
+    const privateToolArgument = 'PRIVATE_TOOL_ARGUMENT'
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: 0,
+          stdout:
+            execution.mode === 'baseline'
+              ? makeClaudeStructuredCompareStdout({
+                  result: 'baseline answer\n',
+                  usage: {
+                    input_tokens: 1200,
+                    output_tokens: 90,
+                    cache_creation_input_tokens: 100,
+                    cache_read_input_tokens: 20,
+                  },
+                })
+              : makeClaudeStructuredCompareStdout({
+                  result: 'graphify answer\n',
+                  usage: {
+                    input_tokens: 400,
+                    output_tokens: 70,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 10,
+                  },
+                  assistant_turns: [
+                    {
+                      turn: 1,
+                      content: [
+                        { type: 'text', text: 'Let me inspect the graph.' },
+                        {
+                          type: 'tool_use',
+                          name: 'retrieve',
+                          input: { question: privateQuestionPayload },
+                        },
+                        {
+                          type: 'tool_use',
+                          name: 'mcp__graphify-ts__impact',
+                          input: { label: 'SessionManager', note: privateToolArgument },
+                        },
+                      ],
+                    },
+                    {
+                      turn: 2,
+                      content: [
+                        {
+                          type: 'tool_use',
+                          name: 'retrieve',
+                          input: { question: `${privateQuestionPayload}_FOLLOW_UP` },
+                        },
+                      ],
+                    },
+                  ],
+                }),
+          stderr: '',
+          elapsedMs: execution.mode === 'baseline' ? 11 : 17,
+        }),
+      },
+    )
+
+    const report = result.reports[0]!
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+    const graphifyTrace = savedReport.graphify_trace as Record<string, unknown> | undefined
+    const graphifyTraceJson = JSON.stringify(graphifyTrace ?? null)
+
+    expect(graphifyTrace).toEqual(
+      expect.objectContaining({
+        tool_call_count: 3,
+        tool_calls_by_name: {
+          retrieve: 2,
+          'mcp__graphify-ts__impact': 1,
+        },
+        per_turn: [
+          expect.objectContaining({
+            turn: 1,
+            tool_call_count: 2,
+            tools: ['retrieve', 'mcp__graphify-ts__impact'],
+          }),
+          expect.objectContaining({
+            turn: 2,
+            tool_call_count: 1,
+            tools: ['retrieve'],
+          }),
+        ],
+      }),
+    )
+    expect(graphifyTraceJson).not.toContain(privateQuestionPayload)
+    expect(graphifyTraceJson).not.toContain(privateToolArgument)
+  })
+
+  it('keeps graphify_trace absent when compare stdout does not expose trace data', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: 0,
+          stdout: makeClaudeStructuredCompareStdout({
+            result: `${execution.mode} answer\n`,
+            usage: {
+              input_tokens: execution.mode === 'baseline' ? 1200 : 400,
+              output_tokens: execution.mode === 'baseline' ? 90 : 70,
+              cache_creation_input_tokens: execution.mode === 'baseline' ? 100 : 0,
+              cache_read_input_tokens: execution.mode === 'baseline' ? 20 : 10,
+            },
+          }),
+          stderr: '',
+          elapsedMs: execution.mode === 'baseline' ? 11 : 17,
+        }),
+      },
+    )
+
+    const report = result.reports[0]!
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+
+    expect(savedReport).not.toHaveProperty('graphify_trace')
   })
 
   it('preserves Claude structured usage parsing through compare execution', async () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -2173,6 +2173,7 @@ describe('compare runtime', () => {
         },
       }),
     )
+    expect(savedReport).not.toHaveProperty('graphify_trace')
   })
 
   it('redacts persisted compare stderr summaries', async () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1094,6 +1094,96 @@ describe('compare runtime', () => {
     expect(graphifyTraceJson).not.toContain(privateToolArgument)
   })
 
+  it('preserves compact graphify trace metadata when graphify exits non-zero with structured stdout', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const privateQuestionPayload = 'PRIVATE_FAILED_QUESTION_PAYLOAD'
+    const privateToolArgument = 'PRIVATE_FAILED_TOOL_ARGUMENT'
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: execution.mode === 'graphify' ? 23 : 0,
+          stdout:
+            execution.mode === 'baseline'
+              ? makeClaudeStructuredCompareStdout({
+                  result: 'baseline answer\n',
+                  usage: {
+                    input_tokens: 1200,
+                    output_tokens: 90,
+                    cache_creation_input_tokens: 100,
+                    cache_read_input_tokens: 20,
+                  },
+                })
+              : makeClaudeStructuredCompareStdout({
+                  result: 'graphify partial output\n',
+                  usage: {
+                    input_tokens: 400,
+                    output_tokens: 70,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 10,
+                  },
+                  assistant_turns: [
+                    {
+                      turn: 1,
+                      content: [
+                        {
+                          type: 'tool_use',
+                          name: 'retrieve',
+                          input: { question: privateQuestionPayload },
+                        },
+                        {
+                          type: 'tool_use',
+                          name: 'mcp__graphify-ts__impact',
+                          input: { label: 'SessionManager', note: privateToolArgument },
+                        },
+                      ],
+                    },
+                  ],
+                }),
+          stderr: execution.mode === 'graphify' ? 'runner exited with a failure\n' : '',
+          elapsedMs: execution.mode === 'baseline' ? 11 : 17,
+        }),
+      },
+    )
+
+    const report = result.reports[0]!
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+    const graphifyTrace = savedReport.graphify_trace as Record<string, unknown> | undefined
+    const graphifyTraceJson = JSON.stringify(graphifyTrace ?? null)
+
+    expect(report.status.graphify).toBe('failed')
+    expect(report.usage.graphify).toBeNull()
+    expect(readFileSync(report.answer_paths.graphify, 'utf8')).toBe('graphify partial output\n')
+    expect(graphifyTrace).toEqual(
+      expect.objectContaining({
+        tool_call_count: 2,
+        tool_calls_by_name: {
+          'mcp__graphify-ts__impact': 1,
+          retrieve: 1,
+        },
+        per_turn: [
+          expect.objectContaining({
+            turn: 1,
+            tool_call_count: 2,
+            tools: ['retrieve', 'mcp__graphify-ts__impact'],
+          }),
+        ],
+      }),
+    )
+    expect(graphifyTraceJson).not.toContain(privateQuestionPayload)
+    expect(graphifyTraceJson).not.toContain(privateToolArgument)
+  })
+
   it('keeps graphify_trace absent when compare stdout does not expose trace data', async () => {
     const graph = makeGraph()
     writeProjectFiles()

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1094,6 +1094,81 @@ describe('compare runtime', () => {
     expect(graphifyTraceJson).not.toContain(privateToolArgument)
   })
 
+  it('sorts graphify_trace per_turn by numeric turn when structured messages arrive out of order', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: 0,
+          stdout:
+            execution.mode === 'baseline'
+              ? makeClaudeStructuredCompareStdout({
+                  result: 'baseline answer\n',
+                  usage: {
+                    input_tokens: 1200,
+                    output_tokens: 90,
+                    cache_creation_input_tokens: 100,
+                    cache_read_input_tokens: 20,
+                  },
+                })
+              : makeClaudeStructuredCompareStdout({
+                  result: 'graphify answer\n',
+                  usage: {
+                    input_tokens: 400,
+                    output_tokens: 70,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 10,
+                  },
+                  assistant_turns: [
+                    {
+                      turn: 2,
+                      content: [{ type: 'tool_use', name: 'retrieve', input: { question: 'follow-up' } }],
+                    },
+                    {
+                      turn: 1,
+                      content: [{ type: 'tool_use', name: 'mcp__graphify-ts__impact', input: { label: 'SessionManager' } }],
+                    },
+                  ],
+                }),
+          stderr: '',
+          elapsedMs: execution.mode === 'baseline' ? 11 : 17,
+        }),
+      },
+    )
+
+    const report = result.reports[0]!
+    const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+    const graphifyTrace = savedReport.graphify_trace as Record<string, unknown> | undefined
+
+    expect(graphifyTrace).toEqual(
+      expect.objectContaining({
+        per_turn: [
+          expect.objectContaining({
+            turn: 1,
+            tool_call_count: 1,
+            tools: ['mcp__graphify-ts__impact'],
+          }),
+          expect.objectContaining({
+            turn: 2,
+            tool_call_count: 1,
+            tools: ['retrieve'],
+          }),
+        ],
+      }),
+    )
+  })
+
   it('preserves compact graphify trace metadata when graphify exits non-zero with structured stdout', async () => {
     const graph = makeGraph()
     writeProjectFiles()


### PR DESCRIPTION
Closes #162

## Summary
- add optional graphify trace metadata to compare reports with safe tool-call counts and per-turn summaries
- persist and summarize Graphify MCP/tool usage without storing raw tool payloads or prompt bodies
- cover trace persistence, failed-run behavior, ordering, and summary output in compare tests

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal compare summaries show a compact "Graphify trace:" line with aggregated tool-call totals and top tools.
  * Compare reports persist compact trace metadata with per-turn tool usage summaries and aggregate statistics.

* **Documentation**
  * Clarified that persisted trace metadata intentionally excludes raw tool inputs, prompts, and full payloads.

* **Tests**
  * Added coverage ensuring traces are persisted in compact, redacted form and omitted when no trace data is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->