### PR TITLE
Fix runtime-generation routing false positives

### DIFF
--- a/src/contracts/retrieval-gate.ts
+++ b/src/contracts/retrieval-gate.ts
@@ -38,6 +38,15 @@ export type RetrievalTargetDomainHint =
   | 'frontend_display'
   | 'unknown'
 
+export interface RetrievalGenerationDebugSignals {
+  display_shaped: boolean
+  generic_generation_shaped: boolean
+  backend_runtime_shaped: boolean
+  report_generation_shaped: boolean
+  build_static_shaped: boolean
+  explanation_shaped: boolean
+}
+
 export interface RetrievalGateSignals {
   has_pr_diff: boolean
   has_stack_trace: boolean
@@ -45,6 +54,7 @@ export interface RetrievalGateSignals {
   mentioned_symbols: ReadonlyArray<string>
   generation_intent?: RetrievalGenerationIntent
   target_domain_hint?: RetrievalTargetDomainHint
+  generation_debug?: RetrievalGenerationDebugSignals
   excluded_domains?: ReadonlyArray<RetrievalExcludedDomain>
   excluded_terms?: ReadonlyArray<string>
   excluded_path_hints?: ReadonlyArray<string>

--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -24,6 +24,7 @@ import type {
   RetrievalGateDecision,
   RetrievalExcludedDomain,
   RetrievalGateSignals,
+  RetrievalGenerationDebugSignals,
   RetrievalGenerationIntent,
   RetrievalIntent,
   RetrievalLevel,
@@ -99,7 +100,8 @@ export function classifyRetrievalLevel(input: RetrievalGateInput): RetrievalGate
   const hasStackTrace = input.hasStackTrace ?? STACK_TRACE_RE.test(prompt)
   const hasPrDiff = input.hasPrDiff === true
   const intent = input.intent ?? detectIntent(positivePrompt)
-  const generationIntent = detectGenerationIntent(positivePrompt)
+  const generationClassification = detectGenerationIntent(positivePrompt)
+  const generationIntent = generationClassification.intent
   const targetDomainHint = targetDomainHintForGenerationIntent(generationIntent)
 
   const signals: RetrievalGateSignals = {
@@ -109,6 +111,7 @@ export function classifyRetrievalLevel(input: RetrievalGateInput): RetrievalGate
     mentioned_symbols: detectedSymbols,
     generation_intent: generationIntent,
     target_domain_hint: targetDomainHint,
+    generation_debug: generationClassification.debug,
     ...(exclusions.excludedDomains.length > 0 ? { excluded_domains: exclusions.excludedDomains } : {}),
     ...(exclusions.excludedTerms.length > 0 ? { excluded_terms: exclusions.excludedTerms } : {}),
     ...(exclusions.excludedPathHints.length > 0 ? { excluded_path_hints: exclusions.excludedPathHints } : {}),
@@ -209,22 +212,47 @@ function detectIntent(prompt: string): RetrievalIntent {
   return 'unknown'
 }
 
-function detectGenerationIntent(prompt: string): RetrievalGenerationIntent {
+function detectGenerationIntent(prompt: string): {
+  intent: RetrievalGenerationIntent
+  debug: RetrievalGenerationDebugSignals
+} {
   const lower = prompt.toLowerCase()
   const displayShaped = /\b(?:display(?:ed|ing)?|render(?:ed|ing)?|show(?:n|ing)?|visible|view|ui|frontend|front-end|component|screen|page|footer|header|label|date|timestamp)\b/i.test(lower)
-  const generationShaped = /\b(?:generat(?:e|ed|es|ing|ion)|creat(?:e|ed|es|ing|ion)|build(?:s|ing|er)?|assembl(?:e|ed|es|ing)|produc(?:e|ed|es|ing)|persist(?:ed|ing)?|sav(?:e|ed|es|ing)|pipeline|runtime|orchestrator|worker|job|repository|service)\b/i.test(lower)
-  const explanationShaped = /\b(?:explain|how|trace|walk|flow|path|lifecycle)\b/i.test(lower)
-
-  if (generationShaped && explanationShaped) {
-    return 'runtime_generation'
+  const genericGenerationShaped = /\b(?:generat(?:e|ed|es|ing|ion)|creat(?:e|ed|es|ing|ion)|build(?:s|ing|er)?|assembl(?:e|ed|es|ing)|produc(?:e|ed|es|ing))\b/i.test(lower)
+  const backendRuntimeShaped = /\b(?:pipeline|runtime|orchestrator|worker|job|repository|service|controller|api|backend|persist(?:ed|ing)?|sav(?:e|ed|es|ing)|db(?:sync|[- ]sync)?)\b/i.test(lower)
+  const reportGenerationShaped = /\b(?:idea\s+report|report\s+generation|final\s+report|planner|research|metrics?|scor(?:e|ing)|quality(?:\s|-)?gate|renderer|synthesis|assemble|assembly)\b/i.test(lower)
+  const buildStaticShaped = /\b(?:next\.js|nextjs|app\s+router|route\s+segment|landing\s+page|static|ssg|isr|server\s+component)\b/i.test(lower)
+  const explanationShaped = /\b(?:explain|how|why|trace|walk|flow|path|lifecycle|fail(?:s|ing|ed)?)\b/i.test(lower)
+  const debug: RetrievalGenerationDebugSignals = {
+    display_shaped: displayShaped,
+    generic_generation_shaped: genericGenerationShaped,
+    backend_runtime_shaped: backendRuntimeShaped,
+    report_generation_shaped: reportGenerationShaped,
+    build_static_shaped: buildStaticShaped,
+    explanation_shaped: explanationShaped,
   }
-  if (generationShaped && !displayShaped) {
-    return 'runtime_generation'
+
+  const strongRuntimeShaped = backendRuntimeShaped || reportGenerationShaped
+
+  if (buildStaticShaped && !strongRuntimeShaped) {
+    return { intent: 'unknown', debug }
+  }
+  if (displayShaped && !strongRuntimeShaped) {
+    return { intent: 'display_rendering', debug }
+  }
+  if (strongRuntimeShaped && (genericGenerationShaped || explanationShaped)) {
+    return { intent: 'runtime_generation', debug }
+  }
+  if (genericGenerationShaped && explanationShaped && !displayShaped && !buildStaticShaped) {
+    return { intent: 'runtime_generation', debug }
+  }
+  if (genericGenerationShaped && !displayShaped && !buildStaticShaped && strongRuntimeShaped) {
+    return { intent: 'runtime_generation', debug }
   }
   if (displayShaped) {
-    return 'display_rendering'
+    return { intent: 'display_rendering', debug }
   }
-  return 'unknown'
+  return { intent: 'unknown', debug }
 }
 
 function targetDomainHintForGenerationIntent(intent: RetrievalGenerationIntent): RetrievalTargetDomainHint {

--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -35,6 +35,7 @@ export type {
   RetrievalGateDecision,
   RetrievalExcludedDomain,
   RetrievalGateSignals,
+  RetrievalGenerationDebugSignals,
   RetrievalGenerationIntent,
   RetrievalIntent,
   RetrievalLevel,
@@ -244,9 +245,6 @@ function detectGenerationIntent(prompt: string): {
     return { intent: 'runtime_generation', debug }
   }
   if (genericGenerationShaped && explanationShaped && !displayShaped && !buildStaticShaped) {
-    return { intent: 'runtime_generation', debug }
-  }
-  if (genericGenerationShaped && !displayShaped && !buildStaticShaped && strongRuntimeShaped) {
     return { intent: 'runtime_generation', debug }
   }
   if (displayShaped) {

--- a/tests/unit/retrieval-gate.test.ts
+++ b/tests/unit/retrieval-gate.test.ts
@@ -199,6 +199,69 @@ describe('classifyRetrievalLevel — signal extraction', () => {
     expect(decision.signals.target_domain_hint).toBe('frontend_display')
   })
 
+  it('keeps generated-report UI prompts out of backend runtime routing', () => {
+    const decision = classify({ prompt: 'How is the generated report rendered in the UI?' })
+    const signals = decision.signals as typeof decision.signals & {
+      generation_debug?: {
+        display_shaped: boolean
+        generic_generation_shaped: boolean
+        backend_runtime_shaped: boolean
+        report_generation_shaped: boolean
+        build_static_shaped: boolean
+        explanation_shaped: boolean
+      }
+    }
+
+    expect(decision.level).toBe(1)
+    expect(decision.signals.generation_intent).toBe('display_rendering')
+    expect(decision.signals.target_domain_hint).toBe('frontend_display')
+    expect(signals.generation_debug).toEqual(expect.objectContaining({
+      display_shaped: true,
+      generic_generation_shaped: true,
+      backend_runtime_shaped: false,
+      build_static_shaped: false,
+    }))
+  })
+
+  it('keeps component-creation prompts out of backend runtime routing', () => {
+    const decision = classify({ prompt: 'How is this component created?' })
+    expect(decision.level).toBe(1)
+    expect(decision.signals.generation_intent).toBe('display_rendering')
+    expect(decision.signals.target_domain_hint).toBe('frontend_display')
+  })
+
+  it('keeps landing-page generation prompts out of backend runtime routing', () => {
+    const decision = classify({ prompt: 'How is the landing page generated?' })
+    const signals = decision.signals as typeof decision.signals & {
+      generation_debug?: {
+        build_static_shaped: boolean
+        backend_runtime_shaped: boolean
+      }
+    }
+
+    expect(decision.level).toBe(1)
+    expect(decision.signals.generation_intent).toBe('unknown')
+    expect(decision.signals.target_domain_hint).toBe('unknown')
+    expect(signals.generation_debug).toEqual(expect.objectContaining({
+      build_static_shaped: true,
+      backend_runtime_shaped: false,
+    }))
+  })
+
+  it('keeps Next.js page-generation prompts out of backend runtime routing', () => {
+    const decision = classify({ prompt: 'How does Next.js generate this page?' })
+    expect(decision.level).toBe(2)
+    expect(decision.signals.generation_intent).toBe('unknown')
+    expect(decision.signals.target_domain_hint).toBe('unknown')
+  })
+
+  it('prefers display rendering for mixed generated-and-displayed prompts without backend runtime markers', () => {
+    const decision = classify({ prompt: 'Explain how the report is generated and displayed' })
+    expect(decision.level).toBe(1)
+    expect(decision.signals.generation_intent).toBe('display_rendering')
+    expect(decision.signals.target_domain_hint).toBe('frontend_display')
+  })
+
   it('prefers runtime generation for explanatory prompts that also mention display terms', () => {
     const decision = classify({ prompt: 'Explain how the idea report is generated and displayed in the footer' })
     expect(decision.signals.generation_intent).toBe('runtime_generation')

--- a/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
+++ b/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
@@ -579,4 +579,50 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
     expect(labels).toEqual(expect.arrayContaining(['pickPipelineLabel()', 'ReportFooter()']))
     expect(sourceFiles.some((sourceFile) => sourceFile.includes('platform/src/features/idea-detail/components/ReportFooter.tsx'))).toBe(true)
   })
+
+  it('keeps generated-report UI prompts routed to frontend display helpers', () => {
+    const result = retrieveContext(buildFixtureGraph(), {
+      question: 'How is the generated report rendered in the UI?',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    })
+
+    const labels = result.matched_nodes.map((node) => node.label)
+    const sourceFiles = result.matched_nodes.map((node) => normalizePathForAssertion(node.source_file))
+
+    expect(result.retrieval_gate?.signals.generation_intent).toBe('display_rendering')
+    expect(result.retrieval_gate?.signals.target_domain_hint).toBe('frontend_display')
+    expect(labels).toEqual(expect.arrayContaining(['ReportFooter()', 'pickGeneratedAt()']))
+    expect(labels).not.toEqual(expect.arrayContaining([
+      '.generateFromProblem()',
+      '.startPipeline()',
+      '.addJob()',
+      '.process()',
+    ]))
+    expect(sourceFiles.some((sourceFile) => sourceFile.includes('platform/src/features/idea-detail/components/ReportFooter.tsx'))).toBe(true)
+  })
+
+  it('keeps mixed generated-and-displayed prompts routed to frontend display helpers when backend markers are absent', () => {
+    const result = retrieveContext(buildFixtureGraph(), {
+      question: 'Explain how the report is generated and displayed in the footer',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    })
+
+    const labels = result.matched_nodes.map((node) => node.label)
+    const sourceFiles = result.matched_nodes.map((node) => normalizePathForAssertion(node.source_file))
+
+    expect(result.retrieval_gate?.signals.generation_intent).toBe('display_rendering')
+    expect(result.retrieval_gate?.signals.target_domain_hint).toBe('frontend_display')
+    expect(labels).toEqual(expect.arrayContaining(['ReportFooter()', 'pickGeneratedAt()', 'pickPipelineLabel()']))
+    expect(labels).not.toEqual(expect.arrayContaining([
+      '.generateFromProblem()',
+      '.startPipeline()',
+      '.addJob()',
+      '.process()',
+    ]))
+    expect(sourceFiles.some((sourceFile) => sourceFile.includes('platform/src/features/idea-detail/components/ReportFooter.tsx'))).toBe(true)
+  })
 })

--- a/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
+++ b/tests/unit/spi-nest-di-runtime-calls-realistic.test.ts
@@ -594,12 +594,10 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
     expect(result.retrieval_gate?.signals.generation_intent).toBe('display_rendering')
     expect(result.retrieval_gate?.signals.target_domain_hint).toBe('frontend_display')
     expect(labels).toEqual(expect.arrayContaining(['ReportFooter()', 'pickGeneratedAt()']))
-    expect(labels).not.toEqual(expect.arrayContaining([
-      '.generateFromProblem()',
-      '.startPipeline()',
-      '.addJob()',
-      '.process()',
-    ]))
+    expect(labels).not.toContain('.generateFromProblem()')
+    expect(labels).not.toContain('.startPipeline()')
+    expect(labels).not.toContain('.addJob()')
+    expect(labels).not.toContain('.process()')
     expect(sourceFiles.some((sourceFile) => sourceFile.includes('platform/src/features/idea-detail/components/ReportFooter.tsx'))).toBe(true)
   })
 
@@ -617,12 +615,10 @@ describe('SPI realistic Nest DI runtime-call fixture', () => {
     expect(result.retrieval_gate?.signals.generation_intent).toBe('display_rendering')
     expect(result.retrieval_gate?.signals.target_domain_hint).toBe('frontend_display')
     expect(labels).toEqual(expect.arrayContaining(['ReportFooter()', 'pickGeneratedAt()', 'pickPipelineLabel()']))
-    expect(labels).not.toEqual(expect.arrayContaining([
-      '.generateFromProblem()',
-      '.startPipeline()',
-      '.addJob()',
-      '.process()',
-    ]))
+    expect(labels).not.toContain('.generateFromProblem()')
+    expect(labels).not.toContain('.startPipeline()')
+    expect(labels).not.toContain('.addJob()')
+    expect(labels).not.toContain('.process()')
     expect(sourceFiles.some((sourceFile) => sourceFile.includes('platform/src/features/idea-detail/components/ReportFooter.tsx'))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- tighten runtime-generation detection so UI/display and build-time prompts stop auto-routing into backend slices
- expose `generation_debug` flags in retrieval-gate signals for routing diagnostics
- add retrieval-gate and fixture-backed regressions for generated/displayed false positives

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional generation-debug flags to retrieval signals to surface intent/shaping markers (display rendering, generic generation, backend runtime, report generation, static build, explanation shaping).
* **Tests**
  * Expanded test coverage to validate routing/classification for generated-report UI and frontend-display prompts, including assertions for the new generation-debug flags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->