### PR TITLE
Prepare 0.25.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-05-23
+
+### Changed
+
+- **Natural runtime-generation explain prompts now auto-route to behavior slices**: prompts like `How idea report is being generated` no longer need special "trace the backend runtime pipeline" wording to reach level-3 runtime retrieval.
+- **`pack --task explain` now defaults to `slice-v1` for runtime-generation questions**: users no longer need to know the experimental retrieval flag to get `execution_slice` output for these backend runtime prompts.
+- **`compare` stays aligned with `pack` for runtime-generation prompts**: compare-mode madar prompt packs now use the same runtime-generation routing defaults as the main CLI path, so proof artifacts match the user-facing behavior.
+
 ## [0.25.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ Want a broader local-first walkthrough that also covers install, `prompt`, and a
 
 ---
 
-## What's new in 0.25.0
+## What's new in 0.25.1
 
-- Backend runtime answers now emit a much richer `execution_slice`: you get a clearer primary runtime path, prompt-scoped `phase_coverage`, and summarized side-effect / terminal / omitted branches instead of one flattened path dump.
-- Go repos now get first-pass semantic indexing for receiver methods, local-package and cross-package calls, and common `net/http`, Gin, and Chi route entrypoints, so generated graphs and retrieval answers are much closer to real handler → service → repository flow.
-- This is a feature release on top of the `0.24.1` Copilot installer patch. For the previous MCP startup fix, see the [`0.24.1` changelog entry](CHANGELOG.md#0241---2026-05-23).
+- Natural-language runtime-generation prompts like `How idea report is being generated` now route to behavior-slice retrieval automatically, so users do not need special trace phrasing to get backend runtime answers.
+- `madar pack --task explain` now defaults to `slice-v1` for those runtime-generation prompts, which means `execution_slice` shows up without asking users to discover the extra retrieval flag.
+- `madar compare` now uses the same runtime-generation defaults as `madar pack`, so compare artifacts stay aligned with the actual CLI behavior.
+
+The larger **0.25.0** feature release is still the main capability jump: richer backend `execution_slice` output plus first-pass Go semantic indexing for handler → service → repository style flows. See the [`0.25.0` changelog entry](CHANGELOG.md#0250---2026-05-23) for that broader release.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -78,7 +80,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.24.1. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.25.1. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.25.0",
+            "version": "0.25.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "description": "Local context plane and context compiler for AI coding agents. Turn TypeScript/Node workspaces and PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump @lubab/madar from 0.25.0 to 0.25.1
- document the natural runtime-generation routing fix in the changelog and README
- refresh release surfaces for the next npm publish handoff

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Runtime-generation explain prompts now auto-route without requiring special syntax
  * `pack --task explain` defaults to `slice-v1` for runtime-generation queries
  * `compare` runtime-generation routing aligned with `pack` behavior

* **Documentation**
  * Updated changelog and version information for 0.25.1 release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->