### PR TITLE
Prepare 0.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-23
+
+### Added
+
+- **First-pass Go semantic indexing**: extraction now resolves conservative Go call flow across local-package imports, receiver methods, and statically resolvable cross-package calls, and it recognizes common `net/http`, Gin, and Chi route entrypoints so Go repos produce far more truthful runtime retrieval paths.
+
+### Changed
+
+- **`execution_slice` runtime answers are much more explicit**: backend runtime packs now add separated `primary_path`, `side_effects`, `terminal_boundaries`, `omitted_branches`, and `phase_coverage` output, so runtime answers no longer flatten every step and branch into one ambiguous list.
+- **Execution-phase expectations are prompt-scoped**: queue/worker/persistence questions no longer invent missing controller or service phases just because the prompt mentions requests, and observed phases now emit in canonical runtime order (`controller` → `service` → `queue` → `worker` → `persistence`).
+
 ## [0.24.1] - 2026-05-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Want a broader local-first walkthrough that also covers install, `prompt`, and a
 
 ---
 
-## What's new in 0.24.1
+## What's new in 0.25.0
 
-- `madar copilot install` now writes `.vscode/mcp.json` to launch the local `madar` CLI directly through Node when the CLI is available, which trims avoidable MCP startup overhead versus going through `npx` every time.
-- Copilot installer inputs are more robust: relative `packageRoot` values are now resolved before the launcher config is written, so the generated CLI path stays absolute and stable across different working directories.
-- This is a focused patch release. For the broader package/repo alignment and public launch changes, see the [`0.24.0` changelog entry](CHANGELOG.md#0240---2026-05-22).
+- Backend runtime answers now emit a much richer `execution_slice`: you get a clearer primary runtime path, prompt-scoped `phase_coverage`, and summarized side-effect / terminal / omitted branches instead of one flattened path dump.
+- Go repos now get first-pass semantic indexing for receiver methods, local-package and cross-package calls, and common `net/http`, Gin, and Chi route entrypoints, so generated graphs and retrieval answers are much closer to real handler → service → repository flow.
+- This is a feature release on top of the `0.24.1` Copilot installer patch. For the previous MCP startup fix, see the [`0.24.1` changelog entry](CHANGELOG.md#0241---2026-05-23).
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.24.1",
+            "version": "0.25.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump @lubab/madar to 0.25.0 in package.json and package-lock.json
- add 0.25.0 release notes for execution_slice runtime improvements and first-pass Go semantic indexing
- refresh the README whats-new section for the new feature release

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Go semantic indexing with improved support for receiver methods, local and cross-package call resolution, and common web framework route detection
  * More detailed runtime execution output with explicit fields for execution paths, side effects, boundaries, and branch coverage
  * Refined execution-phase handling with proper canonical ordering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->