### PR TITLE
Add deterministic answer quality benchmark verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the TypeScript package will be documented in this file.
 - **Pack-only compare mode**: `graphify-ts compare --baseline-mode pack_only` now compares one bounded raw-context baseline prompt against one compiled graphify pack, persists the compact pack audit fields in `report.json`, and keeps `native_agent` as the provider-reported runtime benchmark path.
 - **Share-safe proof reports**: `compare`, `review-compare`, and runner-backed `benchmark --exec ...` executions now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
 - **Generate performance benchmark harness**: adds a small synthetic benchmark flow for `generate`, `update`, `cluster-only`, and SPI cold/warm cache runs, with structured metrics for wall-clock time, file/extraction counts, graph size, output bytes, and cache-hit reasons plus new docs for manual large-repo measurements.
+- **Deterministic answer-quality rubric skeleton**: shared GoValidate benchmark gates now include answer-term checks plus manual-review concept notes, and `verify-answer-quality.js` can validate saved benchmark answer artifacts without calling an LLM.
 
 ### Changed
 

--- a/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
+++ b/docs/benchmarks/2026-05-12-govalidate-report-generation/README.md
@@ -77,6 +77,7 @@ The shared gate definition now lives in:
 
 - `docs/benchmarks/govalidate-suite/quality-gates.json`
 - `docs/benchmarks/govalidate-suite/verify-pack-quality.js`
+- `docs/benchmarks/govalidate-suite/verify-answer-quality.js`
 
 For this prompt, the shared `docs-artifact` gate encodes the same runtime-path requirements and ceilings that were checked for the `v0.22.7` run:
 
@@ -107,6 +108,17 @@ node docs/benchmarks/govalidate-suite/verify-pack-quality.js \
   --config docs/benchmarks/govalidate-suite/quality-gates.json \
   --gate docs-artifact
 ```
+
+Run the answer-quality verifier against the saved graphify answer with:
+
+```bash
+node docs/benchmarks/govalidate-suite/verify-answer-quality.js \
+  --answer path/to/graphify-answer.txt \
+  --config docs/benchmarks/govalidate-suite/quality-gates.json \
+  --gate docs-artifact
+```
+
+The pack check and the answer check serve different purposes: the pack verifier confirms the runtime slice stayed compact and grounded in the expected path, while the answer verifier catches obvious missing facts or forbidden claims in the saved answer text. Neither replaces manual review.
 
 ## Reproducing from this directory
 

--- a/docs/benchmarks/govalidate-suite/README.md
+++ b/docs/benchmarks/govalidate-suite/README.md
@@ -1,11 +1,12 @@
 # GoValidate shared benchmark quality gates
 
-This directory holds the shared pack-quality gates for committed GoValidate benchmark artifacts.
+This directory holds the shared pack-quality and answer-quality gates for committed GoValidate benchmark artifacts.
 
 ## Files
 
 - `quality-gates.json` — named gate definitions plus the prompt text they apply to
 - `verify-pack-quality.js` — deterministic verifier for persisted `graphify-ts compare` reports
+- `verify-answer-quality.js` — deterministic verifier for saved `*-answer.txt` artifacts
 
 ## Usage
 
@@ -26,6 +27,28 @@ node docs/benchmarks/govalidate-suite/verify-pack-quality.js \
 ```
 
 The verifier reads `report.pack`, checks normalized matched-node labels against the required/forbidden lists, enforces the numeric ceilings, prints a deterministic pass/fail summary, and exits non-zero on malformed input or any gate failure. Label matching lowercases and strips non-alphanumeric characters, so gate labels must still contain at least one alphanumeric character after normalization.
+
+## Answer quality usage
+
+By gate name:
+
+```bash
+node docs/benchmarks/govalidate-suite/verify-answer-quality.js \
+  --answer path/to/graphify-answer.txt \
+  --gate docs-artifact
+```
+
+By prompt text:
+
+```bash
+node docs/benchmarks/govalidate-suite/verify-answer-quality.js \
+  --answer path/to/graphify-answer.txt \
+  --prompt "Explain how idea report is getting generated"
+```
+
+The answer-quality verifier applies deterministic answer-term checks from `quality-gates.json`: required answer terms must appear, forbidden answer terms must stay absent, and the script exits non-zero on malformed input or failed term checks. `required_concepts`, `answer_quality_notes`, and `manual_review_notes` are printed as manual-review guidance so the rubric stays deterministic without pretending substring matching can fully grade answer quality.
+
+CLI shape: `--answer <answer.txt>` plus exactly one of `--gate <name>` or `--prompt <text>`.
 
 ## Compare report metadata
 

