### PR TITLE
Fix pack_only compare explain-pack parity

### DIFF
--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -38,7 +38,7 @@ node dist/src/cli/bin.js compare "How does login create a session?" \
   --yes
 ```
 
-If you want to isolate the context-compiler claim without MCP/tool-call behavior, switch to `--baseline-mode pack_only`. That mode compares one bounded raw-context baseline prompt against one compiled graphify pack and persists the compact pack audit fields (`token_count`, matched nodes, relationships, coverage, selection diagnostics, and runtime-generation explain-pack `execution_slice` details when present) in `report.json`.
+If you want to isolate the context-compiler claim without MCP/tool-call behavior, switch to `--baseline-mode pack_only`. That mode compares one bounded raw-context baseline prompt against one compiled graphify pack built from the same explain-pack payload core as `graphify-ts pack --task explain`, and persists the compact pack audit fields (`token_count`, matched nodes, relationships, coverage, selection diagnostics, and runtime-generation explain-pack `execution_slice` details when present) in `report.json`.
 
 For runtime-generation prompts, those compact explain packs now also preserve NestJS/BullMQ-style enqueue-to-worker handoffs in their runtime-generation explain-pack relationships via `enqueues_job` semantic edges in both SPI and legacy extraction paths. This first pass is intentionally conservative: it applies when job names are literal and the queue receiver is statically recognizable, including WorkerHost-style BullMQ processors with a queue-scoped `process()` handler. When it matches, queue-backed worker routes survive slice selection without pretending the producer directly calls the worker.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -64,7 +64,7 @@ graphify-ts compare "how does password reset request enqueue the reset email" \
   --yes
 ```
 
-This does **not** measure model quality. It is a safe local smoke check that proves `compare` can build both prompts, isolate one bounded raw-context baseline against one compiled graphify pack, and save the artifact bundle without requiring a hosted model. Real model-backed compare runs are optional.
+This does **not** measure model quality. It is a safe local smoke check that proves `compare` can build both prompts, isolate one bounded raw-context baseline against one compiled graphify pack rendered from the same explain-pack core as `graphify-ts pack --task explain`, and save the artifact bundle without requiring a hosted model. Real model-backed compare runs are optional.
 
 ## Expected output
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -5,6 +5,7 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } 
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
+import { buildExplainPackPayload } from './context-pack-command.js'
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
@@ -586,49 +587,6 @@ function buildBoundedCorpusExcerpt(question: string, graph: KnowledgeGraph, corp
   return `${note}\n${excerpt}`.trimEnd()
 }
 
