### PR TITLE
feat: add public GoValidate benchmark suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the TypeScript package will be documented in this file.
 - **Share-safe proof reports**: `compare`, `review-compare`, and runner-backed `benchmark --exec ...` executions now emit a companion `report.share-safe.json` with stable path placeholders while keeping the full local `report.json`.
 - **Generate performance benchmark harness**: adds a small synthetic benchmark flow for `generate`, `update`, `cluster-only`, and SPI cold/warm cache runs, with structured metrics for wall-clock time, file/extraction counts, graph size, output bytes, and cache-hit reasons plus new docs for manual large-repo measurements.
 - **Deterministic answer-quality rubric skeleton**: shared GoValidate benchmark gates now include answer-term checks plus manual-review concept notes, and `verify-answer-quality.js` can validate saved benchmark answer artifacts without calling an LLM.
+- **Public GoValidate benchmark suite**: adds `docs/benchmarks/govalidate-suite/questions.json` with stable prompt ids and descriptions for ten realistic product questions, preserves optional `id`/`description` metadata in shared benchmark question files, and documents the suite as a conservative public prompt set that stays separate from the dated single-prompt benchmark artifact.
 
 ### Changed
 

--- a/docs/benchmarks/govalidate-suite/README.md
+++ b/docs/benchmarks/govalidate-suite/README.md
@@ -1,12 +1,35 @@
-# GoValidate shared benchmark quality gates
+# GoValidate shared benchmark suite
 
-This directory holds the shared pack-quality and answer-quality gates for committed GoValidate benchmark artifacts.
+This directory holds the public GoValidate benchmark suite inputs plus the shared pack-quality and answer-quality gates for committed benchmark artifacts.
 
 ## Files
 
+- `questions.json` - public multi-prompt suite with stable prompt `id` values, human-readable descriptions, and realistic questions contributors can run locally
 - `quality-gates.json` — named gate definitions plus the prompt text they apply to
 - `verify-pack-quality.js` — deterministic verifier for persisted `graphify-ts compare` reports
 - `verify-answer-quality.js` — deterministic verifier for saved `*-answer.txt` artifacts
+
+## Public suite usage
+
+`questions.json` is the conservative public prompt set for multi-prompt GoValidate runs. It is intentionally public-only:
+
+- do not commit private GoValidate source labels or snippets to this file
+- do not invent benchmark numbers in this directory
+- keep the current dated single-prompt benchmark artifact separate from this suite
+
+The suite is meant to widen prompt coverage across realistic tasks, not to claim universal token reduction or universal answer quality.
+
+Example compare command:
+
+```bash
+graphify-ts compare \
+  --questions docs/benchmarks/govalidate-suite/questions.json \
+  --exec "cat {prompt_file} | claude -p --output-format json" \
+  --yes \
+  --baseline-mode native_agent
+```
+
+Run the suite locally against your own checked-out GoValidate workspace and review the saved reports before making any public claims.
 
 ## Usage
 

--- a/docs/benchmarks/govalidate-suite/questions.json
+++ b/docs/benchmarks/govalidate-suite/questions.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "report-generation",
+    "description": "Trace the runtime path that generates idea or report-style output.",
+    "question": "Explain how idea report generation works end to end."
+  },
+  {
+    "id": "credits-accounting",
+    "description": "Find where credits are charged, decremented, or reconciled.",
+    "question": "How are user credits consumed and recorded during an AI action?"
+  },
+  {
+    "id": "waitlist-invite-codes",
+    "description": "Follow the flow for waitlist approvals, invite-code issuance, and redemption.",
+    "question": "How do waitlist approvals and invite codes work?"
+  },
+  {
+    "id": "pdf-export",
+    "description": "Identify the path that turns application data into an exported PDF.",
+    "question": "How is a PDF export generated and returned to the user?"
+  },
+  {
+    "id": "ai-landing-pages",
+    "description": "Locate the backend and rendering flow for AI-generated landing pages.",
+    "question": "How are AI landing pages generated and published?"
+  },
+  {
+    "id": "nda-sharing",
+    "description": "Cover the share flow for NDAs or similar protected documents.",
+    "question": "How does NDA sharing work, including access checks and delivery?"
+  },
+  {
+    "id": "stripe-limits",
+    "description": "Find where Stripe-related usage or plan limits are enforced.",
+    "question": "Where are Stripe billing or usage limits enforced?"
+  },
+  {
+    "id": "pipeline-status-broadcast",
+    "description": "Trace how long-running pipeline status updates are broadcast to clients.",
+    "question": "How is pipeline status broadcast while background work is running?"
+  },
+  {
+    "id": "impact-review",
+    "description": "Prompt for the main code path and dependencies involved in an impact or review flow.",
+    "question": "What code paths are involved when the app builds an impact review?"
+  },
+  {
+    "id": "provider-model-calls",
+    "description": "Identify where provider selection and model calls are issued for AI work.",
+    "question": "Where does the app choose providers or models before making AI calls?"
+  }
+]

