### PR TITLE
feat: add execution-slice output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
-- **Execution-slice context packs**: runtime-generation backend explain packs now expose a separate `execution_slice` section with ordered runtime steps and partial-path signaling while preserving the raw `slice` metadata for compatibility.
+- **Execution-slice context packs**: runtime-generation backend packs now expose a separate `execution_slice` section with ordered runtime steps and partial-path signaling while preserving the raw `slice` metadata for compatibility.
 - **Pack-only compare mode**: `graphify-ts compare --baseline-mode pack_only` now compares one bounded raw-context baseline prompt against one compiled graphify pack, persists the compact pack audit fields in `report.json`, and keeps `native_agent` as the provider-reported runtime benchmark path.
 - **Share-safe proof reports**: `compare`, `review-compare`, and runner-backed `benchmark --exec ...` executions now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
 - **Generate performance benchmark harness**: adds a small synthetic benchmark flow for `generate`, `update`, `cluster-only`, and SPI cold/warm cache runs, with structured metrics for wall-clock time, file/extraction counts, graph size, output bytes, and cache-hit reasons plus new docs for manual large-repo measurements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
+- **Execution-slice context packs**: runtime-generation backend explain packs now expose a separate `execution_slice` section with ordered runtime steps and partial-path signaling while preserving the raw `slice` metadata for compatibility.
 - **Pack-only compare mode**: `graphify-ts compare --baseline-mode pack_only` now compares one bounded raw-context baseline prompt against one compiled graphify pack, persists the compact pack audit fields in `report.json`, and keeps `native_agent` as the provider-reported runtime benchmark path.
 - **Share-safe proof reports**: `compare`, `review-compare`, and runner-backed `benchmark --exec ...` executions now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
 - **Generate performance benchmark harness**: adds a small synthetic benchmark flow for `generate`, `update`, `cluster-only`, and SPI cold/warm cache runs, with structured metrics for wall-clock time, file/extraction counts, graph size, output bytes, and cache-hit reasons plus new docs for manual large-repo measurements.

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -38,7 +38,7 @@ node dist/src/cli/bin.js compare "How does login create a session?" \
   --yes
 ```
 
-If you want to isolate the context-compiler claim without MCP/tool-call behavior, switch to `--baseline-mode pack_only`. That mode compares one bounded raw-context baseline prompt against one compiled graphify pack and persists the compact pack audit fields (`token_count`, matched nodes, relationships, coverage, and selection diagnostics) in `report.json`.
+If you want to isolate the context-compiler claim without MCP/tool-call behavior, switch to `--baseline-mode pack_only`. That mode compares one bounded raw-context baseline prompt against one compiled graphify pack and persists the compact pack audit fields (`token_count`, matched nodes, relationships, coverage, selection diagnostics, and runtime-generation explain-pack `execution_slice` details when present) in `report.json`.
 
 If you switch to `--baseline-mode native_agent`, prefer a structured Anthropic runner such as `cat {prompt_file} | claude -p --output-format json`. Plain-text Claude runs still save paired answers, but the report cannot compute Anthropic-billed reductions without the trailing JSON usage block. Multi-question native-agent runs also emit suite-level comparable-question wins/losses for input tokens, turns, and latency, plus mean/median input-token reduction, comparable-question denominators when some runs are excluded from the aggregate, and best/worst prompt outcomes in the terminal summary.
 

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -59,19 +59,6 @@ export interface ContextPackSliceMetadata {
   selected_paths: ContextPackSlicePath[]
 }
 
-export interface ContextPackExecutionStep {
-  node_id?: string
-  label: string
-  source_file?: string
-  line_number?: number
-}
-
-export interface ContextPackExecutionSlice {
-  status: 'complete' | 'partial'
-  steps: ContextPackExecutionStep[]
-  boundary_reason?: string
-}
-
 export type ContextRepresentationType =
   | 'detail'
   | 'summary'
@@ -220,7 +207,6 @@ export interface CompiledContextPack<
   selection_diagnostics?: ContextPackSelectionDiagnostics
   retrieval_strategy?: ContextPackRetrievalStrategy
   slice?: ContextPackSliceMetadata
-  execution_slice?: ContextPackExecutionSlice
   /**
    * Retrieval-gate decision (#75) attached when the caller invoked the
    * gate before building the pack. Carries `level`, `reason`, `intent`,

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -59,6 +59,21 @@ export interface ContextPackSliceMetadata {
   selected_paths: ContextPackSlicePath[]
 }
 
+export interface ContextPackExecutionSliceStep {
+  node_id?: string
+  label: string
+  source_file: string
+  line_number: number
+  node_kind?: string
+  framework_role?: string
+}
+
+export interface ContextPackExecutionSlice {
+  status: 'complete' | 'partial'
+  boundary_reason?: string
+  steps: ContextPackExecutionSliceStep[]
+}
+
 export type ContextRepresentationType =
   | 'detail'
   | 'summary'
@@ -207,6 +222,7 @@ export interface CompiledContextPack<
   selection_diagnostics?: ContextPackSelectionDiagnostics
   retrieval_strategy?: ContextPackRetrievalStrategy
   slice?: ContextPackSliceMetadata
+  execution_slice?: ContextPackExecutionSlice
   /**
    * Retrieval-gate decision (#75) attached when the caller invoked the
    * gate before building the pack. Carries `level`, `reason`, `intent`,

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -59,6 +59,19 @@ export interface ContextPackSliceMetadata {
   selected_paths: ContextPackSlicePath[]
 }
 
+export interface ContextPackExecutionStep {
+  node_id?: string
+  label: string
+  source_file?: string
+  line_number?: number
+}
+
+export interface ContextPackExecutionSlice {
+  status: 'complete' | 'partial'
+  steps: ContextPackExecutionStep[]
+  boundary_reason?: string
+}
+
 export type ContextRepresentationType =
   | 'detail'
   | 'summary'
@@ -207,6 +220,7 @@ export interface CompiledContextPack<
   selection_diagnostics?: ContextPackSelectionDiagnostics
   retrieval_strategy?: ContextPackRetrievalStrategy
   slice?: ContextPackSliceMetadata
+  execution_slice?: ContextPackExecutionSlice
   /**
    * Retrieval-gate decision (#75) attached when the caller invoked the
    * gate before building the pack. Carries `level`, `reason`, `intent`,

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'node:fs'
 import { basename } from 'node:path'
 
 import type {
+  ContextPackExecutionSlice,
+  ContextPackExecutionSliceStep,
   CompiledContextPack,
   ContextPackClaim,
   ContextPackCoverage,
@@ -137,6 +139,7 @@ export interface RetrieveResult {
   retrieval_gate?: RetrievalGateDecision
   retrieval_strategy?: ContextPackRetrievalStrategy
   slice?: ContextPackSliceMetadata
+  execution_slice?: ContextPackExecutionSlice
 }
 
 export interface CompactRetrieveMatchedNode extends Omit<RetrieveMatchedNode, 'community_label' | 'file_type' | 'framework_boost'> {
@@ -1429,6 +1432,273 @@ function augmentSliceCandidateIdsForDebug(
   return expanded
 }
 
+function runtimeGenerationExecutionSliceApplies(
+  taskContract: ContextPackTaskContract,
+  retrievalGate: RetrievalGateDecision,
+  sliceMetadata: ContextPackSliceMetadata | undefined,
+): boolean {
+  return retrievalGate.signals.generation_intent === 'runtime_generation'
+    && retrievalGate.signals.target_domain_hint === 'backend_runtime'
+    && taskContract.task_kind === 'explain'
+    && sliceMetadata !== undefined
+}
+
+function executionSliceFlowRelation(relation: string): boolean {
+  return relation === 'calls' || relation === 'controller_route' || relation === 'route_handler' || relation === 'method'
+}
+
+function promptExpectsPersistenceStep(question: string): boolean {
+  return /\b(?:persist(?:ence|ent)?|repository|database|db|store|storage)\b/i.test(question)
+}
+
+function persistenceLikeExecutionStep(
+  node: Pick<RetrieveMatchedNode, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:persist|repository|database|db|storage|store|sessionstore|createsession|insert|write|save)\b/.test(lower)
+}
+
+function executionSliceStepPriority(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+  question: string,
+): number {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  let value = 0
+
+  if (promptExpectsPersistenceStep(question) && persistenceLikeExecutionStep(node)) {
+    value += 100
+  }
+  if (/\b(?:route|controller|service|worker|job|pipeline|orchestrator|repository|store)\b/.test(lower)) {
+    value += 10
+  }
+  if (/\b(?:validate|validator|schema|dto|spec|test|guard|config|env)\b/.test(lower)) {
+    value -= 5
+  }
+
+  return value
+}
+
+function executionSliceStepFromGraph(
+  graph: KnowledgeGraph,
+  nodeId: string,
+  rootPath?: string,
+): ContextPackExecutionSliceStep {
+  const attributes = graph.nodeAttributes(nodeId)
+  return {
+    node_id: nodeId,
+    label: String(attributes.label ?? nodeId),
+    source_file: relativizeSourceFile(String(attributes.source_file ?? ''), rootPath),
+    line_number: lineNumberFromSourceLocation(String(attributes.source_location ?? '')) ?? 0,
+    ...(typeof attributes.node_kind === 'string' ? { node_kind: attributes.node_kind } : {}),
+    ...(typeof attributes.framework_role === 'string' ? { framework_role: attributes.framework_role } : {}),
+  }
+}
+
+function collectExecutionSliceScope(
+  graph: KnowledgeGraph,
+  sliceMetadata: ContextPackSliceMetadata,
+  anchorIds: readonly string[],
+  resolveNodeId: (nodeId: string | undefined, label: string) => string | undefined,
+): { orderedIds: string[]; idSet: ReadonlySet<string> } {
+  const orderedIds: string[] = []
+  const idSet = new Set<string>()
+  let addedSelectedFlowPath = false
+  const addNodeId = (nodeId: string | undefined): void => {
+    if (!nodeId || idSet.has(nodeId) || !graph.hasNode(nodeId)) {
+      return
+    }
+    idSet.add(nodeId)
+    orderedIds.push(nodeId)
+  }
+
+  for (const anchorId of anchorIds) {
+    addNodeId(anchorId)
+  }
+
+  for (const path of sliceMetadata.selected_paths) {
+    if (!executionSliceFlowRelation(path.relation)) {
+      continue
+    }
+    const beforeSize = idSet.size
+    addNodeId(resolveNodeId(path.from_id, path.from))
+    addNodeId(resolveNodeId(path.to_id, path.to))
+    if (idSet.size > beforeSize) {
+      addedSelectedFlowPath = true
+    }
+  }
+
+  if (addedSelectedFlowPath) {
+    return { orderedIds, idSet }
+  }
+
+  const queue = anchorIds.map((nodeId) => ({ nodeId, depth: 0 }))
+  const bestDepthByNode = new Map(anchorIds.map((nodeId) => [nodeId, 0]))
+  const enqueueNeighbor = (nodeId: string, depth: number): void => {
+    const bestDepth = bestDepthByNode.get(nodeId)
+    if (bestDepth !== undefined && bestDepth <= depth) {
+      return
+    }
+    bestDepthByNode.set(nodeId, depth)
+    queue.push({ nodeId, depth })
+  }
+
+  while (queue.length > 0) {
+    const { nodeId, depth } = queue.shift()!
+    addNodeId(nodeId)
+    if (depth >= 6) {
+      continue
+    }
+    for (const predecessorId of graph.predecessors(nodeId)) {
+      if (executionSliceFlowRelation(String(graph.edgeAttributes(predecessorId, nodeId).relation ?? 'related_to'))) {
+        enqueueNeighbor(predecessorId, depth + 1)
+      }
+    }
+    for (const successorId of graph.successors(nodeId)) {
+      if (executionSliceFlowRelation(String(graph.edgeAttributes(nodeId, successorId).relation ?? 'related_to'))) {
+        enqueueNeighbor(successorId, depth + 1)
+      }
+    }
+  }
+
+  return { orderedIds, idSet }
+}
+
+function pickExecutionSliceStart(
+  graph: KnowledgeGraph,
+  orderedIds: readonly string[],
+  idSet: ReadonlySet<string>,
+  nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
+  question: string,
+): string | undefined {
+  const roots = orderedIds.filter((nodeId) =>
+    [...graph.predecessors(nodeId)].every((predecessorId) =>
+      !idSet.has(predecessorId)
+      || !executionSliceFlowRelation(String(graph.edgeAttributes(predecessorId, nodeId).relation ?? 'related_to')),
+    ),
+  )
+  const candidates = roots.length > 0 ? roots : orderedIds
+
+  return [...candidates].sort((left, right) => {
+    const leftStep = nodeById.get(left)
+    const rightStep = nodeById.get(right)
+    return (rightStep ? executionSliceStepPriority(rightStep, question) : 0)
+      - (leftStep ? executionSliceStepPriority(leftStep, question) : 0)
+  })[0]
+}
+
+function walkExecutionSlice(
+  graph: KnowledgeGraph,
+  startId: string,
+  idSet: ReadonlySet<string>,
+  nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
+  question: string,
+): string[] {
+  const orderedPathIds: string[] = []
+  const seen = new Set<string>()
+  let currentId: string | undefined = startId
+
+  while (currentId && !seen.has(currentId)) {
+    orderedPathIds.push(currentId)
+    seen.add(currentId)
+
+    const nextId: string | undefined = [...graph.successors(currentId)]
+      .filter((candidateId) =>
+        idSet.has(candidateId)
+        && !seen.has(candidateId)
+        && executionSliceFlowRelation(String(graph.edgeAttributes(currentId!, candidateId).relation ?? 'related_to')),
+      )
+      .sort((left, right) => {
+        const leftStep = nodeById.get(left)
+        const rightStep = nodeById.get(right)
+        return (rightStep ? executionSliceStepPriority(rightStep, question) : 0)
+          - (leftStep ? executionSliceStepPriority(leftStep, question) : 0)
+      })[0]
+
+    currentId = nextId
+  }
+
+  return orderedPathIds
+}
+
+function buildExecutionSlice(
+  graph: KnowledgeGraph,
+  taskContract: ContextPackTaskContract,
+  retrievalGate: RetrievalGateDecision,
+  question: string,
+  sliceMetadata: ContextPackSliceMetadata | undefined,
+  rootPath?: string,
+): ContextPackExecutionSlice | undefined {
+  if (!runtimeGenerationExecutionSliceApplies(taskContract, retrievalGate, sliceMetadata) || !sliceMetadata) {
+    return undefined
+  }
+
+  const nodeIdByLabel = new Map<string, string>()
+  for (const [nodeId, attributes] of graph.nodeEntries()) {
+    const label = String(attributes.label ?? nodeId)
+    if (!nodeIdByLabel.has(label)) {
+      nodeIdByLabel.set(label, nodeId)
+    }
+  }
+
+  const resolveNodeId = (nodeId: string | undefined, label: string): string | undefined => {
+    if (nodeId && graph.hasNode(nodeId)) {
+      return nodeId
+    }
+    return nodeIdByLabel.get(label)
+  }
+
+  const anchorIds = sliceMetadata.anchors
+    .map((anchor) => resolveNodeId(anchor.node_id, anchor.label))
+    .filter((nodeId): nodeId is string => typeof nodeId === 'string')
+  const { orderedIds, idSet } = collectExecutionSliceScope(graph, sliceMetadata, anchorIds, resolveNodeId)
+  if (orderedIds.length === 0) {
+    return {
+      status: 'partial',
+      boundary_reason: 'slice missing runtime path',
+      steps: [],
+    }
+  }
+
+  const nodeById = new Map(
+    orderedIds
+      .map((nodeId) => [nodeId, executionSliceStepFromGraph(graph, nodeId, rootPath)] as const),
+  )
+  const startId = pickExecutionSliceStart(graph, orderedIds, idSet, nodeById, question)
+  if (!startId) {
+    return {
+      status: 'partial',
+      boundary_reason: 'slice missing runtime path',
+      steps: [],
+    }
+  }
+
+  const orderedPathIds = walkExecutionSlice(graph, startId, idSet, nodeById, question)
+
+  const seen = new Set<string>()
+  const steps = orderedPathIds.flatMap((nodeId) => {
+    if (seen.has(nodeId)) {
+      return []
+    }
+    seen.add(nodeId)
+    const node = nodeById.get(nodeId)
+    return node ? [node] : []
+  })
+
+  const expectsPersistence = promptExpectsPersistenceStep(question)
+  const reachedPersistence = steps.some((step) => persistenceLikeExecutionStep(step))
+
+  return expectsPersistence && !reachedPersistence
+    ? {
+        status: 'partial',
+        boundary_reason: 'slice stops before expected persistence step',
+        steps,
+      }
+    : {
+        status: 'complete',
+        steps,
+      }
+}
+
 function buildFrameworkQuestionProfile(question: string, questionTokens: readonly string[]): FrameworkQuestionProfile {
   const hasRoutePath = containsUrlLikeRoutePath(question)
   const hasRouteKeyword = includesAnyToken(questionTokens, ['route', 'routes', 'router', 'endpoint', 'endpoints'])
@@ -1840,6 +2110,7 @@ export function contextPackFromRetrieveResult(
     ...(result.selection_diagnostics ? { selection_diagnostics: result.selection_diagnostics } : {}),
     ...(result.retrieval_strategy ? { retrieval_strategy: result.retrieval_strategy } : {}),
     ...(result.slice ? { slice: result.slice } : {}),
+    ...(result.execution_slice ? { execution_slice: result.execution_slice } : {}),
     ...(result.retrieval_gate ? { retrieval_gate: result.retrieval_gate } : {}),
   }
 }
@@ -1868,6 +2139,7 @@ function buildRetrieveResultFromOrderedCandidates(
     bridge_nodes: [...new Set(orderedCandidates.map((node) => node.label).filter((label) => retrieveGraphSignals.bridgeNodeLabels.has(label)))],
   }
   const structuralIds = structuralSliceNodeIds(sliceMetadata, orderedCandidates, options.question)
+  const executionSlice = buildExecutionSlice(graph, taskContract, retrievalGate, options.question, sliceMetadata, rootPath)
   const nodeCandidates: Array<ContextPackNodeCandidate<ContextPackNode>> = orderedCandidates.map((node) => {
     let builtEntry: RetrieveMatchedNode | undefined
     let tokenCost: number | undefined
@@ -1984,6 +2256,7 @@ function buildRetrieveResultFromOrderedCandidates(
     ...(pack.retrieval_gate ? { retrieval_gate: pack.retrieval_gate } : {}),
     retrieval_strategy: options.retrievalStrategy ?? 'default',
     ...(sliceMetadata ? { slice: sliceMetadata } : {}),
+    ...(executionSlice ? { execution_slice: executionSlice } : {}),
   }
 }
 
@@ -2718,6 +2991,7 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
   const compactFrameworkLimit =
     frameworkProfile.frameworkShaped && result.matched_nodes.some((node) => (node.framework_boost ?? 0) > 0) ? 5 : Number.POSITIVE_INFINITY
   const fullPack = contextPackFromRetrieveResult(result)
+  const executionSlice = result.execution_slice
   const promotedSliceNodeIds = promotedSliceCompactNodeIds(result)
   const compactPack = promotedSliceNodeIds.length > 0
     ? compactContextPack(fullPack, {
@@ -2743,6 +3017,7 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
     ...(compactPack.shared_file_type ? { shared_file_type: compactPack.shared_file_type } : {}),
     retrieval_strategy: result.retrieval_strategy ?? 'default',
     ...(result.slice ? { slice: result.slice } : {}),
+    ...(executionSlice ? { execution_slice: executionSlice } : {}),
     ...(result.retrieval_gate ? { retrieval_gate: result.retrieval_gate } : {}),
   }
 }
@@ -2790,6 +3065,7 @@ export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveR
     ...(result.selection_diagnostics ? { selection_diagnostics: result.selection_diagnostics } : {}),
     retrieval_strategy: result.retrieval_strategy ?? 'default',
     ...(result.slice ? { slice: result.slice } : {}),
+    ...(compactResult.execution_slice ? { execution_slice: compactResult.execution_slice } : {}),
     ...(result.retrieval_gate ? { retrieval_gate: result.retrieval_gate } : {}),
   }
 }

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -1,121 +1,41 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { ContextPackExecutionSlice } from '../../src/contracts/context-pack.js'
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
+import { build } from '../../src/pipeline/build.js'
+import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+
+function buildRuntimeGenerationGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'auth_route', label: 'POST /login', file_type: 'code', source_file: '/src/auth/routes.ts', source_location: 'L10', node_kind: 'route', framework: 'express', framework_role: 'express_route', community: 0 },
+          { id: 'auth_controller', label: 'AuthController.login', file_type: 'code', source_file: '/src/auth/controller.ts', source_location: 'L20', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_controller', community: 0 },
+          { id: 'auth_service', label: 'AuthService.login', file_type: 'code', source_file: '/src/auth/service.ts', source_location: 'L30', node_kind: 'method', community: 0 },
+          { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L40', node_kind: 'method', community: 1 },
+          { id: 'auth_test', label: 'AuthService.login.spec', file_type: 'code', source_file: '/tests/auth.service.spec.ts', source_location: 'L50', node_kind: 'function', community: 2 },
+        ],
+        edges: [
+          { source: 'auth_route', target: 'auth_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: '/src/auth/routes.ts' },
+          { source: 'auth_controller', target: 'auth_service', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
+          { source: 'auth_service', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          { source: 'auth_service', target: 'auth_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
 
 describe('context-pack-command', () => {
-  it('emits a compact deterministic explain pack', async () => {
-    const graph = new KnowledgeGraph()
-    const executionSlice: ContextPackExecutionSlice = {
-      status: 'complete',
-      steps: [
-        { label: 'POST /login' },
-        { label: 'AuthController.login' },
-        { label: 'AuthService.login' },
-        { label: 'SessionStore.createSession' },
-      ],
-    }
+  it('preserves execution_slice for runtime-generation explain packs', async () => {
+    const graph = buildRuntimeGenerationGraph()
     const dependencies: ContextPackCommandDependencies = {
       loadGraph: vi.fn().mockReturnValue(graph),
-      retrieveContext: vi.fn().mockReturnValue({
-        question: 'how does auth work',
-        token_count: 42,
-        matched_nodes: [],
-        relationships: [],
-        community_context: [],
-        graph_signals: { god_nodes: [], bridge_nodes: [] },
-        task_contract: {
-          version: 1,
-          task_kind: 'explain',
-          task_intent: 'explain',
-          evidence_recipe_id: 'explain',
-          budget: 1800,
-          prompt: 'how does auth work',
-          required_evidence: ['primary', 'supporting', 'structural'],
-          preferred_evidence: ['primary', 'supporting', 'structural'],
-          semantic_required: ['implementation', 'structure'],
-          semantic_optional: ['contracts', 'configuration', 'tests'],
-        },
-        claims: [
-          {
-            evidence_class: 'primary',
-            text: 'primary evidence: AuthService',
-            node_labels: ['AuthService'],
-          },
-        ],
-        expandable: [
-          {
-            kind: 'nodes',
-            handle_id: 'expand:explain:structural:demo',
-            evidence_class: 'structural',
-            count: 1,
-            preview: [
-              {
-                node_id: 'logger',
-                label: 'Logger',
-                source_file: 'src/logger.ts',
-                line_range: {
-                  start_line: 3,
-                  end_line: 3,
-                },
-              },
-            ],
-            follow_up: {
-              kind: 'context_pack',
-              task_kind: 'explain',
-              evidence_class: 'structural',
-              focus_files: ['src/logger.ts'],
-              focus_ranges: [
-                {
-                  source_file: 'src/logger.ts',
-                  start_line: 3,
-                  end_line: 3,
-                },
-              ],
-            },
-          },
-        ],
-        coverage: {
-          required_evidence: ['primary', 'supporting', 'structural'],
-          semantic_required: ['implementation', 'structure'],
-          semantic_optional: ['contracts', 'configuration', 'tests'],
-          entries: [],
-          semantic_entries: [
-            {
-              category: 'implementation',
-              label: 'implementation',
-              required: true,
-              available_nodes: 1,
-              selected_nodes: 1,
-              status: 'covered',
-            },
-          ],
-          missing_required: [],
-          missing_semantic: [],
-          available_relationships: 0,
-          selected_relationships: 0,
-        },
-      }),
-      compactRetrieveResult: vi.fn().mockReturnValue({
-        question: 'how does auth work',
-        token_count: 18,
-        matched_nodes: [
-          {
-            label: 'AuthService',
-            source_file: 'src/auth.ts',
-            line_number: 12,
-            snippet: 'export class AuthService {}',
-            relevance_band: 'direct',
-            community: 0,
-          },
-        ],
-        relationships: [],
-        community_context: [],
-        graph_signals: { god_nodes: [], bridge_nodes: [] },
-        shared_file_type: 'code',
-        execution_slice: executionSlice,
-      }),
+      retrieveContext: vi.fn((currentGraph, options) => retrieveContext(currentGraph, options as never)),
+      compactRetrieveResult,
       analyzePrImpact: vi.fn(),
       compactPrImpactResult: vi.fn(),
       analyzeImpact: vi.fn(),
@@ -123,75 +43,38 @@ describe('context-pack-command', () => {
     }
 
     const output = await runContextPackCommand({
-      prompt: 'how does auth work',
+      prompt: 'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
       budget: 1800,
       task: 'explain',
       graphPath: 'graphify-out/graph.json',
+      retrievalStrategy: 'slice-v1',
     }, dependencies)
 
-    const payload = JSON.parse(output) as Record<string, unknown>
+    const payload = JSON.parse(output) as {
+      pack?: {
+        execution_slice?: {
+          status?: string
+          steps?: Array<{ label?: string }>
+        }
+      }
+    }
 
     expect(dependencies.loadGraph).toHaveBeenCalledWith('graphify-out/graph.json')
     expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
-      question: 'how does auth work',
+      question: 'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
       budget: 1800,
       taskIntent: 'explain',
+      retrievalStrategy: 'slice-v1',
     })
-    expect(payload).toEqual(expect.objectContaining({
-      task: 'explain',
-      task_intent: 'explain',
-      prompt: 'how does auth work',
-      budget: 1800,
-      graph_path: 'graphify-out/graph.json',
-      plan: expect.objectContaining({
-        task_kind: 'explain',
-        evidence: expect.objectContaining({
-          recipe_id: 'explain',
-        }),
-      }),
-      claims: [
-        {
-          evidence_class: 'primary',
-          text: 'primary evidence: AuthService',
-          node_labels: ['AuthService'],
-        },
+    expect(payload.pack?.execution_slice).toEqual({
+      status: 'complete',
+      steps: [
+        expect.objectContaining({ label: 'POST /login' }),
+        expect.objectContaining({ label: 'AuthController.login' }),
+        expect.objectContaining({ label: 'AuthService.login' }),
+        expect.objectContaining({ label: 'SessionStore.createSession' }),
       ],
-      expandable: [
-        expect.objectContaining({
-          handle_id: 'expand:explain:structural:demo',
-        }),
-      ],
-      coverage: expect.objectContaining({
-        semantic_entries: [
-          expect.objectContaining({
-            category: 'implementation',
-            status: 'covered',
-          }),
-        ],
-      }),
-      missing_context: [],
-      missing_semantic: [],
-      pack: {
-        question: 'how does auth work',
-        token_count: 18,
-        matched_nodes: [
-          {
-            label: 'AuthService',
-            source_file: 'src/auth.ts',
-            line_number: 12,
-            snippet: 'export class AuthService {}',
-            relevance_band: 'direct',
-            community: 0,
-          },
-        ],
-        relationships: [],
-        community_context: [],
-        graph_signals: { god_nodes: [], bridge_nodes: [] },
-        shared_file_type: 'code',
-        execution_slice: executionSlice,
-      },
-    }))
-    expect((payload.pack as { execution_slice?: ContextPackExecutionSlice }).execution_slice).toEqual(executionSlice)
+    })
   })
 
   it('normalizes sub-minimum explain budgets before retrieving', async () => {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { ContextPackExecutionSlice } from '../../src/contracts/context-pack.js'
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
 
 describe('context-pack-command', () => {
   it('emits a compact deterministic explain pack', async () => {
     const graph = new KnowledgeGraph()
+    const executionSlice: ContextPackExecutionSlice = {
+      status: 'complete',
+      steps: [
+        { label: 'POST /login' },
+        { label: 'AuthController.login' },
+        { label: 'AuthService.login' },
+        { label: 'SessionStore.createSession' },
+      ],
+    }
     const dependencies: ContextPackCommandDependencies = {
       loadGraph: vi.fn().mockReturnValue(graph),
       retrieveContext: vi.fn().mockReturnValue({
@@ -104,6 +114,7 @@ describe('context-pack-command', () => {
         community_context: [],
         graph_signals: { god_nodes: [], bridge_nodes: [] },
         shared_file_type: 'code',
+        execution_slice: executionSlice,
       }),
       analyzePrImpact: vi.fn(),
       compactPrImpactResult: vi.fn(),
@@ -177,8 +188,10 @@ describe('context-pack-command', () => {
         community_context: [],
         graph_signals: { god_nodes: [], bridge_nodes: [] },
         shared_file_type: 'code',
+        execution_slice: executionSlice,
       },
     }))
+    expect((payload.pack as { execution_slice?: ContextPackExecutionSlice }).execution_slice).toEqual(executionSlice)
   })
 
   it('normalizes sub-minimum explain budgets before retrieving', async () => {

--- a/tests/unit/retrieve-slice-v1.test.ts
+++ b/tests/unit/retrieve-slice-v1.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import type { ContextPackExecutionSlice } from '../../src/contracts/context-pack.js'
 import { build } from '../../src/pipeline/build.js'
 import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+
+interface ExecutionSliceExpectation {
+  status: 'complete' | 'partial'
+  steps: Array<{
+    node_id?: string
+    label: string
+    source_file?: string
+    line_number?: number
+  }>
+  boundary_reason?: string
+}
 
 function buildSliceGraph(options: { includePersistenceStep?: boolean } = {}) {
   const { includePersistenceStep = true } = options
@@ -59,7 +69,7 @@ function compactFor(prompt: string, graph = buildSliceGraph()) {
   } as never)
 
   return compactRetrieveResult(retrieval) as ReturnType<typeof compactRetrieveResult> & {
-    execution_slice?: ContextPackExecutionSlice
+    execution_slice?: ExecutionSliceExpectation
   }
 }
 

--- a/tests/unit/retrieve-slice-v1.test.ts
+++ b/tests/unit/retrieve-slice-v1.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import type { ContextPackExecutionSlice } from '../../src/contracts/context-pack.js'
 import { build } from '../../src/pipeline/build.js'
-import { retrieveContext } from '../../src/runtime/retrieve.js'
+import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
 
-function buildSliceGraph() {
+function buildSliceGraph(options: { includePersistenceStep?: boolean } = {}) {
+  const { includePersistenceStep = true } = options
+
   return build(
     [
       {
@@ -29,7 +32,9 @@ function buildSliceGraph() {
           { source: 'auth_controller', target: 'auth_guard', relation: 'uses_guard', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
           { source: 'auth_controller', target: 'auth_service', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
           { source: 'auth_service', target: 'login_validator', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
-          { source: 'auth_service', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          ...(includePersistenceStep
+            ? [{ source: 'auth_service', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' } as const]
+            : []),
           { source: 'auth_service', target: 'auth_env', relation: 'reads_env', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
           { source: 'auth_service', target: 'auth_contract', relation: 'depends_on', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
           { source: 'auth_service', target: 'auth_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
@@ -43,6 +48,19 @@ function buildSliceGraph() {
     ],
     { directed: true },
   )
+}
+
+function compactFor(prompt: string, graph = buildSliceGraph()) {
+  const retrieval = retrieveContext(graph, {
+    question: prompt,
+    budget: 3000,
+    retrievalLevel: 4,
+    retrievalStrategy: 'slice-v1',
+  } as never)
+
+  return compactRetrieveResult(retrieval) as ReturnType<typeof compactRetrieveResult> & {
+    execution_slice?: ContextPackExecutionSlice
+  }
 }
 
 function labelsFor(prompt: string, overrides: Record<string, unknown> = {}): string[] {
@@ -103,6 +121,30 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
     expect(labels).not.toContain('index.ts')
     expect((sliced as any).slice.mode).toBe('debug')
     expect((sliced as any).slice.directions).toEqual(['backward', 'forward'])
+  })
+
+  it('surfaces an execution slice for runtime-generation backend prompts', () => {
+    const compact = compactFor('Trace how `POST /login` reaches persistence in the backend runtime pipeline')
+
+    expect(compact.execution_slice).toEqual({
+      status: 'complete',
+      steps: [
+        expect.objectContaining({ label: 'POST /login' }),
+        expect.objectContaining({ label: 'AuthController.login' }),
+        expect.objectContaining({ label: 'AuthService.login' }),
+        expect.objectContaining({ label: 'SessionStore.createSession' }),
+      ],
+    })
+  })
+
+  it('marks execution slices partial when the route cannot reach persistence', () => {
+    const compact = compactFor(
+      'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
+      buildSliceGraph({ includePersistenceStep: false }),
+    )
+
+    expect(compact.execution_slice?.status).toBe('partial')
+    expect(compact.execution_slice?.boundary_reason).toMatch(/missing|boundary|stops/i)
   })
 
   it('can pull direct graph neighbors into a level-1 slice even when they do not lexically match', () => {

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -1,16 +1,19 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { handleStdioRequest } from '../../src/runtime/stdio-server.js'
 
 const tempRoots: string[] = []
+const scratchRoot = join(process.cwd(), '.test-artifacts', 'stdio-slice-surface')
 let previousToolProfile: string | undefined
 
 function createGraphPath(): string {
-  const root = mkdtempSync(join(tmpdir(), 'graphify-stdio-slice-'))
+  mkdirSync(scratchRoot, { recursive: true })
+  const root = join(scratchRoot, `graphify-stdio-slice-${randomUUID()}`)
+  mkdirSync(root, { recursive: true })
   tempRoots.push(root)
   const graphifyOut = join(root, 'graphify-out')
   const graphPath = join(graphifyOut, 'graph.json')

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -15,16 +15,25 @@ function createGraphPath(): string {
   const graphifyOut = join(root, 'graphify-out')
   const graphPath = join(graphifyOut, 'graph.json')
   mkdirSync(graphifyOut, { recursive: true })
-  writeFileSync(join(root, 'auth.ts'), 'export function login() {}\n', 'utf8')
+  writeFileSync(join(root, 'routes.ts'), 'export const loginRoute = "POST /login"\n', 'utf8')
+  writeFileSync(join(root, 'controller.ts'), 'export class AuthController { login() {} }\n', 'utf8')
+  writeFileSync(join(root, 'auth.ts'), 'export class AuthService { login() {} }\n', 'utf8')
+  writeFileSync(join(root, 'session-store.ts'), 'export class SessionStore { createSession() {} }\n', 'utf8')
   writeFileSync(join(root, 'auth.spec.ts'), 'test("login", () => {})\n', 'utf8')
   writeFileSync(join(graphifyOut, 'GRAPH_REPORT.md'), '# Graph report\n', 'utf8')
   writeFileSync(graphPath, JSON.stringify({
     root_path: root,
     nodes: [
-      { id: 'auth_service', label: 'AuthService.login', source_file: join(root, 'auth.ts'), source_location: 'L1', file_type: 'code', community: 0 },
-      { id: 'auth_test', label: 'AuthService.login.spec', source_file: join(root, 'auth.spec.ts'), source_location: 'L2', file_type: 'code', community: 1 },
+      { id: 'auth_route', label: 'POST /login', source_file: join(root, 'routes.ts'), source_location: 'L1', file_type: 'code', node_kind: 'route', framework: 'express', framework_role: 'express_route', community: 0 },
+      { id: 'auth_controller', label: 'AuthController.login', source_file: join(root, 'controller.ts'), source_location: 'L1', file_type: 'code', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_controller', community: 0 },
+      { id: 'auth_service', label: 'AuthService.login', source_file: join(root, 'auth.ts'), source_location: 'L1', file_type: 'code', node_kind: 'method', community: 0 },
+      { id: 'session_store', label: 'SessionStore.createSession', source_file: join(root, 'session-store.ts'), source_location: 'L1', file_type: 'code', node_kind: 'method', community: 1 },
+      { id: 'auth_test', label: 'AuthService.login.spec', source_file: join(root, 'auth.spec.ts'), source_location: 'L2', file_type: 'code', node_kind: 'function', community: 2 },
     ],
     edges: [
+      { source: 'auth_route', target: 'auth_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: join(root, 'routes.ts') },
+      { source: 'auth_controller', target: 'auth_service', relation: 'calls', confidence: 'EXTRACTED', source_file: join(root, 'controller.ts') },
+      { source: 'auth_service', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: join(root, 'auth.ts') },
       { source: 'auth_service', target: 'auth_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: join(root, 'auth.ts') },
     ],
     hyperedges: [],
@@ -123,6 +132,29 @@ describe('stdio slice-v1 surface', () => {
 
     expect(JSON.stringify(retrieveResponse)).toContain('retrieval_strategy must be one of default, slice-v1')
     expect(JSON.stringify(contextPackResponse)).toContain('retrieval_strategy must be one of default, slice-v1')
+  })
+
+  it('includes execution_slice in runtime-generation context_pack responses', async () => {
+    const graphPath = createGraphPath()
+
+    const contextPackResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
+          budget: 1000,
+          task: 'explain',
+          retrieval_strategy: 'slice-v1',
+          verbose: true,
+        },
+      },
+    }))
+
+    const contextPackText = ((contextPackResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? ''
+
+    expect(contextPackText).toContain('"execution_slice"')
   })
 
   it('rejects retrieval_strategy for review context packs instead of ignoring it', async () => {


### PR DESCRIPTION
## Summary
- add a separate `execution_slice` field to compact runtime-generation backend packs while preserving the existing `slice` metadata
- cover complete and partial execution-path behavior across retrieve, context_pack command, and stdio surfaces
- document the new output in the changelog and proof workflows docs

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] CI=1 npm run test:run

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution-slice context packs with ordered runtime steps and partial-path signaling, surfaced alongside existing slice metadata in runtime-generation backend packs.

* **Documentation**
  * Updated baseline-mode documentation to reflect the expanded set of compact pack audit fields captured in reports, including execution-slice runtime-generation details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->