### PR TITLE
Fix runtime-generation explain routing defaults

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -10,6 +10,7 @@ import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIO
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
 import { parsePromptRunnerJsonRecord, parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner.js'
+import { classifyRetrievalLevel } from '../runtime/retrieval-gate.js'
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
@@ -982,7 +983,12 @@ function retrieveCompareContext(graph: KnowledgeGraph, question: string, budget:
   const originalCwd = process.cwd()
   try {
     process.chdir(projectRoot)
-    const retrieval = retrieveContext(retrievalGraph, { question, budget: Math.max(budget, 200) })
+    const gate = classifyRetrievalLevel({ prompt: question })
+    const retrieval = retrieveContext(retrievalGraph, {
+      question,
+      budget: Math.max(budget, 200),
+      ...(gate.signals.generation_intent === 'runtime_generation' ? { retrievalStrategy: 'slice-v1' as const } : {}),
+    })
     for (const matchedNode of retrieval.matched_nodes) {
       matchedNode.source_file = originalSourceFiles.get(matchedNode.source_file) ?? matchedNode.source_file
     }

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -194,6 +194,18 @@ function baseResponse(options: PackCliOptions, plan: TaskContextPlan, budget: nu
   }
 }
 
+function defaultExplainRetrievalStrategy(
+  prompt: string,
+): PackCliOptions['retrievalStrategy'] | undefined {
+  const gate = classifyRetrievalLevel({
+    prompt,
+  })
+
+  return gate.signals.generation_intent === 'runtime_generation'
+    ? 'slice-v1'
+    : undefined
+}
+
 export async function runContextPackCommand(
   options: PackCliOptions,
   dependencies: ContextPackCommandDependencies = DEFAULT_DEPENDENCIES,
@@ -258,12 +270,17 @@ export async function runContextPackCommand(
     })
   }
 
+  const effectiveExplainRetrievalStrategy =
+    options.retrievalStrategy ?? defaultExplainRetrievalStrategy(options.prompt)
+
   const retrieval = dependencies.retrieveContext(graph, {
     question: options.prompt,
     budget: plannerBudget,
     taskIntent: initialPlan.evidence.recipe_id,
     ...(options.retrievalLevel !== undefined ? { retrievalLevel: options.retrievalLevel } : {}),
-    ...(options.retrievalStrategy !== undefined ? { retrievalStrategy: options.retrievalStrategy } : {}),
+    ...(effectiveExplainRetrievalStrategy !== undefined
+      ? { retrievalStrategy: effectiveExplainRetrievalStrategy }
+      : {}),
   })
   return JSON.stringify({
     ...baseResponse(options, initialPlan, plannerBudget),

--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -124,7 +124,13 @@ export function classifyRetrievalLevel(input: RetrievalGateInput): RetrievalGate
     }
   }
 
-  const decision = decideLevel({ intent, hasPrDiff, hasStackTrace, mentions: detectedPaths.length + detectedSymbols.length })
+  const decision = decideLevel({
+    intent,
+    generationIntent,
+    hasPrDiff,
+    hasStackTrace,
+    mentions: detectedPaths.length + detectedSymbols.length,
+  })
   return {
     ...decision,
     skipped_retrieval: decision.level === 0,
@@ -135,11 +141,12 @@ export function classifyRetrievalLevel(input: RetrievalGateInput): RetrievalGate
 
 function decideLevel(opts: {
   intent: RetrievalIntent
+  generationIntent: RetrievalGenerationIntent
   hasPrDiff: boolean
   hasStackTrace: boolean
   mentions: number
 }): { level: RetrievalLevel; reason: string } {
-  const { intent, hasPrDiff, hasStackTrace, mentions } = opts
+  const { intent, generationIntent, hasPrDiff, hasStackTrace, mentions } = opts
 
   // Stack trace is strong evidence of a behavior-tracing question regardless
   // of intent classification.
@@ -151,6 +158,10 @@ function decideLevel(opts: {
   // questions about the change.
   if (hasPrDiff && (intent === 'review' || intent === 'impact' || intent === 'test')) {
     return { level: 5, reason: `PR diff present + ${intent} intent — full PR impact pack` }
+  }
+
+  if (generationIntent === 'runtime_generation' && (intent === 'unknown' || intent === 'explain')) {
+    return { level: 3, reason: 'runtime generation intent — behavior slice retrieval' }
   }
 
   switch (intent) {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -782,6 +782,7 @@ describe('compare runtime', () => {
     const retrieval = retrieveContext(graph, {
       question: 'how does login create a session',
       budget: 3000,
+      retrievalStrategy: 'slice-v1',
     })
 
     const explainPayload = JSON.parse(

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -101,6 +101,44 @@ describe('context-pack-command', () => {
     }))
   })
 
+  it('defaults runtime-generation explain packs to slice-v1 retrieval', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn((currentGraph, options) => retrieveContext(currentGraph, options as never)),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'How `POST /login` reaches persistence in the backend runtime pipeline',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+    }, dependencies)
+
+    const payload = JSON.parse(output) as {
+      pack?: {
+        retrieval_strategy?: string
+        execution_slice?: {
+          status?: string
+        }
+      }
+    }
+
+    expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
+      question: 'How `POST /login` reaches persistence in the backend runtime pipeline',
+      budget: 1800,
+      taskIntent: 'explain',
+      retrievalStrategy: 'slice-v1',
+    })
+    expect(payload.pack?.retrieval_strategy).toBe('slice-v1')
+    expect(payload.pack?.execution_slice?.status).toBe('complete')
+  })
+
   it('normalizes sub-minimum explain budgets before retrieving', async () => {
     const graph = new KnowledgeGraph()
     const dependencies: ContextPackCommandDependencies = {

--- a/tests/unit/retrieval-gate.test.ts
+++ b/tests/unit/retrieval-gate.test.ts
@@ -185,6 +185,14 @@ describe('classifyRetrievalLevel — signal extraction', () => {
     expect(decision.signals.target_domain_hint).toBe('backend_runtime')
   })
 
+  it('escalates natural runtime-generation prompts to behavior-slice retrieval', () => {
+    const decision = classify({ prompt: 'How idea report is being generated' })
+    expect(decision.signals.generation_intent).toBe('runtime_generation')
+    expect(decision.signals.target_domain_hint).toBe('backend_runtime')
+    expect(decision.level).toBe(3)
+    expect(decision.reason).toMatch(/runtime generation|behavior slice/i)
+  })
+
   it('detects frontend display prompts separately from runtime generation prompts', () => {
     const decision = classify({ prompt: 'Where is the generated date displayed in the report footer?' })
     expect(decision.signals.generation_intent).toBe('display_rendering')
@@ -210,7 +218,7 @@ describe('classifyRetrievalLevel — exclusions and negation', () => {
     const signals = decision.signals as typeof decision.signals & { excluded_domains?: string[] }
 
     expect(decision.intent).toBe('explain')
-    expect(decision.level).toBe(1)
+    expect(decision.level).toBe(3)
     expect(signals.excluded_domains).toContain('test')
   })
 


### PR DESCRIPTION
## Summary
- route natural runtime-generation explain prompts to behavior-slice retrieval
- default pack and compare explain flows to slice-v1 for those prompts
- add regression coverage for retrieval gate, pack, and compare consistency

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Context retrieval now intelligently selects the appropriate retrieval strategy based on query classification, with specialized handling for runtime-generation queries.

* **Tests**
  * Added comprehensive test coverage for runtime-generation context handling and behavior-based retrieval level classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->