### PR TITLE
Improve graph_summary runtime path ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For practical multi-agent workflows across Claude Code, Codex, Copilot, Cursor, 
 
 ## MCP tools
 
-These seven MCP tools handle the most common agent workflows in the default **core** profile. The full surface is 26 tools, opt-in via `GRAPHIFY_TOOL_PROFILE=full` or `--profile full` on install. `--profile strict` still uses the lean core tool surface, but changes the installed guidance so the agent starts with one `context_pack` call and expands only when the pack diagnostics say evidence is missing. Start with `graph_summary` for a bounded deterministic first-turn overview, then use `retrieve` or `context_pack` when you need task-specific evidence.
+These seven MCP tools handle the most common agent workflows in the default **core** profile. The full surface is 26 tools, opt-in via `GRAPHIFY_TOOL_PROFILE=full` or `--profile full` on install. `--profile strict` still uses the lean core tool surface, but changes the installed guidance so the agent starts with one `context_pack` call and expands only when the pack diagnostics say evidence is missing. Start with `graph_summary` for a bounded deterministic first-turn overview, then use `retrieve` or `context_pack` when you need task-specific evidence. It is intentionally a compact at-a-glance summary, not a full runtime trace.
 
 | Tool | When the agent uses it |
 |---|---|

--- a/src/runtime/graph-summary.ts
+++ b/src/runtime/graph-summary.ts
@@ -7,6 +7,19 @@ const SUMMARY_ARRAY_CAP = 10
 const ENTRY_NODE_KINDS = new Set(['route', 'router', 'controller', 'page', 'layout', 'middleware'])
 const ENTRY_FRAMEWORK_ROLE_HINTS = ['route', 'router', 'controller', 'page', 'layout', 'middleware', 'app', 'plugin', 'procedure']
 const RUNTIME_METADATA_KEYS = ['route_path', 'mount_path', 'procedure_name', 'router_name'] as const
