### PR TITLE
Publish GoValidate v0.23.0 validation benchmark

### DIFF
--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/README.md
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/README.md
@@ -1,0 +1,192 @@
+# 2026-05-21 — GoValidate v0.23.0 validation run
+
+This folder records a real validation pass of the published `@mohammednagy/graphify-ts@0.23.0` CLI against the local GoValidate workspace.
+
+The goal is **not** to manufacture a clean win. The goal is to show what the released `0.23.0` surfaces did on a realistic repo, including regressions, missing context, and cases where one metric improved while another got worse.
+
+## Scope
+
+- **Workspace:** GoValidate root workspace (`backend`, `platform`, `landing-page`, `proxy`, docs, generated artifacts)
+- **CLI under test:** published `graphify-ts 0.23.0`
+- **Model/runtime:** Claude CLI with structured JSON usage (`cat {prompt_file} | claude -p --output-format json`)
+- **Validation surfaces:** `generate --spi`, `summary`, `pack`, single-prompt `compare`, `pack_only`, and the public 10-question GoValidate suite
+
+## Graph generation and `graph_summary` sanity check
+
+`generate . --spi` succeeded on the real workspace:
+
+- corpus: **1403 files**, **~892,952 words**
+- extracted: **1243 code files** (+ **40 non-code**)
+- graph: **7371 nodes**, **12,394 edges**, **1492 communities**
+- semantic anomalies: **5**
+
+The bounded `summary` output stayed compact and did **not** elevate fixtures, tests, or benchmark files as first-class runtime paths. The main framework signal was `nestjs`. That said, the summary still returned **no `runtime_paths`** on this workspace, and the raw `summary` JSON included local absolute source paths, so only the findings are published here rather than the raw file.
+
+## Single prompt: report-generation inspection
+
+Prompt:
+
+> `Explain how idea report is getting generated`
+
+### `native_agent` interpretation
+
+This is the provider-reported benchmark path.
+
+| Metric | Baseline | Graphify | Outcome |
+| --- | ---: | ---: | ---: |
+| Input tokens (Anthropic-reported) | 259,912 | 297,784 | **1.15x more** |
+| Turns | 4 | 4 | same |
+| Latency | 259,985 ms | 49,163 ms | **5.29x faster** |
+
+The deterministic answer-quality gate **failed**:
+
+- missing required answer term: `GenerateIdeaReportService`
+
+See: `report-generation-answer-quality.txt`
+
+### `pack_only` interpretation
+
+This is the context-quality path at a comparable prompt budget. It is **not** provider-reported model usage.
+
+`0.23.0` single-prompt `native_agent` reports do not persist `report.pack`, so the shared pack-quality gate for this prompt was evaluated through a separate `pack_only` compare run.
+
+The direct `pack` command did emit an `execution_slice`, but the raw local output is not committed because it contained absolute paths. The safe summary is captured in `report-generation-pack-inspection.txt`.
+
+Observed direct `pack` inspection:
+
+- retrieval strategy: `slice-v1`
+- token_count: **1517**
+- matched_nodes: **40**
+- relationships: **58**
+- `execution_slice.status`: **complete**
+- observed path: `.generateFromProblem()` → `.startPipeline()` → `.addJob()` → `.dispatchWave()` → `.plan()` → `.process()` → `.broadcastRunFailed()`
+
+That is useful validation data: the slice exists, but it is not the report-generation route the quality gate expected.
+
+For the separate committed `pack_only` compare artifact, the shared `docs-artifact` gate still failed:
+
+- missing required labels: `IdeaReportController`, `GenerateIdeaReportService`
+- committed `pack_only` artifact size: **1456 tokens**, **37 matched nodes**, **57 relationships**
+
+See: `report-generation-pack-quality.txt`
+
+## 3-question smoke suite
+
+The required limit-3 smoke run completed successfully before the full suite.
+
+Those results were used only as an execution gate before spending tokens on the full 10-question run. The published benchmark claims in this folder are based on the **full suite** below, not the smoke pass.
+
+## Full 10-question suite (`native_agent`)
+
+This is the main provider-reported result for `0.23.0` on the public GoValidate suite.
+
+### Aggregate outcome
+
+- input tokens: **7 wins**, **3 losses**
+- **mean input-token reduction: 14.7%**
+- **median input-token reduction: 26.8%**
+- turns: **8 wins**, **2 losses**
+- latency: **9 wins**, **1 loss**
+
+Best/worst outcomes:
+
+- **Best input-token win:** `credits-accounting` (**74.4% less**)
+- **Worst input-token regression:** `waitlist-invite-codes` (**144.2% more**)
+- **Best turn win:** `impact-review` (**64.7% fewer**)
+- **Worst turn regression:** `waitlist-invite-codes` (**166.7% more**)
+- **Best latency win:** `pdf-export` (**74.1% faster**)
+- **Worst latency regression:** `ai-landing-pages` (**31.8% slower**)
+
+### Per-prompt outcomes
+
+Percentages below are **baseline-relative change** (`1 - graphify / baseline`): positive values mean graphify-ts used less/fewer/less time; negative values mean regression.
+
+These rows come from the **full 10-question suite run**, not from the separate single-prompt artifact above. The suite question ids map to the committed files under `suite-share-safe/`. In particular, `report-generation` below refers to the public suite prompt `Explain how idea report generation works end to end.`, which is distinct from the separate single-prompt validation prompt `Explain how idea report is getting generated`.
+
+| Prompt id | Input tokens | Turns | Latency |
+| --- | ---: | ---: | ---: |
+| `report-generation` | -39.4% | -42.9% | 45.6% |
+| `credits-accounting` | 74.4% | 60.0% | 47.0% |
+| `waitlist-invite-codes` | -144.2% | -166.7% | 38.0% |
+| `pdf-export` | 19.4% | 18.2% | 74.1% |
+| `ai-landing-pages` | -0.1% | 10.0% | -31.8% |
+| `nda-sharing` | 74.3% | 57.1% | 36.0% |
+| `stripe-limits` | 57.0% | 55.0% | 33.8% |
+| `pipeline-status-broadcast` | 16.4% | 16.7% | 29.4% |
+| `impact-review` | 55.2% | 64.7% | 43.4% |
+| `provider-model-calls` | 34.2% | 37.5% | 8.7% |
+
+## Published artifacts in this folder
+
+Only files safe to publish are kept here.
+
+- `report-generation.report.share-safe.json` — single-prompt `native_agent` example
+- `report-generation-pack-only.report.share-safe.json` — single-prompt `pack_only` example
+- `report-generation-pack-inspection.txt` — safe summary of the raw `pack --retrieval-strategy slice-v1` inspection
+- `suite-share-safe/` — all 10 full-suite per-question `report.share-safe.json` artifacts
+- `suite-best-win.report.share-safe.json` — `credits-accounting`
+- `suite-worst-regression.report.share-safe.json` — `waitlist-invite-codes`
+- `report-generation-answer-quality.txt`
+- `report-generation-pack-quality.txt`
+
+## Important interpretation notes
+
+1. **`pack_only` and `native_agent` mean different things.**
+   - `pack_only` is a context-quality check at roughly comparable prompt budget.
+   - `native_agent` is the provider-reported token/turn/latency benchmark path.
+
+2. **A faster run is not automatically a token win.**
+   - The single report-generation prompt was much faster, but still used more provider-reported input tokens.
+
+3. **A compact pack still has to follow the right route.**
+   - The `execution_slice` existed, but it landed on a planner/orchestrator path instead of the report-generation service path expected by the gate.
+
+4. **This is not a universal marketing claim.**
+   - `0.23.0` won on most suite prompts, but it also had clear regressions on specific workflows.
+
+## Reproduction commands
+
+These are the public commands this validation is based on:
+
+```bash
+npm install -g @mohammednagy/graphify-ts@0.23.0
+graphify-ts --version
+
+rm -rf graphify-out
+graphify-ts generate . --spi
+
+graphify-ts summary graphify-out/graph.json
+
+graphify-ts pack "Explain how idea report is getting generated" \
+  --task explain \
+  --retrieval-level 4 \
+  --retrieval-strategy slice-v1 \
+  --budget 4000 \
+  --graph graphify-out/graph.json
+
+graphify-ts compare "Explain how idea report is getting generated" \
+  --exec 'cat {prompt_file} | claude -p --output-format json' \
+  --yes \
+  --baseline-mode native_agent
+
+graphify-ts compare "Explain how idea report is getting generated" \
+  --exec 'cat {prompt_file}' \
+  --yes \
+  --baseline-mode pack_only
+
+graphify-ts compare \
+  --questions docs/benchmarks/govalidate-suite/questions.json \
+  --exec 'cat {prompt_file} | claude -p --output-format json' \
+  --yes \
+  --baseline-mode native_agent
+```
+
+## Bottom line
+
+The released `0.23.0` build is **not** a clean universal win on GoValidate.
+
+- It produced meaningful wins on **7/10** suite prompts for input tokens and **9/10** for latency.
+- It also had real regressions, especially on **report-generation** and **waitlist/invite-code** flows.
+- The report-generation `execution_slice` existed, but it did **not** follow the service path expected by the shared gate.
+
+That makes this a credible validation artifact: it shows where `0.23.0` helped, where it regressed, and why `pack_only` and `native_agent` must be interpreted separately.

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-answer-quality.txt
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-answer-quality.txt
@@ -1,0 +1,6 @@
+docs-artifact FAIL
+prompt: Explain how idea report is getting generated
+missing required answer terms: GenerateIdeaReportService
+required concepts (manual review): runtime path stays on controller -> service flow
+answer quality notes: Deterministic answer checks are necessary but not sufficient for benchmark claims.
+manual review notes: Confirm the answer explains how the report is generated, not just where files exist.

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-pack-inspection.txt
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-pack-inspection.txt
@@ -1,0 +1,31 @@
+Published inspection summary for the raw local `graphify-ts pack` output.
+
+The raw `report-generation-pack.json` file was not committed because it contained local absolute paths.
+
+Command under inspection:
+
+graphify-ts pack "Explain how idea report is getting generated" \
+  --task explain \
+  --retrieval-level 4 \
+  --retrieval-strategy slice-v1 \
+  --budget 4000 \
+  --graph graphify-out/graph.json
+
+Observed values:
+
+- retrieval_strategy: slice-v1
+- token_count: 1517
+- matched_nodes: 40
+- relationships: 58
+- execution_slice.status: complete
+- execution_slice.steps: 7
+
+Observed execution_slice steps:
+
+1. .generateFromProblem()
+2. .startPipeline()
+3. .addJob()
+4. .dispatchWave()
+5. .plan()
+6. .process()
+7. .broadcastRunFailed()

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-pack-only.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-pack-only.report.share-safe.json
@@ -1,0 +1,1825 @@
+{
+  "question": "Explain how idea report is getting generated",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline_mode": "pack_only",
+  "baseline_prompt_tokens": 2749,
+  "graphify_prompt_tokens": 2835,
+  "reduction_ratio": 1,
+  "baseline_effective_prompt_tokens": 2749,
+  "graphify_effective_prompt_tokens": 2835,
+  "effective_reduction_ratio": 1,
+  "baseline_reused_context_tokens": 0,
+  "graphify_reused_context_tokens": 0,
+  "baseline_total_tokens": null,
+  "graphify_total_tokens": null,
+  "total_reduction_ratio": null,
+  "baseline_prompt_tokens_estimated": 2749,
+  "graphify_prompt_tokens_estimated": 2835,
+  "reduction_ratio_estimated": 1,
+  "prompt_token_estimator": {
+    "source": "local_tokenizer",
+    "model": "cl100k_base",
+    "exact": false
+  },
+  "prompt_token_source": {
+    "baseline": "estimated_cl100k_base",
+    "graphify": "estimated_cl100k_base"
+  },
+  "usage": {
+    "baseline": null,
+    "graphify": null
+  },
+  "started_at": "2026-05-21T18:08:41.720Z",
+  "completed_at": "2026-05-21T18:08:57.866Z",
+  "elapsed_ms": {
+    "baseline": 32,
+    "graphify": 9
+  },
+  "status": {
+    "baseline": "succeeded",
+    "graphify": "succeeded"
+  },
+  "answer_paths": {
+    "baseline": "<artifact-root>/baseline-answer.txt",
+    "graphify": "<artifact-root>/graphify-answer.txt"
+  },
+  "exit_code": {
+    "baseline": 0,
+    "graphify": 0
+  },
+  "stderr": {
+    "baseline": null,
+    "graphify": null
+  },
+  "failure_reason": {
+    "baseline": null,
+    "graphify": null
+  },
+  "evidence": {
+    "baseline": null,
+    "graphify": null
+  },
+  "pack": {
+    "question": "Explain how idea report is getting generated",
+    "token_count": 1456,
+    "matched_nodes": [
+      {
+        "node_id": "ideas_authenticated_request_requireideasuserid",
+        "label": "requireIdeasUserId",
+        "source_file": "backend/src/modules/ideas/interface/http/ideas-authenticated-request.ts",
+        "line_number": 16,
+        "source_domain": "production",
+        "snippet": "\nexport const requireIdeasUserId = (\n  req: AuthenticatedIdeasRequest,",
+        "match_score": 4.729932442559171,
+        "relevance_band": "direct",
+        "community": 297,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "label": ".generateTitle()",
+        "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts",
+        "line_number": 55,
+        "source_domain": "production",
+        "snippet": "   */\n  async generateTitle(\n    problemStatement: string,",
+        "match_score": 5.763623978201635,
+        "relevance_band": "direct",
+        "community": 256,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "label": ".generateFromProblem()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts",
+        "line_number": 75,
+        "source_domain": "production",
+        "snippet": "\n  @Post('analyze')\n  @UseGuards(AuthGuard, PlanEnforcementGuard)",
+        "match_score": 5.724909028578037,
+        "relevance_band": "direct",
+        "community": 299,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route"
+      },
+      {
+        "node_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "label": ".generate()",
+        "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts",
+        "line_number": 36,
+        "source_domain": "production",
+        "snippet": "\n  async generate(\n    params: CertificateGenerateParams,",
+        "match_score": 6.041176470588235,
+        "relevance_band": "direct",
+        "community": 281,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "title_generation_service_titlegenerationservice",
+        "label": "TitleGenerationService",
+        "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts",
+        "line_number": 34,
+        "source_domain": "production",
+        "snippet": " */\n@Injectable()\nexport class TitleGenerationService {",
+        "match_score": 6.019599108465988,
+        "relevance_band": "direct",
+        "community": 256,
+        "framework": "nestjs",
+        "framework_role": "nest_provider",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "class"
+      },
+      {
+        "node_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+        "label": ".claimQueuedPipelineRun()",
+        "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts",
+        "line_number": 418,
+        "source_domain": "production",
+        "snippet": "   */\n  async claimQueuedPipelineRun(\n    ideaId: string,",
+        "match_score": 7.401121256633713,
+        "relevance_band": "direct",
+        "community": 778,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "idea_generation_controller_ideagenerationcontroller",
+        "label": "IdeaGenerationController",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts",
+        "line_number": 53,
+        "source_domain": "production",
+        "snippet": "\n@ApiTags('ideas')\n@Controller('ideas')",
+        "match_score": 6.1024100521296925,
+        "relevance_band": "direct",
+        "community": 299,
+        "framework": "nestjs",
+        "framework_role": "nest_controller",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "class"
+      },
+      {
+        "node_id": "badge_generator_service_badgegeneratorservice_generate",
+        "label": ".generate()",
+        "source_file": "backend/src/modules/certification/services/badge-generator.service.ts",
+        "line_number": 33,
+        "source_domain": "production",
+        "snippet": "\n  async generate(params: BadgeGenerateParams): Promise<BadgeGenerateResult> {\n    const { tier, score, verifyToken } = params;",
+        "match_score": 5.928571428571429,
+        "relevance_band": "direct",
+        "community": 483,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "ideas_service_ideasservice_createidea",
+        "label": ".createIdea()",
+        "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts",
+        "line_number": 78,
+        "source_domain": "production",
+        "snippet": "   */\n  async createIdea(userId: string, problem: string): Promise<Idea> {\n    this.logger.info('Creating new idea', { userId });",
+        "match_score": 7.488723661345151,
+        "relevance_band": "direct",
+        "community": 1187,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+        "label": ".releaseQueuedPipelineClaim()",
+        "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts",
+        "line_number": 453,
+        "source_domain": "production",
+        "snippet": "\n  async releaseQueuedPipelineClaim(\n    ideaId: string,",
+        "match_score": 6.3976311409935125,
+        "relevance_band": "direct",
+        "community": 299,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+        "label": ".generateFallbackTitle()",
+        "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts",
+        "line_number": 195,
+        "source_domain": "production",
+        "snippet": "   */\n  private generateFallbackTitle(\n    problemStatement: string,",
+        "match_score": 5.665102108036891,
+        "relevance_band": "direct",
+        "community": 256,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+        "label": ".releaseUnusedCreditReservation()",
+        "source_file": "backend/src/modules/credits/services/idea-generation-compensation.service.ts",
+        "line_number": 57,
+        "source_domain": "production",
+        "snippet": "\n  async releaseUnusedCreditReservation(\n    creditId?: string | null",
+        "match_score": 7.8733240795064106,
+        "relevance_band": "direct",
+        "community": 1114,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "ideas_service_ideasservice_updatetitle",
+        "label": ".updateTitle()",
+        "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts",
+        "line_number": 378,
+        "source_domain": "production",
+        "snippet": "   */\n  async updateTitle(ideaId: string, summarizedTitle: string): Promise<void> {\n    const objectId = new ObjectId(ideaId);",
+        "match_score": 7.399758110197487,
+        "relevance_band": "direct",
+        "community": 299,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "idea_generation_controller_ideagenerationcontroller_getstatusmessage",
+        "label": ".getStatusMessage()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts",
+        "line_number": 343,
+        "source_domain": "production",
+        "snippet": "\n  private getStatusMessage(status: IdeaStatus): string {\n    const messages: Record<IdeaStatus, string> = {",
+        "match_score": 7.951321121537978,
+        "relevance_band": "direct",
+        "community": 299,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "title_generation_service_titlegenerationservice_buildsystemprompt",
+        "label": ".buildSystemPrompt()",
+        "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts",
+        "line_number": 145,
+        "source_domain": "production",
+        "snippet": "   */\n  private buildSystemPrompt(): string {\n    return `You are a startup idea title generator. Your task is to create concise, engaging titles from problem statements.",
+        "match_score": 7.8926579760856335,
+        "relevance_band": "direct",
+        "community": 256,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "title_generation_service_titlegenerationservice_builduserprompt",
+        "label": ".buildUserPrompt()",
+        "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts",
+        "line_number": 183,
+        "source_domain": "production",
+        "snippet": "   */\n  private buildUserPrompt(problemStatement: string): string {\n    return `Generate a concise title for this startup idea:",
+        "match_score": 7.892634499923329,
+        "relevance_band": "direct",
+        "community": 256,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+        "label": ".extractKeyPhrasesTitle()",
+        "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts",
+        "line_number": 227,
+        "source_domain": "production",
+        "snippet": "   */\n  private extractKeyPhrasesTitle(problemStatement: string): string {\n    // Clean and normalize the text",
+        "match_score": 7.843326916087411,
+        "relevance_band": "direct",
+        "community": 256,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "certificate_generator_service_certificategeneratorservice_generatepdffromhtml",
+        "label": ".generatePdfFromHtml()",
+        "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts",
+        "line_number": 90,
+        "source_domain": "production",
+        "snippet": "\n  private async generatePdfFromHtml(html: string): Promise<Buffer> {\n    let browser: puppeteer.Browser | undefined;",
+        "match_score": 7.156302521008403,
+        "relevance_band": "direct",
+        "community": 281,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "structured_logger_service_structuredlogger_info",
+        "label": ".info()",
+        "source_file": "backend/src/common/logger/structured-logger.service.ts",
+        "line_number": 101,
+        "source_domain": "production",
+        "snippet": "\n  info(message: string, data?: LogContext | Error) {\n    this.write('info', message, data);",
+        "match_score": 5.981811989100818,
+        "relevance_band": "related",
+        "community": 120,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "structured_logger_service_structuredlogger_warn",
+        "label": ".warn()",
+        "source_file": "backend/src/common/logger/structured-logger.service.ts",
+        "line_number": 105,
+        "source_domain": "production",
+        "snippet": "\n  warn(message: string, data?: LogContext | Error) {\n    this.write('warn', message, data);",
+        "match_score": 5.981811989100818,
+        "relevance_band": "related",
+        "community": 3,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "structured_logger_service_structuredlogger_error",
+        "label": ".error()",
+        "source_file": "backend/src/common/logger/structured-logger.service.ts",
+        "line_number": 113,
+        "source_domain": "production",
+        "snippet": "\n  error(message: string, data?: ErrorData) {\n    const errorData = {",
+        "match_score": 5.981811989100818,
+        "relevance_band": "related",
+        "community": 86,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+        "label": ".callLlm()",
+        "source_file": "backend/src/modules/pipeline/providers/llm-provider-resolver.service.ts",
+        "line_number": 100,
+        "source_domain": "production",
+        "snippet": "\n  async callLlm(resolved: ResolvedProvider, params: Omit<LlmChatParams, 'apiKey' | 'baseUrl'>): Promise<LlmChatResult> {\n    const client = this.getClient(resolved.clientType);",
+        "match_score": 7.681811989100818,
+        "relevance_band": "related",
+        "community": 553,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+        "label": ".resolve()",
+        "source_file": "backend/src/modules/pipeline/providers/llm-provider-resolver.service.ts",
+        "line_number": 43,
+        "source_domain": "production",
+        "snippet": "\n  async resolve(userId: string, modelTier: ModelTier, modelOverride?: string): Promise<ResolvedProvider> {\n    const tierConfig = MODEL_TIER_DEFAULTS[modelTier];",
+        "match_score": 7.681811989100818,
+        "relevance_band": "related",
+        "community": 550,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "certification_service_certificationservice_claimbadge",
+        "label": ".claimBadge()",
+        "source_file": "backend/src/modules/certification/services/certification.service.ts",
+        "line_number": 126,
+        "source_domain": "production",
+        "snippet": "\n  async claimBadge(\n    ideaId: string,",
+        "match_score": 6.970588235294118,
+        "relevance_band": "related",
+        "community": 497,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "certificate_html",
+        "label": "certificate-html.ts",
+        "source_file": "backend/src/modules/certification/templates/certificate-html.ts",
+        "line_number": 1,
+        "source_domain": "production",
+        "snippet": "import type {\n  CertificationMetrics,",
+        "match_score": 1.25,
+        "relevance_band": "related",
+        "community": 495,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+        "label": ".startPipeline()",
+        "source_file": "backend/src/modules/pipeline/api/pipeline-trigger.service.ts",
+        "line_number": 24,
+        "source_domain": "production",
+        "snippet": "\n  async startPipeline(userId: string, rawIdea: string, existingIdeaId?: string): Promise<{ ideaId: string; jobId: string }> {\n    const ideaId = existingIdeaId ?? randomUUID();",
+        "match_score": 8.362454514289018,
+        "relevance_band": "related",
+        "community": 1285,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "storage_service_storageservice_uploadfile",
+        "label": ".uploadFile()",
+        "source_file": "backend/src/modules/storage/storage.service.ts",
+        "line_number": 166,
+        "source_domain": "production",
+        "snippet": "   */\n  async uploadFile(\n    key: string,",
+        "match_score": 5.970588235294118,
+        "relevance_band": "related",
+        "community": 253,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+        "label": ".formatErrorForJson()",
+        "source_file": "backend/src/common/utils/error-logger.util.ts",
+        "line_number": 248,
+        "source_domain": "production",
+        "snippet": "   */\n  static formatErrorForJson(error: unknown): Record<string, any> {\n    if (error instanceof Error) {",
+        "match_score": 4.131811989100818,
+        "relevance_band": "related",
+        "community": 382,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "certificate_generator_service_certificategeneratorservice",
+        "label": "CertificateGeneratorService",
+        "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts",
+        "line_number": 29,
+        "source_domain": "production",
+        "snippet": "\n@Injectable()\nexport class CertificateGeneratorService {",
+        "match_score": 4.139705882352941,
+        "relevance_band": "related",
+        "community": 281,
+        "framework": "nestjs",
+        "framework_role": "nest_provider",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "class"
+      },
+      {
+        "node_id": "badge_svg",
+        "label": "badge-svg.ts",
+        "source_file": "backend/src/modules/certification/templates/badge-svg.ts",
+        "line_number": 1,
+        "source_domain": "production",
+        "snippet": "import type { CertificationTier } from '../certification.types';\n",
+        "match_score": 1.25,
+        "relevance_band": "related",
+        "community": 484,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "certificate_html_rendercertificatehtml",
+        "label": "renderCertificateHtml()",
+        "source_file": "backend/src/modules/certification/templates/certificate-html.ts",
+        "line_number": 94,
+        "source_domain": "production",
+        "snippet": "\nexport function renderCertificateHtml(params: CertificateHtmlParams): string {\n  const {",
+        "match_score": 4.220588235294118,
+        "relevance_band": "related",
+        "community": 1073,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "badge_generator_service_badgegeneratorservice",
+        "label": "BadgeGeneratorService",
+        "source_file": "backend/src/modules/certification/services/badge-generator.service.ts",
+        "line_number": 26,
+        "source_domain": "production",
+        "snippet": "\n@Injectable()\nexport class BadgeGeneratorService {",
+        "match_score": 4.0375,
+        "relevance_band": "related",
+        "community": 483,
+        "framework": "nestjs",
+        "framework_role": "nest_provider",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "class"
+      },
+      {
+        "node_id": "certificate_generator_service_certificategeneratorservice_buildasseturl",
+        "label": ".buildAssetUrl()",
+        "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts",
+        "line_number": 126,
+        "source_domain": "production",
+        "snippet": "\n  private buildAssetUrl(verifyToken: string, filename: string): string {\n    const cdnBase = this.config.badgeCdnBaseUrl;",
+        "match_score": 6.070588235294117,
+        "relevance_band": "related",
+        "community": 281,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "certificate_generator_service_certificategeneratorservice_dataurltobuffer",
+        "label": ".dataUrlToBuffer()",
+        "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts",
+        "line_number": 121,
+        "source_domain": "production",
+        "snippet": "\n  private dataUrlToBuffer(dataUrl: string): Buffer {\n    const base64Data = dataUrl.split(',')[1];",
+        "match_score": 6.070588235294117,
+        "relevance_band": "related",
+        "community": 281,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "badge_generator_service_badgegeneratorservice_buildasseturl",
+        "label": ".buildAssetUrl()",
+        "source_file": "backend/src/modules/certification/services/badge-generator.service.ts",
+        "line_number": 92,
+        "source_domain": "production",
+        "snippet": "   */\n  private buildAssetUrl(verifyToken: string, filename: string): string {\n    const cdnBase = this.config.badgeCdnBaseUrl;",
+        "match_score": 5.964285714285714,
+        "relevance_band": "related",
+        "community": 483,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "badge_svg_renderbadgesvg",
+        "label": "renderBadgeSvg()",
+        "source_file": "backend/src/modules/certification/templates/badge-svg.ts",
+        "line_number": 17,
+        "source_domain": "production",
+        "snippet": "\nexport function renderBadgeSvg({ tier, score }: BadgeSvgParams): string {\n  const colors = TIER_COLORS[tier];",
+        "match_score": 4.214285714285714,
+        "relevance_band": "related",
+        "community": 484,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      },
+      {
+        "node_id": "plan_enforcement_guard_planenforcement",
+        "label": "PlanEnforcement",
+        "source_file": "backend/src/modules/auth/plan-enforcement.guard.ts",
+        "line_number": 28,
+        "source_domain": "production",
+        "snippet": "\nexport const PlanEnforcement = (usageType: UsageType) => {\n  return (",
+        "match_score": 4.117385480758447,
+        "relevance_band": "related",
+        "community": 299,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved"
+      }
+    ],
+    "relationships": [
+      {
+        "from_id": "idea_generation_controller_ideagenerationcontroller_getstatusmessage",
+        "from": ".getStatusMessage()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller",
+        "to": "IdeaGenerationController",
+        "relation": "method"
+      },
+      {
+        "from_id": "idea_generation_controller_ideagenerationcontroller_getstatusmessage",
+        "from": ".getStatusMessage()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_buildsystemprompt",
+        "from": ".buildSystemPrompt()",
+        "to_id": "title_generation_service_titlegenerationservice",
+        "to": "TitleGenerationService",
+        "relation": "method"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_buildsystemprompt",
+        "from": ".buildSystemPrompt()",
+        "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "to": ".generateTitle()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_builduserprompt",
+        "from": ".buildUserPrompt()",
+        "to_id": "title_generation_service_titlegenerationservice",
+        "to": "TitleGenerationService",
+        "relation": "method"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_builduserprompt",
+        "from": ".buildUserPrompt()",
+        "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "to": ".generateTitle()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+        "from": ".releaseUnusedCreditReservation()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+        "from": ".extractKeyPhrasesTitle()",
+        "to_id": "title_generation_service_titlegenerationservice",
+        "to": "TitleGenerationService",
+        "relation": "method"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+        "from": ".extractKeyPhrasesTitle()",
+        "to_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+        "to": ".generateFallbackTitle()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_createidea",
+        "from": ".createIdea()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_createidea",
+        "from": ".createIdea()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+        "from": ".claimQueuedPipelineRun()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+        "from": ".claimQueuedPipelineRun()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+        "from": ".claimQueuedPipelineRun()",
+        "to_id": "structured_logger_service_structuredlogger_warn",
+        "to": ".warn()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_updatetitle",
+        "from": ".updateTitle()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_updatetitle",
+        "from": ".updateTitle()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generatepdffromhtml",
+        "from": ".generatePdfFromHtml()",
+        "to_id": "certificate_generator_service_certificategeneratorservice",
+        "to": "CertificateGeneratorService",
+        "relation": "method"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generatepdffromhtml",
+        "from": ".generatePdfFromHtml()",
+        "to_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "to": ".generate()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+        "from": ".releaseQueuedPipelineClaim()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+        "from": ".releaseQueuedPipelineClaim()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+        "from": ".releaseQueuedPipelineClaim()",
+        "to_id": "structured_logger_service_structuredlogger_warn",
+        "to": ".warn()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "idea_generation_controller_ideagenerationcontroller",
+        "from": "IdeaGenerationController",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "method"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "certificate_generator_service_certificategeneratorservice",
+        "to": "CertificateGeneratorService",
+        "relation": "method"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "certification_service_certificationservice_claimbadge",
+        "to": ".claimBadge()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "certificate_generator_service_certificategeneratorservice_buildasseturl",
+        "to": ".buildAssetUrl()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "certificate_generator_service_certificategeneratorservice_dataurltobuffer",
+        "to": ".dataUrlToBuffer()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "storage_service_storageservice_uploadfile",
+        "to": ".uploadFile()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "certificate_html_rendercertificatehtml",
+        "to": "renderCertificateHtml()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice",
+        "from": "TitleGenerationService",
+        "to_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+        "to": ".generateFallbackTitle()",
+        "relation": "method"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice",
+        "from": "TitleGenerationService",
+        "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "to": ".generateTitle()",
+        "relation": "method"
+      },
+      {
+        "from_id": "badge_generator_service_badgegeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "badge_generator_service_badgegeneratorservice",
+        "to": "BadgeGeneratorService",
+        "relation": "method"
+      },
+      {
+        "from_id": "badge_generator_service_badgegeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "badge_generator_service_badgegeneratorservice_buildasseturl",
+        "to": ".buildAssetUrl()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "badge_generator_service_badgegeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "badge_svg_renderbadgesvg",
+        "to": "renderBadgeSvg()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "badge_generator_service_badgegeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "storage_service_storageservice_uploadfile",
+        "to": ".uploadFile()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "badge_generator_service_badgegeneratorservice_generate",
+        "from": ".generate()",
+        "to_id": "certification_service_certificationservice_claimbadge",
+        "to": ".claimBadge()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+        "to": ".generateFallbackTitle()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "structured_logger_service_structuredlogger_error",
+        "to": ".error()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "structured_logger_service_structuredlogger_warn",
+        "to": ".warn()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+        "to": ".formatErrorForJson()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+        "to": ".callLlm()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+        "to": ".resolve()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+        "from": ".generateTitle()",
+        "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "to": ".generateFromProblem()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "from": ".generateFromProblem()",
+        "to_id": "ideas_authenticated_request_requireideasuserid",
+        "to": "requireIdeasUserId",
+        "relation": "calls"
+      },
+      {
+        "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "from": ".generateFromProblem()",
+        "to_id": "plan_enforcement_guard_planenforcement",
+        "to": "PlanEnforcement",
+        "relation": "calls"
+      },
+      {
+        "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "from": ".generateFromProblem()",
+        "to_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+        "to": ".startPipeline()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+        "from": ".generateFallbackTitle()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+        "from": ".startPipeline()",
+        "to_id": "structured_logger_service_structuredlogger_error",
+        "to": ".error()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+        "from": ".startPipeline()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+        "from": ".resolve()",
+        "to_id": "structured_logger_service_structuredlogger_info",
+        "to": ".info()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certification_service_certificationservice_claimbadge",
+        "from": ".claimBadge()",
+        "to_id": "storage_service_storageservice_uploadfile",
+        "to": ".uploadFile()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_buildasseturl",
+        "from": ".buildAssetUrl()",
+        "to_id": "certificate_generator_service_certificategeneratorservice",
+        "to": "CertificateGeneratorService",
+        "relation": "method"
+      },
+      {
+        "from_id": "certificate_generator_service_certificategeneratorservice_dataurltobuffer",
+        "from": ".dataUrlToBuffer()",
+        "to_id": "certificate_generator_service_certificategeneratorservice",
+        "to": "CertificateGeneratorService",
+        "relation": "method"
+      },
+      {
+        "from_id": "structured_logger_service_structuredlogger_info",
+        "from": ".info()",
+        "to_id": "storage_service_storageservice_uploadfile",
+        "to": ".uploadFile()",
+        "relation": "calls"
+      },
+      {
+        "from_id": "badge_generator_service_badgegeneratorservice_buildasseturl",
+        "from": ".buildAssetUrl()",
+        "to_id": "badge_generator_service_badgegeneratorservice",
+        "to": "BadgeGeneratorService",
+        "relation": "method"
+      },
+      {
+        "from_id": "certificate_html_rendercertificatehtml",
+        "from": "renderCertificateHtml()",
+        "to_id": "certificate_html",
+        "to": "certificate-html.ts",
+        "relation": "contains"
+      },
+      {
+        "from_id": "badge_svg_renderbadgesvg",
+        "from": "renderBadgeSvg()",
+        "to_id": "badge_svg",
+        "to": "badge-svg.ts",
+        "relation": "contains"
+      }
+    ],
+    "community_context": [
+      {
+        "id": 3,
+        "label": "Backend Subscription Expiration Service",
+        "node_count": 67
+      },
+      {
+        "id": 86,
+        "label": "Backend Vercel Service",
+        "node_count": 12
+      },
+      {
+        "id": 120,
+        "label": "Backend PDF Export Service",
+        "node_count": 10
+      },
+      {
+        "id": 256,
+        "label": "Backend Title Generation Service",
+        "node_count": 7
+      },
+      {
+        "id": 253,
+        "label": "Backend Storage Service",
+        "node_count": 7
+      },
+      {
+        "id": 299,
+        "label": "Backend Idea Generation Controller",
+        "node_count": 6
+      },
+      {
+        "id": 281,
+        "label": "Backend Certificate Generator Service",
+        "node_count": 6
+      },
+      {
+        "id": 297,
+        "label": "Backend Idea Artifacts Controller",
+        "node_count": 6
+      },
+      {
+        "id": 382,
+        "label": "Backend Error Logger Util",
+        "node_count": 5
+      },
+      {
+        "id": 483,
+        "label": "Backend Badge Generator Service — Asset",
+        "node_count": 4
+      },
+      {
+        "id": 553,
+        "label": "Backend Llm Provider Resolver Service",
+        "node_count": 4
+      },
+      {
+        "id": 550,
+        "label": "Backend Lets Build Executor — Build",
+        "node_count": 4
+      },
+      {
+        "id": 497,
+        "label": "Backend Certification Service — Add",
+        "node_count": 4
+      },
+      {
+        "id": 484,
+        "label": "Backend Badge SVG",
+        "node_count": 4
+      },
+      {
+        "id": 495,
+        "label": "Backend Certificate HTML",
+        "node_count": 4
+      },
+      {
+        "id": 778,
+        "label": "Backend Ideas Service — Pipeline",
+        "node_count": 3
+      },
+      {
+        "id": 1114,
+        "label": "Backend Credits Service — Credit",
+        "node_count": 2
+      },
+      {
+        "id": 1187,
+        "label": "Backend Ideas Service — Create",
+        "node_count": 2
+      },
+      {
+        "id": 1285,
+        "label": "Backend Pipeline Controller — Pipeline",
+        "node_count": 2
+      },
+      {
+        "id": 1073,
+        "label": "Backend Certificate HTML — HTML",
+        "node_count": 2
+      }
+    ],
+    "graph_signals": {
+      "god_nodes": [
+        ".info()",
+        ".warn()",
+        ".error()"
+      ],
+      "bridge_nodes": [
+        ".info()",
+        ".warn()",
+        ".error()"
+      ]
+    },
+    "shared_file_type": "code",
+    "retrieval_strategy": "default",
+    "retrieval_gate": {
+      "level": 1,
+      "reason": "explain intent without explicit reference — local context",
+      "skipped_retrieval": false,
+      "intent": "explain",
+      "signals": {
+        "has_pr_diff": false,
+        "has_stack_trace": false,
+        "mentioned_paths": [],
+        "mentioned_symbols": [],
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      }
+    },
+    "claims": [
+      {
+        "evidence_class": "primary",
+        "text": "primary evidence: .getStatusMessage(), .buildSystemPrompt(), .buildUserPrompt()",
+        "node_labels": [
+          ".getStatusMessage()",
+          ".buildSystemPrompt()",
+          ".buildUserPrompt()"
+        ]
+      },
+      {
+        "evidence_class": "supporting",
+        "text": "supporting evidence: .startPipeline(), .callLlm(), .resolve()",
+        "node_labels": [
+          ".startPipeline()",
+          ".callLlm()",
+          ".resolve()"
+        ]
+      }
+    ],
+    "coverage": {
+      "required_evidence": [
+        "primary",
+        "supporting",
+        "structural"
+      ],
+      "semantic_required": [
+        "implementation",
+        "structure"
+      ],
+      "semantic_optional": [
+        "contracts",
+        "configuration",
+        "tests"
+      ],
+      "entries": [
+        {
+          "evidence_class": "primary",
+          "required": true,
+          "available_nodes": 18,
+          "selected_nodes": 18,
+          "status": "covered"
+        },
+        {
+          "evidence_class": "supporting",
+          "required": true,
+          "available_nodes": 19,
+          "selected_nodes": 19,
+          "status": "covered"
+        },
+        {
+          "evidence_class": "structural",
+          "required": true,
+          "available_nodes": 0,
+          "selected_nodes": 0,
+          "status": "missing"
+        }
+      ],
+      "semantic_entries": [
+        {
+          "category": "implementation",
+          "label": "implementation",
+          "required": true,
+          "available_nodes": 33,
+          "selected_nodes": 33,
+          "status": "covered"
+        },
+        {
+          "category": "structure",
+          "label": "structure",
+          "required": true,
+          "available_nodes": 0,
+          "selected_nodes": 0,
+          "status": "missing"
+        },
+        {
+          "category": "contracts",
+          "label": "contracts",
+          "required": false,
+          "available_nodes": 4,
+          "selected_nodes": 4,
+          "status": "covered"
+        },
+        {
+          "category": "configuration",
+          "label": "configuration",
+          "required": false,
+          "available_nodes": 0,
+          "selected_nodes": 0,
+          "status": "missing"
+        },
+        {
+          "category": "tests",
+          "label": "tests",
+          "required": false,
+          "available_nodes": 0,
+          "selected_nodes": 0,
+          "status": "missing"
+        }
+      ],
+      "missing_required": [
+        "structural"
+      ],
+      "missing_semantic": [
+        "structure"
+      ],
+      "available_relationships": 57,
+      "selected_relationships": 57
+    },
+    "selection_diagnostics": {
+      "selection_strategy": "value-per-token",
+      "budget": 3000,
+      "used_tokens": 1456,
+      "required_overflow": false,
+      "ranking": [
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller_getstatusmessage",
+          "label": ".getStatusMessage()",
+          "evidence_class": "primary",
+          "score": 12.75,
+          "token_cost": 42,
+          "density": 0.30357142857142855,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_buildsystemprompt",
+          "label": ".buildSystemPrompt()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 53,
+          "density": 0.2830188679245283,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_builduserprompt",
+          "label": ".buildUserPrompt()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 45,
+          "density": 0.3333333333333333,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+          "label": ".releaseUnusedCreditReservation()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 35,
+          "density": 0.42857142857142855,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+          "label": ".extractKeyPhrasesTitle()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 44,
+          "density": 0.3409090909090909,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_createidea",
+          "label": ".createIdea()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 49,
+          "density": 0.30612244897959184,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+          "label": ".claimQueuedPipelineRun()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 36,
+          "density": 0.4166666666666667,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updatetitle",
+          "label": ".updateTitle()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 47,
+          "density": 0.3191489361702128,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certificate_generator_service_certificategeneratorservice_generatepdffromhtml",
+          "label": ".generatePdfFromHtml()",
+          "evidence_class": "primary",
+          "score": 13.5,
+          "token_cost": 47,
+          "density": 0.2872340425531915,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+          "label": ".releaseQueuedPipelineClaim()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 34,
+          "density": 0.4411764705882353,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller",
+          "label": "IdeaGenerationController",
+          "evidence_class": "primary",
+          "score": 12.75,
+          "token_cost": 28,
+          "density": 0.45535714285714285,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certificate_generator_service_certificategeneratorservice_generate",
+          "label": ".generate()",
+          "evidence_class": "primary",
+          "score": 13.5,
+          "token_cost": 28,
+          "density": 0.48214285714285715,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice",
+          "label": "TitleGenerationService",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 28,
+          "density": 0.5357142857142857,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "badge_generator_service_badgegeneratorservice_generate",
+          "label": ".generate()",
+          "evidence_class": "primary",
+          "score": 13.429,
+          "token_cost": 46,
+          "density": 0.29193478260869565,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_generatetitle",
+          "label": ".generateTitle()",
+          "evidence_class": "primary",
+          "score": 14.764,
+          "token_cost": 31,
+          "density": 0.476258064516129,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "label": ".generateFromProblem()",
+          "evidence_class": "primary",
+          "score": 12.475,
+          "token_cost": 38,
+          "density": 0.3282894736842105,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+          "label": ".generateFallbackTitle()",
+          "evidence_class": "primary",
+          "score": 14.665,
+          "token_cost": 33,
+          "density": 0.44439393939393934,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_authenticated_request_requireideasuserid",
+          "label": "requireIdeasUserId",
+          "evidence_class": "primary",
+          "score": 10.23,
+          "token_cost": 37,
+          "density": 0.2764864864864865,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "label": ".startPipeline()",
+          "evidence_class": "supporting",
+          "score": 13.5,
+          "token_cost": 63,
+          "density": 0.21428571428571427,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "label": ".callLlm()",
+          "evidence_class": "supporting",
+          "score": 12.25,
+          "token_cost": 68,
+          "density": 0.1801470588235294,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "label": ".resolve()",
+          "evidence_class": "supporting",
+          "score": 12.25,
+          "token_cost": 56,
+          "density": 0.21875,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "certification_service_certificationservice_claimbadge",
+          "label": ".claimBadge()",
+          "evidence_class": "supporting",
+          "score": 12.25,
+          "token_cost": 30,
+          "density": 0.4083333333333333,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "certificate_generator_service_certificategeneratorservice_buildasseturl",
+          "label": ".buildAssetUrl()",
+          "evidence_class": "supporting",
+          "score": 13.5,
+          "token_cost": 50,
+          "density": 0.27,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certificate_generator_service_certificategeneratorservice_dataurltobuffer",
+          "label": ".dataUrlToBuffer()",
+          "evidence_class": "supporting",
+          "score": 13.5,
+          "token_cost": 45,
+          "density": 0.3,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "structured_logger_service_structuredlogger_info",
+          "label": ".info()",
+          "evidence_class": "supporting",
+          "score": 12.232,
+          "token_cost": 39,
+          "density": 0.31364102564102564,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "structured_logger_service_structuredlogger_warn",
+          "label": ".warn()",
+          "evidence_class": "supporting",
+          "score": 12.232,
+          "token_cost": 39,
+          "density": 0.31364102564102564,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "structured_logger_service_structuredlogger_error",
+          "label": ".error()",
+          "evidence_class": "supporting",
+          "score": 12.232,
+          "token_cost": 33,
+          "density": 0.37066666666666664,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "storage_service_storageservice_uploadfile",
+          "label": ".uploadFile()",
+          "evidence_class": "supporting",
+          "score": 13.471,
+          "token_cost": 24,
+          "density": 0.5612916666666666,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "badge_generator_service_badgegeneratorservice_buildasseturl",
+          "label": ".buildAssetUrl()",
+          "evidence_class": "supporting",
+          "score": 13.464,
+          "token_cost": 51,
+          "density": 0.264,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certificate_html_rendercertificatehtml",
+          "label": "renderCertificateHtml()",
+          "evidence_class": "supporting",
+          "score": 11.721,
+          "token_cost": 34,
+          "density": 0.3447352941176471,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "badge_svg_renderbadgesvg",
+          "label": "renderBadgeSvg()",
+          "evidence_class": "supporting",
+          "score": 11.714,
+          "token_cost": 44,
+          "density": 0.26622727272727276,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certificate_generator_service_certificategeneratorservice",
+          "label": "CertificateGeneratorService",
+          "evidence_class": "supporting",
+          "score": 11.64,
+          "token_cost": 26,
+          "density": 0.4476923076923077,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "label": ".formatErrorForJson()",
+          "evidence_class": "supporting",
+          "score": 11.632,
+          "token_cost": 42,
+          "density": 0.27695238095238095,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "plan_enforcement_guard_planenforcement",
+          "label": "PlanEnforcement",
+          "evidence_class": "supporting",
+          "score": 11.617,
+          "token_cost": 34,
+          "density": 0.3416764705882353,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "badge_generator_service_badgegeneratorservice",
+          "label": "BadgeGeneratorService",
+          "evidence_class": "supporting",
+          "score": 11.537,
+          "token_cost": 26,
+          "density": 0.44373076923076926,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certificate_html",
+          "label": "certificate-html.ts",
+          "evidence_class": "supporting",
+          "score": 8.75,
+          "token_cost": 23,
+          "density": 0.3804347826086957,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "badge_svg",
+          "label": "badge-svg.ts",
+          "evidence_class": "supporting",
+          "score": 8.75,
+          "token_cost": 28,
+          "density": 0.3125,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        }
+      ]
+    }
+  },
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "baseline_prompt": "<artifact-root>/baseline-prompt.txt",
+    "graphify_prompt": "<artifact-root>/graphify-prompt.txt",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": null,
+      "input_tokens_source": "estimated_cl100k_base",
+      "effective_tokens_source": "session_reuse_estimate",
+      "total_tokens_source": "not_available"
+    },
+    "graphify": {
+      "provider": null,
+      "input_tokens_source": "estimated_cl100k_base",
+      "effective_tokens_source": "session_reuse_estimate",
+      "total_tokens_source": "not_available"
+    },
+    "reduction_basis": "estimated"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-pack-quality.txt
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation-pack-quality.txt
@@ -1,0 +1,3 @@
+docs-artifact FAIL
+prompt: Explain how idea report is getting generated
+missing required labels: IdeaReportController, GenerateIdeaReportService

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/report-generation.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "Explain how idea report is getting generated",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 9,
+      "cache_creation_input_tokens": 69086,
+      "cache_read_input_tokens": 190817,
+      "output_tokens": 2625,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 69086,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1489,
+          "cache_read_input_tokens": 64122,
+          "cache_creation_input_tokens": 4964,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 4964
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 259912,
+    "uncached_input_tokens_anthropic_exact": 69095,
+    "cached_input_tokens_anthropic_exact": 190817,
+    "total_cost_usd": 0.9902247499999995,
+    "num_turns": 4,
+    "duration_ms": 259985,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 24,
+      "cache_creation_input_tokens": 125486,
+      "cache_read_input_tokens": 172274,
+      "output_tokens": 2914,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 125486,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 2398,
+          "cache_read_input_tokens": 74217,
+          "cache_creation_input_tokens": 23700,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 23700
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 297784,
+    "uncached_input_tokens_anthropic_exact": 125510,
+    "cached_input_tokens_anthropic_exact": 172274,
+    "total_cost_usd": 0.9433945,
+    "num_turns": 4,
+    "duration_ms": 49163,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.87,
+    "num_turns": 1,
+    "duration_ms": 5.29,
+    "cost_usd": 1.05
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:01:35.623Z",
+  "completed_at": "2026-05-21T18:07:01.021Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-best-win.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-best-win.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How are user credits consumed and recorded during an AI action?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 18,
+      "cache_creation_input_tokens": 71185,
+      "cache_read_input_tokens": 1056528,
+      "output_tokens": 4620,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 71185,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 2128,
+          "cache_read_input_tokens": 104339,
+          "cache_creation_input_tokens": 1461,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1461
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 1127731,
+    "uncached_input_tokens_anthropic_exact": 71203,
+    "cached_input_tokens_anthropic_exact": 1056528,
+    "total_cost_usd": 1.08876025,
+    "num_turns": 15,
+    "duration_ms": 97612,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 24,
+      "cache_creation_input_tokens": 79315,
+      "cache_read_input_tokens": 209594,
+      "output_tokens": 3061,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 79315,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 2026,
+          "cache_read_input_tokens": 76693,
+          "cache_creation_input_tokens": 9746,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 9746
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 288933,
+    "uncached_input_tokens_anthropic_exact": 79339,
+    "cached_input_tokens_anthropic_exact": 209594,
+    "total_cost_usd": 0.6771607500000001,
+    "num_turns": 6,
+    "duration_ms": 51748,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 3.9,
+    "num_turns": 2.5,
+    "duration_ms": 1.89,
+    "cost_usd": 1.61
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:29:57.273Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-001.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-001.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "Explain how idea report generation works end to end.",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 34928,
+      "cache_read_input_tokens": 413705,
+      "output_tokens": 3087,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 34928,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1376,
+          "cache_read_input_tokens": 64144,
+          "cache_creation_input_tokens": 5399,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 5399
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448645,
+    "uncached_input_tokens_anthropic_exact": 34940,
+    "cached_input_tokens_anthropic_exact": 413705,
+    "total_cost_usd": 0.74466435,
+    "num_turns": 7,
+    "duration_ms": 191615,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 22,
+      "cache_creation_input_tokens": 115249,
+      "cache_read_input_tokens": 510201,
+      "output_tokens": 6790,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 115249,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 4631,
+          "cache_read_input_tokens": 111181,
+          "cache_creation_input_tokens": 10517,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 10517
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 625472,
+    "uncached_input_tokens_anthropic_exact": 115271,
+    "cached_input_tokens_anthropic_exact": 510201,
+    "total_cost_usd": 1.1452667499999998,
+    "num_turns": 10,
+    "duration_ms": 104147,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.72,
+    "num_turns": 0.7,
+    "duration_ms": 1.84,
+    "cost_usd": 0.65
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:27:14.986Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-002.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-002.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How are user credits consumed and recorded during an AI action?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 18,
+      "cache_creation_input_tokens": 71185,
+      "cache_read_input_tokens": 1056528,
+      "output_tokens": 4620,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 71185,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 2128,
+          "cache_read_input_tokens": 104339,
+          "cache_creation_input_tokens": 1461,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1461
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 1127731,
+    "uncached_input_tokens_anthropic_exact": 71203,
+    "cached_input_tokens_anthropic_exact": 1056528,
+    "total_cost_usd": 1.08876025,
+    "num_turns": 15,
+    "duration_ms": 97612,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 24,
+      "cache_creation_input_tokens": 79315,
+      "cache_read_input_tokens": 209594,
+      "output_tokens": 3061,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 79315,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 2026,
+          "cache_read_input_tokens": 76693,
+          "cache_creation_input_tokens": 9746,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 9746
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 288933,
+    "uncached_input_tokens_anthropic_exact": 79339,
+    "cached_input_tokens_anthropic_exact": 209594,
+    "total_cost_usd": 0.6771607500000001,
+    "num_turns": 6,
+    "duration_ms": 51748,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 3.9,
+    "num_turns": 2.5,
+    "duration_ms": 1.89,
+    "cost_usd": 1.61
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:29:57.273Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-003.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-003.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How do waitlist approvals and invite codes work?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 13,
+      "cache_creation_input_tokens": 32324,
+      "cache_read_input_tokens": 158247,
+      "output_tokens": 2271,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32324,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 1627,
+          "cache_read_input_tokens": 61982,
+          "cache_creation_input_tokens": 4957,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 4957
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 190584,
+    "uncached_input_tokens_anthropic_exact": 32337,
+    "cached_input_tokens_anthropic_exact": 158247,
+    "total_cost_usd": 0.6618560000000001,
+    "num_turns": 3,
+    "duration_ms": 150047,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 26,
+      "cache_creation_input_tokens": 98847,
+      "cache_read_input_tokens": 366549,
+      "output_tokens": 5931,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 98847,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 4341,
+          "cache_read_input_tokens": 83939,
+          "cache_creation_input_tokens": 22039,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 22039
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 465422,
+    "uncached_input_tokens_anthropic_exact": 98873,
+    "cached_input_tokens_anthropic_exact": 366549,
+    "total_cost_usd": 0.94947325,
+    "num_turns": 8,
+    "duration_ms": 93102,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.41,
+    "num_turns": 0.38,
+    "duration_ms": 1.61,
+    "cost_usd": 0.7
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:34:15.942Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-004.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-004.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How is a PDF export generated and returned to the user?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 16,
+      "cache_creation_input_tokens": 44499,
+      "cache_read_input_tokens": 736264,
+      "output_tokens": 2655,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 44499,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1068,
+          "cache_read_input_tokens": 76996,
+          "cache_creation_input_tokens": 2118,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2118
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 780779,
+    "uncached_input_tokens_anthropic_exact": 44515,
+    "cached_input_tokens_anthropic_exact": 736264,
+    "total_cost_usd": 0.71270575,
+    "num_turns": 11,
+    "duration_ms": 203768,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 33,
+      "cache_creation_input_tokens": 85808,
+      "cache_read_input_tokens": 543711,
+      "output_tokens": 2745,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 85808,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 1048,
+          "cache_read_input_tokens": 89705,
+          "cache_creation_input_tokens": 2541,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2541
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 629552,
+    "uncached_input_tokens_anthropic_exact": 85841,
+    "cached_input_tokens_anthropic_exact": 543711,
+    "total_cost_usd": 0.8769455,
+    "num_turns": 9,
+    "duration_ms": 52846,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.24,
+    "num_turns": 1.22,
+    "duration_ms": 3.86,
+    "cost_usd": 0.81
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:38:43.366Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-005.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-005.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How are AI landing pages generated and published?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 15,
+      "cache_creation_input_tokens": 35940,
+      "cache_read_input_tokens": 622332,
+      "output_tokens": 2276,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 35940,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 843,
+          "cache_read_input_tokens": 69055,
+          "cache_creation_input_tokens": 1500,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1500
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 658287,
+    "uncached_input_tokens_anthropic_exact": 35955,
+    "cached_input_tokens_anthropic_exact": 622332,
+    "total_cost_usd": 0.5927660000000001,
+    "num_turns": 10,
+    "duration_ms": 46895,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 28,
+      "cache_creation_input_tokens": 93157,
+      "cache_read_input_tokens": 565601,
+      "output_tokens": 3221,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 93157,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1655,
+          "cache_read_input_tokens": 93197,
+          "cache_creation_input_tokens": 6408,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6408
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 658786,
+    "uncached_input_tokens_anthropic_exact": 93185,
+    "cached_input_tokens_anthropic_exact": 565601,
+    "total_cost_usd": 0.94569675,
+    "num_turns": 9,
+    "duration_ms": 61808,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1,
+    "num_turns": 1.11,
+    "duration_ms": 0.76,
+    "cost_usd": 0.63
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:40:42.239Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-006.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-006.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does NDA sharing work, including access checks and delivery?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 26,
+      "cache_creation_input_tokens": 70799,
+      "cache_read_input_tokens": 1751092,
+      "output_tokens": 5593,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 70799,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 2559,
+          "cache_read_input_tokens": 104325,
+          "cache_creation_input_tokens": 1089,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1089
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 1821917,
+    "uncached_input_tokens_anthropic_exact": 70825,
+    "cached_input_tokens_anthropic_exact": 1751092,
+    "total_cost_usd": 1.4579947499999997,
+    "num_turns": 21,
+    "duration_ms": 117348,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 31,
+      "cache_creation_input_tokens": 90499,
+      "cache_read_input_tokens": 377531,
+      "output_tokens": 3237,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 90499,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 1877,
+          "cache_read_input_tokens": 95369,
+          "cache_creation_input_tokens": 2252,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2252
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 468061,
+    "uncached_input_tokens_anthropic_exact": 90530,
+    "cached_input_tokens_anthropic_exact": 377531,
+    "total_cost_usd": 0.8354642500000001,
+    "num_turns": 9,
+    "duration_ms": 75080,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 3.89,
+    "num_turns": 2.33,
+    "duration_ms": 1.56,
+    "cost_usd": 1.75
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:44:09.264Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-007.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-007.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "Where are Stripe billing or usage limits enforced?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 18,
+      "cache_creation_input_tokens": 54881,
+      "cache_read_input_tokens": 930713,
+      "output_tokens": 4766,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 54881,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1621,
+          "cache_read_input_tokens": 88321,
+          "cache_creation_input_tokens": 1175,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1175
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 985612,
+    "uncached_input_tokens_anthropic_exact": 54899,
+    "cached_input_tokens_anthropic_exact": 930713,
+    "total_cost_usd": 0.9276027499999999,
+    "num_turns": 20,
+    "duration_ms": 90007,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 26,
+      "cache_creation_input_tokens": 75258,
+      "cache_read_input_tokens": 348249,
+      "output_tokens": 3383,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 75258,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1906,
+          "cache_read_input_tokens": 75994,
+          "cache_creation_input_tokens": 6388,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6388
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 423533,
+    "uncached_input_tokens_anthropic_exact": 75284,
+    "cached_input_tokens_anthropic_exact": 348249,
+    "total_cost_usd": 0.7291920000000001,
+    "num_turns": 9,
+    "duration_ms": 59619,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 2.33,
+    "num_turns": 2.22,
+    "duration_ms": 1.51,
+    "cost_usd": 1.27
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:46:54.390Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-008.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-008.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How is pipeline status broadcast while background work is running?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 17,
+      "cache_creation_input_tokens": 55092,
+      "cache_read_input_tokens": 857679,
+      "output_tokens": 3468,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 55092,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1326,
+          "cache_read_input_tokens": 87926,
+          "cache_creation_input_tokens": 1781,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1781
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 912788,
+    "uncached_input_tokens_anthropic_exact": 55109,
+    "cached_input_tokens_anthropic_exact": 857679,
+    "total_cost_usd": 0.8599494999999999,
+    "num_turns": 12,
+    "duration_ms": 90065,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 39,
+      "cache_creation_input_tokens": 99361,
+      "cache_read_input_tokens": 663898,
+      "output_tokens": 2968,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 99361,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 675,
+          "cache_read_input_tokens": 105298,
+          "cache_creation_input_tokens": 1189,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1189
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 763298,
+    "uncached_input_tokens_anthropic_exact": 99400,
+    "cached_input_tokens_anthropic_exact": 663898,
+    "total_cost_usd": 1.02735025,
+    "num_turns": 10,
+    "duration_ms": 63614,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.2,
+    "num_turns": 1.2,
+    "duration_ms": 1.42,
+    "cost_usd": 0.84
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:49:40.648Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-009.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-009.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "What code paths are involved when the app builds an impact review?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 17,
+      "cache_creation_input_tokens": 46325,
+      "cache_read_input_tokens": 781766,
+      "output_tokens": 4617,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 46325,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1123,
+          "cache_read_input_tokens": 79926,
+          "cache_creation_input_tokens": 1014,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1014
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 828108,
+    "uncached_input_tokens_anthropic_exact": 46342,
+    "cached_input_tokens_anthropic_exact": 781766,
+    "total_cost_usd": 0.79592425,
+    "num_turns": 17,
+    "duration_ms": 87782,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 25,
+      "cache_creation_input_tokens": 77567,
+      "cache_read_input_tokens": 293241,
+      "output_tokens": 2678,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 77567,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 1161,
+          "cache_read_input_tokens": 82952,
+          "cache_creation_input_tokens": 1741,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 1741
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 370833,
+    "uncached_input_tokens_anthropic_exact": 77592,
+    "cached_input_tokens_anthropic_exact": 293241,
+    "total_cost_usd": 0.69848925,
+    "num_turns": 6,
+    "duration_ms": 49696,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 2.23,
+    "num_turns": 2.83,
+    "duration_ms": 1.77,
+    "cost_usd": 1.14
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:52:13.712Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-010.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-share-safe/question-010.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "Where does the app choose providers or models before making AI calls?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 13,
+      "cache_creation_input_tokens": 42137,
+      "cache_read_input_tokens": 507814,
+      "output_tokens": 2515,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 42137,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 1087,
+          "cache_read_input_tokens": 76109,
+          "cache_creation_input_tokens": 643,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 643
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 549964,
+    "uncached_input_tokens_anthropic_exact": 42150,
+    "cached_input_tokens_anthropic_exact": 507814,
+    "total_cost_usd": 0.5802032500000001,
+    "num_turns": 8,
+    "duration_ms": 48188,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 25,
+      "cache_creation_input_tokens": 79300,
+      "cache_read_input_tokens": 282692,
+      "output_tokens": 2488,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 79300,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 1523,
+          "cache_read_input_tokens": 81468,
+          "cache_creation_input_tokens": 4956,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 4956
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 362017,
+    "uncached_input_tokens_anthropic_exact": 79325,
+    "cached_input_tokens_anthropic_exact": 282692,
+    "total_cost_usd": 0.699296,
+    "num_turns": 5,
+    "duration_ms": 44006,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.52,
+    "num_turns": 1.6,
+    "duration_ms": 1.1,
+    "cost_usd": 0.83
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:54:01.383Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-worst-regression.report.share-safe.json
+++ b/docs/benchmarks/2026-05-21-govalidate-v0-23-0-validation/suite-worst-regression.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How do waitlist approvals and invite codes work?",
+  "graph_path": "<project-root>/graphify-out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 13,
+      "cache_creation_input_tokens": 32324,
+      "cache_read_input_tokens": 158247,
+      "output_tokens": 2271,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32324,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 1627,
+          "cache_read_input_tokens": 61982,
+          "cache_creation_input_tokens": 4957,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 4957
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 190584,
+    "uncached_input_tokens_anthropic_exact": 32337,
+    "cached_input_tokens_anthropic_exact": 158247,
+    "total_cost_usd": 0.6618560000000001,
+    "num_turns": 3,
+    "duration_ms": 150047,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "graphify": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 26,
+      "cache_creation_input_tokens": 98847,
+      "cache_read_input_tokens": 366549,
+      "output_tokens": 5931,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 98847,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 6,
+          "output_tokens": 4341,
+          "cache_read_input_tokens": 83939,
+          "cache_creation_input_tokens": 22039,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 22039
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 465422,
+    "uncached_input_tokens_anthropic_exact": 98873,
+    "cached_input_tokens_anthropic_exact": 366549,
+    "total_cost_usd": 0.94947325,
+    "num_turns": 8,
+    "duration_ms": 93102,
+    "result_path": "<artifact-root>/graphify-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.41,
+    "num_turns": 0.38,
+    "duration_ms": 1.61,
+    "cost_usd": 0.7
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "graphify": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "graphify": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-21T18:22:05.302Z",
+  "completed_at": "2026-05-21T18:34:15.942Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "graphify_answer": "<artifact-root>/graphify-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}


### PR DESCRIPTION
## Summary
- add a dated GoValidate v0.23.0 validation benchmark folder under `docs/benchmarks/`
- publish the mixed-result findings, including single-prompt failures, suite wins/losses, and explicit caveats
- include safe artifact examples plus deterministic answer-quality and pack-quality outputs

## Test Plan
- published `graphify-ts 0.23.0` validation run on the real GoValidate workspace
- 3-question native-agent smoke suite
- full 10-question native-agent suite
- path-safety scan on committed artifacts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark validation documentation for v0.23.0, including comprehensive test suite results, quality assessments, performance analysis, and comparative metrics across multiple validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->