--- a/src/infrastructure/benchmark/questions.ts
+++ b/src/infrastructure/benchmark/questions.ts
@@ -25,6 +25,8 @@ export interface BenchmarkQuestionResult {
 }
 
 export interface BenchmarkQuestionSpec {
+  id?: string
+  description?: string
   question: string
   expected_labels?: string[]
 }
@@ -53,6 +55,10 @@ export function normalizeBenchmarkQuestion(question: BenchmarkQuestionInput): Be
     return { question, expected_labels: [] }
   }
   return {
+    ...(typeof question.id === 'string' && question.id.trim().length > 0 ? { id: question.id.trim() } : {}),
+    ...(typeof question.description === 'string' && question.description.trim().length > 0
+      ? { description: question.description.trim() }
+      : {}),
     question: question.question.trim(),
     expected_labels: Array.isArray(question.expected_labels) ? question.expected_labels.filter((label) => label.trim().length > 0) : [],
   }
@@ -74,12 +80,24 @@ export function loadBenchmarkQuestions(questionsPath: string): BenchmarkQuestion
       throw new Error(`Question file entry ${index + 1} must include a non-empty question string`)
     }
 
+    const id = 'id' in entry ? entry.id : undefined
+    if (id !== undefined && (typeof id !== 'string' || id.trim().length === 0)) {
+      throw new Error(`Question file entry ${index + 1} id must be a non-empty string when provided`)
+    }
+
+    const description = 'description' in entry ? entry.description : undefined
+    if (description !== undefined && (typeof description !== 'string' || description.trim().length === 0)) {
+      throw new Error(`Question file entry ${index + 1} description must be a non-empty string when provided`)
+    }
+
     const expectedLabels = 'expected_labels' in entry ? entry.expected_labels : undefined
     if (expectedLabels !== undefined && (!Array.isArray(expectedLabels) || expectedLabels.some((label) => typeof label !== 'string'))) {
       throw new Error(`Question file entry ${index + 1} expected_labels must be an array of strings`)
     }
 
     return normalizeBenchmarkQuestion({
+      ...(id !== undefined ? { id: id as string } : {}),
+      ...(description !== undefined ? { description: description as string } : {}),
       question,
       ...(expectedLabels !== undefined ? { expected_labels: expectedLabels as string[] } : {}),
     })

--- a/src/infrastructure/benchmark/questions.ts
+++ b/src/infrastructure/benchmark/questions.ts
@@ -7,6 +7,8 @@ import { type PromptRunnerUsage } from '../prompt-runner.js'
 import { type BenchmarkPromptArtifacts, type BenchmarkPromptTokenSource } from './runner.js'
 
 export interface BenchmarkQuestionResult {
+  id?: string
+  description?: string
   question: string
   query_tokens: number
   effective_query_tokens?: number
@@ -152,6 +154,8 @@ export function evaluateBenchmarkQuestion(graph: KnowledgeGraph, question: Bench
   return {
     question: questionSpec.question,
     result: {
+      ...(questionSpec.id ? { id: questionSpec.id } : {}),
+      ...(questionSpec.description ? { description: questionSpec.description } : {}),
       question: questionSpec.question,
       query_tokens: match.queryTokens,
       reduction: Number((corpusTokens / match.queryTokens).toFixed(1)),

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -13,6 +13,7 @@ const BENCHMARK_STYLESHEET = resolve('docs', 'benchmarks', 'styles.css')
 const PACK_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'verify-pack-quality.js')
 const ANSWER_VERIFIER_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'verify-answer-quality.js')
 const PACK_GATE_CONFIG_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'quality-gates.json')
+const SUITE_QUESTIONS_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'questions.json')
 const SUITE_README_PATH = resolve('docs', 'benchmarks', 'govalidate-suite', 'README.md')
 
 interface PackQualityGateDefinition {
@@ -495,6 +496,43 @@ describe('shared GoValidate benchmark suite README', () => {
     expect(readme).toContain('verify-answer-quality.js')
     expect(readme).toContain('--answer <answer.txt>')
     expect(readme.toLowerCase()).toContain('deterministic answer-term checks')
+  })
+
+  it('ships a public multi-prompt suite with stable ids and no private expected labels', () => {
+    expect(existsSync(SUITE_QUESTIONS_PATH)).toBe(true)
+
+    const questions = JSON.parse(readFileSync(SUITE_QUESTIONS_PATH, 'utf8')) as Array<{
+      id?: unknown
+      description?: unknown
+      question?: unknown
+      expected_labels?: unknown
+    }>
+
+    expect(questions.length).toBeGreaterThanOrEqual(8)
+    expect(questions.length).toBeLessThanOrEqual(12)
+
+    const ids = questions.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(questions.length)
+
+    for (const entry of questions) {
+      expect(typeof entry.id).toBe('string')
+      expect((entry.id as string).trim().length).toBeGreaterThan(0)
+      expect(typeof entry.description).toBe('string')
+      expect((entry.description as string).trim().length).toBeGreaterThan(0)
+      expect(typeof entry.question).toBe('string')
+      expect((entry.question as string).trim().length).toBeGreaterThan(0)
+      expect(entry.expected_labels ?? []).toEqual([])
+    }
+  })
+
+  it('documents the suite as conservative and separate from the single-prompt benchmark artifact', () => {
+    const lower = readme.toLowerCase()
+
+    expect(lower).toContain('questions.json')
+    expect(lower).toContain('single-prompt benchmark')
+    expect(lower).toContain('do not commit private')
+    expect(lower).toContain('do not invent benchmark numbers')
+    expect(lower).toContain('native_agent')
   })
 })
 

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -221,6 +221,37 @@ describe('runBenchmark', () => {
     })
   })
 
