### PR TITLE
Add execution_slice phase and branch modeling

### DIFF
--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -68,10 +68,45 @@ export interface ContextPackExecutionSliceStep {
   framework_role?: string
 }
 
+export interface ContextPackExecutionSliceBoundary {
+  from?: string
+  to?: string
+  relation: string
+}
+
+export interface ContextPackExecutionSliceBranch {
+  steps: ContextPackExecutionSliceStep[]
+  boundary_reason?: string
+}
+
+export interface ContextPackExecutionSliceOmittedBranch {
+  from?: string
+  to?: string
+  relation?: string
+  reason?: string
+}
+
+export interface ContextPackExecutionSlicePrimaryPath {
+  steps: ContextPackExecutionSliceStep[]
+  boundaries?: ContextPackExecutionSliceBoundary[]
+  boundary_reason?: string
+}
+
+export interface ContextPackExecutionSlicePhaseCoverage {
+  expected: string[]
+  observed: string[]
+  missing: string[]
+}
+
 export interface ContextPackExecutionSlice {
   status: 'complete' | 'partial'
   boundary_reason?: string
   steps: ContextPackExecutionSliceStep[]
+  primary_path?: ContextPackExecutionSlicePrimaryPath
+  side_effects?: ContextPackExecutionSliceBranch[]
+  terminal_boundaries?: ContextPackExecutionSliceBranch[]
+  omitted_branches?: ContextPackExecutionSliceOmittedBranch[]
+  phase_coverage?: ContextPackExecutionSlicePhaseCoverage
 }
 
 export type ContextRepresentationType =

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1250,6 +1250,26 @@ function hasHttpVerbIntent(question: string, questionTokens: readonly string[], 
   return hasHeadVerb && includesAnyToken(questionTokens, ['request', 'requests'])
 }
 
+function promptWantsControllerStep(question: string): boolean {
+  const questionTokens = tokenizeQuestion(question)
+  const hasRoutePath = containsUrlLikeRoutePath(question)
+  const hasRouteKeyword = includesAnyToken(questionTokens, [
+    'route', 'routes', 'router', 'controller', 'controllers', 'handler', 'handlers', 'endpoint', 'endpoints', 'request', 'requests',
+  ])
+
+  return hasRoutePath || hasHttpVerbIntent(question, questionTokens, hasRoutePath, hasRouteKeyword) || hasRouteKeyword
+}
+
+function promptWantsServiceStep(question: string): boolean {
+  if (promptWantsControllerStep(question)) {
+    return true
+  }
+
+  const questionTokens = tokenizeQuestion(question)
+  return includesAnyToken(questionTokens, ['service', 'services', 'provider', 'providers', 'usecase', 'usecases', 'application', 'applications'])
+    || /\b(?:use-case|orchestrator)\b/i.test(question)
+}
+
 function promptWantsRuntimePipeline(question: string): boolean {
   return /\b(runtime|pipeline|service|orchestrator|job|agent|scoring|report(?: builder)?|persistence|repository|queue|worker)\b/i.test(question)
 }
@@ -1667,7 +1687,7 @@ function workerLikeExecutionStep(
   node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
 ): boolean {
   const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
-  return /\b(?:worker|processor|process\b|orchestrator)\b/.test(lower)
+  return /\b(?:worker|processor|process(?:[-_/]\w+))\b/.test(lower)
 }
 
 function lowValueExecutionStep(
@@ -1699,7 +1719,13 @@ function executionPhasesForStep(step: ContextPackExecutionSliceStep): Set<Execut
 }
 
 function expectedExecutionPhases(question: string): ExecutionPhase[] {
-  const phases: ExecutionPhase[] = ['controller', 'service']
+  const phases: ExecutionPhase[] = []
+  if (promptWantsControllerStep(question)) {
+    phases.push('controller')
+  }
+  if (promptWantsServiceStep(question)) {
+    phases.push('service')
+  }
   if (promptWantsRuntimePipeline(question)) {
     phases.push('queue', 'worker')
   }
@@ -1893,7 +1919,10 @@ function phaseCoverageForPath(
       observed.add('worker')
     }
   }
-  const orderedObserved = expected.filter((phase) => observed.has(phase))
+  const orderedObserved = [
+    ...expected.filter((phase) => observed.has(phase)),
+    ...[...observed].filter((phase) => !expected.includes(phase)),
+  ]
   const missing = expected.filter((phase) => !observed.has(phase))
   return { expected, observed: orderedObserved, missing }
 }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -3,6 +3,9 @@ import { basename } from 'node:path'
 
 import type {
   ContextPackExecutionSlice,
+  ContextPackExecutionSliceBoundary,
+  ContextPackExecutionSliceBranch,
+  ContextPackExecutionSliceOmittedBranch,
   ContextPackExecutionSliceStep,
   CompiledContextPack,
   ContextPackClaim,
@@ -1557,6 +1560,19 @@ function executionSliceStepFromGraph(
   }
 }
 