+const MAX_RUNTIME_PATH_HOPS = 6
+const RELATION_QUALITY_SCORES: Record<string, number> = {
+  enqueues_job: 5,
+  controller_route: 4,
+  route_handler: 4,
+  calls: 4,
+  method: 3,
+  registers_controller: 2,
+  guarded_by: 1,
+  uses_authorization: 1,
+  uses_middleware: 1,
+  intercepts: 1,
+}
 
 export interface GraphSummaryTopModule {
   label: string
@@ -48,6 +61,23 @@ type NodeSummary = {
   explicitEntrySignal: boolean
   runtimeEligible: boolean
   sourceDomain: string
+}
+
+type RuntimeTraversal = {
+  hops: number
+  relationScore: number
+  minDomainScore: number
+}
+
+type RuntimePathCandidate = {
+  path: GraphSummaryRuntimePath
+  fromSourceFile: string
+  toSourceFile: string
+  entryScore: number
+  minDomainScore: number
+  relationScore: number
+  terminalScore: number
+  hopScore: number
 }
 
 function normalizeString(value: unknown): string {
@@ -205,6 +235,76 @@ function entrypointScore(node: NodeSummary, exported: boolean): number {
   return score
 }
 
+function sourceDomainScore(sourceDomain: string): number {
+  switch (sourceDomain) {
+    case 'production':
+      return 7
+    case '':
+    case 'unknown':
+      return 6
+    case 'config':
+      return 5
+    case 'docs':
+      return 2
+    case 'test':
+    case 'fixture':
+    case 'benchmark':
+    case 'generated':
+      return 0
+    default:
+      return 4
+  }
+}
+
+function relationQualityScore(relation: unknown): number {
+  const normalized = normalizeString(relation).toLowerCase()
+  return RELATION_QUALITY_SCORES[normalized] ?? 1
+}
+
+function terminalNodeScore(node: NodeSummary, graph: KnowledgeGraph): number {
+  const attributes = graph.nodeAttributes(node.id)
+  const normalized = [
+    node.label,
+    node.sourceFile,
+    normalizeString(attributes.node_kind),
+    normalizeString(attributes.framework_role),
+  ].join(' ').toLowerCase()
+
+  let score = 0
+  if (/\b(worker|consumer|processor|repository|repo|store|persistence|service|gateway|client)\b/.test(normalized)) {
+    score += 3
+  }
+  if (/\b(queue|job)\b/.test(normalized)) {
+    score += 2
+  }
+  if (/\b(helper|util|utility|dto|logger|logging|log|type|schema|constant)\b/.test(normalized)) {
+    score -= 2
+  }
+  return score
+}
+
+function runtimeHopScore(hops: number): number {
+  if (hops <= 0) {
+    return 0
+  }
+  if (hops === 1) {
+    return 1
+  }
+  if (hops <= 4) {
+    return 3
+  }
+  if (hops <= MAX_RUNTIME_PATH_HOPS) {
+    return 2
+  }
+  return 0
+}
+
+function compareNodeIdentity(left: NodeSummary, right: NodeSummary): number {
+  return left.label.localeCompare(right.label)
+    || left.sourceFile.localeCompare(right.sourceFile)
+    || left.id.localeCompare(right.id)
+}
+
 function entrypoints(graph: KnowledgeGraph, nodes: readonly NodeSummary[]): GraphSummaryEntrypoint[] {
   return sortedBounded(
     nodes
@@ -236,9 +336,34 @@ function runtimeEntryCandidates(nodes: readonly NodeSummary[]): NodeSummary[] {
     })
 }
 
-function shortestRuntimeDistances(graph: KnowledgeGraph, startId: string, runtimeNodeIds: ReadonlySet<string>): Map<string, number> {
-  const distances = new Map<string, number>([[startId, 0]])
-  const queue = [startId]
+function strongerRuntimeTraversal(candidate: RuntimeTraversal, existing: RuntimeTraversal): boolean {
+  if (candidate.hops !== existing.hops) {
+    return candidate.hops < existing.hops
+  }
+  if (candidate.relationScore !== existing.relationScore) {
+    return candidate.relationScore > existing.relationScore
+  }
+  if (candidate.minDomainScore !== existing.minDomainScore) {
+    return candidate.minDomainScore > existing.minDomainScore
+  }
+  return false
+}
+
+function bestRuntimeTraversals(
+  graph: KnowledgeGraph,
+  start: NodeSummary,
+  runtimeNodeIds: ReadonlySet<string>,
+  nodeMap: ReadonlyMap<string, NodeSummary>,
+): Map<string, RuntimeTraversal> {
+  const traversals = new Map<string, RuntimeTraversal>([[
+    start.id,
+    {
+      hops: 0,
+      relationScore: 0,
+      minDomainScore: sourceDomainScore(start.sourceDomain),
+    },
+  ]])
+  const queue = [start.id]
 
   while (queue.length > 0) {
     const nodeId = queue.shift()
@@ -246,70 +371,111 @@ function shortestRuntimeDistances(graph: KnowledgeGraph, startId: string, runtim
       continue
     }
 
-    const distance = distances.get(nodeId)
-    if (distance === undefined) {
+    const traversal = traversals.get(nodeId)
+    if (!traversal) {
       continue
     }
 
-    for (const neighbor of graph.successors(nodeId)) {
-      if (!runtimeNodeIds.has(neighbor) || distances.has(neighbor)) {
+    if (traversal.hops >= MAX_RUNTIME_PATH_HOPS) {
+      continue
+    }
+
+    const neighbors = graph.successors(nodeId)
+      .filter((neighbor) => runtimeNodeIds.has(neighbor))
+      .map((neighbor) => nodeMap.get(neighbor))
+      .filter((neighbor): neighbor is NodeSummary => neighbor !== undefined)
+      .sort(compareNodeIdentity)
+
+    for (const neighbor of neighbors) {
+      const edge = graph.edgeAttributes(nodeId, neighbor.id)
+      const candidate: RuntimeTraversal = {
+        hops: traversal.hops + 1,
+        relationScore: traversal.relationScore + relationQualityScore(edge.relation),
+        minDomainScore: Math.min(traversal.minDomainScore, sourceDomainScore(neighbor.sourceDomain)),
+      }
+      const existing = traversals.get(neighbor.id)
+      if (existing && !strongerRuntimeTraversal(candidate, existing)) {
         continue
       }
-      distances.set(neighbor, distance + 1)
-      queue.push(neighbor)
+      traversals.set(neighbor.id, candidate)
+      queue.push(neighbor.id)
     }
   }
 
-  return distances
+  return traversals
 }
 
-function strongerRuntimePath(left: GraphSummaryRuntimePath, right: GraphSummaryRuntimePath): GraphSummaryRuntimePath {
-  if (right.hops > left.hops) {
-    return right
+function compareRuntimePathCandidates(left: RuntimePathCandidate, right: RuntimePathCandidate): number {
+  return right.entryScore - left.entryScore
+    || right.minDomainScore - left.minDomainScore
+    || right.relationScore - left.relationScore
+    || right.terminalScore - left.terminalScore
+    || right.hopScore - left.hopScore
+    || right.path.hops - left.path.hops
+    || left.path.from.localeCompare(right.path.from)
+    || left.path.to.localeCompare(right.path.to)
+    || left.fromSourceFile.localeCompare(right.fromSourceFile)
+    || left.toSourceFile.localeCompare(right.toSourceFile)
+}
+
+function runtimePathCandidate(
+  graph: KnowledgeGraph,
+  start: NodeSummary,
+  terminal: NodeSummary,
+  traversal: RuntimeTraversal,
+): RuntimePathCandidate {
+  const startAttributes = graph.nodeAttributes(start.id)
+  return {
+    path: {
+      from: start.label,
+      to: terminal.label,
+      hops: traversal.hops,
+    },
+    fromSourceFile: start.sourceFile,
+    toSourceFile: terminal.sourceFile,
+    entryScore: entrypointScore(start, normalizeBoolean(startAttributes.exported)),
+    minDomainScore: traversal.minDomainScore,
+    relationScore: traversal.relationScore,
+    terminalScore: terminalNodeScore(terminal, graph),
+    hopScore: runtimeHopScore(traversal.hops),
   }
-  return left
 }
 
 function runtimePaths(graph: KnowledgeGraph, nodes: readonly NodeSummary[]): GraphSummaryRuntimePath[] {
   const runtimeNodeIds = new Set(nodes.filter((node) => node.runtimeEligible).map((node) => node.id))
   const nodeMap = new Map(nodes.map((node) => [node.id, node] as const))
-  const paths = new Map<string, GraphSummaryRuntimePath>()
+  const paths = new Map<string, RuntimePathCandidate>()
 
   for (const start of runtimeEntryCandidates(nodes)) {
-    const distances = shortestRuntimeDistances(graph, start.id, runtimeNodeIds)
-    const terminals = [...distances.entries()]
-      .filter(([nodeId, hops]) => nodeId !== start.id && hops > 0)
+    const traversals = bestRuntimeTraversals(graph, start, runtimeNodeIds, nodeMap)
+    const terminals = [...traversals.entries()]
+      .filter(([nodeId, traversal]) => nodeId !== start.id && traversal.hops > 0)
       .filter(([nodeId]) => graph.successors(nodeId).filter((neighbor) => runtimeNodeIds.has(neighbor)).length === 0)
-      .map(([nodeId, hops]) => ({
+      .map(([nodeId, traversal]) => ({
         node: nodeMap.get(nodeId),
-        hops,
+        traversal,
       }))
-      .filter((entry): entry is { node: NodeSummary; hops: number } => entry.node !== undefined)
-      .sort((left, right) => right.hops - left.hops
-        || left.node.label.localeCompare(right.node.label)
-        || left.node.sourceFile.localeCompare(right.node.sourceFile))
+      .filter((entry): entry is { node: NodeSummary; traversal: RuntimeTraversal } => entry.node !== undefined)
+      .map(({ node, traversal }) => runtimePathCandidate(graph, start, node, traversal))
+      .sort(compareRuntimePathCandidates)
 
     const best = terminals[0]
     if (!best) {
       continue
     }
 
-    const path = {
-      from: start.label,
-      to: best.node.label,
-      hops: best.hops,
-    }
+    const path = best.path
     const key = JSON.stringify([path.from, path.to])
     const existing = paths.get(key)
-    paths.set(key, existing ? strongerRuntimePath(existing, path) : path)
+    if (!existing || compareRuntimePathCandidates(best, existing) < 0) {
+      paths.set(key, best)
+    }
   }
 
   return sortedBounded(
     [...paths.values()],
-    (left, right) => left.from.localeCompare(right.from)
-      || left.to.localeCompare(right.to)
-      || left.hops - right.hops,
-  )
+    compareRuntimePathCandidates,
+  ).map((candidate) => candidate.path)
 }
 
 export function buildGraphSummary(graph: KnowledgeGraph): GraphSummary {

--- a/tests/unit/graph-summary.test.ts
+++ b/tests/unit/graph-summary.test.ts
@@ -313,6 +313,132 @@ describe('buildGraphSummary', () => {
     expect(repeatedSummary.runtime_paths).toEqual(summary.runtime_paths)
   })
 
+  it('prefers production runtime paths over benchmark paths when the summary is capped', () => {
+    const graph = makeManyRuntimePathsGraph(SUMMARY_ARRAY_CAP)
+
+    graph.addNode('benchmark-entry', {
+      label: 'ABenchmarkEntry',
+      source_file: 'benchmarks/runtime/entry.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'benchmark',
+    })
+    graph.addNode('benchmark-handler', {
+      label: 'ABenchmarkHandler',
+      source_file: 'benchmarks/runtime/handler.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'benchmark',
+    })
+    graph.addNode('benchmark-sink', {
+      label: 'ABenchmarkSink',
+      source_file: 'benchmarks/runtime/sink.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'benchmark',
+    })
+
+    graph.addEdge('benchmark-entry', 'benchmark-handler', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'benchmarks/runtime/entry.ts',
+    })
+    graph.addEdge('benchmark-handler', 'benchmark-sink', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'benchmarks/runtime/handler.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toHaveLength(SUMMARY_ARRAY_CAP)
+    expect(summary.runtime_paths).not.toContainEqual({
+      from: 'ABenchmarkEntry',
+      to: 'ABenchmarkSink',
+      hops: 2,
+    })
+    expect(summary.runtime_paths).toContainEqual({
+      from: 'RuntimeEntry09',
+      to: 'RuntimeSink09',
+      hops: 2,
+    })
+  })
+
+  it('ranks queue-backed runtime paths ahead of shallow helper paths', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('helper-entry', {
+      label: 'AHelperEntry',
+      source_file: 'src/helpers/entry.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('helper-terminal', {
+      label: 'AHelperTerminal',
+      source_file: 'src/helpers/terminal.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addEdge('helper-entry', 'helper-terminal', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/helpers/entry.ts',
+    })
+
+    graph.addNode('queue-route', {
+      label: 'ZQueueRoute',
+      source_file: 'src/routes/queue.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      node_kind: 'route',
+      route_path: '/jobs',
+    })
+    graph.addNode('queue-dispatcher', {
+      label: 'QueueDispatcher',
+      source_file: 'src/queue/dispatcher.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'service',
+    })
+    graph.addNode('queue-worker', {
+      label: 'QueueWorker',
+      source_file: 'src/queue/worker.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'worker',
+    })
+    graph.addEdge('queue-route', 'queue-dispatcher', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/routes/queue.ts',
+    })
+    graph.addEdge('queue-dispatcher', 'queue-worker', {
+      relation: 'enqueues_job',
+      confidence: 'EXTRACTED',
+      source_file: 'src/queue/dispatcher.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toEqual([
+      { from: 'ZQueueRoute', to: 'QueueWorker', hops: 2 },
+      { from: 'AHelperEntry', to: 'AHelperTerminal', hops: 1 },
+    ])
+  })
+
   it('keeps distinct runtime paths when labels contain control characters', () => {
     const graph = new KnowledgeGraph(true)
 


### PR DESCRIPTION
## Summary
- rank graph_summary runtime_paths by entrypoint signal, source-domain quality, relation quality, terminal usefulness, and bounded hop score
- demote benchmark/generated-style paths behind production paths while keeping deterministic bounded output and the existing response shape
- add regression tests for production-vs-benchmark truncation and queue-backed path ordering, and clarify README wording that graph_summary is a bounded overview, not a full runtime trace

## Test Plan
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- node dist/src/cli/bin.js summary /Users/mohammednaji/Desktop/projects/graphify-ts/graphify-out/graph.json > /tmp/issue-230-summary.json

Fixes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify that the MCP tools description is an intentionally compact summary rather than a full runtime trace.

* **Tests**
  * Added tests verifying runtime path prioritization when results are capped.
  * Added tests validating runtime path ranking and hop count accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/graphify-ts/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->