### PR TITLE
Fix Copilot MCP startup latency

### DIFF
--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -1326,7 +1326,7 @@ function readPackageName(packageRoot: string): string {
   return resolvePackageName(packageRoot)
 }
 
-function resolvePackageCliPath(packageRoot = findPackageRoot()): string {
+function readPackageCliDeclaration(packageRoot = findPackageRoot()): { packageJsonPath: string, cliPath: string | undefined } {
   const packageJsonPath = join(packageRoot, 'package.json')
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
   if (!isRecord(packageJson)) {
@@ -1349,10 +1349,18 @@ function resolvePackageCliPath(packageRoot = findPackageRoot()): string {
   }
 
   if (!relativeBinPath) {
-    throw new Error(`Could not locate a ${CLI_BIN_NAMES.join(' or ')} bin entry in ${packageJsonPath}`)
+    return { packageJsonPath, cliPath: undefined }
   }
 
-  const cliPath = join(packageRoot, relativeBinPath)
+  return { packageJsonPath, cliPath: join(packageRoot, relativeBinPath) }
+}
+
+function findPackageCliPath(packageRoot = findPackageRoot()): string | undefined {
+  const { cliPath } = readPackageCliDeclaration(packageRoot)
+  if (!cliPath) {
+    return undefined
+  }
+
   let cliPathIsFile = false
   try {
     cliPathIsFile = existsSync(cliPath) && statSync(cliPath).isFile()
@@ -1360,6 +1368,17 @@ function resolvePackageCliPath(packageRoot = findPackageRoot()): string {
     cliPathIsFile = false
   }
   if (!cliPathIsFile) {
+    return undefined
+  }
+  return cliPath
+}
+
+function resolvePackageCliPath(packageRoot = findPackageRoot()): string {
+  const { packageJsonPath, cliPath } = readPackageCliDeclaration(packageRoot)
+  if (!cliPath) {
+    throw new Error(`Could not locate a ${CLI_BIN_NAMES.join(' or ')} bin entry in ${packageJsonPath}`)
+  }
+  if (!existsSync(cliPath) || !statSync(cliPath).isFile()) {
     throw new Error(`Could not locate a ${CLI_BIN_NAMES.join(' or ')} CLI at ${cliPath} declared by ${packageJsonPath}`)
   }
   return cliPath
@@ -1437,6 +1456,7 @@ function installMcpServer(
   target: McpConfigTarget = 'claude',
   nodePlatform = process.platform,
   options: McpInstallOptions = {},
+  packageRoot = findPackageRoot(),
 ): string {
   const mcpJsonPath = join(projectDir, MCP_CONFIG_PATHS[target])
   ensureParentDirectory(mcpJsonPath)
@@ -1454,6 +1474,9 @@ function installMcpServer(
 
   const npxCommand = nodePlatform === 'win32' ? 'npx.cmd' : 'npx'
   const npxArgs = ['--yes', installPackageSpecifier(), 'serve', '--stdio', graphPath]
+  const directCliPath = isVscode ? findPackageCliPath(packageRoot) : undefined
+  const command = directCliPath ? process.execPath : npxCommand
+  const args = directCliPath ? [directCliPath, 'serve', '--stdio', graphPath] : npxArgs
   // Default to the lean MCP tool surface ("core" = 6 tools). Reduces cache_creation
   // overhead per session vs. advertising all tools. Users can opt into the full
   // 25-tool surface by setting MADAR_TOOL_PROFILE=full in this env block.
@@ -1468,7 +1491,7 @@ function installMcpServer(
     ? { ...existingEnv, MADAR_TOOL_PROFILE: envProfile }
     : { MADAR_TOOL_PROFILE: 'core', ...existingEnv }
   const serverConfig = isVscode
-    ? { type: 'stdio', command: npxCommand, args: npxArgs, env }
+    ? { type: 'stdio', command, args, env }
     : { command: npxCommand, args: npxArgs, env }
 
   mcpServers[SKILL_SLUG] = serverConfig
@@ -1868,8 +1891,8 @@ export function geminiUninstall(projectDir = '.', options: Pick<InstallSkillOpti
   return messages.join('\n')
 }
 
-export function installCopilotMcp(projectDir = '.', options: McpInstallOptions = {}): string {
-  const message = installMcpServer(resolve(projectDir), 'copilot', process.platform, options)
+export function installCopilotMcp(projectDir = '.', options: McpInstallOptions = {}, packageRoot = findPackageRoot()): string {
+  const message = installMcpServer(resolve(projectDir), 'copilot', process.platform, options, packageRoot)
   if (options.profile === 'strict') {
     return `${message}\n\nGitHub Copilot will now use the madar strict compact MCP profile: call context_pack once, answer from the pack when coverage is complete, and expand only when diagnostics show missing evidence.`
   }

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -1892,7 +1892,7 @@ export function geminiUninstall(projectDir = '.', options: Pick<InstallSkillOpti
 }
 
 export function installCopilotMcp(projectDir = '.', options: McpInstallOptions = {}, packageRoot = findPackageRoot()): string {
-  const message = installMcpServer(resolve(projectDir), 'copilot', process.platform, options, packageRoot)
+  const message = installMcpServer(resolve(projectDir), 'copilot', process.platform, options, resolve(packageRoot))
   if (options.profile === 'strict') {
     return `${message}\n\nGitHub Copilot will now use the madar strict compact MCP profile: call context_pack once, answer from the pack when coverage is complete, and expand only when diagnostics show missing evidence.`
   }

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import * as ts from 'typescript'
 
 import {
@@ -595,6 +595,29 @@ describe('install helpers', () => {
           '--stdio',
           normalizeAssertionPath(join(projectDir, 'out', 'graph.json')),
         ])
+      })
+    })
+  })
+
+  it('resolves a relative Copilot packageRoot before writing the CLI launcher path', () => {
+    withOpenCodePackageRoot((packageRoot, cliPath) => {
+      withTempDir((projectDir) => {
+        const installCopilotWithPackageRoot = installCopilotMcp as (
+          projectDir?: string,
+          options?: { profile?: 'core' | 'full' | 'strict' },
+          packageRoot?: string,
+        ) => string
+        installCopilotWithPackageRoot(projectDir, {}, normalizeAssertionPath(relative(process.cwd(), packageRoot)))
+
+        const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.vscode', 'mcp.json'), 'utf8')) as {
+          servers?: {
+            'madar'?: {
+              args?: string[]
+            }
+          }
+        }
+
+        expect(normalizeAssertionPaths(mcpConfig.servers?.['madar']?.args ?? []).at(0)).toBe(normalizeAssertionPath(cliPath))
       })
     })
   })

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -20,7 +20,7 @@ import {
   uninstallCopilotMcp,
   uninstallSkill,
 } from '../../src/infrastructure/install.js'
-import { normalizeAssertionPath } from './helpers/platform.js'
+import { normalizeAssertionPath, normalizeAssertionPaths } from './helpers/platform.js'
 
 const PACKAGE_CLI_RELATIVE_PATH = join('dist', 'src', 'cli', 'bin.js')
 
@@ -564,6 +564,38 @@ describe('install helpers', () => {
       }
 
       expect(mcpConfig.servers?.['madar']?.env?.MADAR_TOOL_PROFILE).toBe('core')
+    })
+  })
+
+  it('writes the VS Code Copilot MCP server as a direct CLI launch instead of npx', () => {
+    withOpenCodePackageRoot((packageRoot, cliPath) => {
+      withTempDir((projectDir) => {
+        const installCopilotWithPackageRoot = installCopilotMcp as (
+          projectDir?: string,
+          options?: { profile?: 'core' | 'full' | 'strict' },
+          packageRoot?: string,
+        ) => string
+        installCopilotWithPackageRoot(projectDir, {}, packageRoot)
+
+        const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.vscode', 'mcp.json'), 'utf8')) as {
+          servers?: {
+            'madar'?: {
+              type?: string
+              command?: string
+              args?: string[]
+            }
+          }
+        }
+
+        expect(mcpConfig.servers?.['madar']?.type).toBe('stdio')
+        expect(normalizeAssertionPath(mcpConfig.servers?.['madar']?.command ?? '')).toBe(normalizeAssertionPath(process.execPath))
+        expect(normalizeAssertionPaths(mcpConfig.servers?.['madar']?.args ?? [])).toEqual([
+          normalizeAssertionPath(cliPath),
+          'serve',
+          '--stdio',
+          normalizeAssertionPath(join(projectDir, 'out', 'graph.json')),
+        ])
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- write Copilot MCP configs to launch the local madar CLI directly through Node when available
- keep the existing npx fallback when the local CLI is unavailable
- add a regression test for the direct Copilot launcher path

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced MCP server installation for VS Code/Copilot with improved CLI binary path detection and fallback handling.
  * MCP server config can prefer launching a directly resolved CLI executable (when available) instead of using npx.
  * installCopilotMcp now accepts an optional packageRoot to control package resolution.

* **Tests**
  * Added unit tests validating VS Code Copilot MCP config for direct CLI launches and relative packageRoot resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->