+  test('preserves prompt metadata in benchmark per-question results', () => {
+    withTempDir((tempDir) => {
+      const graphPath = join(tempDir, 'graphify-out', 'graph.json')
+      mkdirSync(join(tempDir, 'graphify-out'), { recursive: true })
+      toJson(makeGraph(), { 0: ['n1', 'n2'], 1: ['n3', 'n4'], 2: ['n5'] }, graphPath)
+
+      const result = runBenchmark(graphPath, 10_000, [
+        {
+          id: 'auth-flow',
+          description: 'Trace the authentication path.',
+          question: 'how does authentication work',
+          expected_labels: ['authentication'],
+        },
+      ])
+
+      expect('reduction_ratio' in result).toBe(true)
+      if (!('reduction_ratio' in result)) {
+        return
+      }
+
+      expect(result.per_question).toEqual([
+        expect.objectContaining({
+          id: 'auth-flow',
+          description: 'Trace the authentication path.',
+          question: 'how does authentication work',
+          expected_labels: ['authentication'],
+        }),
+      ])
+    })
+  })
+
   test('returns reduction metrics', () => {
     withTempDir((tempDir) => {
       const graphPath = join(tempDir, 'graphify-out', 'graph.json')

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -149,6 +149,76 @@ describe('runBenchmark', () => {
       { question: 'workspace architecture docs', expected_labels: ['Workspace Architecture', 'architecture.md'] },
       { question: 'billing flow', expected_labels: [] },
     ])
+  })
+
+  test('preserves prompt metadata from shared question files', () => {
+    withTempDir((tempDir) => {
+      const questionsPath = join(tempDir, 'benchmark-questions.json')
+      writeFileSync(
+        questionsPath,
+        `${JSON.stringify([
+          {
+            id: 'report-generation',
+            description: 'Trace how report generation is assembled end to end.',
+            question: 'How is the report generated?',
+            expected_labels: [],
+          },
+        ], null, 2)}\n`,
+        'utf8',
+      )
+
+      expect(loadBenchmarkQuestions(questionsPath)).toEqual([
+        {
+          id: 'report-generation',
+          description: 'Trace how report generation is assembled end to end.',
+          question: 'How is the report generated?',
+          expected_labels: [],
+        },
+      ])
+    })
+  })
+
+  test('rejects blank prompt ids when present in shared question files', () => {
+    withTempDir((tempDir) => {
+      const questionsPath = join(tempDir, 'benchmark-questions.json')
+      writeFileSync(
+        questionsPath,
+        `${JSON.stringify([
+          {
+            id: '   ',
+            question: 'How is the report generated?',
+            expected_labels: [],
+          },
+        ], null, 2)}\n`,
+        'utf8',
+      )
+
+      expect(() => loadBenchmarkQuestions(questionsPath)).toThrow(
+        'Question file entry 1 id must be a non-empty string when provided',
+      )
+    })
+  })
+
+  test('rejects blank prompt descriptions when present in shared question files', () => {
+    withTempDir((tempDir) => {
+      const questionsPath = join(tempDir, 'benchmark-questions.json')
+      writeFileSync(
+        questionsPath,
+        `${JSON.stringify([
+          {
+            id: 'report-generation',
+            description: '   ',
+            question: 'How is the report generated?',
+            expected_labels: [],
+          },
+        ], null, 2)}\n`,
+        'utf8',
+      )
+
+      expect(() => loadBenchmarkQuestions(questionsPath)).toThrow(
+        'Question file entry 1 description must be a non-empty string when provided',
+      )
+    })
   })
 
   test('returns reduction metrics', () => {


### PR DESCRIPTION
## Summary
- add a public GoValidate benchmark suite question set with stable prompt ids and descriptions
- preserve optional benchmark question metadata through loading and benchmark per-question results
- document the suite as a conservative public prompt set separate from the dated single-prompt artifact

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] CI=1 npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched a public GoValidate benchmark suite with 10 standardized test questions covering report generation, API limits, export workflows, and other key scenarios.

* **Documentation**
  * Enhanced benchmark suite documentation with usage examples, stable question identifiers, and clear guidance distinguishing this suite from existing benchmarks.

* **Tests**
  * Added comprehensive validation tests for the benchmark suite structure and question metadata handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->