### PR TITLE
chore: prepare 0.23.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-05-21
+
+### Docs
+
+- **0.23.0 release docs are easier to discover**: the README now surfaces `graphify-ts summary`, the core MCP `graph_summary` tool, `execution_slice`, share-safe compare artifacts, and `compare --baseline-mode pack_only` in the main product story instead of leaving them mostly to the changelog and proof docs.
+- **SPI guidance is explicit**: the public docs now explain that `--spi` is still opt-in, when framework-heavy TypeScript/JavaScript repos should use it, and why it helps with storage-oriented prompts, Next.js App Router boundaries, and cached reruns.
+- **The getting-started walkthrough matches current behavior**: the sample flow now includes a bounded `summary` step, an optional `generate --spi` branch, pack-only compare usage, and notes that queue-backed runtime questions may surface `execution_slice` plus `report.share-safe.json`.
+- **Capability docs translate semantics into user value**: the language matrix now explains how Python FastAPI semantics, queue-worker `enqueues_job` edges, SPI `storage_operation` hints, and Next.js `runtime_boundary` metadata improve real retrieval answers.
+
 ## [0.23.0] - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ npm install -g @mohammednagy/graphify-ts
 
 cd your-project
 graphify-ts generate .          # builds graphify-out/graph.json (no API key, no cloud)
+graphify-ts summary             # bounded repo overview before deeper retrieval
 graphify-ts claude install      # wires Claude Code to use it via MCP
 graphify-ts doctor              # checks graph freshness + agent/MCP wiring
 graphify-ts status              # compact readiness summary + next commands
@@ -54,6 +55,7 @@ graphify-ts opencode install    # OpenCode
 **Or use it without MCP** — pipe the compiled prompt directly to your agent's CLI:
 
 ```bash
+graphify-ts summary                             # bounded JSON overview before pack/prompt
 graphify-ts pack "how does auth work?" --task explain          # compact CLI context payload
 graphify-ts prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
 ```
@@ -61,6 +63,24 @@ graphify-ts prompt "how does auth work?" --provider claude     # provider-ready 
 Want a tiny reproducible workspace for local demos? Start with [`examples/sample-workspace/`](examples/sample-workspace/) and the [sample workspace tutorial](docs/tutorials/sample-workspace.md).
 
 Want a broader local-first walkthrough that also covers install, `prompt`, and a safe `compare` smoke check? Use the [end-to-end getting started tutorial](docs/tutorials/getting-started.md).
+
+---
+
+## What's new in 0.23.0
+
+- Start broad, then zoom in: `graphify-ts summary` and the core MCP `graph_summary` tool now provide the same bounded first-turn overview of counts, domains, top modules, frameworks, entrypoints, and high-signal runtime paths.
+- Runtime-generation explain packs can now expose an `execution_slice` with ordered steps and partial-path signaling, so backend queue/report-generation flows are easier to inspect without dumping a large raw slice.
+- Proof workflows are easier to share safely: `compare`, `review-compare`, and runner-backed `benchmark --exec ...` now emit a companion `report.share-safe.json`, and `compare --baseline-mode pack_only` isolates one bounded raw-context baseline prompt against one compiled graphify pack.
+- Public evaluation is stronger: the shared [GoValidate benchmark suite](docs/benchmarks/govalidate-suite/README.md) now ships stable prompt ids, pack-quality gates, and deterministic answer-quality checks.
+- Extraction and retrieval got smarter in places users notice: Python now has first-pass FastAPI semantics, runtime-generation packs preserve queue-to-worker handoffs, and `--spi` adds stronger storage and Next.js App Router hints.
+
+If you want the proof-oriented workflow behind those surfaces, start with [proof workflows](docs/proof-workflows.md) and the [GoValidate shared benchmark suite](docs/benchmarks/govalidate-suite/README.md).
+
+### When to use `--spi`
+
+`--spi` is **still opt-in** in 0.23.0. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+
+`--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 
 ---
 
@@ -171,6 +191,8 @@ Full-profile additions: `context_pack`, `context_expand`, `context_prompt`, `con
 
 Within one MCP stdio session, identical `context_pack` requests for `task=explain` are reused automatically when the graph version and relevant prompt/options match. The cache is memory-only, skips delta-session packs, and invalidates itself when `graph.json` changes.
 
+When the selected question is a runtime-generation flow, the shared compact response can also carry an `execution_slice` section with ordered steps and partial-path signaling. That gives agents a stable "what happens next" sketch without forcing them to read the full raw slice first.
+
 ---
 
 ## Common commands
@@ -224,8 +246,10 @@ Everything stays local by default. No telemetry, no cloud upload, no API key req
 ## Documentation & receipts
 
 - [Quick start guide](docs/proof-workflows.md) — three reproducible workflows: local proof, A/B compare, federated proof