--- a/docs/benchmarks/govalidate-suite/quality-gates.json
+++ b/docs/benchmarks/govalidate-suite/quality-gates.json
@@ -5,9 +5,25 @@
       "IdeaReportController",
       "GenerateIdeaReportService"
     ],
+    "required_answer_terms": [
+      "idea report",
+      "GenerateIdeaReportService"
+    ],
     "forbidden_labels": [
       "IdeaReportSharePage",
       "GenerateIdeaReportScript"
+    ],
+    "forbidden_answer_terms": [
+      "IdeaReportSharePage"
+    ],
+    "required_concepts": [
+      "runtime path stays on controller -> service flow"
+    ],
+    "answer_quality_notes": [
+      "Deterministic answer checks are necessary but not sufficient for benchmark claims."
+    ],
+    "manual_review_notes": [
+      "Confirm the answer explains how the report is generated, not just where files exist."
     ],
     "max_pack_tokens": 1456,
     "max_matched_nodes": 38,

--- a/docs/benchmarks/govalidate-suite/verify-answer-quality.js
+++ b/docs/benchmarks/govalidate-suite/verify-answer-quality.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function usage() {
+  return [
+    'Usage:',
+    '  node docs/benchmarks/govalidate-suite/verify-answer-quality.js --answer <answer.txt> (--gate <name> | --prompt <text>) [--config <quality-gates.json>]',
+  ].join('\n')
+}
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}
+
+function parseArgs(argv) {
+  const args = { answer: null, gate: null, prompt: null, config: null }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const value = argv[index + 1]
+
+    if (arg === '--answer') {
+      args.answer = value ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--gate') {
+      args.gate = value ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--prompt') {
+      args.prompt = value ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--config') {
+      args.config = value ?? null
+      index += 1
+      continue
+    }
+    fail(`Unknown argument: ${arg}\n${usage()}`)
+  }
+
+  if (!args.answer) {
+    fail(`Missing required --answer argument.\n${usage()}`)
+  }
+  if ((args.gate ? 1 : 0) + (args.prompt ? 1 : 0) !== 1) {
+    fail(`Pass exactly one of --gate or --prompt.\n${usage()}`)
+  }
+
+  return args
+}
+
+function readJsonFile(path, label) {
+  let raw
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (error) {
+    fail(`Failed to read ${label}: ${path}\n${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    fail(`Failed to parse ${label}: ${path}\n${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function readTextFile(path, label) {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (error) {
+    fail(`Failed to read ${label}: ${path}\n${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function normalizeText(value) {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function validateStringArray(gateName, fieldName, value, { allowEmpty = false } = {}) {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || normalizeText(entry).length === 0)) {
+    fail(`Malformed gate definition for ${gateName}: ${fieldName} must be a string array`)
+  }
+  if (!allowEmpty && value.length === 0) {
+    fail(`Malformed gate definition for ${gateName}: ${fieldName} must be a non-empty string array`)
+  }
+  return value.map((entry) => entry.trim())
+}
+
+function validateGateDefinition(gateName, gate) {
+  if (gate === null || typeof gate !== 'object' || Array.isArray(gate)) {
+    fail(`Malformed gate definition for ${gateName}: expected an object`)
+  }
+
+  if (typeof gate.prompt !== 'string' || gate.prompt.trim() === '') {
+    fail(`Malformed gate definition for ${gateName}: prompt must be a non-empty string`)
+  }
+
+  return {
+    prompt: gate.prompt.trim(),
+    required_answer_terms: validateStringArray(gateName, 'required_answer_terms', gate.required_answer_terms),
+    forbidden_answer_terms: validateStringArray(gateName, 'forbidden_answer_terms', gate.forbidden_answer_terms, { allowEmpty: true }),
+    required_concepts: validateStringArray(gateName, 'required_concepts', gate.required_concepts),
+    answer_quality_notes: validateStringArray(gateName, 'answer_quality_notes', gate.answer_quality_notes),
+    manual_review_notes: validateStringArray(gateName, 'manual_review_notes', gate.manual_review_notes),
+  }
+}
+
+function loadGateConfig(configPath) {
+  const parsed = readJsonFile(configPath, 'gate config')
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail(`Malformed gate config: expected a JSON object at ${configPath}`)
+  }
+
+  const entries = Object.entries(parsed)
+  if (entries.length === 0) {
+    fail(`Malformed gate config: expected at least one gate entry in ${configPath}`)
+  }
+
+  return new Map(entries.map(([gateName, gate]) => [gateName, validateGateDefinition(gateName, gate)]))
+}
+
+function resolveGate(gates, selector) {
+  if (selector.gate) {
+    const gate = gates.get(selector.gate)
+    if (!gate) {
+      fail(`Unknown gate: ${selector.gate}`)
+    }
+    return { gateName: selector.gate, gate }
+  }
+
+  const matches = [...gates.entries()].filter(([gateName, gate]) => gateName === selector.prompt || gate.prompt === selector.prompt)
+  if (matches.length === 0) {
+    fail(`No gate matches prompt: ${selector.prompt}`)
+  }
+  if (matches.length > 1) {
+    fail(`Prompt matches multiple gates: ${selector.prompt}`)
+  }
+
+  const [gateName, gate] = matches[0]
+  return { gateName, gate }
+}
+
+function verifyAnswerQuality(gateName, gate, answerText) {
+  const normalizedAnswer = normalizeText(answerText)
+  const missingRequired = gate.required_answer_terms.filter((term) => !normalizedAnswer.includes(normalizeText(term)))
+  const forbiddenPresent = gate.forbidden_answer_terms.filter((term) => normalizedAnswer.includes(normalizeText(term)))
+  const failures = []
+
+  if (missingRequired.length > 0) {
+    failures.push(`missing required answer terms: ${missingRequired.join(', ')}`)
+  }
+  if (forbiddenPresent.length > 0) {
+    failures.push(`forbidden answer terms present: ${forbiddenPresent.join(', ')}`)
+  }
+
+  const lines = [
+    `${gateName} ${failures.length === 0 ? 'PASS' : 'FAIL'}`,
+    `prompt: ${gate.prompt}`,
+  ]
+
+  if (failures.length === 0) {
+    lines.push(`required answer terms present: ${gate.required_answer_terms.join(', ')}`)
+    lines.push('forbidden answer terms present: none')
+  } else {
+    lines.push(...failures)
+  }
+
+  lines.push(`required concepts (manual review): ${gate.required_concepts.join(', ')}`)
+  lines.push(`answer quality notes: ${gate.answer_quality_notes.join(', ')}`)
+  lines.push(`manual review notes: ${gate.manual_review_notes.join(', ')}`)
+
+  return { ok: failures.length === 0, output: lines.join('\n') }
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const args = parseArgs(process.argv.slice(2))
+const configPath = args.config ? resolve(args.config) : resolve(scriptDir, 'quality-gates.json')
+const answerPath = resolve(args.answer)
+const answerText = readTextFile(answerPath, 'answer artifact')
+const gates = loadGateConfig(configPath)
+const { gateName, gate } = resolveGate(gates, args)
+const result = verifyAnswerQuality(gateName, gate, answerText)
+
+if (result.ok) {
+  console.log(result.output)
+  process.exit(0)
+}
+
+console.error(result.output)
+process.exit(1)

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -11,7 +11,9 @@ const REVIEW_ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-05-02-govalidate
 const REPORT_GENERATION_ARTIFACT_DIR = resolve('docs', 'benchmarks', '2026-05-12-govalidate-report-generation')
 const BENCHMARK_STYLESHEET = resolve('docs', 'benchmarks', 'styles.css')
 const PACK_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'verify-pack-quality.js')
+const ANSWER_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'verify-answer-quality.js')
 const PACK_GATE_CONFIG_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'quality-gates.json')
+const SUITE_README_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'README.md')
 
 interface PackQualityGateDefinition {
   prompt: string
@@ -20,6 +22,11 @@ interface PackQualityGateDefinition {
   max_pack_tokens: number
   max_matched_nodes: number
   max_relationships: number
+  required_answer_terms: string[]
+  forbidden_answer_terms: string[]
+  required_concepts: string[]
+  answer_quality_notes: string[]
+  manual_review_notes: string[]
 }
 
 const DOCS_ARTIFACT_GATE: PackQualityGateDefinition = {
@@ -29,6 +36,11 @@ const DOCS_ARTIFACT_GATE: PackQualityGateDefinition = {
   max_pack_tokens: 1_456,
   max_matched_nodes: 38,
   max_relationships: 57,
+  required_answer_terms: ['idea report', 'GenerateIdeaReportService'],
+  forbidden_answer_terms: ['IdeaReportSharePage'],
+  required_concepts: ['runtime path stays on controller -> service flow'],
+  answer_quality_notes: ['Deterministic answer checks are necessary but not sufficient for benchmark claims.'],
+  manual_review_notes: ['Confirm the answer explains how the report is generated, not just where files exist.'],
 }
 
 function buildMatchedNodes(totalCount: number, labels: readonly string[]): CompareReportPack['matched_nodes'] {
@@ -146,6 +158,40 @@ function runPackVerifier(
     return spawnSync(
       process.execPath,
       [PACK_VERIFIER_PATH, '--gate', 'docs-artifact', '--config', configArg, '--report', reportArg],
+      { encoding: 'utf8' },
+    )
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+}
+
+function runAnswerVerifier(
+  testName: string,
+  answerText: string,
+  options: {
+    gateConfig?: Record<string, unknown>
+    relativeConfigPath?: boolean
+    relativeAnswerPath?: boolean
+  } = {},
+): ReturnType<typeof spawnSync> {
+  const fixtureRoot = join(
+    process.cwd(),
+    'graphify-out',
+    'benchmark-artifact-answer-quality',
+    `${testName}-${process.pid}-${Date.now()}`,
+  )
+  const answerPath = join(fixtureRoot, 'graphify-answer.txt')
+  const configPath = join(fixtureRoot, 'quality-gates.json')
+  const answerArg = options.relativeAnswerPath ? relative(process.cwd(), answerPath) : answerPath
+  const configArg = options.relativeConfigPath ? relative(process.cwd(), configPath) : configPath
+  mkdirSync(fixtureRoot, { recursive: true })
+  writeFileSync(answerPath, answerText, 'utf8')
+  writeFileSync(configPath, `${JSON.stringify(options.gateConfig ?? { 'docs-artifact': DOCS_ARTIFACT_GATE }, null, 2)}\n`, 'utf8')
+
+  try {
+    return spawnSync(
+      process.execPath,
+      [ANSWER_VERIFIER_PATH, '--gate', 'docs-artifact', '--config', configArg, '--answer', answerArg],
       { encoding: 'utf8' },
     )
   } finally {
@@ -297,6 +343,7 @@ describe('public benchmark artifact (2026-05-12 govalidate report generation)', 
 
   it('README points readers to the shared suite verifier and gate config', () => {
     expect(readme).toContain(toPosixPath(relative(process.cwd(), PACK_VERIFIER_PATH)))
+    expect(readme).toContain(toPosixPath(relative(process.cwd(), ANSWER_VERIFIER_PATH)))
     expect(readme).toContain(toPosixPath(relative(process.cwd(), PACK_GATE_CONFIG_PATH)))
   })
 })
@@ -406,6 +453,48 @@ describe('shared GoValidate pack-quality verifier contract', () => {
     expect(result.status).not.toBe(0)
     expect(output).toContain('Malformed gate definition for docs-artifact')
     expect(output).toContain('labels must contain at least one alphanumeric character after normalization')
+  })
+})
+
+describe('shared GoValidate answer-quality verifier contract', () => {
+  it('accepts docs-artifact answers that satisfy deterministic term checks and prints manual review guidance', () => {
+    const result = runAnswerVerifier(
+      'pass',
+      'The idea report is generated when GenerateIdeaReportService handles the controller runtime path.',
+    )
+    const output = combinedOutput(result)
+
+    expect(result.status).toBe(0)
+    expect(output).toContain('docs-artifact')
+    expect(output).toContain('PASS')
+    expect(output).toContain('required answer terms present: idea report, GenerateIdeaReportService')
+    expect(output).toContain('forbidden answer terms present: none')
+    expect(output).toContain('required concepts (manual review): runtime path stays on controller -> service flow')
+    expect(output).toContain('manual review notes: Confirm the answer explains how the report is generated, not just where files exist.')
+  })
+
+  it('fails docs-artifact answers with a useful per-gate summary when answer checks are violated', () => {
+    const result = runAnswerVerifier(
+      'fail',
+      'IdeaReportSharePage renders the final page.',
+    )
+    const output = combinedOutput(result)
+
+    expect(result.status).not.toBe(0)
+    expect(output).toContain('docs-artifact')
+    expect(output).toContain('missing required answer terms: idea report, GenerateIdeaReportService')
+    expect(output).toContain('forbidden answer terms present: IdeaReportSharePage')
+  })
+})
+
+describe('shared GoValidate benchmark suite README', () => {
+  const readme = readFileSync(SUITE_README_PATH, 'utf8')
+
+  it('documents the answer-quality verifier alongside the pack verifier', () => {
+    expect(readme).toContain('verify-pack-quality.js')
+    expect(readme).toContain('verify-answer-quality.js')
+    expect(readme).toContain('--answer <answer.txt>')
+    expect(readme.toLowerCase()).toContain('deterministic answer-term checks')
   })
 })
 

--- a/tests/unit/benchmark-quality.test.ts
+++ b/tests/unit/benchmark-quality.test.ts
@@ -77,6 +77,11 @@ interface SharedPackQualityGate {
   max_pack_tokens: number
   max_matched_nodes: number
   max_relationships: number
+  required_answer_terms: string[]
+  forbidden_answer_terms: string[]
+  required_concepts: string[]
+  answer_quality_notes: string[]
+  manual_review_notes: string[]
 }
 
 function resetRunnerOutputDir(): void {
@@ -503,7 +508,7 @@ describe('retrieval quality benchmark', () => {
 })
 
 describe('shared GoValidate pack-quality gate config', () => {
-  it('defines explicit label allow/deny lists and pack ceilings for each shared gate entry', () => {
+  it('defines explicit pack and answer quality gates for each shared gate entry', () => {
     const gateConfig = JSON.parse(readFileSync(SHARED_PACK_QUALITY_GATES_PATH, 'utf8')) as Record<string, SharedPackQualityGate>
     const entries = Object.entries(gateConfig)
 
@@ -521,6 +526,15 @@ describe('shared GoValidate pack-quality gate config', () => {
       expect(gate.max_matched_nodes).toBeGreaterThan(0)
       expect(Number.isInteger(gate.max_relationships)).toBe(true)
       expect(gate.max_relationships).toBeGreaterThanOrEqual(0)
+      expect(Array.isArray(gate.required_answer_terms)).toBe(true)
+      expect(gate.required_answer_terms.length).toBeGreaterThan(0)
+      expect(Array.isArray(gate.forbidden_answer_terms)).toBe(true)
+      expect(Array.isArray(gate.required_concepts)).toBe(true)
+      expect(gate.required_concepts.length).toBeGreaterThan(0)
+      expect(Array.isArray(gate.answer_quality_notes)).toBe(true)
+      expect(gate.answer_quality_notes.length).toBeGreaterThan(0)
+      expect(Array.isArray(gate.manual_review_notes)).toBe(true)
+      expect(gate.manual_review_notes.length).toBeGreaterThan(0)
     }
   })
 })


### PR DESCRIPTION
## Summary
- add a shared verify-answer-quality.js CLI for saved benchmark answer artifacts
- extend the GoValidate quality gate config with deterministic answer-term checks and manual-review guidance
- cover the verifier and docs with benchmark artifact tests and update benchmark/changelog docs

## Test Plan
- npm run typecheck
- npm run build
- npm run test:run

Closes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added answer-quality verifier to validate benchmark answers against configured quality gates using deterministic required/forbidden term checks, without invoking an LLM.

* **Documentation**
  * Updated benchmark documentation with answer-quality verification usage guides, CLI arguments, and validation behavior specifications.

* **Tests**
  * Added and updated tests for answer-quality verifier functionality and expanded quality gate configuration schema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->