### PR TITLE
Improve runtime-generation semantic generation-core focus

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -238,6 +238,25 @@ function timestampDirectoryName(date: Date): string {
   return iso.slice(0, 19).replace(/:/g, '-')
 }
 
+function promptWantsReportGenerationCore(prompt: string): boolean {
+  return /\b(?:report(?:\s+generation)?|generated\s+report|validation\s+report|final\s+report|assembly|assemble|synthesis|renderer|render|planner|research|metrics?|scor(?:e|ing)|quality(?:\s|-)?gate)\b/i.test(prompt)
+}
+
+function generationCoreInstructions(question: string, retrieval: RetrieveResult): string[] {
+  if (
+    retrieval.retrieval_gate?.signals.generation_intent !== 'runtime_generation'
+    || retrieval.retrieval_gate?.signals.target_domain_hint !== 'backend_runtime'
+    || !promptWantsReportGenerationCore(question)
+  ) {
+    return []
+  }
+
+  return [
+    'Treat HTTP/controller entrypoints as trigger context, not the full answer, when downstream generation-core evidence is present.',
+    'Follow planner, research, assembly, scoring, rendering, and persistence evidence before concluding the flow.',
+  ]
+}
+
 function summarizeExecTemplate(execTemplate: string): CompareExecCommandSummary {
   const placeholders = [...execTemplate.matchAll(EXEC_TEMPLATE_PLACEHOLDER_PATTERN)].map((match) => match[0])
 
@@ -1110,6 +1129,7 @@ export function buildMadarPromptPack(input: BuildMadarPromptPackInput): CompareP
     instructions: [
       'Answer the question using only the provided graph-guided retrieval output.',
       'If the retrieval does not contain the answer, say so.',
+      ...generationCoreInstructions(input.question, input.retrieval),
     ],
     stable_prefix_title: 'Retrieved graph context',
     stable_sections: [

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1270,6 +1270,10 @@ function promptWantsRuntimePipeline(question: string): boolean {
   return /\b(runtime|pipeline|service|orchestrator|job|agent|scoring|report(?: builder)?|persistence|repository|queue|worker)\b/i.test(question)
 }
 
+function promptWantsReportGenerationCore(question: string): boolean {
+  return /\b(?:report(?:\s+generation)?|generated\s+report|validation\s+report|final\s+report|assembly|assemble|synthesis|renderer|render|planner|research|metrics?|scor(?:e|ing)|quality(?:\s|-)?gate)\b/i.test(question)
+}
+
 function methodLikeLabel(label: string): boolean {
   return /(?:[.#:]|^\.)[A-Za-z_$][\w$]*\(?\)?$/u.test(label)
 }
@@ -1305,9 +1309,75 @@ function runtimeFlowRelation(relation: string): boolean {
   return relation === 'calls' || relation === 'enqueues_job'
 }
 
+function lowValueReportGenerationCompactNode(
+  node: {
+    label: string
+    source_file: string
+    node_kind?: string | undefined
+    framework_role?: string | undefined
+  },
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return lowValueExecutionStep({
+    label: node.label,
+    source_file: node.source_file,
+    ...(node.node_kind !== undefined ? { node_kind: node.node_kind } : {}),
+    ...(node.framework_role !== undefined ? { framework_role: node.framework_role } : {}),
+  })
+    || /\b(?:title|status|suggest|guard|auth|interceptor|refund|claim|cancel|signedurl|buildperspective|letsbuild|publish|delete)\b/.test(lower)
+    || /(?:^|[.#])(?:generatefallbacktitle|generatetitle|getstatusmessage|claimqueuedpipelinerun|releasequeuedpipelineclaim|releaseunusedcreditreservation|generatebuildperspective|generatesignedurl|generateletsbuild|publishidea|getidea|listideas|deleteidea|suggestimprovements)[A-Za-z_$\w]*\(?\)?$/i.test(node.label)
+}
+
+function reportGenerationCompactApplies(result: RetrieveResult): boolean {
+  if (
+    result.retrieval_strategy !== 'slice-v1'
+    || !promptWantsRuntimePipeline(result.question)
+    || !promptWantsReportGenerationCore(result.question)
+    || !result.slice
+    || promptExpectsPersistenceStep(result.question)
+  ) {
+    return false
+  }
+
+  if (result.slice.anchors.some((anchor) => anchor.reason === 'symbol mention' || anchor.reason === 'path mention')) {
+    return false
+  }
+
+  return result.slice.anchors.some((anchor) => anchor.reason === 'generation core heuristic')
+    || (result.execution_slice?.steps.length ?? 0) >= 3
+}
+
+function reportGenerationCompactPriority(
+  node: Pick<RetrieveMatchedNode, 'label' | 'source_file' | 'node_kind' | 'framework_role' | 'relevance_band'>,
+  executionStepLabels: ReadonlySet<string>,
+): number {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  let value = 0
+
+  if (executionStepLabels.has(node.label)) value += 80
+  if (/\b(?:planner|plan\b|research|assembly|assemble|renderer|render|synth|quality(?:-| )gate|dispatchwave|dispatchdbsync|broadcastrunstarted|broadcastrunfailed|queue|job|worker|orchestrator|process|persist|save)\b/.test(lower)) value += 40
+  if (/\bscoremetrics\b/.test(lower)) value += 35
+  if (pipelineBridgeNode(node)) value += 20
+  if (node.relevance_band === 'direct') value += 5
+
+  if (
+    /(?:^|[.#])(?:generatescoringledger|generatesensitivityanalysis|generatesuggestednextsteps|scoremetricbatch|deduplicateevidencerefs|mapcompositetorecommendation|normalizemetric|parsejson)\(?\)?$/i.test(node.label)
+    || /\b(?:metrichumanprompt|fallbackmetric)\b/.test(lower)
+  ) {
+    value -= 35
+  }
+  if (lowValueReportGenerationCompactNode(node)) value -= 100
+
+  return value
+}
+
 function compactSlicePromotionApplies(result: RetrieveResult): boolean {
   if (result.retrieval_strategy !== 'slice-v1' || !promptWantsRuntimePipeline(result.question)) {
     return false
+  }
+
+  if (reportGenerationCompactApplies(result)) {
+    return true
   }
 
   return (result.slice?.anchors ?? []).some((anchor) =>
@@ -1329,6 +1399,82 @@ function structuralSlicePromotionApplies(
 function promotedSliceCompactNodeIds(result: RetrieveResult): string[] {
   if (!compactSlicePromotionApplies(result) || !result.slice) {
     return []
+  }
+
+  if (reportGenerationCompactApplies(result)) {
+    const matchedById = new Map(
+      result.matched_nodes
+        .map((node) => (typeof node.node_id === 'string' && node.node_id.length > 0 ? [node.node_id, node] as const : null))
+        .filter((entry): entry is readonly [string, RetrieveMatchedNode] => entry !== null),
+    )
+    const executionStepLabels = new Set<string>()
+    const promoted = new Set<string>()
+    const addPromoted = (nodeId: string | undefined): void => {
+      if (typeof nodeId !== 'string' || nodeId.length === 0) {
+        return
+      }
+      const node = matchedById.get(nodeId)
+      if (!node || supportingPolicyOrLoggerNode(node) || lowValueReportGenerationCompactNode(node)) {
+        return
+      }
+      promoted.add(nodeId)
+    }
+    const addPromotedByLabel = (label: string): void => {
+      for (const node of result.matched_nodes) {
+        if (node.label !== label) {
+          continue
+        }
+        addPromoted(node.node_id)
+      }
+    }
+
+    for (const anchor of result.slice.anchors) {
+      addPromoted(anchor.node_id)
+    }
+
+    for (const step of result.execution_slice?.steps ?? []) {
+      executionStepLabels.add(step.label)
+      addPromoted(step.node_id)
+      addPromotedByLabel(step.label)
+    }
+    for (const step of result.execution_slice?.primary_path?.steps ?? []) {
+      executionStepLabels.add(step.label)
+      addPromoted(step.node_id)
+      addPromotedByLabel(step.label)
+    }
+
+    for (const path of result.slice.selected_paths) {
+      if (!runtimeFlowRelation(path.relation)) {
+        continue
+      }
+
+      const fromNode = typeof path.from_id === 'string' ? matchedById.get(path.from_id) : undefined
+      const toNode = typeof path.to_id === 'string' ? matchedById.get(path.to_id) : undefined
+      if (fromNode && pipelineBridgeNode(fromNode)) {
+        addPromoted(path.from_id)
+      }
+      if (toNode && pipelineBridgeNode(toNode)) {
+        addPromoted(path.to_id)
+      }
+    }
+
+    return result.matched_nodes
+      .filter((node) => typeof node.node_id === 'string' && promoted.has(node.node_id))
+      .sort((left, right) => {
+        const priorityDelta = reportGenerationCompactPriority(right, executionStepLabels)
+          - reportGenerationCompactPriority(left, executionStepLabels)
+        if (priorityDelta !== 0) {
+          return priorityDelta
+        }
+        const leftPipeline = pipelineBridgeNode(left) ? 1 : 0
+        const rightPipeline = pipelineBridgeNode(right) ? 1 : 0
+        if (leftPipeline !== rightPipeline) {
+          return rightPipeline - leftPipeline
+        }
+        return right.match_score - left.match_score
+      })
+      .flatMap((node) => (typeof node.node_id === 'string' ? [node.node_id] : []))
+      .slice(0, 24)
   }
 
   const promoted = new Set<string>(
@@ -1368,6 +1514,82 @@ function promotedSliceCompactNodeIds(result: RetrieveResult): string[] {
     .slice(0, 24)
 }
 
+function promotedSliceCompactLabels(result: RetrieveResult): string[] {
+  if (!compactSlicePromotionApplies(result) || !result.slice) {
+    return []
+  }
+
+  if (reportGenerationCompactApplies(result)) {
+    const matchedById = new Map(
+    result.matched_nodes
+      .map((node) => (typeof node.node_id === 'string' && node.node_id.length > 0 ? [node.node_id, node] as const : null))
+      .filter((entry): entry is readonly [string, RetrieveMatchedNode] => entry !== null),
+    )
+    const representativeByLabel = new Map<string, RetrieveMatchedNode>()
+    for (const node of result.matched_nodes) {
+    if (!representativeByLabel.has(node.label)) {
+      representativeByLabel.set(node.label, node)
+    }
+    }
+
+    const executionStepLabels = new Set<string>()
+    const promotedLabels = new Set<string>()
+    const addPromotedLabel = (label: string | undefined, node?: RetrieveMatchedNode): void => {
+    if (typeof label !== 'string' || label.length === 0) {
+      return
+    }
+    const candidate = node ?? representativeByLabel.get(label)
+    if (!candidate || supportingPolicyOrLoggerNode(candidate) || lowValueReportGenerationCompactNode(candidate)) {
+      return
+    }
+    promotedLabels.add(label)
+    }
+
+    for (const anchor of result.slice.anchors) {
+    addPromotedLabel(anchor.label, typeof anchor.node_id === 'string' ? matchedById.get(anchor.node_id) : undefined)
+    }
+
+    for (const step of result.execution_slice?.steps ?? []) {
+    executionStepLabels.add(step.label)
+    addPromotedLabel(step.label, typeof step.node_id === 'string' ? matchedById.get(step.node_id) : undefined)
+    }
+    for (const step of result.execution_slice?.primary_path?.steps ?? []) {
+    executionStepLabels.add(step.label)
+    addPromotedLabel(step.label, typeof step.node_id === 'string' ? matchedById.get(step.node_id) : undefined)
+    }
+
+    for (const path of result.slice.selected_paths) {
+    if (!runtimeFlowRelation(path.relation)) {
+      continue
+    }
+
+    const fromNode = typeof path.from_id === 'string' ? matchedById.get(path.from_id) : representativeByLabel.get(path.from)
+    const toNode = typeof path.to_id === 'string' ? matchedById.get(path.to_id) : representativeByLabel.get(path.to)
+    if (fromNode && pipelineBridgeNode(fromNode)) {
+      addPromotedLabel(fromNode.label, fromNode)
+    }
+    if (toNode && pipelineBridgeNode(toNode)) {
+      addPromotedLabel(toNode.label, toNode)
+    }
+    }
+
+    return [...promotedLabels]
+    .sort((left, right) => {
+      const leftNode = representativeByLabel.get(left)
+      const rightNode = representativeByLabel.get(right)
+      const priorityDelta = (rightNode ? reportGenerationCompactPriority(rightNode, executionStepLabels) : 0)
+        - (leftNode ? reportGenerationCompactPriority(leftNode, executionStepLabels) : 0)
+      if (priorityDelta !== 0) {
+        return priorityDelta
+      }
+      return left.localeCompare(right)
+    })
+    .slice(0, 24)
+  }
+
+  return result.slice.anchors.map((anchor) => anchor.label)
+}
+
 function structuralSliceNodeIds(
   sliceMetadata: ContextPackSliceMetadata | undefined,
   orderedCandidates: readonly ScoredNode[],
@@ -1378,14 +1600,20 @@ function structuralSliceNodeIds(
   }
 
   const nodesById = new Map(orderedCandidates.map((node) => [node.id, node]))
-  const forwardRuntimeFlow = new Map<string, ContextPackSliceMetadata['selected_paths']>()
+  const runtimeFlowNeighbors = new Map<string, string[]>()
+  const addRuntimeFlowNeighbor = (fromId: string, toId: string): void => {
+    const current = runtimeFlowNeighbors.get(fromId) ?? []
+    if (!current.includes(toId)) {
+      current.push(toId)
+      runtimeFlowNeighbors.set(fromId, current)
+    }
+  }
   for (const path of sliceMetadata.selected_paths) {
-    if (path.direction !== 'forward' || !runtimeFlowRelation(path.relation) || typeof path.from_id !== 'string' || typeof path.to_id !== 'string') {
+    if (!runtimeFlowRelation(path.relation) || typeof path.from_id !== 'string' || typeof path.to_id !== 'string') {
       continue
     }
-    const current = forwardRuntimeFlow.get(path.from_id) ?? []
-    current.push(path)
-    forwardRuntimeFlow.set(path.from_id, current)
+    addRuntimeFlowNeighbor(path.from_id, path.to_id)
+    addRuntimeFlowNeighbor(path.to_id, path.from_id)
   }
 
   const structural = new Set<string>()
@@ -1405,8 +1633,8 @@ function structuralSliceNodeIds(
       continue
     }
 
-    for (const path of forwardRuntimeFlow.get(current.id) ?? []) {
-      const target = nodesById.get(path.to_id!)
+    for (const neighborId of runtimeFlowNeighbors.get(current.id) ?? []) {
+      const target = nodesById.get(neighborId)
       if (!target) {
         continue
       }
@@ -1416,9 +1644,9 @@ function structuralSliceNodeIds(
         structural.add(target.id)
       }
 
-      if (!seen.has(target.id)) {
-        seen.add(target.id)
-        queue.push({ id: target.id, depth: nextDepth })
+      if (!seen.has(neighborId)) {
+        seen.add(neighborId)
+        queue.push({ id: neighborId, depth: nextDepth })
       }
     }
   }
@@ -2768,9 +2996,10 @@ function buildRetrieveResultFromOrderedCandidates(
   const nodeCandidates: Array<ContextPackNodeCandidate<ContextPackNode>> = orderedCandidates.map((node) => {
     let builtEntry: RetrieveMatchedNode | undefined
     let tokenCost: number | undefined
-    const evidenceClass = structuralIds.has(node.id)
+    const baseEvidenceClass = retrieveEvidenceClassForBand(node.relevanceBand)
+    const evidenceClass = structuralIds.has(node.id) && !(promptExpectsPersistenceStep(options.question) && node.relevanceBand === 'direct')
       ? 'structural'
-      : retrieveEvidenceClassForBand(node.relevanceBand)
+      : baseEvidenceClass
     const graphSignal = retrieveGraphSignals.bridgeNodeIds.has(node.id)
       ? 'bridge'
       : retrieveGraphSignals.godNodeIds.has(node.id)
@@ -3618,10 +3847,12 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
   const fullPack = contextPackFromRetrieveResult(result)
   const executionSlice = compactExecutionSlice(result.execution_slice)
   const promotedSliceNodeIds = promotedSliceCompactNodeIds(result)
-  const compactPack = promotedSliceNodeIds.length > 0
+  const promotedSliceLabels = promotedSliceCompactLabels(result)
+  const compactPack = promotedSliceNodeIds.length > 0 || promotedSliceLabels.length > 0
     ? compactContextPack(fullPack, {
         kind: 'review',
         seed_node_ids: promotedSliceNodeIds,
+        seed_labels: promotedSliceLabels,
         max_supporting_nodes: 0,
       })
     : compactContextPack(fullPack, {

--- a/src/runtime/retrieve/slicing.ts
+++ b/src/runtime/retrieve/slicing.ts
@@ -128,6 +128,14 @@ function promptWantsRuntimePipeline(prompt: string | undefined): boolean {
   return /\b(runtime|pipeline|service|orchestrator|job|agent|scoring|report(?: builder)?|persistence|repository|generat(?:e|ed|es|ing|ion)|create|created)\b/i.test(prompt)
 }
 
+function promptWantsReportGenerationCore(prompt: string | undefined): boolean {
+  if (!prompt) {
+    return false
+  }
+
+  return /\b(?:report(?:\s+generation)?|generated\s+report|validation\s+report|final\s+report|assembly|assemble|synthesis|renderer|render|planner|research|metrics?|scor(?:e|ing)|quality(?:\s|-)?gate)\b/i.test(prompt)
+}
+
 function promptMentionsHttpRoute(prompt: string | undefined): boolean {
   if (!prompt) {
     return false
@@ -171,9 +179,23 @@ function effectivePolicy(
   const broadRuntimeGeneration = options.generationIntent === 'runtime_generation'
     && options.targetDomainHint === 'backend_runtime'
     && !hasExactMethodAnchor
+  const hasGenerationCoreAnchor = anchors.some((anchor) => anchor.reason === 'generation core heuristic')
 
   if (!hasMethodAnchor && !pipelinePrompt) {
     return base
+  }
+
+  if (broadRuntimeGeneration && pipelinePrompt && hasGenerationCoreAnchor && promptWantsReportGenerationCore(options.prompt)) {
+    return {
+      ...base,
+      directions: ['backward', 'forward'],
+      backward_relations: new Set(['calls', 'enqueues_job', 'controller_route', 'route_handler', 'method']),
+      forward_relations: new Set(RUNTIME_FLOW_RELATIONS),
+      helper_relations: new Set(['injects', 'depends_on', 'module_provides']),
+      backward_depth: Math.max(base.backward_depth, 3),
+      forward_depth: Math.max(base.forward_depth, 4),
+      runtime_flow_only: true,
+    }
   }
 
   if (broadRuntimeGeneration && hasMethodAnchor && pipelinePrompt) {
@@ -301,6 +323,27 @@ function runtimeGenerationAnchorValue(node: SliceScoredNode): number {
   return value
 }
 
+function semanticGenerationCoreAnchorValue(node: SliceScoredNode, prompt: string | undefined): number {
+  const lower = `${node.label} ${node.nodeKind ?? ''} ${node.frameworkRole ?? ''} ${node.sourceFile}`.toLowerCase()
+  let value = runtimeGenerationAnchorValue(node)
+
+  if (!promptWantsReportGenerationCore(prompt)) {
+    return value
+  }
+
+  if (routeOrControllerLikeNode(node)) value -= 7
+  if (/\b(?:title|status|guard|auth|interceptor|refund|suggest|list|health|planenforcement)\b/.test(lower)) value -= 4
+  if (/\b(?:planner|plan\b)\b/.test(lower)) value += 11
+  if (/\b(?:assembly|assemble|quality(?:-| )gate|renderer|render|synthesis|final(?:-| )report)\b/.test(lower)) value += 10
+  if (/\b(?:research|extract|metrics?|scor(?:e|ing))\b/.test(lower)) value += 7
+  if (/\b(?:orchestrator|pipeline)\b/.test(lower)) value += 4
+  if (/\b(?:worker|section)\b/.test(lower)) value += 2
+  if (/\b(?:persist|repository|db(?:-| )sync|save)\b/.test(lower)) value += 3
+  if (/\b(?:index\.json|state)\b/.test(lower)) value += 2
+
+  return value
+}
+
 function runtimeFlowRelationPriority(
   relation: string,
   node: SliceScoredNode,
@@ -368,6 +411,8 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
   const exactMethodAnchors = matchedAnchors.filter((node) => node.exactLabelMatch && methodLikeNode(node))
   const nonBarrelMatchedAnchors = matchedAnchors.filter((node) => !isBarrelLike(node.label, node.sourceFile))
   const broadRuntimeGeneration = broadRuntimeGenerationPrompt(options)
+  const reportGenerationPrompt = promptWantsReportGenerationCore(options.prompt)
+  const explicitPathAnchor = matchedAnchors.find((node) => node.literalPathMatch)
   const routePromptAnchors = broadRuntimeGeneration && promptMentionsHttpRoute(options.prompt)
     ? scored
       .filter((node) => routeOrControllerLikeNode(node) && !isBarrelLike(node.label, node.sourceFile) && !frontendDisplayLikeNode(node))
@@ -380,6 +425,20 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
           + (right.sourcePathMatch ? 1 : 0)
         return rightPriority - leftPriority || right.score - left.score
       })
+    : []
+  const semanticCoreAnchors = broadRuntimeGeneration && reportGenerationPrompt
+    ? scored
+      .filter((node) =>
+        methodLikeNode(node)
+        && !routeOrControllerLikeNode(node)
+        && !isBarrelLike(node.label, node.sourceFile)
+        && !frontendDisplayLikeNode(node)
+        && node.score > 0,
+      )
+      .map((node) => ({ node, value: semanticGenerationCoreAnchorValue(node, options.prompt) }))
+      .filter((entry) => entry.value > 0)
+      .sort((left, right) => right.value - left.value || right.node.score - left.node.score)
+      .map((entry) => entry.node)
     : []
   const intentAnchors = (() => {
     if (options.generationIntent === 'runtime_generation' && options.targetDomainHint === 'backend_runtime') {
@@ -402,18 +461,42 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
 
     return []
   })()
-  const anchorPool = exactMethodAnchors.length > 0
-    ? exactMethodAnchors.slice(0, 1)
-    : routePromptAnchors.length > 0
-    ? routePromptAnchors.slice(0, 1)
-    : intentAnchors.length > 0
-    ? intentAnchors.slice(0, broadRuntimeGeneration ? 1 : 2)
-    : matchedAnchors.length > 0
-    ? (nonBarrelMatchedAnchors.length > 0 ? nonBarrelMatchedAnchors : matchedAnchors)
-    : scored.filter((node) => !isBarrelLike(node.label, node.sourceFile)).slice(0, 1)
+  const generationCoreAnchorIds = new Set<string>()
+  let anchorPool: SliceScoredNode[]
+  if (exactMethodAnchors.length > 0) {
+    anchorPool = exactMethodAnchors.slice(0, 1)
+  } else if (explicitPathAnchor) {
+    anchorPool = [explicitPathAnchor]
+  } else if (broadRuntimeGeneration && reportGenerationPrompt && semanticCoreAnchors.length > 0) {
+    const primaryRuntimeAnchor = routePromptAnchors[0]
+      ?? intentAnchors[0]
+      ?? nonBarrelMatchedAnchors[0]
+      ?? matchedAnchors[0]
+    const selected = [
+      ...(primaryRuntimeAnchor ? [primaryRuntimeAnchor] : []),
+      ...semanticCoreAnchors.filter((node) => node.id !== primaryRuntimeAnchor?.id).slice(0, 2),
+    ]
+    anchorPool = selected
+    for (const node of selected) {
+      if (primaryRuntimeAnchor && node.id === primaryRuntimeAnchor.id) {
+        continue
+      }
+      generationCoreAnchorIds.add(node.id)
+    }
+  } else if (routePromptAnchors.length > 0) {
+    anchorPool = routePromptAnchors.slice(0, 1)
+  } else if (intentAnchors.length > 0) {
+    anchorPool = intentAnchors.slice(0, broadRuntimeGeneration ? 1 : 2)
+  } else if (matchedAnchors.length > 0) {
+    anchorPool = nonBarrelMatchedAnchors.length > 0 ? nonBarrelMatchedAnchors : matchedAnchors
+  } else {
+    anchorPool = scored.filter((node) => !isBarrelLike(node.label, node.sourceFile)).slice(0, 1)
+  }
 
   for (const node of anchorPool) {
-    const reason = node.exactLabelMatch
+    const reason = generationCoreAnchorIds.has(node.id)
+      ? 'generation core heuristic'
+      : node.exactLabelMatch
       ? 'symbol mention'
       : node.literalPathMatch
         ? 'path mention'
@@ -429,7 +512,8 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
       reason,
     })
     seen.add(node.id)
-    if (anchors.length >= 2) {
+    const maxAnchors = broadRuntimeGeneration && reportGenerationPrompt ? 3 : 2
+    if (anchors.length >= maxAnchors) {
       break
     }
   }
@@ -671,6 +755,14 @@ function addAnchorPredecessors(
 
       const predecessor = scoredById.get(predecessorId) ?? sliceNodeFromGraph(graph, predecessorId)
       scoredById.set(predecessorId, predecessor)
+      if (
+        broadRuntimeGenerationPrompt(options)
+        && promptWantsReportGenerationCore(options.prompt)
+        && routeOrControllerLikeNode(predecessor)
+        && !anchoredIds.has(predecessorId)
+      ) {
+        continue
+      }
       if (shouldSuppressNode(graph, predecessor, anchoredIds, options)) {
         continue
       }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -862,6 +862,40 @@ describe('compare runtime', () => {
     }
   })
 
+  it('tells broad runtime-generation answers not to stop at the HTTP trigger when downstream generation core evidence exists', () => {
+    const pack = buildMadarPromptPack({
+      question: 'How idea report is being generated',
+      retrieval: {
+        question: 'How idea report is being generated',
+        token_count: 120,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: {
+          god_nodes: [],
+          bridge_nodes: [],
+        },
+        retrieval_gate: {
+          level: 3,
+          reason: 'runtime generation intent — behavior slice retrieval',
+          skipped_retrieval: false,
+          intent: 'unknown',
+          signals: {
+            has_pr_diff: false,
+            has_stack_trace: false,
+            mentioned_paths: [],
+            mentioned_symbols: [],
+            generation_intent: 'runtime_generation',
+            target_domain_hint: 'backend_runtime',
+          },
+        },
+      },
+    })
+
+    expect(pack.prompt).toContain('Treat HTTP/controller entrypoints as trigger context, not the full answer, when downstream generation-core evidence is present.')
+    expect(pack.prompt).toContain('Follow planner, research, assembly, scoring, rendering, and persistence evidence before concluding the flow.')
+  })
+
   it('computes prompt token counts from the exact prompt text', () => {
     const graph = makeGraph()
     const corpusText = makeCorpusText()

--- a/tests/unit/retrieve-production-correctness.test.ts
+++ b/tests/unit/retrieve-production-correctness.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { build } from '../../src/pipeline/build.js'
 import { computeContextPackDiagnostics } from '../../src/runtime/context-pack-diagnostics.js'
-import { contextPackFromRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+import { compactRetrieveResult, contextPackFromRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
 
 function buildProductionPipelineGraph() {
   return build(
@@ -100,6 +100,113 @@ function buildBidirectionalHubGraph() {
           { source: 'other_controller_a', target: 'auth_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/export.controller.ts' },
           { source: 'other_controller_b', target: 'auth_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/publish.controller.ts' },
           { source: 'other_worker', target: 'add_job', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/lets-build.worker.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
+function buildBroadReportGenerationGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'route', label: '.generateFromProblem()', file_type: 'code', source_file: '/src/ideas/idea-generation.controller.ts', source_location: 'L20', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_route', community: 0 },
+          { id: 'create_idea', label: '.createIdea()', file_type: 'code', source_file: '/src/ideas/ideas.service.ts', source_location: 'L30', node_kind: 'method', framework_role: 'nest_provider', community: 0 },
+          { id: 'start_pipeline', label: '.startPipeline()', file_type: 'code', source_file: '/src/pipeline/pipeline-trigger.service.ts', source_location: 'L40', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+          { id: 'add_job', label: '.addJob()', file_type: 'code', source_file: '/src/pipeline/queue-registry.service.ts', source_location: 'L50', node_kind: 'method', framework_role: 'queue', community: 1 },
+          { id: 'title_generation', label: '.generateTitle()', file_type: 'code', source_file: '/src/ideas/title-generation.service.ts', source_location: 'L60', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+          { id: 'status_endpoint', label: '.getIdeaStatus()', file_type: 'code', source_file: '/src/ideas/idea-status.controller.ts', source_location: 'L70', node_kind: 'method', framework_role: 'nest_route', community: 1 },
+          { id: 'planner', label: '.plan()', file_type: 'code', source_file: '/src/pipeline/planner/planner.service.ts', source_location: 'L80', node_kind: 'method', framework_role: 'worker', community: 2 },
+          { id: 'section_worker', label: '.processSection()', file_type: 'code', source_file: '/src/pipeline/research/section-research.worker.ts', source_location: 'L90', node_kind: 'method', framework_role: 'worker', community: 2 },
+          { id: 'research', label: '.search()', file_type: 'code', source_file: '/src/pipeline/research/research-agent.service.ts', source_location: 'L100', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'assembly', label: '.assembleReport()', file_type: 'code', source_file: '/src/pipeline/assembly/assembly.service.ts', source_location: 'L110', node_kind: 'method', framework_role: 'service', community: 3 },
+          { id: 'scoring', label: '.score()', file_type: 'code', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts', source_location: 'L120', node_kind: 'method', framework_role: 'service', community: 3 },
+          { id: 'quality_gate', label: '.validateReport()', file_type: 'code', source_file: '/src/pipeline/assembly/report-quality-gate.service.ts', source_location: 'L130', node_kind: 'method', framework_role: 'service', community: 3 },
+          { id: 'renderer', label: '.renderFinalReport()', file_type: 'code', source_file: '/src/pipeline/assembly/deterministic-final-report.renderer.ts', source_location: 'L140', node_kind: 'method', framework_role: 'service', community: 3 },
+          { id: 'persist', label: '.saveStructuredReport()', file_type: 'code', source_file: '/src/pipeline/persistence/db-sync.worker.ts', source_location: 'L150', node_kind: 'method', framework_role: 'repository', community: 4 },
+        ],
+        edges: [
+          { source: 'route', target: 'create_idea', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-generation.controller.ts' },
+          { source: 'route', target: 'start_pipeline', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-generation.controller.ts' },
+          { source: 'route', target: 'title_generation', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-generation.controller.ts' },
+          { source: 'start_pipeline', target: 'add_job', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/pipeline-trigger.service.ts' },
+          { source: 'planner', target: 'section_worker', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/planner/planner.service.ts' },
+          { source: 'section_worker', target: 'research', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/research/section-research.worker.ts' },
+          { source: 'section_worker', target: 'assembly', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/research/section-research.worker.ts' },
+          { source: 'assembly', target: 'scoring', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'assembly', target: 'quality_gate', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'assembly', target: 'renderer', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'assembly', target: 'persist', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'status_endpoint', target: 'route', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-status.controller.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
+function buildReportGenerationLeafHelperGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'route', label: '.generateFromProblem()', file_type: 'code', source_file: '/src/ideas/idea-generation.controller.ts', source_location: 'L20', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_route', community: 0 },
+          { id: 'start_pipeline', label: '.startPipeline()', file_type: 'code', source_file: '/src/pipeline/pipeline-trigger.service.ts', source_location: 'L40', node_kind: 'method', framework_role: 'service', community: 1 },
+          { id: 'planner', label: '.plan()', file_type: 'code', source_file: '/src/pipeline/planner/planner.service.ts', source_location: 'L50', node_kind: 'method', framework_role: 'worker', community: 1 },
+          { id: 'assembly', label: '.assembleReport()', file_type: 'code', source_file: '/src/pipeline/assembly/assembly.service.ts', source_location: 'L60', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'score_report', label: '.scoreReport()', file_type: 'code', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts', source_location: 'L70', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'generate_scoring_ledger', label: '.generateScoringLedger()', file_type: 'code', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts', source_location: 'L80', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'generate_sensitivity_analysis', label: '.generateSensitivityAnalysis()', file_type: 'code', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts', source_location: 'L90', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'persist', label: '.saveStructuredReport()', file_type: 'code', source_file: '/src/pipeline/persistence/db-sync.worker.ts', source_location: 'L100', node_kind: 'method', framework_role: 'repository', community: 3 },
+          { id: 'title_generation', label: '.generateTitle()', file_type: 'code', source_file: '/src/ideas/title-generation.service.ts', source_location: 'L110', node_kind: 'method', framework_role: 'service', community: 4 },
+        ],
+        edges: [
+          { source: 'route', target: 'start_pipeline', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-generation.controller.ts' },
+          { source: 'start_pipeline', target: 'planner', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/pipeline-trigger.service.ts' },
+          { source: 'planner', target: 'assembly', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/planner/planner.service.ts' },
+          { source: 'assembly', target: 'score_report', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'score_report', target: 'generate_scoring_ledger', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts' },
+          { source: 'score_report', target: 'generate_sensitivity_analysis', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts' },
+          { source: 'assembly', target: 'persist', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'route', target: 'title_generation', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-generation.controller.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
+function buildReverseFlowReportGenerationGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'route', label: '.generateFromProblem()', file_type: 'code', source_file: '/src/ideas/idea-generation.controller.ts', source_location: 'L20', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_route', community: 0 },
+          { id: 'start_pipeline', label: '.startPipeline()', file_type: 'code', source_file: '/src/pipeline/pipeline-trigger.service.ts', source_location: 'L30', node_kind: 'method', framework_role: 'service', community: 1 },
+          { id: 'add_job', label: '.addJob()', file_type: 'code', source_file: '/src/pipeline/queue-registry.service.ts', source_location: 'L40', node_kind: 'method', framework_role: 'queue', community: 1 },
+          { id: 'process', label: '.process()', file_type: 'code', source_file: '/src/pipeline/orchestrator.worker.ts', source_location: 'L50', node_kind: 'method', framework_role: 'worker', community: 2 },
+          { id: 'assemble_report', label: '.assembleReport()', file_type: 'code', source_file: '/src/pipeline/assembly/assembly.service.ts', source_location: 'L60', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'score_metrics', label: '.scoreMetrics()', file_type: 'code', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts', source_location: 'L70', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'generate_scoring_ledger', label: '.generateScoringLedger()', file_type: 'code', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts', source_location: 'L80', node_kind: 'method', framework_role: 'service', community: 2 },
+          { id: 'persist', label: '.saveStructuredReport()', file_type: 'code', source_file: '/src/pipeline/persistence/db-sync.worker.ts', source_location: 'L90', node_kind: 'method', framework_role: 'repository', community: 3 },
+          { id: 'status', label: '.getStatusMessage()', file_type: 'code', source_file: '/src/ideas/idea-generation.controller.ts', source_location: 'L100', node_kind: 'method', framework_role: 'service', community: 4 },
+          { id: 'title_generation', label: '.generateTitle()', file_type: 'code', source_file: '/src/ideas/title-generation.service.ts', source_location: 'L110', node_kind: 'method', framework_role: 'service', community: 4 },
+        ],
+        edges: [
+          { source: 'start_pipeline', target: 'route', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/pipeline-trigger.service.ts' },
+          { source: 'add_job', target: 'start_pipeline', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/queue-registry.service.ts' },
+          { source: 'process', target: 'add_job', relation: 'enqueues_job', confidence: 'EXTRACTED', source_file: '/src/pipeline/orchestrator.worker.ts' },
+          { source: 'assemble_report', target: 'process', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/assembly.service.ts' },
+          { source: 'score_metrics', target: 'assemble_report', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts' },
+          { source: 'generate_scoring_ledger', target: 'score_metrics', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/assembly/metrics-scoring.service.ts' },
+          { source: 'persist', target: 'assemble_report', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/pipeline/persistence/db-sync.worker.ts' },
+          { source: 'status', target: 'route', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/idea-generation.controller.ts' },
+          { source: 'title_generation', target: 'route', relation: 'calls', confidence: 'EXTRACTED', source_file: '/src/ideas/title-generation.service.ts' },
         ],
       },
     ],
@@ -236,5 +343,114 @@ describe('retrieveContext production retrieval regressions', () => {
     for (const path of forbiddenPaths) {
       expect(result.slice?.selected_paths).not.toContainEqual(expect.objectContaining(path))
     }
+  })
+
+  it('adds a semantic generation-core anchor for broad report-generation prompts instead of centering only the HTTP trigger', () => {
+    const result = retrieveContext(buildBroadReportGenerationGraph(), {
+      question: 'How idea report is being generated',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    })
+
+    expect(result.slice?.anchors.map((anchor) => anchor.label)).toEqual(expect.arrayContaining([
+      '.generateFromProblem()',
+    ]))
+    expect(
+      result.slice?.anchors.some((anchor) => [
+        '.plan()',
+        '.processSection()',
+        '.search()',
+        '.assembleReport()',
+        '.score()',
+        '.validateReport()',
+        '.renderFinalReport()',
+        '.saveStructuredReport()',
+      ].includes(anchor.label)),
+    ).toBe(true)
+    expect(result.matched_nodes.map((node) => node.label)).toEqual(expect.arrayContaining([
+      '.plan()',
+      '.processSection()',
+      '.search()',
+      '.assembleReport()',
+      '.score()',
+      '.validateReport()',
+      '.renderFinalReport()',
+      '.saveStructuredReport()',
+    ]))
+  })
+
+  it('prefers central report-generation nodes over leaf helper generators for broad report-generation prompts', () => {
+    const result = retrieveContext(buildReportGenerationLeafHelperGraph(), {
+      question: 'How idea report is being generated',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    })
+
+    const anchorLabels = result.slice?.anchors.map((anchor) => anchor.label) ?? []
+    expect(anchorLabels).toEqual(expect.arrayContaining([
+      '.generateFromProblem()',
+    ]))
+    expect(anchorLabels).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^\.plan\(\)$|^\.assembleReport\(\)$|^\.scoreReport\(\)$/),
+    ]))
+    expect(anchorLabels).not.toEqual(expect.arrayContaining([
+      '.generateScoringLedger()',
+      '.generateSensitivityAnalysis()',
+      '.generateTitle()',
+    ]))
+  })
+
+  it('keeps backward-selected runtime flow as structural evidence for broad report-generation prompts', () => {
+    const result = retrieveContext(buildReverseFlowReportGenerationGraph(), {
+      question: 'How idea report is being generated',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    })
+
+    expect(result.slice?.selected_paths).toEqual(expect.arrayContaining([
+      expect.objectContaining({ from: '.startPipeline()', to: '.generateFromProblem()', relation: 'calls' }),
+      expect.objectContaining({ from: '.addJob()', to: '.startPipeline()', relation: 'calls' }),
+      expect.objectContaining({ from: '.process()', to: '.addJob()', relation: 'enqueues_job' }),
+      expect.objectContaining({ from: '.scoreMetrics()', to: '.assembleReport()', relation: 'calls' }),
+    ]))
+
+    const matched = result.matched_nodes.map((node) => ({ label: node.label, evidence_class: node.evidence_class }))
+    expect(matched).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: '.startPipeline()', evidence_class: 'structural' }),
+      expect.objectContaining({ label: '.addJob()', evidence_class: 'structural' }),
+      expect.objectContaining({ label: '.process()', evidence_class: 'structural' }),
+      expect.objectContaining({ label: '.assembleReport()', evidence_class: 'structural' }),
+      expect.objectContaining({ label: '.scoreMetrics()', evidence_class: 'structural' }),
+    ]))
+    expect(matched).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: '.getStatusMessage()', evidence_class: 'structural' }),
+      expect.objectContaining({ label: '.generateTitle()', evidence_class: 'structural' }),
+    ]))
+  })
+
+  it('compacts broad report-generation packs around the execution flow instead of status/title noise', () => {
+    const compact = compactRetrieveResult(retrieveContext(buildReverseFlowReportGenerationGraph(), {
+      question: 'How idea report is being generated',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    }))
+
+    const labels = compact.matched_nodes.map((node) => node.label)
+    expect(labels).toEqual(expect.arrayContaining([
+      '.generateFromProblem()',
+      '.startPipeline()',
+      '.addJob()',
+      '.process()',
+      '.assembleReport()',
+      '.scoreMetrics()',
+    ]))
+    expect(labels).not.toEqual(expect.arrayContaining([
+      '.getStatusMessage()',
+      '.generateTitle()',
+    ]))
   })
 })


### PR DESCRIPTION
## Summary
- add report-generation-aware slice-v1 heuristics so broad prompts keep trigger context but also recover downstream generation-core/runtime-flow evidence
- preserve backward-selected runtime flow as structural evidence and compact broad report-generation packs around execution flow instead of status/title noise
- add regressions for broad report-generation anchor selection, reverse-flow structural recovery, compact pack behavior, and compare prompt instructions

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced retrieval relevance and context selection for report-generation queries.
  * Improved prioritization of relevant information in search results.

* **Tests**
  * Added comprehensive test coverage for report-generation retrieval behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->