-function formatGraphifyContextSections(retrieval: RetrieveResult): ContextPromptStableSection[] {
-  const nodeLines = retrieval.matched_nodes.map((node) => {
-    const source = node.source_file ? ` @ ${node.source_file}${node.line_number > 0 ? `:${node.line_number}` : ''}` : ''
-    const community = node.community_label ? ` [${node.community_label}]` : ''
-    const snippet = node.snippet ? `\n  ${node.snippet}` : ''
-    return `- ${node.label}${source}${community}${snippet}`
-  })
-  const relationshipLines = retrieval.relationships.map((relationship) => `- ${relationship.from} -[${relationship.relation}]-> ${relationship.to}`)
-  const communityLines = retrieval.community_context.map((community) => `- ${community.label} (${community.node_count} nodes)`)
-  const signalLines = [...retrieval.graph_signals.god_nodes, ...retrieval.graph_signals.bridge_nodes]
-
-  return [
-    {
-      ref: 'matched_nodes',
-      sort_key: '10-matched-nodes',
-      title: 'Matched nodes',
-      body: nodeLines.length > 0 ? nodeLines.join('\n') : '- (none)',
-    },
-    {
-      ref: 'relationships',
-      sort_key: '20-relationships',
-      title: 'Relationships',
-      body: relationshipLines.length > 0 ? relationshipLines.join('\n') : '- (none)',
-    },
-    ...(communityLines.length > 0
-      ? [{
-          ref: 'community_context',
-          sort_key: '30-community-context',
-          title: 'Community context',
-          body: communityLines.join('\n'),
-        }]
-      : []),
-    ...(signalLines.length > 0
-      ? [{
-          ref: 'graph_signals',
-          sort_key: '40-graph-signals',
-          title: 'Graph signals',
-          body: `- ${signalLines.join(', ')}`,
-        }]
-      : []),
-  ]
-}
-
 function compareReportPackFromRetrieveResult(retrieval: RetrieveResult): CompareReportPack {
   const compact = compactRetrieveResult(retrieval)
   return {
@@ -1137,13 +1095,24 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
 }
 
 export function buildGraphifyPromptPack(input: BuildGraphifyPromptPackInput): ComparePromptPack {
+  const explainPayload = JSON.stringify(
+    buildExplainPackPayload(compactRetrieveResult(input.retrieval), input.retrieval),
+    null,
+    2,
+  )
   const builtPrompt = buildContextPrompt({
     instructions: [
       'Answer the question using only the provided graph-guided retrieval output.',
       'If the retrieval does not contain the answer, say so.',
     ],
     stable_prefix_title: 'Retrieved graph context',
-    stable_sections: formatGraphifyContextSections(input.retrieval),
+    stable_sections: [
+      {
+        ref: 'explain_pack_payload',
+        sort_key: '10-explain-pack-payload',
+        body: explainPayload,
+      },
+    ],
     dynamic_sections: [
       { title: 'Question', body: input.question },
       { body: 'Answer:' },

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -44,6 +44,10 @@ interface ContextPlaneMetadata {
   retrieval_gate?: RetrievalGateDecision
 }
 
+export interface ExplainPackPayload extends ContextPlaneMetadata {
+  pack: ReturnType<typeof compactRetrieveResult>
+}
+
 function emptyCoverage(): ContextPackCoverage {
   return {
     required_evidence: [],
@@ -74,6 +78,21 @@ function contextMetadata(
     missing_context: coverage.missing_required,
     missing_semantic: coverage.missing_semantic,
     ...(payload.retrieval_gate ? { retrieval_gate: payload.retrieval_gate } : {}),
+  }
+}
+
+export function buildExplainPackPayload(
+  pack: ReturnType<typeof compactRetrieveResult>,
+  retrieval: Partial<{
+    claims: ContextPackClaim[]
+    expandable: ContextPackExpandableRef[]
+    coverage: ContextPackCoverage
+    retrieval_gate: RetrievalGateDecision
+  }>,
+): ExplainPackPayload {
+  return {
+    pack,
+    ...contextMetadata(retrieval),
   }
 }
 
@@ -246,11 +265,8 @@ export async function runContextPackCommand(
     ...(options.retrievalLevel !== undefined ? { retrievalLevel: options.retrievalLevel } : {}),
     ...(options.retrievalStrategy !== undefined ? { retrievalStrategy: options.retrievalStrategy } : {}),
   })
-  const explainPack = dependencies.compactRetrieveResult(retrieval)
-
   return JSON.stringify({
     ...baseResponse(options, initialPlan, plannerBudget),
-    pack: explainPack,
-    ...contextMetadata(retrieval),
+    ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval),
   })
 }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -15,6 +15,7 @@ import {
   runCompareCommand,
   resolveCompareQuestions,
 } from '../../src/infrastructure/compare.js'
+import { runContextPackCommand } from '../../src/infrastructure/context-pack-command.js'
 import { parsePromptRunnerOutput } from '../../src/infrastructure/prompt-runner.js'
 import { saveManifest } from '../../src/pipeline/manifest.js'
 import { toJson } from '../../src/pipeline/export.js'
@@ -563,7 +564,7 @@ describe('compare runtime', () => {
     expect(followUpGraphifyPrompt).toContain('Session delta:')
     expect(followUpGraphifyPrompt).toContain('Question:\nwhere is session storage defined')
     expect(followUpGraphifyPrompt).not.toContain('Retrieved graph context:')
-    expect(followUpReport.graphify_prompt_tokens_estimated).toBeGreaterThan(estimateQueryTokens(followUpGraphifyPrompt))
+    expect(followUpReport.graphify_reused_context_tokens).toBeGreaterThan(0)
     expect(followUpReport.graphify_effective_prompt_tokens).toBe(
       Math.max(0, followUpReport.graphify_prompt_tokens_estimated - followUpReport.graphify_reused_context_tokens),
     )
@@ -772,19 +773,90 @@ describe('compare runtime', () => {
     ).toThrow(/too small/i)
   })
 
-  it('builds a graphify prompt pack from existing retrieval output', () => {
+  it('builds a graphify prompt pack from the same explain-pack payload core as graphify-ts pack', async () => {
     const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
     const retrieval = retrieveContext(graph, {
       question: 'how does login create a session',
       budget: 3000,
     })
 
+    const explainPayload = JSON.parse(
+      await runContextPackCommand({
+        prompt: retrieval.question,
+        budget: 3000,
+        task: 'explain',
+        graphPath,
+      }),
+    ) as Record<string, unknown>
     const pack = buildGraphifyPromptPack({ question: retrieval.question, retrieval })
+    const expectedPromptCore = JSON.stringify({
+      pack: explainPayload.pack,
+      claims: explainPayload.claims,
+      expandable: explainPayload.expandable,
+      coverage: explainPayload.coverage,
+      missing_context: explainPayload.missing_context,
+      missing_semantic: explainPayload.missing_semantic,
+      retrieval_gate: explainPayload.retrieval_gate,
+    }, null, 2)
 
-    expect(pack.prompt).toContain('Retrieved graph context:')
-    expect(pack.prompt).toContain('authenticateUser')
-    expect(pack.prompt).toContain('SessionManager')
-    expect(pack.prompt).toContain('calls')
+    expect(pack.prompt).toContain(expectedPromptCore)
+    expect(pack.prompt).toContain('"pack"')
+    expect(pack.prompt).toContain('"coverage"')
+    expect(pack.prompt).toContain('"missing_context"')
+  })
+
+  it('includes runtime-generation execution_slice data in pack_only graphify prompts when present', () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const originalRetrieveContext = retrieveRuntime.retrieveContext
+    const retrieveSpy = vi.spyOn(retrieveRuntime, 'retrieveContext').mockImplementation((inputGraph, options) => ({
+      ...originalRetrieveContext(inputGraph, options),
+      retrieval_strategy: 'slice-v1',
+      execution_slice: {
+        status: 'partial',
+        boundary_reason: 'slice stops before expected persistence step',
+        steps: [
+          {
+            node_id: 'auth_user',
+            label: 'authenticateUser',
+            source_file: 'src/auth.ts',
+            line_number: 10,
+            node_kind: 'function',
+          },
+          {
+            node_id: 'session_manager',
+            label: 'SessionManager',
+            source_file: 'src/session.ts',
+            line_number: 3,
+            node_kind: 'class',
+          },
+        ],
+      },
+    }))
+
+    try {
+      const result = generateCompareArtifacts({
+        graphPath,
+        question: 'Explain the runtime path for login session creation',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+        baselineMode: 'pack_only',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      })
+
+      const report = result.reports[0]!
+      const graphifyPrompt = readFileSync(report.paths.graphify_prompt, 'utf8')
+
+      expect(graphifyPrompt).toContain('"execution_slice"')
+      expect(graphifyPrompt).toContain('"status": "partial"')
+      expect(graphifyPrompt).toContain('"boundary_reason": "slice stops before expected persistence step"')
+      expect(graphifyPrompt).toContain('"retrieval_strategy": "slice-v1"')
+    } finally {
+      retrieveSpy.mockRestore()
+    }
   })
 
   it('computes prompt token counts from the exact prompt text', () => {
@@ -861,6 +933,8 @@ describe('compare runtime', () => {
     expect(baselinePrompt).toContain('return new SessionManager().createSession(credentials.userId)')
     expect(baselinePrompt).toContain('export class SessionManager')
     expect(graphifyPrompt).toContain('Retrieved graph context:')
+    expect(graphifyPrompt).toContain('"pack"')
+    expect(graphifyPrompt).toContain('"coverage"')
     expect(savedReport).toEqual(
       expect.objectContaining({
         question: 'how does login create a session',
@@ -3061,8 +3135,10 @@ describe('compare runtime', () => {
       })
 
       const graphifyPrompt = readFileSync(result.reports[0]!.paths.graphify_prompt, 'utf8')
-      expect(graphifyPrompt).toContain('ArchiveDash @ ../../../vault/private-notes.txt:1')
-      expect(graphifyPrompt).toContain('ArchiveNested @ ../../../vault/private/notes.txt:1')
+      expect(graphifyPrompt).toContain('"label": "ArchiveDash"')
+      expect(graphifyPrompt).toContain('"source_file": "../../../vault/private-notes.txt"')
+      expect(graphifyPrompt).toContain('"label": "ArchiveNested"')
+      expect(graphifyPrompt).toContain('"source_file": "../../../vault/private/notes.txt"')
       expect(graphifyPrompt).not.toContain('outside dash snippet')
       expect(graphifyPrompt).not.toContain('outside nested snippet')
     } finally {


### PR DESCRIPTION
## Summary
- share the explain-pack payload builder between `graphify-ts pack --task explain` and compare prompt generation
- render `--baseline-mode pack_only` graphify prompts from the same compact explain-pack JSON, including `execution_slice` when present
- update compare regressions and user docs to reflect pack-only parity with the explain-pack core

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified baseline comparison behavior and report contents in proof-workflows guide
  * Expanded getting-started tutorial with detailed explanation of safe local compare verification

* **Improvements**
  * Enhanced prompt payload structure for compare operations
  * Reports now persistently include execution details when available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->