+- [GoValidate shared benchmark suite](docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates
 - [Public roadmap](docs/roadmap.md) — contributor-facing priority tracks and issue links
 - [Language and capability matrix](docs/language-capability-matrix.md) — exactly what each file type and language gets
+- [Performance benchmark harness](docs/benchmarks/performance/README.md) — repeatable `generate` / `update` / `cluster-only` measurements
 - [MCP tool examples](examples/mcp-tool-examples.md) — real input/output for every tool
 - [Benchmark hub](https://github.com/mohanagy/graphify-ts/tree/main/docs/benchmarks) — committed wrappers and provider-reported evidence
 - [Changelog](CHANGELOG.md) — full per-release notes

--- a/docs/language-capability-matrix.md
+++ b/docs/language-capability-matrix.md
@@ -62,6 +62,17 @@ For `.ts`, `.tsx`, `.js`, and `.jsx`, the JS/TS extractor can emit framework-sem
 
 These roles are meant to be consumed as structural hints by retrieval and workflow tools. They are not guaranteed for heavily dynamic wrapper abstractions, runtime-generated routes, or custom meta-programming layers that fall back to the base AST graph.
 
+## Runtime retrieval hints users will notice
+
+The matrix above describes extraction coverage. The newer retrieval/runtime hints below describe what users should expect to see in answers and compact packs once a graph already exists:
+
+| Situation | What graphify-ts preserves | Why users care |
+|---|---|---|
+| Queue-backed NestJS / BullMQ flows | `enqueues_job` semantic edges preserve the producer → worker handoff in compact runtime-generation explain packs | Backend "what happens after enqueue?" questions keep the worker path instead of pretending the controller calls the worker directly |
+| Storage-oriented prompts with `--spi` | `storage_operation` metadata marks likely read/write endpoints on Prisma model operations and repository CRUD methods | "Where is this entity read or written?" questions rank persistence endpoints more accurately |
+| Next.js App Router with `--spi` | `runtime_boundary` metadata plus `next_client_component` and `next_server_action` roles for visible `'use client'` / `'use server'` boundaries | Client/server/server-action questions stay aligned with the app-router boundary the user actually cares about |
+| Python FastAPI workspaces | first-pass router / route / endpoint / dependency semantics on top of Python cross-file import/call resolution | FastAPI route/dependency questions return more than plain function listings, even before a deeper framework-specific pass exists |
+
 ## How to read this matrix
 
 - **Supported** means `graphify-ts` has a registered capability and a live handler for that extension or URL type.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -18,7 +18,21 @@ graphify-ts generate examples/sample-workspace --no-html
 
 This creates `examples/sample-workspace/graphify-out/graph.json`.
 
-## 3. Build a compact pack
+If your real repo is framework-heavy TypeScript/JavaScript and you care about richer NestJS / Next.js / Prisma / tRPC retrieval hints, rerun the same step with the still-opt-in SPI pipeline:
+
+```bash
+graphify-ts generate examples/sample-workspace --spi --no-html
+```
+
+## 3. Start with a bounded summary
+
+```bash
+graphify-ts summary examples/sample-workspace/graphify-out/graph.json
+```
+
+This prints the deterministic high-signal overview first: graph counts, source domains, top modules, frameworks, entrypoints, and runtime paths. It is the fastest way to decide whether you need a deeper `pack`, `prompt`, or MCP retrieval call.
+
+## 4. Build a compact pack
 
 ```bash
 graphify-ts pack "how does password reset request enqueue the reset email" \
@@ -26,9 +40,9 @@ graphify-ts pack "how does password reset request enqueue the reset email" \
   --task explain
 ```
 
-This is the fastest way to confirm the route → service → job flow is represented in the graph.
+This is the fastest way to confirm the route → service → job flow is represented in the graph. On runtime-generation questions like this one, newer reports can also preserve an `execution_slice` so you can inspect ordered steps without reading the whole raw slice.
 
-## 4. Compile a provider-ready prompt
+## 5. Compile a provider-ready prompt
 
 ```bash
 graphify-ts prompt "where is reset token persisted before the email job runs" \
@@ -38,30 +52,34 @@ graphify-ts prompt "where is reset token persisted before the email job runs" \
 
 `prompt` only compiles the prompt payload. It does **not** call Claude or spend paid model tokens by itself.
 
-## 5. Run a safe compare smoke check
+## 6. Run a safe compare smoke check
 
 If you want to exercise `compare` without calling a paid model, use a local echo-style runner:
 
 ```bash
 graphify-ts compare "how does password reset request enqueue the reset email" \
   --graph examples/sample-workspace/graphify-out/graph.json \
+  --baseline-mode pack_only \
   --exec 'cat {prompt_file}' \
   --yes
 ```
 
-This does **not** measure model quality. It is a safe local smoke check that proves `compare` can build both prompts and save the artifact bundle without requiring a hosted model. Real model-backed compare runs are optional.
+This does **not** measure model quality. It is a safe local smoke check that proves `compare` can build both prompts, isolate one bounded raw-context baseline against one compiled graphify pack, and save the artifact bundle without requiring a hosted model. Real model-backed compare runs are optional.
 
 ## Expected output
 
 - `generate` should write `examples/sample-workspace/graphify-out/graph.json`
+- `summary` should print the bounded overview before any deeper retrieval
 - `pack` should print a compact JSON payload with matched nodes from the password reset flow
 - `prompt` should print a provider-ready prompt payload
 - `compare` should create an artifact directory under `graphify-out/compare/` containing prompt and answer files plus both `report.json` and `report.share-safe.json`
+- runtime-generation compare reports may also carry an `execution_slice` inside `report.json` when graphify-ts can preserve the ordered backend flow compactly
 
 ## Troubleshooting
 
 - **`graphify-ts: command not found`**: make sure the global npm install succeeded, or run from a local repo checkout after `npm run build`.
 - **`graph.json` missing**: rerun `graphify-ts generate examples/sample-workspace --no-html` before `pack`, `prompt`, or `compare`.
+- **Need stronger framework-aware hints?** Regenerate with `graphify-ts generate examples/sample-workspace --spi --no-html` if your real workspace relies on Next.js App Router, NestJS, Prisma, or similar framework-specific boundaries.
 - **`compare` looks noisy**: the `cat {prompt_file}` runner is only a local smoke check. Use a real terminal model runner later if you want meaningful answer comparisons.
 - **Need more questions?** Start with `examples/sample-workspace/prompt-examples.json`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.23.0",
+    "version": "0.23.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mohammednagy/graphify-ts",
-            "version": "0.23.0",
+            "version": "0.23.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mohammednagy/graphify-ts",
-    "version": "0.23.0",
+    "version": "0.23.1",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/tests/unit/why-graphify-doc.test.ts
+++ b/tests/unit/why-graphify-doc.test.ts
@@ -59,6 +59,24 @@ describe('public marketing copy honesty', () => {
       expect(lower).toContain('context plane')
     })
 
+    it('surfaces the 0.23.0 user-facing additions in the main README flow', () => {
+      expect(lower).toContain("what's new in 0.23.0")
+      expect(content).toContain('`graphify-ts summary`')
+      expect(content).toContain('`graph_summary`')
+      expect(content).toContain('`execution_slice`')
+      expect(content).toContain('report.share-safe.json')
+      expect(content).toContain('--baseline-mode pack_only')
+      expect(content).toContain('docs/benchmarks/govalidate-suite/')
+    })
+
+    it('explains when users should opt into --spi', () => {
+      expect(lower).toContain('when to use `--spi`')
+      expect(lower).toContain('still opt-in')
+      expect(lower).toContain('storage-oriented prompts')
+      expect(lower).toContain('next.js')
+      expect(lower).toContain('disk cache')
+    })
+
     it('keeps the README core MCP surface aligned with the shipped graph_summary tool', () => {
       expect(content).toContain('These seven MCP tools')
       expect(content).toContain('`graph_stats`')
@@ -99,6 +117,36 @@ describe('public marketing copy honesty', () => {
 
     it('links the 2026-05-09 auth-e2e benchmark folder from the README', () => {
       expect(content).toContain('docs/benchmarks/2026-05-09-govalidate-auth-e2e/')
+    })
+  })
+
+  describe('docs/tutorials/getting-started.md', () => {
+    const content = readDoc('docs/tutorials/getting-started.md')
+    const lower = content.toLowerCase()
+
+    it('starts the walkthrough with generate, summary, and compact retrieval surfaces', () => {
+      expect(content).toContain('graphify-ts generate examples/sample-workspace --no-html')
+      expect(content).toContain('graphify-ts summary examples/sample-workspace/graphify-out/graph.json')
+      expect(content).toContain('graphify-ts pack')
+      expect(content).toContain('graphify-ts prompt')
+    })
+
+    it('mentions the opt-in SPI path and the compare artifacts users should notice', () => {
+      expect(content).toContain('graphify-ts generate examples/sample-workspace --spi --no-html')
+      expect(content).toContain('--baseline-mode pack_only')
+      expect(content).toContain('report.share-safe.json')
+      expect(lower).toContain('execution_slice')
+    })
+  })
+
+  describe('docs/language-capability-matrix.md', () => {
+    const content = readDoc('docs/language-capability-matrix.md')
+
+    it('translates the latest runtime retrieval semantics into user-facing capability notes', () => {
+      expect(content).toContain('`enqueues_job`')
+      expect(content).toContain('`storage_operation`')
+      expect(content).toContain('`runtime_boundary`')
+      expect(content).toContain('FastAPI')
     })
   })
 


### PR DESCRIPTION
## Summary
- align the public docs with the 0.23.0 release surface
- bump the package metadata and changelog to 0.23.1
- keep the public copy locked with doc-honesty tests

## Testing
- npm run typecheck
- npm run build
- npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with 0.23.0 highlights, quickstart step and clearer `--spi` guidance; added “What’s new in 0.23.0”.
  * Enhanced getting-started tutorial with safer compare workflow, richer SPI-based rerun option, and expanded expected output/troubleshooting (including optional execution_slice).
  * Added a language/capability matrix section describing runtime/retrieval semantics for NestJS, Prisma, Next.js, and FastAPI; updated CHANGELOG.

* **Tests**
  * Added checks to validate README and docs content.

* **Chores**
  * Bumped package version to 0.23.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->