+type ExecutionPhase = 'controller' | 'service' | 'queue' | 'worker' | 'persistence'
+
+interface ExecutionFlowEdge {
+  fromId: string
+  toId: string
+  relation: string
+}
+
+interface ExecutionPathCandidate {
+  nodeIds: string[]
+  edges: ExecutionFlowEdge[]
+}
+
 function collectExecutionSliceScope(
   graph: KnowledgeGraph,
   sliceMetadata: ContextPackSliceMetadata,
@@ -1624,6 +1640,358 @@ function collectExecutionSliceScope(
   }
 
   return { orderedIds, idSet }
+}
+
+function controllerLikeExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:route|controller|handler|endpoint)\b/.test(lower)
+}
+
+function serviceLikeExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:service|provider|application|usecase|use-case|trigger|orchestrator)\b/.test(lower)
+}
+
+function queueLikeExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:queue|enqueue|job|addjob|pipeline)\b/.test(lower)
+}
+
+function workerLikeExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:worker|processor|process\b|orchestrator)\b/.test(lower)
+}
+
+function lowValueExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:logger|log|status|getstatus|get|list|health|validate|validator|suggest|guard|interceptor|swagger|spec|test|env|config)\b/.test(lower)
+    || /(?:^|[.#])(?:get|list|status|validate|suggest)[A-Za-z_$\w]*\(?\)?$/i.test(node.label)
+    || /^process\(\)$/i.test(node.label)
+    || /^\.add\(\)$/i.test(node.label)
+}
+
+function terminalBoundaryExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /(?:^|[.#])(?:cancel|claim|status|get|list|retry)[A-Za-z_$\w]*\(?\)?$/i.test(node.label)
+    || /\b(?:cancel|claim|status)\b/.test(lower)
+}
+
+function executionPhasesForStep(step: ContextPackExecutionSliceStep): Set<ExecutionPhase> {
+  const phases = new Set<ExecutionPhase>()
+  if (controllerLikeExecutionStep(step)) phases.add('controller')
+  if (serviceLikeExecutionStep(step)) phases.add('service')
+  if (queueLikeExecutionStep(step)) phases.add('queue')
+  if (workerLikeExecutionStep(step)) phases.add('worker')
+  if (persistenceLikeExecutionStep(step)) phases.add('persistence')
+  return phases
+}
+
+function expectedExecutionPhases(question: string): ExecutionPhase[] {
+  const phases: ExecutionPhase[] = ['controller', 'service']
+  if (promptWantsRuntimePipeline(question)) {
+    phases.push('queue', 'worker')
+  }
+  if (promptExpectsPersistenceStep(question)) {
+    phases.push('persistence')
+  }
+  return [...new Set(phases)]
+}
+
+function missingExecutionPhaseBoundaryReason(phase: ExecutionPhase): string {
+  switch (phase) {
+    case 'worker':
+      return 'missing expected worker phase'
+    case 'persistence':
+      return 'missing expected persistence phase'
+    case 'queue':
+      return 'missing expected queue phase'
+    case 'service':
+      return 'missing expected service phase'
+    case 'controller':
+    default:
+      return 'missing expected controller phase'
+  }
+}
+
+function executionFlowAdjacency(
+  graph: KnowledgeGraph,
+  sliceMetadata: ContextPackSliceMetadata,
+  idSet: ReadonlySet<string>,
+  resolveNodeId: (nodeId: string | undefined, label: string) => string | undefined,
+): Map<string, ExecutionFlowEdge[]> {
+  const adjacency = new Map<string, ExecutionFlowEdge[]>()
+  const record = (edge: ExecutionFlowEdge): void => {
+    const current = adjacency.get(edge.fromId) ?? []
+    current.push(edge)
+    adjacency.set(edge.fromId, current)
+  }
+
+  for (const path of sliceMetadata.selected_paths) {
+    if (path.direction !== 'forward' || !executionSliceFlowRelation(path.relation)) {
+      continue
+    }
+    const fromId = resolveNodeId(path.from_id, path.from)
+    const toId = resolveNodeId(path.to_id, path.to)
+    if (!fromId || !toId || !idSet.has(fromId) || !idSet.has(toId)) {
+      continue
+    }
+    record({ fromId, toId, relation: path.relation })
+  }
+
+  if (adjacency.size > 0) {
+    return adjacency
+  }
+
+  for (const fromId of idSet) {
+    for (const toId of graph.successors(fromId)) {
+      if (!idSet.has(toId)) {
+        continue
+      }
+      const relation = String(graph.edgeAttributes(fromId, toId).relation ?? 'related_to')
+      if (!executionSliceFlowRelation(relation)) {
+        continue
+      }
+      record({ fromId, toId, relation })
+    }
+  }
+
+  return adjacency
+}
+
+function enumerateExecutionPaths(
+  adjacency: ReadonlyMap<string, ExecutionFlowEdge[]>,
+  startId: string,
+  blockedIds: ReadonlySet<string> = new Set(),
+  maxDepth: number = 8,
+): ExecutionPathCandidate[] {
+  const visit = (
+    currentId: string,
+    visited: Set<string>,
+    nodeIds: string[],
+    edges: ExecutionFlowEdge[],
+  ): ExecutionPathCandidate[] => {
+    const partial = [{ nodeIds, edges }]
+    if (edges.length >= maxDepth) {
+      return partial
+    }
+
+    const candidates = (adjacency.get(currentId) ?? [])
+      .filter((edge) => !visited.has(edge.toId) && !blockedIds.has(edge.toId))
+    if (candidates.length === 0) {
+      return partial
+    }
+
+    return [
+      ...partial,
+      ...candidates.flatMap((edge) => {
+      const nextVisited = new Set(visited)
+      nextVisited.add(edge.toId)
+      return visit(edge.toId, nextVisited, [...nodeIds, edge.toId], [...edges, edge])
+      }),
+    ]
+  }
+
+  return visit(startId, new Set([startId]), [startId], [])
+}
+
+function executionPathScore(
+  path: ExecutionPathCandidate,
+  nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
+  question: string,
+): number {
+  const steps = path.nodeIds
+    .map((nodeId) => nodeById.get(nodeId))
+    .filter((step): step is ContextPackExecutionSliceStep => step !== undefined)
+  const observedPhases = new Set<ExecutionPhase>()
+  for (const step of steps) {
+    for (const phase of executionPhasesForStep(step)) {
+      observedPhases.add(phase)
+    }
+  }
+
+  let score = steps.reduce((total, step) => total + executionSliceStepPriority(step, question), 0)
+  if (observedPhases.has('controller')) score += 10
+  if (observedPhases.has('service')) score += 20
+  if (observedPhases.has('queue')) score += 35
+  if (observedPhases.has('worker')) score += 45
+  if (observedPhases.has('persistence')) score += 90
+  if (path.edges.some((edge) => edge.relation === 'enqueues_job')) score += 30
+
+  if (promptExpectsPersistenceStep(question) && !observedPhases.has('persistence')) {
+    score -= 120
+  }
+  if (promptWantsRuntimePipeline(question) && observedPhases.has('queue') && !observedPhases.has('worker')) {
+    score -= 60
+  }
+
+  const lastStep = steps.at(-1)
+  const lastStepPhases = lastStep ? executionPhasesForStep(lastStep) : new Set<ExecutionPhase>()
+  if (
+    promptExpectsPersistenceStep(question)
+    && observedPhases.has('worker')
+    && !observedPhases.has('persistence')
+    && lastStep
+    && !lastStepPhases.has('worker')
+    && !lastStepPhases.has('persistence')
+  ) {
+    score -= 35
+  }
+  if (lastStep && terminalBoundaryExecutionStep(lastStep)) {
+    score -= 15
+  }
+  if (lastStep && lowValueExecutionStep(lastStep)) {
+    score -= 40
+  }
+
+  return score + path.edges.length
+}
+
+function primaryPathBoundaries(
+  path: ExecutionPathCandidate,
+  nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
+): ContextPackExecutionSliceBoundary[] {
+  return path.edges
+    .filter((edge) => edge.relation === 'enqueues_job')
+    .map((edge) => {
+      const from = nodeById.get(edge.fromId)?.label
+      const to = nodeById.get(edge.toId)?.label
+      return {
+        ...(from ? { from } : {}),
+        ...(to ? { to } : {}),
+        relation: edge.relation,
+      }
+    })
+}
+
+function phaseCoverageForPath(
+  steps: readonly ContextPackExecutionSliceStep[],
+  boundaries: readonly ContextPackExecutionSliceBoundary[],
+  question: string,
+): { expected: ExecutionPhase[]; observed: ExecutionPhase[]; missing: ExecutionPhase[] } {
+  const expected = expectedExecutionPhases(question)
+  const observed = new Set<ExecutionPhase>()
+  for (const step of steps) {
+    for (const phase of executionPhasesForStep(step)) {
+      observed.add(phase)
+    }
+  }
+  if (boundaries.some((boundary) => boundary.relation === 'enqueues_job')) {
+    observed.add('queue')
+    if (steps.some((step) => workerLikeExecutionStep(step))) {
+      observed.add('worker')
+    }
+  }
+  const orderedObserved = expected.filter((phase) => observed.has(phase))
+  const missing = expected.filter((phase) => !observed.has(phase))
+  return { expected, observed: orderedObserved, missing }
+}
+
+function branchBoundaryReason(
+  branchSteps: readonly ContextPackExecutionSliceStep[],
+  kind: 'side_effect' | 'terminal' | 'omitted',
+): string | undefined {
+  if (kind === 'terminal') {
+    return 'branch terminates before rejoining the primary runtime path'
+  }
+  if (kind === 'omitted') {
+    return 'low-value branch omitted from compact execution slice'
+  }
+  if (branchSteps.some((step) => lowValueExecutionStep(step))) {
+    return 'secondary branch summarized to preserve compact output'
+  }
+  return undefined
+}
+
+function classifyExecutionBranch(
+  branchSteps: readonly ContextPackExecutionSliceStep[],
+): 'side_effect' | 'terminal' | 'omitted' {
+  if (branchSteps.length === 0 || branchSteps.every((step) => lowValueExecutionStep(step))) {
+    return 'omitted'
+  }
+  if (terminalBoundaryExecutionStep(branchSteps.at(-1) ?? branchSteps[0]!)) {
+    return 'terminal'
+  }
+  return 'side_effect'
+}
+
+function collectExecutionBranches(
+  adjacency: ReadonlyMap<string, ExecutionFlowEdge[]>,
+  primaryPath: ExecutionPathCandidate,
+  nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
+  question: string,
+): {
+  sideEffects: ContextPackExecutionSliceBranch[]
+  terminalBoundaries: ContextPackExecutionSliceBranch[]
+  omittedBranches: ContextPackExecutionSliceOmittedBranch[]
+} {
+  const primaryEdgeKeys = new Set(primaryPath.edges.map((edge) => `${edge.fromId}:${edge.relation}:${edge.toId}`))
+  const primaryNodeIds = new Set(primaryPath.nodeIds)
+  const branchStartSeen = new Set<string>()
+  const sideEffects: ContextPackExecutionSliceBranch[] = []
+  const terminalBoundaries: ContextPackExecutionSliceBranch[] = []
+  const omittedBranches: ContextPackExecutionSliceOmittedBranch[] = []
+
+  for (const nodeId of primaryPath.nodeIds) {
+    for (const edge of adjacency.get(nodeId) ?? []) {
+      const edgeKey = `${edge.fromId}:${edge.relation}:${edge.toId}`
+      if (primaryEdgeKeys.has(edgeKey) || branchStartSeen.has(edgeKey)) {
+        continue
+      }
+      branchStartSeen.add(edgeKey)
+
+      const branchCandidates = enumerateExecutionPaths(adjacency, edge.toId, primaryNodeIds, 4)
+      const branchPath = branchCandidates.sort((left, right) =>
+        executionPathScore(right, nodeById, question) - executionPathScore(left, nodeById, question)
+      )[0] ?? { nodeIds: [edge.toId], edges: [] }
+      const branchSteps = branchPath.nodeIds
+        .map((id) => nodeById.get(id))
+        .filter((step): step is ContextPackExecutionSliceStep => step !== undefined)
+        .slice(0, 3)
+      const branchKind = classifyExecutionBranch(branchSteps)
+      const branchReason = branchBoundaryReason(branchSteps, branchKind)
+
+      if (branchKind === 'side_effect' && sideEffects.length < 3) {
+        sideEffects.push({
+          steps: branchSteps,
+          ...(branchReason ? { boundary_reason: branchReason } : {}),
+        })
+        continue
+      }
+
+      if (branchKind === 'terminal' && terminalBoundaries.length < 3) {
+        terminalBoundaries.push({
+          steps: branchSteps,
+          ...(branchReason ? { boundary_reason: branchReason } : {}),
+        })
+        continue
+      }
+
+      if (omittedBranches.length < 6) {
+        const from = nodeById.get(edge.fromId)?.label
+        const to = nodeById.get(edge.toId)?.label
+        omittedBranches.push({
+          ...(from ? { from } : {}),
+          ...(to ? { to } : {}),
+          relation: edge.relation,
+          ...(branchReason ? { reason: branchReason } : {}),
+        })
+      }
+    }
+  }
+
+  return { sideEffects, terminalBoundaries, omittedBranches }
 }
 
 function pickExecutionSliceStart(
@@ -1744,31 +2112,79 @@ function buildExecutionSlice(
     }
   }
 
-  const orderedPathIds = walkExecutionSlice(graph, startId, idSet, nodeById, question)
+  const adjacency = executionFlowAdjacency(graph, sliceMetadata, idSet, resolveNodeId)
+  const pathCandidates = enumerateExecutionPaths(adjacency, startId)
+  const primaryPathCandidates = pathCandidates.length > 0 ? pathCandidates : [{
+    nodeIds: walkExecutionSlice(graph, startId, idSet, nodeById, question),
+    edges: [] as ExecutionFlowEdge[],
+  }]
+  const primaryPath = primaryPathCandidates.sort((left, right) =>
+    executionPathScore(right, nodeById, question) - executionPathScore(left, nodeById, question)
+  )[0]!
 
-  const seen = new Set<string>()
-  const steps = orderedPathIds.flatMap((nodeId) => {
-    if (seen.has(nodeId)) {
-      return []
-    }
-    seen.add(nodeId)
-    const node = nodeById.get(nodeId)
-    return node ? [node] : []
-  })
+  const steps = primaryPath.nodeIds
+    .map((nodeId) => nodeById.get(nodeId))
+    .filter((step): step is ContextPackExecutionSliceStep => step !== undefined)
+  const boundaries = primaryPathBoundaries(primaryPath, nodeById)
+  const phaseCoverage = phaseCoverageForPath(steps, boundaries, question)
+  const missingPhase = phaseCoverage.missing[0]
+  const boundaryReason = missingPhase ? missingExecutionPhaseBoundaryReason(missingPhase) : undefined
+  const branches = collectExecutionBranches(adjacency, primaryPath, nodeById, question)
 
-  const expectsPersistence = promptExpectsPersistenceStep(question)
-  const reachedPersistence = steps.some((step) => persistenceLikeExecutionStep(step))
+  return {
+    status: missingPhase ? 'partial' : 'complete',
+    ...(boundaryReason ? { boundary_reason: boundaryReason } : {}),
+    steps,
+    primary_path: {
+    steps,
+    ...(boundaries.length > 0 ? { boundaries } : {}),
+    ...(boundaryReason ? { boundary_reason: boundaryReason } : {}),
+    },
+    ...(branches.sideEffects.length > 0 ? { side_effects: branches.sideEffects } : {}),
+    ...(branches.terminalBoundaries.length > 0 ? { terminal_boundaries: branches.terminalBoundaries } : {}),
+    ...(branches.omittedBranches.length > 0 ? { omitted_branches: branches.omittedBranches } : {}),
+    phase_coverage: phaseCoverage,
+  }
+}
 
-  return expectsPersistence && !reachedPersistence
-    ? {
-        status: 'partial',
-        boundary_reason: 'slice stops before expected persistence step',
-        steps,
-      }
-    : {
-        status: 'complete',
-        steps,
-      }
+function compactExecutionSliceStep(step: ContextPackExecutionSliceStep): ContextPackExecutionSliceStep {
+  return {
+    label: step.label,
+    source_file: basename(step.source_file),
+    line_number: step.line_number,
+  }
+}
+
+function compactExecutionSliceBranch(branch: ContextPackExecutionSliceBranch): ContextPackExecutionSliceBranch {
+  return {
+    steps: branch.steps.map(compactExecutionSliceStep),
+    ...(branch.boundary_reason ? { boundary_reason: branch.boundary_reason } : {}),
+  }
+}
+
+function compactExecutionSlice(executionSlice: ContextPackExecutionSlice | undefined): ContextPackExecutionSlice | undefined {
+  if (!executionSlice) {
+    return undefined
+  }
+
+  return {
+    status: executionSlice.status,
+    ...(executionSlice.boundary_reason ? { boundary_reason: executionSlice.boundary_reason } : {}),
+    steps: executionSlice.steps.map(compactExecutionSliceStep),
+    ...(executionSlice.primary_path
+      ? {
+          primary_path: {
+            steps: executionSlice.primary_path.steps.map(compactExecutionSliceStep),
+            ...(executionSlice.primary_path.boundaries ? { boundaries: executionSlice.primary_path.boundaries } : {}),
+            ...(executionSlice.primary_path.boundary_reason ? { boundary_reason: executionSlice.primary_path.boundary_reason } : {}),
+          },
+        }
+      : {}),
+    ...(executionSlice.side_effects ? { side_effects: executionSlice.side_effects.map(compactExecutionSliceBranch) } : {}),
+    ...(executionSlice.terminal_boundaries ? { terminal_boundaries: executionSlice.terminal_boundaries.map(compactExecutionSliceBranch) } : {}),
+    ...(executionSlice.omitted_branches ? { omitted_branches: executionSlice.omitted_branches } : {}),
+    ...(executionSlice.phase_coverage ? { phase_coverage: executionSlice.phase_coverage } : {}),
+  }
 }
 
 function buildFrameworkQuestionProfile(question: string, questionTokens: readonly string[]): FrameworkQuestionProfile {
@@ -3177,7 +3593,7 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
   const compactFrameworkLimit =
     frameworkProfile.frameworkShaped && result.matched_nodes.some((node) => (node.framework_boost ?? 0) > 0) ? 5 : Number.POSITIVE_INFINITY
   const fullPack = contextPackFromRetrieveResult(result)
-  const executionSlice = result.execution_slice
+  const executionSlice = compactExecutionSlice(result.execution_slice)
   const promotedSliceNodeIds = promotedSliceCompactNodeIds(result)
   const compactPack = promotedSliceNodeIds.length > 0
     ? compactContextPack(fullPack, {

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1254,17 +1254,13 @@ function promptWantsControllerStep(question: string): boolean {
   const questionTokens = tokenizeQuestion(question)
   const hasRoutePath = containsUrlLikeRoutePath(question)
   const hasRouteKeyword = includesAnyToken(questionTokens, [
-    'route', 'routes', 'router', 'controller', 'controllers', 'handler', 'handlers', 'endpoint', 'endpoints', 'request', 'requests',
+    'route', 'routes', 'router', 'controller', 'controllers', 'handler', 'handlers', 'endpoint', 'endpoints',
   ])
 
   return hasRoutePath || hasHttpVerbIntent(question, questionTokens, hasRoutePath, hasRouteKeyword) || hasRouteKeyword
 }
 
 function promptWantsServiceStep(question: string): boolean {
-  if (promptWantsControllerStep(question)) {
-    return true
-  }
-
   const questionTokens = tokenizeQuestion(question)
   return includesAnyToken(questionTokens, ['service', 'services', 'provider', 'providers', 'usecase', 'usecases', 'application', 'applications'])
     || /\b(?:use-case|orchestrator)\b/i.test(question)
@@ -1906,6 +1902,7 @@ function phaseCoverageForPath(
   boundaries: readonly ContextPackExecutionSliceBoundary[],
   question: string,
 ): { expected: ExecutionPhase[]; observed: ExecutionPhase[]; missing: ExecutionPhase[] } {
+  const phaseOrder: ExecutionPhase[] = ['controller', 'service', 'queue', 'worker', 'persistence']
   const expected = expectedExecutionPhases(question)
   const observed = new Set<ExecutionPhase>()
   for (const step of steps) {
@@ -1919,10 +1916,7 @@ function phaseCoverageForPath(
       observed.add('worker')
     }
   }
-  const orderedObserved = [
-    ...expected.filter((phase) => observed.has(phase)),
-    ...[...observed].filter((phase) => !expected.includes(phase)),
-  ]
+  const orderedObserved = phaseOrder.filter((phase) => observed.has(phase))
   const missing = expected.filter((phase) => !observed.has(phase))
   return { expected, observed: orderedObserved, missing }
 }

--- a/src/runtime/retrieve/slicing.ts
+++ b/src/runtime/retrieve/slicing.ts
@@ -189,6 +189,22 @@ function effectivePolicy(
     }
   }
 
+  if (broadRuntimeGeneration && pipelinePrompt) {
+    return {
+      ...base,
+      backward_relations: new Set(['controller_route', 'route_handler', 'method']),
+      forward_relations: new Set([...base.forward_relations, ...RUNTIME_FLOW_RELATIONS]),
+      helper_relations: new Set([
+        ...base.helper_relations,
+        'injects',
+        'depends_on',
+        'module_provides',
+      ]),
+      backward_depth: 1,
+      forward_depth: Math.max(base.forward_depth, 5),
+    }
+  }
+
   if (hasExactMethodAnchor && pipelinePrompt) {
     return {
       ...base,

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -14,13 +14,19 @@ function buildRuntimeGenerationGraph() {
           { id: 'auth_route', label: 'POST /login', file_type: 'code', source_file: '/src/auth/routes.ts', source_location: 'L10', node_kind: 'route', framework: 'express', framework_role: 'express_route', community: 0 },
           { id: 'auth_controller', label: 'AuthController.login', file_type: 'code', source_file: '/src/auth/controller.ts', source_location: 'L20', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_controller', community: 0 },
           { id: 'auth_service', label: 'AuthService.login', file_type: 'code', source_file: '/src/auth/service.ts', source_location: 'L30', node_kind: 'method', community: 0 },
-          { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L40', node_kind: 'method', community: 1 },
-          { id: 'auth_test', label: 'AuthService.login.spec', file_type: 'code', source_file: '/tests/auth.service.spec.ts', source_location: 'L50', node_kind: 'function', community: 2 },
+          { id: 'queue_registry', label: 'QueueRegistry.addJob', file_type: 'code', source_file: '/src/queue/registry.ts', source_location: 'L40', node_kind: 'method', community: 1 },
+          { id: 'auth_worker', label: 'AuthWorker.process', file_type: 'code', source_file: '/src/auth/worker.ts', source_location: 'L50', node_kind: 'method', framework_role: 'worker', community: 1 },
+          { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L60', node_kind: 'method', community: 1 },
+          { id: 'audit_publisher', label: 'AuditPublisher.publishLogin', file_type: 'code', source_file: '/src/auth/audit.ts', source_location: 'L70', node_kind: 'method', community: 2 },
+          { id: 'auth_test', label: 'AuthService.login.spec', file_type: 'code', source_file: '/tests/auth.service.spec.ts', source_location: 'L80', node_kind: 'function', community: 2 },
         ],
         edges: [
           { source: 'auth_route', target: 'auth_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: '/src/auth/routes.ts' },
           { source: 'auth_controller', target: 'auth_service', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
-          { source: 'auth_service', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          { source: 'auth_service', target: 'queue_registry', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          { source: 'auth_service', target: 'audit_publisher', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          { source: 'queue_registry', target: 'auth_worker', relation: 'enqueues_job', confidence: 'EXTRACTED', source_file: '/src/queue/registry.ts' },
+          { source: 'auth_worker', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/worker.ts' },
           { source: 'auth_service', target: 'auth_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
         ],
       },
@@ -55,6 +61,12 @@ describe('context-pack-command', () => {
         execution_slice?: {
           status?: string
           steps?: Array<{ label?: string }>
+          primary_path?: {
+            boundaries?: Array<{ relation?: string }>
+          }
+          phase_coverage?: {
+            missing?: string[]
+          }
         }
       }
     }
@@ -66,15 +78,27 @@ describe('context-pack-command', () => {
       taskIntent: 'explain',
       retrievalStrategy: 'slice-v1',
     })
-    expect(payload.pack?.execution_slice).toEqual({
+    expect(payload.pack?.execution_slice).toEqual(expect.objectContaining({
       status: 'complete',
       steps: [
         expect.objectContaining({ label: 'POST /login' }),
         expect.objectContaining({ label: 'AuthController.login' }),
         expect.objectContaining({ label: 'AuthService.login' }),
+        expect.objectContaining({ label: 'QueueRegistry.addJob' }),
+        expect.objectContaining({ label: 'AuthWorker.process' }),
         expect.objectContaining({ label: 'SessionStore.createSession' }),
       ],
-    })
+      primary_path: expect.objectContaining({
+        boundaries: expect.arrayContaining([
+          expect.objectContaining({ relation: 'enqueues_job' }),
+        ]),
+      }),
+      phase_coverage: {
+        expected: ['controller', 'service', 'queue', 'worker', 'persistence'],
+        observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker', 'persistence']),
+        missing: [],
+      },
+    }))
   })
 
   it('normalizes sub-minimum explain budgets before retrieving', async () => {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -94,8 +94,8 @@ describe('context-pack-command', () => {
         ]),
       }),
       phase_coverage: {
-        expected: ['controller', 'service', 'queue', 'worker', 'persistence'],
-        observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker', 'persistence']),
+        expected: ['controller', 'queue', 'worker', 'persistence'],
+        observed: ['controller', 'service', 'queue', 'worker', 'persistence'],
         missing: [],
       },
     }))

--- a/tests/unit/retrieve-slice-v1.test.ts
+++ b/tests/unit/retrieve-slice-v1.test.ts
@@ -51,8 +51,22 @@ interface ExecutionSliceExpectation {
   }
 }
 
-function buildSliceGraph(options: { includeWorkerStep?: boolean; includePersistenceStep?: boolean } = {}) {
-  const { includeWorkerStep = true, includePersistenceStep = true } = options
+function buildSliceGraph(
+  options: {
+    includeWorkerStep?: boolean
+    includePersistenceStep?: boolean
+    workerLabel?: string
+    workerSourceFile?: string
+    workerFrameworkRole?: string
+  } = {},
+) {
+  const {
+    includeWorkerStep = true,
+    includePersistenceStep = true,
+    workerLabel = 'AuthWorker.process',
+    workerSourceFile = '/src/auth/worker.ts',
+    workerFrameworkRole = 'worker',
+  } = options
 
   return build(
     [
@@ -65,7 +79,7 @@ function buildSliceGraph(options: { includeWorkerStep?: boolean; includePersiste
           { id: 'auth_service', label: 'AuthService.login', file_type: 'code', source_file: '/src/auth/service.ts', source_location: 'L40', node_kind: 'method', community: 0 },
           { id: 'login_validator', label: 'LoginValidator.validate', file_type: 'code', source_file: '/src/auth/login-validator.ts', source_location: 'L50', node_kind: 'method', community: 0 },
           { id: 'queue_registry', label: 'QueueRegistry.addJob', file_type: 'code', source_file: '/src/queue/registry.ts', source_location: 'L60', node_kind: 'method', community: 1 },
-          { id: 'auth_worker', label: 'AuthWorker.process', file_type: 'code', source_file: '/src/auth/worker.ts', source_location: 'L70', node_kind: 'method', framework_role: 'worker', community: 1 },
+          { id: 'auth_worker', label: workerLabel, file_type: 'code', source_file: workerSourceFile, source_location: 'L70', node_kind: 'method', framework_role: workerFrameworkRole, community: 1 },
           { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L80', node_kind: 'method', community: 1 },
           { id: 'audit_publisher', label: 'AuditPublisher.publishLogin', file_type: 'code', source_file: '/src/auth/audit.ts', source_location: 'L90', node_kind: 'method', community: 2 },
           { id: 'session_notifier', label: 'SessionNotifier.sendLoginWebhook', file_type: 'code', source_file: '/src/auth/notifier.ts', source_location: 'L100', node_kind: 'method', community: 2 },
@@ -106,6 +120,26 @@ function buildSliceGraph(options: { includeWorkerStep?: boolean; includePersiste
           { source: 'api_client', target: 'billing_exporter', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/api/client.ts' },
           { source: 'auth_service', target: 'shared_index', relation: 'imports_from', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
           { source: 'shared_index', target: 'shared_cookie', relation: 'exports', confidence: 'EXTRACTED', source_file: '/src/shared/index.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
+function buildWorkerSegmentGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'queue_registry', label: 'QueueRegistry.addJob', file_type: 'code', source_file: '/src/queue/registry.ts', source_location: 'L10', node_kind: 'method', framework_role: 'queue', community: 0 },
+          { id: 'auth_worker', label: 'AuthWorker.process', file_type: 'code', source_file: '/src/auth/worker.ts', source_location: 'L20', node_kind: 'method', framework_role: 'worker', community: 1 },
+          { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L30', node_kind: 'method', framework_role: 'repository', community: 1 },
+        ],
+        edges: [
+          { source: 'queue_registry', target: 'auth_worker', relation: 'enqueues_job', confidence: 'EXTRACTED', source_file: '/src/queue/registry.ts' },
+          { source: 'auth_worker', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/worker.ts' },
         ],
       },
     ],
@@ -305,6 +339,50 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
     expect(compact.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
       expected: expect.arrayContaining(['persistence']),
       missing: expect.arrayContaining(['persistence']),
+    }))
+  })
+
+  it('marks runtime paths partial when queue work only reaches a generic orchestrator.process step', () => {
+    const compact = compactFor(
+      'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
+      buildSliceGraph({
+        workerLabel: 'JobOrchestrator.process',
+        workerSourceFile: '/src/auth/orchestrator.ts',
+        workerFrameworkRole: 'orchestrator',
+      }),
+    )
+
+    expect(compact.execution_slice?.status).toBe('partial')
+    expect(compact.execution_slice?.boundary_reason).toMatch(/worker/i)
+    expect(compact.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
+      missing: expect.arrayContaining(['worker']),
+    }))
+  })
+
+  it('does not require controller or service phases for queue-to-worker persistence questions', () => {
+    const compact = compactFor(
+      'Trace how `QueueRegistry.addJob` reaches persistence in the backend runtime pipeline',
+      buildWorkerSegmentGraph(),
+    )
+
+    expect(compact.execution_slice?.status).toBe('complete')
+    expect(compact.execution_slice?.phase_coverage).toEqual({
+      expected: ['queue', 'worker', 'persistence'],
+      observed: ['queue', 'worker', 'persistence'],
+      missing: [],
+    })
+  })
+
+  it('reports extra observed phases even when the prompt does not require them', () => {
+    const compact = compactFor(
+      'Trace how `QueueRegistry.addJob` runs in the backend runtime pipeline',
+      buildWorkerSegmentGraph(),
+    )
+
+    expect(compact.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
+      expected: ['queue', 'worker'],
+      observed: expect.arrayContaining(['queue', 'worker', 'persistence']),
+      missing: [],
     }))
   })
 

--- a/tests/unit/retrieve-slice-v1.test.ts
+++ b/tests/unit/retrieve-slice-v1.test.ts
@@ -12,10 +12,47 @@ interface ExecutionSliceExpectation {
     line_number?: number
   }>
   boundary_reason?: string
+  primary_path?: {
+    steps: Array<{
+      node_id?: string
+      label: string
+      source_file?: string
+      line_number?: number
+    }>
+    boundaries?: Array<{
+      from?: string
+      to?: string
+      relation: string
+    }>
+    boundary_reason?: string
+  }
+  side_effects?: Array<{
+    steps: Array<{
+      label: string
+    }>
+    boundary_reason?: string
+  }>
+  terminal_boundaries?: Array<{
+    steps: Array<{
+      label: string
+    }>
+    boundary_reason?: string
+  }>
+  omitted_branches?: Array<{
+    from?: string
+    to?: string
+    relation?: string
+    reason?: string
+  }>
+  phase_coverage?: {
+    expected: string[]
+    observed: string[]
+    missing: string[]
+  }
 }
 
-function buildSliceGraph(options: { includePersistenceStep?: boolean } = {}) {
-  const { includePersistenceStep = true } = options
+function buildSliceGraph(options: { includeWorkerStep?: boolean; includePersistenceStep?: boolean } = {}) {
+  const { includeWorkerStep = true, includePersistenceStep = true } = options
 
   return build(
     [
@@ -27,23 +64,39 @@ function buildSliceGraph(options: { includePersistenceStep?: boolean } = {}) {
           { id: 'auth_guard', label: 'AuthGuard', file_type: 'code', source_file: '/src/auth/guard.ts', source_location: 'L30', node_kind: 'class', community: 0 },
           { id: 'auth_service', label: 'AuthService.login', file_type: 'code', source_file: '/src/auth/service.ts', source_location: 'L40', node_kind: 'method', community: 0 },
           { id: 'login_validator', label: 'LoginValidator.validate', file_type: 'code', source_file: '/src/auth/login-validator.ts', source_location: 'L50', node_kind: 'method', community: 0 },
-          { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L60', node_kind: 'method', community: 1 },
-          { id: 'auth_env', label: 'AUTH_COOKIE_DOMAIN', file_type: 'code', source_file: '/src/config/auth.ts', source_location: 'L70', community: 2 },
-          { id: 'auth_contract', label: 'LoginInput', file_type: 'code', source_file: '/src/contracts/auth.ts', source_location: 'L80', community: 0 },
-          { id: 'auth_test', label: 'AuthService.login.spec', file_type: 'code', source_file: '/tests/auth.service.spec.ts', source_location: 'L90', node_kind: 'function', community: 3 },
-          { id: 'billing_exporter', label: 'BillingExporter.syncSessions', file_type: 'code', source_file: '/src/billing/exporter.ts', source_location: 'L100', node_kind: 'method', community: 4 },
-          { id: 'billing_metrics', label: 'BillingMetrics.flush', file_type: 'code', source_file: '/src/billing/metrics.ts', source_location: 'L105', node_kind: 'method', community: 4 },
-          { id: 'api_client', label: 'ApiClient.syncBilling', file_type: 'code', source_file: '/src/api/client.ts', source_location: 'L110', node_kind: 'method', community: 4 },
-          { id: 'shared_index', label: 'index.ts', file_type: 'code', source_file: '/src/shared/index.ts', source_location: 'L120', community: 5 },
-          { id: 'shared_cookie', label: 'CookieService', file_type: 'code', source_file: '/src/shared/cookie.ts', source_location: 'L130', node_kind: 'class', community: 5 },
+          { id: 'queue_registry', label: 'QueueRegistry.addJob', file_type: 'code', source_file: '/src/queue/registry.ts', source_location: 'L60', node_kind: 'method', community: 1 },
+          { id: 'auth_worker', label: 'AuthWorker.process', file_type: 'code', source_file: '/src/auth/worker.ts', source_location: 'L70', node_kind: 'method', framework_role: 'worker', community: 1 },
+          { id: 'session_store', label: 'SessionStore.createSession', file_type: 'code', source_file: '/src/session/store.ts', source_location: 'L80', node_kind: 'method', community: 1 },
+          { id: 'audit_publisher', label: 'AuditPublisher.publishLogin', file_type: 'code', source_file: '/src/auth/audit.ts', source_location: 'L90', node_kind: 'method', community: 2 },
+          { id: 'session_notifier', label: 'SessionNotifier.sendLoginWebhook', file_type: 'code', source_file: '/src/auth/notifier.ts', source_location: 'L100', node_kind: 'method', community: 2 },
+          { id: 'status_helper', label: 'AuthController.getStatusMessage', file_type: 'code', source_file: '/src/auth/controller.ts', source_location: 'L110', node_kind: 'method', community: 0 },
+          { id: 'auth_logger', label: 'Logger.info', file_type: 'code', source_file: '/src/auth/logger.ts', source_location: 'L120', node_kind: 'method', community: 2 },
+          { id: 'auth_env', label: 'AUTH_COOKIE_DOMAIN', file_type: 'code', source_file: '/src/config/auth.ts', source_location: 'L130', community: 3 },
+          { id: 'auth_contract', label: 'LoginInput', file_type: 'code', source_file: '/src/contracts/auth.ts', source_location: 'L140', community: 0 },
+          { id: 'auth_test', label: 'AuthService.login.spec', file_type: 'code', source_file: '/tests/auth.service.spec.ts', source_location: 'L150', node_kind: 'function', community: 4 },
+          { id: 'billing_exporter', label: 'BillingExporter.syncSessions', file_type: 'code', source_file: '/src/billing/exporter.ts', source_location: 'L160', node_kind: 'method', community: 5 },
+          { id: 'billing_metrics', label: 'BillingMetrics.flush', file_type: 'code', source_file: '/src/billing/metrics.ts', source_location: 'L170', node_kind: 'method', community: 5 },
+          { id: 'api_client', label: 'ApiClient.syncBilling', file_type: 'code', source_file: '/src/api/client.ts', source_location: 'L180', node_kind: 'method', community: 5 },
+          { id: 'shared_index', label: 'index.ts', file_type: 'code', source_file: '/src/shared/index.ts', source_location: 'L190', community: 6 },
+          { id: 'shared_cookie', label: 'CookieService', file_type: 'code', source_file: '/src/shared/cookie.ts', source_location: 'L200', node_kind: 'class', community: 6 },
         ],
         edges: [
           { source: 'auth_route', target: 'auth_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: '/src/auth/routes.ts' },
           { source: 'auth_controller', target: 'auth_guard', relation: 'uses_guard', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
           { source: 'auth_controller', target: 'auth_service', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
+          { source: 'auth_controller', target: 'status_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
+          { source: 'auth_controller', target: 'auth_logger', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/controller.ts' },
           { source: 'auth_service', target: 'login_validator', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
-          ...(includePersistenceStep
-            ? [{ source: 'auth_service', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' } as const]
+          { source: 'auth_service', target: 'queue_registry', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          { source: 'auth_service', target: 'audit_publisher', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
+          ...(includeWorkerStep
+            ? [{ source: 'queue_registry', target: 'auth_worker', relation: 'enqueues_job', confidence: 'EXTRACTED', source_file: '/src/queue/registry.ts' } as const]
+            : []),
+          ...(includePersistenceStep && includeWorkerStep
+            ? [{ source: 'auth_worker', target: 'session_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/worker.ts' } as const]
+            : []),
+          ...(includeWorkerStep
+            ? [{ source: 'auth_worker', target: 'session_notifier', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/auth/worker.ts' } as const]
             : []),
           { source: 'auth_service', target: 'auth_env', relation: 'reads_env', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
           { source: 'auth_service', target: 'auth_contract', relation: 'depends_on', confidence: 'EXTRACTED', source_file: '/src/auth/service.ts' },
@@ -135,16 +188,63 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
 
   it('surfaces an execution slice for runtime-generation backend prompts', () => {
     const compact = compactFor('Trace how `POST /login` reaches persistence in the backend runtime pipeline')
+    const secondaryBranchTargets = new Set([
+      ...(compact.execution_slice?.omitted_branches?.map((branch) => branch.to ?? '') ?? []),
+      ...(compact.execution_slice?.terminal_boundaries?.flatMap((branch) => branch.steps.map((step) => step.label)) ?? []),
+    ])
 
-    expect(compact.execution_slice).toEqual({
+    expect(compact.execution_slice).toEqual(expect.objectContaining({
       status: 'complete',
       steps: [
         expect.objectContaining({ label: 'POST /login' }),
         expect.objectContaining({ label: 'AuthController.login' }),
         expect.objectContaining({ label: 'AuthService.login' }),
+        expect.objectContaining({ label: 'QueueRegistry.addJob' }),
+        expect.objectContaining({ label: 'AuthWorker.process' }),
         expect.objectContaining({ label: 'SessionStore.createSession' }),
       ],
-    })
+      primary_path: expect.objectContaining({
+        steps: [
+          expect.objectContaining({ label: 'POST /login' }),
+          expect.objectContaining({ label: 'AuthController.login' }),
+          expect.objectContaining({ label: 'AuthService.login' }),
+          expect.objectContaining({ label: 'QueueRegistry.addJob' }),
+          expect.objectContaining({ label: 'AuthWorker.process' }),
+          expect.objectContaining({ label: 'SessionStore.createSession' }),
+        ],
+        boundaries: expect.arrayContaining([
+          expect.objectContaining({
+            from: 'QueueRegistry.addJob',
+            to: 'AuthWorker.process',
+            relation: 'enqueues_job',
+          }),
+        ]),
+      }),
+      side_effects: expect.arrayContaining([
+        expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({ label: 'AuditPublisher.publishLogin' }),
+          ]),
+        }),
+        expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({ label: 'SessionNotifier.sendLoginWebhook' }),
+          ]),
+        }),
+      ]),
+      omitted_branches: expect.arrayContaining([
+        expect.objectContaining({ to: 'LoginValidator.validate' }),
+      ]),
+      phase_coverage: {
+        expected: ['controller', 'service', 'queue', 'worker', 'persistence'],
+        observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker', 'persistence']),
+        missing: [],
+      },
+    }))
+    expect(
+      secondaryBranchTargets.has('AuthController.getStatusMessage')
+      || secondaryBranchTargets.has('Logger.info'),
+    ).toBe(true)
   })
 
   it('anchors route-shaped backend runtime prompts on the route path', () => {
@@ -173,14 +273,39 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
     )
   })
 
-  it('marks execution slices partial when the route cannot reach persistence', () => {
+  it('marks execution slices partial when the runtime path cannot reach a worker phase', () => {
+    const compact = compactFor(
+      'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
+      buildSliceGraph({ includeWorkerStep: false }),
+    )
+
+    expect(compact.execution_slice?.status).toBe('partial')
+    expect(compact.execution_slice?.boundary_reason).toMatch(/worker/i)
+    expect(compact.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
+      expected: expect.arrayContaining(['worker']),
+      missing: expect.arrayContaining(['worker']),
+    }))
+  })
+
+  it('marks execution slices partial when the runtime path misses persistence after the worker phase', () => {
     const compact = compactFor(
       'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
       buildSliceGraph({ includePersistenceStep: false }),
     )
 
     expect(compact.execution_slice?.status).toBe('partial')
-    expect(compact.execution_slice?.boundary_reason).toMatch(/missing|boundary|stops/i)
+    expect(compact.execution_slice?.boundary_reason).toMatch(/persistence/i)
+    expect(compact.execution_slice?.steps.map((step) => step.label)).toEqual([
+      'POST /login',
+      'AuthController.login',
+      'AuthService.login',
+      'QueueRegistry.addJob',
+      'AuthWorker.process',
+    ])
+    expect(compact.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
+      expected: expect.arrayContaining(['persistence']),
+      missing: expect.arrayContaining(['persistence']),
+    }))
   })
 
   it('can pull direct graph neighbors into a level-1 slice even when they do not lexically match', () => {
@@ -194,7 +319,7 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
     const labels = sliced.matched_nodes.map((node) => node.label)
 
     expect(labels).toContain('AuthService.login')
-    expect(labels).toContain('SessionStore.createSession')
+    expect(labels).toContain('QueueRegistry.addJob')
     expect(labels).not.toContain('index.ts')
   })
 

--- a/tests/unit/retrieve-slice-v1.test.ts
+++ b/tests/unit/retrieve-slice-v1.test.ts
@@ -270,8 +270,8 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
         expect.objectContaining({ to: 'LoginValidator.validate' }),
       ]),
       phase_coverage: {
-        expected: ['controller', 'service', 'queue', 'worker', 'persistence'],
-        observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker', 'persistence']),
+        expected: ['controller', 'queue', 'worker', 'persistence'],
+        observed: ['controller', 'service', 'queue', 'worker', 'persistence'],
         missing: [],
       },
     }))
@@ -368,6 +368,20 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
     expect(compact.execution_slice?.status).toBe('complete')
     expect(compact.execution_slice?.phase_coverage).toEqual({
       expected: ['queue', 'worker', 'persistence'],
+      observed: ['queue', 'worker', 'persistence'],
+      missing: [],
+    })
+  })
+
+  it('does not infer controller or service phases from generic request wording on worker questions', () => {
+    const compact = compactFor(
+      'Why do requests fail after `QueueRegistry.addJob` in the worker runtime pipeline?',
+      buildWorkerSegmentGraph(),
+    )
+
+    expect(compact.execution_slice?.status).toBe('complete')
+    expect(compact.execution_slice?.phase_coverage).toEqual({
+      expected: ['queue', 'worker'],
       observed: ['queue', 'worker', 'persistence'],
       missing: [],
     })

--- a/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
+++ b/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
@@ -515,11 +515,11 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
           ]),
         }),
       ]),
-      phase_coverage: {
-       expected: ['controller', 'service', 'queue', 'worker'],
-       observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker']),
-       missing: [],
-      },
+      phase_coverage: expect.objectContaining({
+        expected: ['queue', 'worker'],
+        observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker', 'persistence']),
+        missing: [],
+      }),
     }))
     expect(sideEffectLabels.length).toBeGreaterThanOrEqual(2)
     expect(sideEffectLabels).toEqual(expect.arrayContaining(['.createIdea()']))

--- a/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
+++ b/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
@@ -460,6 +460,80 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
     expect(result.slice?.anchors.some((anchor) => frontendLabels.includes(anchor.label))).toBe(false)
   })
 
+  it('models primary path, side effects, terminal boundaries, and omitted branches for report-generation prompts', () => {
+    const result = retrieveContext(buildFixtureGraph({ windowsSourcePaths: true }), {
+      question: 'Explain how idea report is getting generated',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    })
+
+    const executionSlice = result.execution_slice
+    const primaryLabels = executionSlice?.primary_path?.steps.map((step) => step.label) ?? []
+    const compact = compactRetrieveResult(result)
+    const compactExecutionSliceSize = JSON.stringify(compact.execution_slice ?? {}).length
+    const sideEffectLabels = executionSlice?.side_effects?.flatMap((branch) => branch.steps.map((step) => step.label)) ?? []
+    const omittedTargets = executionSlice?.omitted_branches?.map((branch) => branch.to ?? '') ?? []
+
+    expect(executionSlice).toEqual(expect.objectContaining({
+      status: 'complete',
+      steps: [
+        expect.objectContaining({ label: '.generateFromProblem()' }),
+        expect.objectContaining({ label: '.startPipeline()' }),
+        expect.objectContaining({ label: '.addJob()' }),
+        expect.objectContaining({ label: '.process()' }),
+        expect.objectContaining({ label: '.save()' }),
+      ],
+      primary_path: expect.objectContaining({
+        steps: [
+          expect.objectContaining({ label: '.generateFromProblem()' }),
+          expect.objectContaining({ label: '.startPipeline()' }),
+          expect.objectContaining({ label: '.addJob()' }),
+          expect.objectContaining({ label: '.process()' }),
+          expect.objectContaining({ label: '.save()' }),
+        ],
+        boundaries: expect.arrayContaining([
+          expect.objectContaining({ from: '.addJob()', to: '.process()', relation: 'enqueues_job' }),
+        ]),
+      }),
+      side_effects: expect.arrayContaining([
+        expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({ label: '.createIdea()' }),
+          ]),
+        }),
+      ]),
+      terminal_boundaries: expect.arrayContaining([
+        expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({ label: '.claimQueuedPipelineRun()' }),
+          ]),
+        }),
+        expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({ label: '.cancelPipeline()' }),
+          ]),
+        }),
+      ]),
+      phase_coverage: {
+       expected: ['controller', 'service', 'queue', 'worker'],
+       observed: expect.arrayContaining(['controller', 'service', 'queue', 'worker']),
+       missing: [],
+      },
+    }))
+    expect(sideEffectLabels.length).toBeGreaterThanOrEqual(2)
+    expect(sideEffectLabels).toEqual(expect.arrayContaining(['.createIdea()']))
+    expect(sideEffectLabels.some((label) => ['.generateTitle()', '.updateTitle()'].includes(label))).toBe(true)
+    expect(omittedTargets.some((label) => ['.suggestProblem()', '.add()', 'Process()', '.score()', '.search()'].includes(label))).toBe(true)
+    expect(primaryLabels).toEqual(expect.arrayContaining([
+      '.startPipeline()',
+      '.addJob()',
+      '.process()',
+    ]))
+    expect(compact.token_count).toBeLessThan(4000)
+    expect(compactExecutionSliceSize).toBeLessThan(4000)
+  })
+
   it('prefers ReportRepository.save for storage-boundary prompts', () => {
     const result = retrieveContext(buildFixtureGraph({ windowsSourcePaths: true }), {
       question: 'Which method writes the report to the database?',


### PR DESCRIPTION
Closes #231

## Summary
- add runtime phase coverage and truthful partial/boundary reporting to `execution_slice`
- distinguish the primary runtime path from bounded side-effect branches and terminal boundaries
- extend retrieval tests for missing worker/persistence phases and primary-path selection

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run
