### PR TITLE
Add v0.25.1 runtime-routing validation artifact

### DIFF
--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/README.md
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/README.md
@@ -1,0 +1,161 @@
+# 2026-05-23 — v0.25.1 runtime-routing validation
+
+This folder records a **mixed, repeatable validation artifact** for the runtime-routing behavior shipped in `madar v0.25.1`.
+
+The goal is not to market a universal win. The goal is to show:
+
+1. which prompt classes route correctly and repeatably through the current pack surface,
+2. what the current `execution_slice` quality looks like on real GoValidate runtime prompts, and
+3. one real `native_agent` result where **cost improved even though latency and manual answer quality did not**.
+
+## Scope
+
+- **Workspace:** local GoValidate workspace with a generated `out/graph.json`
+- **CLI under test:** current `v0.25.1` runtime-routing surface
+- **Deterministic proof:** `pack`-based routing validation plus one `pack_only` compare artifact
+- **Stochastic proof:** one existing `native_agent` compare artifact from 2026-05-23
+
+## Deterministic routing validation
+
+Prompt expectations live in [`prompts.json`](./prompts.json), and the compact per-prompt routing records live in [`routing-validation.json`](./routing-validation.json).
+
+The checked prompt classes all passed:
+
+| Prompt class | Passed | Total |
+| --- | ---: | ---: |
+| positive backend runtime-generation | 5 | 5 |
+| explicit runtime path | 1 | 1 |
+| frontend display | 3 | 3 |
+| ambiguous / mixed | 4 | 4 |
+
+### What the deterministic routing data shows
+
+- Backend runtime-generation prompts stayed on **`runtime_generation` + `backend_runtime`** and auto-selected **`slice-v1`**.
+- Frontend/display prompts stayed on **`display_rendering` + `frontend_display`** and stayed on the **default** retrieval strategy rather than being forced into backend slices.
+- Ambiguous/build-time prompts such as landing-page generation and Next.js page generation stayed **`unknown` / ambiguous** instead of being promoted to backend runtime.
+
+Representative outcomes:
+
+| Prompt id | Actual domain | Retrieval strategy | `execution_slice` | Pack tokens |
+| --- | --- | --- | --- | ---: |
+| `runtime-report-generated` | backend runtime | `slice-v1` | `complete` | 1033 |
+| `runtime-explicit-controller-path` | backend runtime | `slice-v1` | `complete` | 914 |
+| `display-generated-date-ui` | frontend display | `default` | none | 560 |
+| `mixed-nextjs-page-generated` | ambiguous | `default` | none | 195 |
+
+Important nuance:
+
+- Two backend-runtime prompts still produced **partial** execution slices:
+  - `runtime-report-queue-processed`
+  - `runtime-report-saved`
+- Those prompts still passed the routing judgment because they were routed into the correct backend-runtime surface; the partial slice is useful evidence about current slice quality rather than a hidden failure.
+
+## `pack_only` compare artifact
+
+Committed share-safe artifact:
+
+- [`runtime-report-generated.pack-only.report.share-safe.json`](./runtime-report-generated.pack-only.report.share-safe.json)
+
+Observed deterministic values for `How idea report is being generated`:
+
+- baseline prompt tokens: **31,982**
+- madar prompt tokens: **32,537**
+- compact pack token count: **927**
+- matched nodes: **21**
+- relationships: **16**
+- retrieval strategy: **`slice-v1`**
+- `execution_slice.status`: **`complete`**
+- `execution_slice.phase_coverage.observed`: `controller`, `service`, `queue`, `worker`
+
+This is intentionally **not** framed as a token win. On this prompt, the `pack_only` compare shows that the compact pack carried the right runtime-routing and `execution_slice` surface, but the full prompt built around that pack was still slightly larger than the bounded baseline prompt.
+
+## `native_agent` compare artifact
+
+Committed share-safe artifact:
+
+- [`runtime-report-generated.native-agent.report.share-safe.json`](./runtime-report-generated.native-agent.report.share-safe.json)
+
+This is the real 2026-05-23 single-prompt run the issue refers to.
+
+Prompt:
+
+> `How idea report is being generated`
+
+| Metric | Baseline | Madar | Outcome |
+| --- | ---: | ---: | --- |
+| Turns | 2 | 2 | same |
+| Latency (ms) | 176,361 | 224,951 | madar slower |
+| Total input tokens | 113,260 | 118,161 | madar used more |
+| Uncached input tokens | 77,358 | 46,357 | madar used less |
+| Cache creation input tokens | 60,457 | 29,524 | madar used less |
+| Cache read input tokens | 35,902 | 71,804 | madar used more |
+| Total cost (USD) | 1.0739 | 0.7722 | madar cheaper |
+
+Manual answer-quality note:
+
+- [`native-agent-quality-note.txt`](./native-agent-quality-note.txt)
+
+This is the important interpretation point for `v0.25.1`:
+
+- **cost improved**
+- **latency got worse**
+- **total provider-reported input tokens got worse**
+- **manual answer quality was not judged better**
+
+That is a useful validation result, but it is **not** a universal product-win claim.
+
+## Published files
+
+- `prompts.json` — prompt list plus expected routing labels
+- `collect-routing-validation.mjs` — regenerates deterministic routing records from `pack`
+- `routing-validation.json` — compact deterministic per-prompt routing record
+- `runtime-report-generated.pack-only.report.share-safe.json` — deterministic `pack_only` example
+- `runtime-report-generated.native-agent.report.share-safe.json` — stochastic `native_agent` example
+- `native-agent-quality-note.txt` — manual answer-quality note for the single native-agent run
+
+## Reproduction commands
+
+Build the local CLI first:
+
+```bash
+npm install
+npm run build
+```
+
+Regenerate the deterministic routing matrix:
+
+```bash
+node docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs \
+  --graph /absolute/path/to/govalidate/out/graph.json
+```
+
+Regenerate the local `pack_only` compare artifact:
+
+```bash
+node dist/src/cli/bin.js compare "How idea report is being generated" \
+  --graph /absolute/path/to/govalidate/out/graph.json \
+  --exec 'cat {prompt_file}' \
+  --yes \
+  --baseline-mode pack_only
+```
+
+The `native_agent` artifact is intentionally kept separate because it depends on a live model runner. If you want to reproduce that path, use a structured runner such as:
+
+```bash
+node dist/src/cli/bin.js compare "How idea report is being generated" \
+  --graph /absolute/path/to/govalidate/out/graph.json \
+  --exec 'cat {prompt_file} | claude -p --output-format json' \
+  --yes \
+  --baseline-mode native_agent
+```
+
+## Bottom line
+
+`v0.25.1` now has a committed routing-validation artifact showing that:
+
+- the targeted backend-runtime prompts route into `slice-v1`,
+- the display/build-time false-positive prompts stay out of backend-runtime routing,
+- the compact pack can preserve a meaningful `execution_slice`,
+- and a real native-agent run can still be **cheaper while being slower and not clearly better**.
+
+That is the honest state of the current evidence.

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync } from 'node:fs'
-import { dirname, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
 
@@ -61,7 +61,10 @@ function sanitizeSourceFile(sourceFile, workspaceRoot) {
   }
   const absolute = resolve(workspaceRoot, sourceFile)
   const rel = relative(workspaceRoot, absolute)
-  return rel.startsWith('..') ? sourceFile.replaceAll('\\', '/') : rel.replaceAll('\\', '/')
+  if (rel.startsWith('..')) {
+    return isAbsolute(sourceFile) ? '<external-path>' : sourceFile.replaceAll('\\', '/')
+  }
+  return rel.replaceAll('\\', '/')
 }
 
 function inferActualDomain(targetDomainHint) {

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '../../..')
+
+function parseArgs(argv) {
+  const out = {
+    graph: null,
+    prompts: resolve(scriptDir, 'prompts.json'),
+    output: resolve(scriptDir, 'routing-validation.json'),
+    budget: '4000',
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--graph') out.graph = argv[++i] ?? null
+    else if (arg === '--prompts') out.prompts = resolve(process.cwd(), argv[++i] ?? '')
+    else if (arg === '--output') out.output = resolve(process.cwd(), argv[++i] ?? '')
+    else if (arg === '--budget') out.budget = argv[++i] ?? out.budget
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  if (!out.graph) {
+    throw new Error('Usage: node collect-routing-validation.mjs --graph /absolute/path/to/graph.json [--output routing-validation.json]')
+  }
+
+  out.graph = resolve(process.cwd(), out.graph)
+  return out
+}
+
+function sanitizeSourceFile(sourceFile, workspaceRoot) {
+  if (typeof sourceFile !== 'string' || sourceFile.length === 0) {
+    return sourceFile
+  }
+  const absolute = resolve(workspaceRoot, sourceFile)
+  const rel = relative(workspaceRoot, absolute)
+  return rel.startsWith('..') ? sourceFile.replaceAll('\\', '/') : rel.replaceAll('\\', '/')
+}
+
+function inferActualDomain(targetDomainHint) {
+  if (targetDomainHint === 'backend_runtime') return 'backend_runtime'
+  if (targetDomainHint === 'frontend_display') return 'frontend_display'
+  return 'ambiguous'
+}
+
+function runPack(cliPath, graphPath, budget, question) {
+  const result = spawnSync(
+    'node',
+    [cliPath, 'pack', question, '--task', 'explain', '--graph', graphPath, '--budget', budget],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: process.env,
+      maxBuffer: 20 * 1024 * 1024,
+    },
+  )
+
+  if (result.status !== 0) {
+    throw new Error(`pack failed for "${question}": ${result.stderr || result.stdout}`)
+  }
+
+  return JSON.parse(result.stdout)
+}
+
+function evaluatePrompt(prompt, payload) {
+  const pack = payload.pack ?? {}
+  const gate = payload.retrieval_gate ?? pack.retrieval_gate ?? {}
+  const signals = gate.signals ?? {}
+  const generationIntent = signals.generation_intent ?? 'unknown'
+  const targetDomainHint = signals.target_domain_hint ?? 'unknown'
+  const retrievalStrategy = pack.retrieval_strategy ?? 'default'
+  const hasExecutionSlice = pack.execution_slice !== undefined
+
+  const checks = {
+    generation_intent: prompt.allowed_generation_intents?.includes(generationIntent) ?? true,
+    target_domain_hint: prompt.allowed_target_domain_hints?.includes(targetDomainHint) ?? true,
+    retrieval_strategy: prompt.required_retrieval_strategy ? retrievalStrategy === prompt.required_retrieval_strategy : true,
+    execution_slice: typeof prompt.require_execution_slice === 'boolean'
+      ? hasExecutionSlice === prompt.require_execution_slice
+      : true,
+  }
+
+  const failures = Object.entries(checks)
+    .filter(([, passed]) => passed !== true)
+    .map(([name]) => name)
+
+  return {
+    checks,
+    passed: failures.length === 0,
+    failures,
+    actual_domain: inferActualDomain(targetDomainHint),
+  }
+}
+
+const { graph, prompts, output, budget } = parseArgs(process.argv.slice(2))
+const promptList = JSON.parse(readFileSync(prompts, 'utf8'))
+const workspaceRoot = resolve(dirname(graph), '..')
+const cliPath = resolve(repoRoot, 'dist/src/cli/bin.js')
+
+const records = promptList.map((prompt) => {
+  const payload = runPack(cliPath, graph, budget, prompt.question)
+  const pack = payload.pack ?? {}
+  const gate = payload.retrieval_gate ?? pack.retrieval_gate ?? {}
+  const signals = gate.signals ?? {}
+  const evaluation = evaluatePrompt(prompt, payload)
+
+  return {
+    id: prompt.id,
+    class: prompt.class,
+    question: prompt.question,
+    expected_domain: prompt.expected_domain,
+    retrieval_gate: {
+      intent: gate.intent ?? null,
+      generation_intent: signals.generation_intent ?? 'unknown',
+      target_domain_hint: signals.target_domain_hint ?? 'unknown',
+    },
+    retrieval_strategy: pack.retrieval_strategy ?? 'default',
+    pack_token_count: pack.token_count ?? null,
+    matched_nodes: Array.isArray(pack.matched_nodes)
+      ? pack.matched_nodes.map((node) => ({
+          label: node.label,
+          source_file: sanitizeSourceFile(node.source_file, workspaceRoot),
+        }))
+      : [],
+    relationship_count: Array.isArray(pack.relationships) ? pack.relationships.length : 0,
+    has_execution_slice: pack.execution_slice !== undefined,
+    execution_slice_status: pack.execution_slice?.status ?? null,
+    execution_slice_phase_coverage: pack.execution_slice?.phase_coverage ?? null,
+    execution_slice_steps: Array.isArray(pack.execution_slice?.steps)
+      ? pack.execution_slice.steps.map((step) => step.label)
+      : [],
+    routing_judgment: evaluation,
+  }
+})
+
+const summary = {
+  total_prompts: records.length,
+  passed_prompts: records.filter((record) => record.routing_judgment.passed).length,
+  failed_prompts: records.filter((record) => !record.routing_judgment.passed).map((record) => record.id),
+}
+
+writeFileSync(output, `${JSON.stringify({
+  generated_at: new Date().toISOString(),
+  graph_path: '<workspace-root>/out/graph.json',
+  workspace_root: '<workspace-root>',
+  budget: Number(budget),
+  summary,
+  prompts: records,
+}, null, 2)}\n`)

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs
@@ -7,26 +7,48 @@ import { spawnSync } from 'node:child_process'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '../../..')
+const usage = 'Usage: node collect-routing-validation.mjs --graph /absolute/path/to/graph.json [--prompts prompts.json] [--output routing-validation.json] [--budget 4000]'
 
 function parseArgs(argv) {
   const out = {
     graph: null,
     prompts: resolve(scriptDir, 'prompts.json'),
     output: resolve(scriptDir, 'routing-validation.json'),
-    budget: '4000',
+    budget: 4000,
+  }
+
+  const readValue = (arg, next) => {
+    if (typeof next !== 'string' || next.length === 0 || next.startsWith('-')) {
+      throw new Error(`Missing value for ${arg}`)
+    }
+    return next
   }
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i]
-    if (arg === '--graph') out.graph = argv[++i] ?? null
-    else if (arg === '--prompts') out.prompts = resolve(process.cwd(), argv[++i] ?? '')
-    else if (arg === '--output') out.output = resolve(process.cwd(), argv[++i] ?? '')
-    else if (arg === '--budget') out.budget = argv[++i] ?? out.budget
+    const next = argv[i + 1]
+    if (arg === '--graph') {
+      out.graph = readValue(arg, next)
+      i += 1
+    } else if (arg === '--prompts') {
+      out.prompts = resolve(process.cwd(), readValue(arg, next))
+      i += 1
+    } else if (arg === '--output') {
+      out.output = resolve(process.cwd(), readValue(arg, next))
+      i += 1
+    } else if (arg === '--budget') {
+      const parsedBudget = Number(readValue(arg, next))
+      if (!Number.isFinite(parsedBudget) || !Number.isInteger(parsedBudget) || parsedBudget <= 0) {
+        throw new Error(`--budget must be a positive integer, received: ${next ?? ''}`)
+      }
+      out.budget = parsedBudget
+      i += 1
+    }
     else throw new Error(`Unknown argument: ${arg}`)
   }
 
   if (!out.graph) {
-    throw new Error('Usage: node collect-routing-validation.mjs --graph /absolute/path/to/graph.json [--output routing-validation.json]')
+    throw new Error(`Missing required --graph.\n${usage}`)
   }
 
   out.graph = resolve(process.cwd(), out.graph)
@@ -51,7 +73,7 @@ function inferActualDomain(targetDomainHint) {
 function runPack(cliPath, graphPath, budget, question) {
   const result = spawnSync(
     'node',
-    [cliPath, 'pack', question, '--task', 'explain', '--graph', graphPath, '--budget', budget],
+    [cliPath, 'pack', question, '--task', 'explain', '--graph', graphPath, '--budget', String(budget)],
     {
       cwd: repoRoot,
       encoding: 'utf8',
@@ -97,58 +119,71 @@ function evaluatePrompt(prompt, payload) {
   }
 }
 
-const { graph, prompts, output, budget } = parseArgs(process.argv.slice(2))
-const promptList = JSON.parse(readFileSync(prompts, 'utf8'))
-const workspaceRoot = resolve(dirname(graph), '..')
-const cliPath = resolve(repoRoot, 'dist/src/cli/bin.js')
+function main() {
+  const { graph, prompts, output, budget } = parseArgs(process.argv.slice(2))
+  const promptList = JSON.parse(readFileSync(prompts, 'utf8'))
+  const workspaceRoot = resolve(dirname(graph), '..')
+  const cliPath = resolve(repoRoot, 'dist/src/cli/bin.js')
 
-const records = promptList.map((prompt) => {
-  const payload = runPack(cliPath, graph, budget, prompt.question)
-  const pack = payload.pack ?? {}
-  const gate = payload.retrieval_gate ?? pack.retrieval_gate ?? {}
-  const signals = gate.signals ?? {}
-  const evaluation = evaluatePrompt(prompt, payload)
+  const records = promptList.map((prompt) => {
+    const payload = runPack(cliPath, graph, budget, prompt.question)
+    const pack = payload.pack ?? {}
+    const gate = payload.retrieval_gate ?? pack.retrieval_gate ?? {}
+    const signals = gate.signals ?? {}
+    const evaluation = evaluatePrompt(prompt, payload)
 
-  return {
-    id: prompt.id,
-    class: prompt.class,
-    question: prompt.question,
-    expected_domain: prompt.expected_domain,
-    retrieval_gate: {
-      intent: gate.intent ?? null,
-      generation_intent: signals.generation_intent ?? 'unknown',
-      target_domain_hint: signals.target_domain_hint ?? 'unknown',
-    },
-    retrieval_strategy: pack.retrieval_strategy ?? 'default',
-    pack_token_count: pack.token_count ?? null,
-    matched_nodes: Array.isArray(pack.matched_nodes)
-      ? pack.matched_nodes.map((node) => ({
-          label: node.label,
-          source_file: sanitizeSourceFile(node.source_file, workspaceRoot),
-        }))
-      : [],
-    relationship_count: Array.isArray(pack.relationships) ? pack.relationships.length : 0,
-    has_execution_slice: pack.execution_slice !== undefined,
-    execution_slice_status: pack.execution_slice?.status ?? null,
-    execution_slice_phase_coverage: pack.execution_slice?.phase_coverage ?? null,
-    execution_slice_steps: Array.isArray(pack.execution_slice?.steps)
-      ? pack.execution_slice.steps.map((step) => step.label)
-      : [],
-    routing_judgment: evaluation,
+    return {
+      id: prompt.id,
+      class: prompt.class,
+      question: prompt.question,
+      expected_domain: prompt.expected_domain,
+      retrieval_gate: {
+        intent: gate.intent ?? null,
+        generation_intent: signals.generation_intent ?? 'unknown',
+        target_domain_hint: signals.target_domain_hint ?? 'unknown',
+      },
+      retrieval_strategy: pack.retrieval_strategy ?? 'default',
+      pack_token_count: pack.token_count ?? null,
+      matched_nodes: Array.isArray(pack.matched_nodes)
+        ? pack.matched_nodes.map((node) => ({
+            label: node.label,
+            source_file: sanitizeSourceFile(node.source_file, workspaceRoot),
+          }))
+        : [],
+      relationship_count: Array.isArray(pack.relationships) ? pack.relationships.length : 0,
+      has_execution_slice: pack.execution_slice !== undefined,
+      execution_slice_status: pack.execution_slice?.status ?? null,
+      execution_slice_phase_coverage: pack.execution_slice?.phase_coverage ?? null,
+      execution_slice_steps: Array.isArray(pack.execution_slice?.steps)
+        ? pack.execution_slice.steps.map((step) => step.label)
+        : [],
+      routing_judgment: evaluation,
+    }
+  })
+
+  const summary = {
+    total_prompts: records.length,
+    passed_prompts: records.filter((record) => record.routing_judgment.passed).length,
+    failed_prompts: records.filter((record) => !record.routing_judgment.passed).map((record) => record.id),
   }
-})
 
-const summary = {
-  total_prompts: records.length,
-  passed_prompts: records.filter((record) => record.routing_judgment.passed).length,
-  failed_prompts: records.filter((record) => !record.routing_judgment.passed).map((record) => record.id),
+  writeFileSync(output, `${JSON.stringify({
+    generated_at: new Date().toISOString(),
+    graph_path: '<workspace-root>/out/graph.json',
+    workspace_root: '<workspace-root>',
+    budget,
+    summary,
+    prompts: records,
+  }, null, 2)}\n`)
 }
 
-writeFileSync(output, `${JSON.stringify({
-  generated_at: new Date().toISOString(),
-  graph_path: '<workspace-root>/out/graph.json',
-  workspace_root: '<workspace-root>',
-  budget: Number(budget),
-  summary,
-  prompts: records,
-}, null, 2)}\n`)
+try {
+  main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(message)
+  if (!message.includes(usage)) {
+    console.error(usage)
+  }
+  process.exit(1)
+}

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/native-agent-quality-note.txt
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/native-agent-quality-note.txt
@@ -1,0 +1,7 @@
+Prompt: How idea report is being generated
+
+Manual answer-quality note from the 2026-05-23 single native-agent review:
+
+- baseline answer was preferred overall
+- madar answer still surfaced the main pipeline concepts, but it was not judged the better answer for this prompt
+- treat this run as a mixed result: lower cost, worse latency, worse total input tokens, and no manual quality win

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/prompts.json
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/prompts.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "runtime-report-generated",
+    "class": "positive-backend-runtime-generation",
+    "question": "How idea report is being generated",
+    "expected_domain": "backend_runtime",
+    "allowed_generation_intents": ["runtime_generation"],
+    "allowed_target_domain_hints": ["backend_runtime"],
+    "required_retrieval_strategy": "slice-v1"
+  },
+  {
+    "id": "runtime-report-getting-generated",
+    "class": "positive-backend-runtime-generation",
+    "question": "Explain how idea report is getting generated",
+    "expected_domain": "backend_runtime",
+    "allowed_generation_intents": ["runtime_generation"],
+    "allowed_target_domain_hints": ["backend_runtime"],
+    "required_retrieval_strategy": "slice-v1"
+  },
+  {
+    "id": "runtime-report-generation-pipeline",
+    "class": "positive-backend-runtime-generation",
+    "question": "idea report generation pipeline",
+    "expected_domain": "backend_runtime",
+    "allowed_generation_intents": ["runtime_generation"],
+    "allowed_target_domain_hints": ["backend_runtime"],
+    "required_retrieval_strategy": "slice-v1"
+  },
+  {
+    "id": "runtime-report-queue-processed",
+    "class": "positive-backend-runtime-generation",
+    "question": "How does the report job get queued and processed?",
+    "expected_domain": "backend_runtime",
+    "allowed_generation_intents": ["runtime_generation"],
+    "allowed_target_domain_hints": ["backend_runtime"],
+    "required_retrieval_strategy": "slice-v1"
+  },
+  {
+    "id": "runtime-report-saved",
+    "class": "positive-backend-runtime-generation",
+    "question": "Where is the generated report saved?",
+    "expected_domain": "backend_runtime",
+    "allowed_generation_intents": ["runtime_generation"],
+    "allowed_target_domain_hints": ["backend_runtime"],
+    "required_retrieval_strategy": "slice-v1"
+  },
+  {
+    "id": "runtime-explicit-controller-path",
+    "class": "explicit-runtime-path",
+    "question": "Explain the production runtime path for IdeaGenerationController.generateFromProblem and how it creates a GoValidate validation report.",
+    "expected_domain": "backend_runtime",
+    "allowed_generation_intents": ["runtime_generation"],
+    "allowed_target_domain_hints": ["backend_runtime"],
+    "required_retrieval_strategy": "slice-v1",
+    "require_execution_slice": true
+  },
+  {
+    "id": "display-generated-date-ui",
+    "class": "frontend-display",
+    "question": "Where is the generated date displayed in the report UI?",
+    "expected_domain": "frontend_display",
+    "allowed_generation_intents": ["display_rendering"],
+    "allowed_target_domain_hints": ["frontend_display"]
+  },
+  {
+    "id": "display-generated-pdf-ui",
+    "class": "frontend-display",
+    "question": "How is the generated PDF rendered in the UI?",
+    "expected_domain": "frontend_display",
+    "allowed_generation_intents": ["display_rendering"],
+    "allowed_target_domain_hints": ["frontend_display"]
+  },
+  {
+    "id": "display-report-footer",
+    "class": "frontend-display",
+    "question": "How is the report displayed in the footer?",
+    "expected_domain": "frontend_display",
+    "allowed_generation_intents": ["display_rendering"],
+    "allowed_target_domain_hints": ["frontend_display"]
+  },
+  {
+    "id": "mixed-generated-and-displayed",
+    "class": "ambiguous-mixed",
+    "question": "Explain how the report is generated and displayed",
+    "expected_domain": "frontend_display",
+    "allowed_generation_intents": ["display_rendering"],
+    "allowed_target_domain_hints": ["frontend_display"]
+  },
+  {
+    "id": "mixed-landing-page-generated",
+    "class": "ambiguous-mixed",
+    "question": "How is the landing page generated?",
+    "expected_domain": "ambiguous",
+    "allowed_generation_intents": ["unknown"],
+    "allowed_target_domain_hints": ["unknown"]
+  },
+  {
+    "id": "mixed-component-created",
+    "class": "ambiguous-mixed",
+    "question": "How is this component created?",
+    "expected_domain": "frontend_display",
+    "allowed_generation_intents": ["display_rendering"],
+    "allowed_target_domain_hints": ["frontend_display"]
+  },
+  {
+    "id": "mixed-nextjs-page-generated",
+    "class": "ambiguous-mixed",
+    "question": "How does Next.js generate this page?",
+    "expected_domain": "ambiguous",
+    "allowed_generation_intents": ["unknown"],
+    "allowed_target_domain_hints": ["unknown"]
+  }
+]

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/routing-validation.json
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/routing-validation.json
@@ -1,0 +1,1577 @@
+{
+  "generated_at": "2026-05-23T23:42:35.666Z",
+  "graph_path": "<workspace-root>/out/graph.json",
+  "workspace_root": "<workspace-root>",
+  "budget": 4000,
+  "summary": {
+    "total_prompts": 13,
+    "passed_prompts": 13,
+    "failed_prompts": []
+  },
+  "prompts": [
+    {
+      "id": "runtime-report-generated",
+      "class": "positive-backend-runtime-generation",
+      "question": "How idea report is being generated",
+      "expected_domain": "backend_runtime",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      },
+      "retrieval_strategy": "slice-v1",
+      "pack_token_count": 1033,
+      "matched_nodes": [
+        {
+          "label": ".generateFromProblem()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts"
+        },
+        {
+          "label": ".generateScoringLedger()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".generateSensitivityAnalysis()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline-trigger.service.ts"
+        },
+        {
+          "label": ".scoreMetrics()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline.controller.ts"
+        },
+        {
+          "label": ".addJob()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".enrichCompetitor()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts"
+        },
+        {
+          "label": ".retrySection()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts"
+        },
+        {
+          "label": ".generateSuggestedNextSteps()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildFallbackMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".deduplicateEvidenceRefs()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildMetricHumanPrompt()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.prompts.ts"
+        },
+        {
+          "label": ".hasCollapsedMetricValues()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".isMetricDecisionGrade()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "sanitizeJobId()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".handleQualityGateFailure()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        },
+        {
+          "label": ".checkAndDispatchNext()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".dispatchWave()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".broadcastEvent()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".broadcastRunFailed()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".syncFailedStatus()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".broadcastEvent()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-broadcaster.service.ts"
+        },
+        {
+          "label": ".broadcastSectionEvent()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-broadcaster.service.ts"
+        },
+        {
+          "label": ".broadcastRunStarted()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".dispatchDbSync()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        },
+        {
+          "label": ".dispatchDbSync()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        }
+      ],
+      "relationship_count": 21,
+      "has_execution_slice": true,
+      "execution_slice_status": "complete",
+      "execution_slice_phase_coverage": {
+        "expected": [
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "controller",
+          "service",
+          "queue",
+          "worker"
+        ],
+        "missing": []
+      },
+      "execution_slice_steps": [
+        ".generateFromProblem()",
+        ".startPipeline()",
+        ".addJob()",
+        ".broadcastRunFailed()",
+        ".process()"
+      ],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "backend_runtime"
+      }
+    },
+    {
+      "id": "runtime-report-getting-generated",
+      "class": "positive-backend-runtime-generation",
+      "question": "Explain how idea report is getting generated",
+      "expected_domain": "backend_runtime",
+      "retrieval_gate": {
+        "intent": "explain",
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      },
+      "retrieval_strategy": "slice-v1",
+      "pack_token_count": 1033,
+      "matched_nodes": [
+        {
+          "label": ".generateFromProblem()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts"
+        },
+        {
+          "label": ".generateScoringLedger()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".generateSensitivityAnalysis()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline-trigger.service.ts"
+        },
+        {
+          "label": ".scoreMetrics()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline.controller.ts"
+        },
+        {
+          "label": ".addJob()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".enrichCompetitor()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts"
+        },
+        {
+          "label": ".retrySection()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts"
+        },
+        {
+          "label": ".generateSuggestedNextSteps()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildFallbackMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".deduplicateEvidenceRefs()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildMetricHumanPrompt()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.prompts.ts"
+        },
+        {
+          "label": ".hasCollapsedMetricValues()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".isMetricDecisionGrade()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "sanitizeJobId()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".handleQualityGateFailure()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        },
+        {
+          "label": ".checkAndDispatchNext()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".dispatchWave()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".broadcastEvent()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".broadcastRunFailed()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".syncFailedStatus()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".broadcastEvent()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-broadcaster.service.ts"
+        },
+        {
+          "label": ".broadcastSectionEvent()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-broadcaster.service.ts"
+        },
+        {
+          "label": ".broadcastRunStarted()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".dispatchDbSync()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        },
+        {
+          "label": ".dispatchDbSync()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        }
+      ],
+      "relationship_count": 21,
+      "has_execution_slice": true,
+      "execution_slice_status": "complete",
+      "execution_slice_phase_coverage": {
+        "expected": [
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "controller",
+          "service",
+          "queue",
+          "worker"
+        ],
+        "missing": []
+      },
+      "execution_slice_steps": [
+        ".generateFromProblem()",
+        ".startPipeline()",
+        ".addJob()",
+        ".broadcastRunFailed()",
+        ".process()"
+      ],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "backend_runtime"
+      }
+    },
+    {
+      "id": "runtime-report-generation-pipeline",
+      "class": "positive-backend-runtime-generation",
+      "question": "idea report generation pipeline",
+      "expected_domain": "backend_runtime",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      },
+      "retrieval_strategy": "slice-v1",
+      "pack_token_count": 1155,
+      "matched_nodes": [
+        {
+          "label": ".generateFromProblem()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts"
+        },
+        {
+          "label": ".scoreMetricBatch()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".scoreMetrics()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline-trigger.service.ts"
+        },
+        {
+          "label": ".updateCost()",
+          "source_file": "backend/src/modules/pipeline/state/index-manager.service.ts"
+        },
+        {
+          "label": ".updateSectionPromptIO()",
+          "source_file": "backend/src/modules/pipeline/state/index-manager.service.ts"
+        },
+        {
+          "label": ".callLlm()",
+          "source_file": "backend/src/modules/pipeline/providers/llm-provider-resolver.service.ts"
+        },
+        {
+          "label": ".call()",
+          "source_file": "backend/src/modules/pipeline/agent/master-agent.service.ts"
+        },
+        {
+          "label": ".calculateTokenUsage()",
+          "source_file": "backend/src/modules/pipeline/cost/cost-aggregator.service.ts"
+        },
+        {
+          "label": "buildFallbackMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".normalizeMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".hasCollapsedMetricValues()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".isMetricDecisionGrade()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".parseJson()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildGroupedMetricsSystemPrompt()",
+          "source_file": "backend/src/modules/pipeline/assembly/unified-metrics.prompts.ts"
+        },
+        {
+          "label": ".generateScoringLedger()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".generateSensitivityAnalysis()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".generateSuggestedNextSteps()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".deduplicateEvidenceRefs()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".mapCompositeToRecommendation()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildMetricHumanPrompt()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.prompts.ts"
+        },
+        {
+          "label": ".retryPipeline()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-pipeline.controller.ts"
+        },
+        {
+          "label": ".addJob()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline.controller.ts"
+        },
+        {
+          "label": ".proceedWithAnalysis()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-pipeline.controller.ts"
+        },
+        {
+          "label": ".enrichCompetitor()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts"
+        },
+        {
+          "label": ".retrySection()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts"
+        },
+        {
+          "label": ".updateIndex()",
+          "source_file": "backend/src/modules/pipeline/state/index-manager.service.ts"
+        }
+      ],
+      "relationship_count": 25,
+      "has_execution_slice": true,
+      "execution_slice_status": "complete",
+      "execution_slice_phase_coverage": {
+        "expected": [
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "controller",
+          "service",
+          "queue",
+          "worker"
+        ],
+        "missing": []
+      },
+      "execution_slice_steps": [
+        ".generateFromProblem()",
+        ".startPipeline()",
+        ".addJob()",
+        ".broadcastRunFailed()",
+        ".process()"
+      ],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "backend_runtime"
+      }
+    },
+    {
+      "id": "runtime-report-queue-processed",
+      "class": "positive-backend-runtime-generation",
+      "question": "How does the report job get queued and processed?",
+      "expected_domain": "backend_runtime",
+      "retrieval_gate": {
+        "intent": "explain",
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      },
+      "retrieval_strategy": "slice-v1",
+      "pack_token_count": 1239,
+      "matched_nodes": [
+        {
+          "label": ".close()",
+          "source_file": "backend/src/modules/queue/services/email-queue.service.ts"
+        },
+        {
+          "label": ".constructor()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".constructor()",
+          "source_file": "backend/src/modules/pipeline/state/index-manager.service.ts"
+        },
+        {
+          "label": ".constructor()",
+          "source_file": "backend/src/modules/pipeline/providers/llm-provider-resolver.service.ts"
+        },
+        {
+          "label": ".constructor()",
+          "source_file": "backend/src/modules/pipeline/agent/master-agent.service.ts"
+        },
+        {
+          "label": ".processEmailJob()",
+          "source_file": "backend/src/modules/queue/services/email-queue.service.ts"
+        },
+        {
+          "label": ".scoreMetrics()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".initializeQueue()",
+          "source_file": "backend/src/modules/queue/services/email-queue.service.ts"
+        },
+        {
+          "label": "buildFallbackMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".hasCollapsedMetricValues()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".isMetricDecisionGrade()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".constructor()",
+          "source_file": "backend/src/modules/users/email-queue.service.ts"
+        },
+        {
+          "label": ".cacheSchedule()",
+          "source_file": "backend/src/modules/users/email-queue.service.ts"
+        },
+        {
+          "label": ".dequeueDue()",
+          "source_file": "backend/src/modules/users/email-queue.service.ts"
+        },
+        {
+          "label": ".remove()",
+          "source_file": "backend/src/modules/users/email-queue.service.ts"
+        },
+        {
+          "label": ".reschedule()",
+          "source_file": "backend/src/modules/users/email-queue.service.ts"
+        },
+        {
+          "label": ".enqueue()",
+          "source_file": "backend/src/modules/users/email-queue.service.ts"
+        },
+        {
+          "label": ".researchSection()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".runRecovery()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-extractor.service.ts"
+        },
+        {
+          "label": ".persistCostAndIO()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-extractor.service.ts"
+        },
+        {
+          "label": ".persistCost()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-final-synthesis.service.ts"
+        },
+        {
+          "label": ".persistPromptIO()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-final-synthesis.service.ts"
+        },
+        {
+          "label": ".runUnified()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-extractor.service.ts"
+        },
+        {
+          "label": ".classifyIdea()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".run()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-final-synthesis.service.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/market-research.executor.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/tech-feasibility.executor.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/business-model.executor.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/user-personas.executor.ts"
+        },
+        {
+          "label": ".assemble()",
+          "source_file": "backend/src/modules/pipeline/agent/prompt-assembler.ts"
+        },
+        {
+          "label": ".initializeWorker()",
+          "source_file": "backend/src/modules/background-jobs/workers/email.worker.ts"
+        },
+        {
+          "label": ".initializeWorker()",
+          "source_file": "backend/src/modules/background-jobs/workers/scraping.worker.ts"
+        },
+        {
+          "label": ".plan()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".handleQualityGateFailure()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        }
+      ],
+      "relationship_count": 8,
+      "has_execution_slice": true,
+      "execution_slice_status": "partial",
+      "execution_slice_phase_coverage": {
+        "expected": [
+          "controller",
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "service",
+          "queue"
+        ],
+        "missing": [
+          "controller",
+          "worker"
+        ]
+      },
+      "execution_slice_steps": [
+        ".processEmailJob()",
+        ".initializeQueue()",
+        ".constructor()"
+      ],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "backend_runtime"
+      }
+    },
+    {
+      "id": "runtime-report-saved",
+      "class": "positive-backend-runtime-generation",
+      "question": "Where is the generated report saved?",
+      "expected_domain": "backend_runtime",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      },
+      "retrieval_strategy": "slice-v1",
+      "pack_token_count": 1121,
+      "matched_nodes": [
+        {
+          "label": ".search()",
+          "source_file": "backend/src/modules/ideas/infrastructure/search/providers/ai-generated-search.provider.ts"
+        },
+        {
+          "label": ".generateScoringLedger()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".generateSensitivityAnalysis()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".scoreMetrics()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".generateSuggestedNextSteps()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".scoreMetricBatch()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildFallbackMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".deduplicateEvidenceRefs()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".mapCompositeToRecommendation()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildMetricHumanPrompt()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.prompts.ts"
+        },
+        {
+          "label": ".normalizeMetric()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".hasCollapsedMetricValues()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".isMetricDecisionGrade()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": "buildGroupedMetricsSystemPrompt()",
+          "source_file": "backend/src/modules/pipeline/assembly/unified-metrics.prompts.ts"
+        },
+        {
+          "label": "clampCredibilityScore()",
+          "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts"
+        },
+        {
+          "label": ".researchSection()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".runRecovery()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-extractor.service.ts"
+        },
+        {
+          "label": ".runUnified()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-extractor.service.ts"
+        },
+        {
+          "label": ".classifyIdea()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".run()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-final-synthesis.service.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/market-research.executor.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/tech-feasibility.executor.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/business-model.executor.ts"
+        },
+        {
+          "label": ".executeForStructurer()",
+          "source_file": "backend/src/modules/ideas/infrastructure/executors/micro/structurer/user-personas.executor.ts"
+        },
+        {
+          "label": ".persistCostAndIO()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-extractor.service.ts"
+        },
+        {
+          "label": ".persistCost()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-final-synthesis.service.ts"
+        },
+        {
+          "label": ".persistPromptIO()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-final-synthesis.service.ts"
+        },
+        {
+          "label": ".assemble()",
+          "source_file": "backend/src/modules/pipeline/agent/prompt-assembler.ts"
+        }
+      ],
+      "relationship_count": 18,
+      "has_execution_slice": true,
+      "execution_slice_status": "partial",
+      "execution_slice_phase_coverage": {
+        "expected": [
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "service"
+        ],
+        "missing": [
+          "queue",
+          "worker"
+        ]
+      },
+      "execution_slice_steps": [
+        ".search()"
+      ],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "backend_runtime"
+      }
+    },
+    {
+      "id": "runtime-explicit-controller-path",
+      "class": "explicit-runtime-path",
+      "question": "Explain the production runtime path for IdeaGenerationController.generateFromProblem and how it creates a GoValidate validation report.",
+      "expected_domain": "backend_runtime",
+      "retrieval_gate": {
+        "intent": "explain",
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime"
+      },
+      "retrieval_strategy": "slice-v1",
+      "pack_token_count": 914,
+      "matched_nodes": [
+        {
+          "label": ".generateTitle()",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/title-generation.service.ts"
+        },
+        {
+          "label": ".createIdea()",
+          "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts"
+        },
+        {
+          "label": ".releaseUnusedCreditReservation()",
+          "source_file": "backend/src/modules/credits/services/idea-generation-compensation.service.ts"
+        },
+        {
+          "label": ".updateTitle()",
+          "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts"
+        },
+        {
+          "label": ".generateFromProblem()",
+          "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts"
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "backend/src/modules/pipeline/api/pipeline-trigger.service.ts"
+        },
+        {
+          "label": ".claimQueuedPipelineRun()",
+          "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts"
+        },
+        {
+          "label": ".releaseQueuedPipelineClaim()",
+          "source_file": "backend/src/modules/ideas/core/application/ideas.service.ts"
+        },
+        {
+          "label": ".addJob()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".broadcastRunFailed()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".broadcastRunStarted()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": "sanitizeJobId()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        },
+        {
+          "label": ".handleQualityGateFailure()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        },
+        {
+          "label": ".checkAndDispatchNext()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".dispatchWave()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".broadcastEvent()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".syncFailedStatus()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".broadcastEvent()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-broadcaster.service.ts"
+        },
+        {
+          "label": ".broadcastSectionEvent()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly-broadcaster.service.ts"
+        },
+        {
+          "label": ".dispatchDbSync()",
+          "source_file": "backend/src/modules/pipeline/assembly/assembly.service.ts"
+        },
+        {
+          "label": ".dispatchDbSync()",
+          "source_file": "backend/src/modules/pipeline/research/research-agent.service.ts"
+        },
+        {
+          "label": ".process()",
+          "source_file": "backend/src/modules/pipeline/planner/orchestrator.worker.ts"
+        },
+        {
+          "label": ".plan()",
+          "source_file": "backend/src/modules/pipeline/planner/planner.service.ts"
+        },
+        {
+          "label": ".removeJob()",
+          "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts"
+        }
+      ],
+      "relationship_count": 26,
+      "has_execution_slice": true,
+      "execution_slice_status": "complete",
+      "execution_slice_phase_coverage": {
+        "expected": [
+          "controller",
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "controller",
+          "service",
+          "queue",
+          "worker"
+        ],
+        "missing": []
+      },
+      "execution_slice_steps": [
+        ".generateFromProblem()",
+        ".startPipeline()",
+        ".addJob()",
+        ".broadcastRunFailed()",
+        ".process()"
+      ],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "backend_runtime"
+      }
+    },
+    {
+      "id": "display-generated-date-ui",
+      "class": "frontend-display",
+      "question": "Where is the generated date displayed in the report UI?",
+      "expected_domain": "frontend_display",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "display_rendering",
+        "target_domain_hint": "frontend_display"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 560,
+      "matched_nodes": [
+        {
+          "label": "ReportFooter()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "ScoreDisplay",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        },
+        {
+          "label": "formatDate()",
+          "source_file": "platform/src/features/certification/components/VerificationPage.tsx"
+        },
+        {
+          "label": "formatDate()",
+          "source_file": "platform/src/app/coupon-campaigns/[id]/page.tsx"
+        },
+        {
+          "label": "pickGeneratedAt()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "formatDate()",
+          "source_file": "platform/src/features/certification/components/MyBadgesPage.tsx"
+        },
+        {
+          "label": "ScoreDisplay.tsx",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        },
+        {
+          "label": "VerificationPage.tsx",
+          "source_file": "platform/src/features/certification/components/VerificationPage.tsx"
+        },
+        {
+          "label": "page.tsx",
+          "source_file": "landing-page/src/app/ai-market-research/page.tsx"
+        },
+        {
+          "label": "ReportFooter.tsx",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "MyBadgesPage.tsx",
+          "source_file": "platform/src/features/certification/components/MyBadgesPage.tsx"
+        },
+        {
+          "label": "CertificateView()",
+          "source_file": "platform/src/features/certification/components/VerificationPage.tsx"
+        },
+        {
+          "label": "CampaignMeta()",
+          "source_file": "platform/src/app/coupon-campaigns/[id]/page.tsx"
+        },
+        {
+          "label": "BadgeCard()",
+          "source_file": "platform/src/features/certification/components/MyBadgesPage.tsx"
+        },
+        {
+          "label": "getScoreColor",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        },
+        {
+          "label": "ScoreBadge",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        }
+      ],
+      "relationship_count": 16,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "frontend_display"
+      }
+    },
+    {
+      "id": "display-generated-pdf-ui",
+      "class": "frontend-display",
+      "question": "How is the generated PDF rendered in the UI?",
+      "expected_domain": "frontend_display",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "display_rendering",
+        "target_domain_hint": "frontend_display"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 549,
+      "matched_nodes": [
+        {
+          "label": ".render()",
+          "source_file": "platform/src/features/idea-detail/components/IdeaDetailErrorBoundary.tsx"
+        },
+        {
+          "label": "pickGeneratedAt()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": ".render()",
+          "source_file": "platform/src/app/settings/components/ErrorBoundary.tsx"
+        },
+        {
+          "label": "renderPdfDocument()",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/pdf-generator.templates.ts"
+        },
+        {
+          "label": "getPdfDecisionIcon()",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/pdf-generator.templates.ts"
+        },
+        {
+          "label": ".generateHtml()",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/pdf-generator.service.ts"
+        },
+        {
+          "label": "renderPdfCoverPage()",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/pdf-generator.templates.ts"
+        },
+        {
+          "label": ".renderCoverPage()",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/pdf-generator.service.ts"
+        },
+        {
+          "label": "ReportFooter.tsx",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "ReportFooter()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "pickPipelineLabel()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "IdeaDetailErrorBoundary",
+          "source_file": "platform/src/features/idea-detail/components/IdeaDetailErrorBoundary.tsx"
+        },
+        {
+          "label": "relativeTime()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "pdf-generator.templates.ts",
+          "source_file": "backend/src/modules/ideas/infrastructure/services/pdf-generator.templates.ts"
+        },
+        {
+          "label": "SettingsErrorBoundary",
+          "source_file": "platform/src/app/settings/components/ErrorBoundary.tsx"
+        }
+      ],
+      "relationship_count": 16,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "frontend_display"
+      }
+    },
+    {
+      "id": "display-report-footer",
+      "class": "frontend-display",
+      "question": "How is the report displayed in the footer?",
+      "expected_domain": "frontend_display",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "display_rendering",
+        "target_domain_hint": "frontend_display"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 238,
+      "matched_nodes": [
+        {
+          "label": "Footer()",
+          "source_file": "landing-page/src/components/ui/footer.tsx"
+        },
+        {
+          "label": "FOOTER_NAV",
+          "source_file": "landing-page/src/components/ui/footer.tsx"
+        },
+        {
+          "label": "FooterColumn",
+          "source_file": "landing-page/src/components/ui/footer.tsx"
+        },
+        {
+          "label": "FooterLink",
+          "source_file": "landing-page/src/components/ui/footer.tsx"
+        },
+        {
+          "label": "Footer()",
+          "source_file": "platform/src/features/certification/components/VerificationPage.tsx"
+        },
+        {
+          "label": "footer.tsx",
+          "source_file": "landing-page/src/components/ui/footer.tsx"
+        },
+        {
+          "label": "VerificationPage.tsx",
+          "source_file": "platform/src/features/certification/components/VerificationPage.tsx"
+        },
+        {
+          "label": "LEGAL_NAV",
+          "source_file": "landing-page/src/components/ui/footer.tsx"
+        },
+        {
+          "label": "CertificateView()",
+          "source_file": "platform/src/features/certification/components/VerificationPage.tsx"
+        }
+      ],
+      "relationship_count": 7,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "frontend_display"
+      }
+    },
+    {
+      "id": "mixed-generated-and-displayed",
+      "class": "ambiguous-mixed",
+      "question": "Explain how the report is generated and displayed",
+      "expected_domain": "frontend_display",
+      "retrieval_gate": {
+        "intent": "explain",
+        "generation_intent": "display_rendering",
+        "target_domain_hint": "frontend_display"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 457,
+      "matched_nodes": [
+        {
+          "label": "ReportFooter()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "CreditsDisplay()",
+          "source_file": "platform/src/features/credits/components/CreditsDisplay.tsx"
+        },
+        {
+          "label": "ScoreDisplay",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        },
+        {
+          "label": "pickGeneratedAt()",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "ScoreDisplayProps",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        },
+        {
+          "label": "ErrorDisplay()",
+          "source_file": "platform/src/app/admin/pipeline/[ideaId]/page.tsx"
+        },
+        {
+          "label": "CreditsDisplayProps",
+          "source_file": "platform/src/features/credits/components/CreditsDisplay.tsx"
+        },
+        {
+          "label": "CreditsDisplay.tsx",
+          "source_file": "platform/src/features/credits/components/CreditsDisplay.tsx"
+        },
+        {
+          "label": "ScoreDisplay.tsx",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        },
+        {
+          "label": "ReportFooter.tsx",
+          "source_file": "platform/src/features/idea-detail/components/ReportFooter.tsx"
+        },
+        {
+          "label": "useCredits",
+          "source_file": "platform/src/features/credits/hooks/index.ts"
+        },
+        {
+          "label": "page.tsx",
+          "source_file": "landing-page/src/app/ai-market-research/page.tsx"
+        },
+        {
+          "label": "parseError()",
+          "source_file": "platform/src/app/admin/pipeline/[ideaId]/page.tsx"
+        },
+        {
+          "label": "getScoreColor",
+          "source_file": "platform/src/ui/ScoreDisplay.tsx"
+        }
+      ],
+      "relationship_count": 12,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "frontend_display"
+      }
+    },
+    {
+      "id": "mixed-landing-page-generated",
+      "class": "ambiguous-mixed",
+      "question": "How is the landing page generated?",
+      "expected_domain": "ambiguous",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "unknown",
+        "target_domain_hint": "unknown"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 717,
+      "matched_nodes": [
+        {
+          "label": "LandingFooter()",
+          "source_file": "landing-page/src/components/landing/verdict-machine-home.tsx"
+        },
+        {
+          "label": "generateMetadata()",
+          "source_file": "landing-page/src/app/landing/ideas/[ideaId]/page.tsx"
+        },
+        {
+          "label": "getInviteData()",
+          "source_file": "platform/src/app/i/[code]/page.tsx"
+        },
+        {
+          "label": ".generate()",
+          "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts"
+        },
+        {
+          "label": "page",
+          "source_file": "landing-page/src/app/ai-market-research/page.tsx"
+        },
+        {
+          "label": ".generate()",
+          "source_file": "backend/src/modules/certification/services/badge-generator.service.ts"
+        },
+        {
+          "label": ".generatePdfFromHtml()",
+          "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts"
+        },
+        {
+          "label": "verdict-machine-home.tsx",
+          "source_file": "landing-page/src/components/landing/verdict-machine-home.tsx"
+        },
+        {
+          "label": "page.tsx",
+          "source_file": "landing-page/src/app/ai-market-research/page.tsx"
+        },
+        {
+          "label": ".claimBadge()",
+          "source_file": "backend/src/modules/certification/services/certification.service.ts"
+        },
+        {
+          "label": ".uploadFile()",
+          "source_file": "backend/src/modules/storage/storage.service.ts"
+        },
+        {
+          "label": "renderCertificateHtml()",
+          "source_file": "backend/src/modules/certification/templates/certificate-html.ts"
+        },
+        {
+          "label": ".buildAssetUrl()",
+          "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts"
+        },
+        {
+          "label": ".dataUrlToBuffer()",
+          "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts"
+        },
+        {
+          "label": ".buildAssetUrl()",
+          "source_file": "backend/src/modules/certification/services/badge-generator.service.ts"
+        },
+        {
+          "label": "renderBadgeSvg()",
+          "source_file": "backend/src/modules/certification/templates/badge-svg.ts"
+        },
+        {
+          "label": "analysisRows",
+          "source_file": "landing-page/src/components/landing/verdict-machine-home.tsx"
+        },
+        {
+          "label": "outcomes",
+          "source_file": "landing-page/src/components/landing/verdict-machine-home.tsx"
+        },
+        {
+          "label": "CertificateGeneratorService",
+          "source_file": "backend/src/modules/certification/services/certificate-generator.service.ts"
+        },
+        {
+          "label": "BadgeGeneratorService",
+          "source_file": "backend/src/modules/certification/services/badge-generator.service.ts"
+        }
+      ],
+      "relationship_count": 24,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "ambiguous"
+      }
+    },
+    {
+      "id": "mixed-component-created",
+      "class": "ambiguous-mixed",
+      "question": "How is this component created?",
+      "expected_domain": "frontend_display",
+      "retrieval_gate": {
+        "intent": "unknown",
+        "generation_intent": "display_rendering",
+        "target_domain_hint": "frontend_display"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 500,
+      "matched_nodes": [
+        {
+          "label": "severityForNormal()",
+          "source_file": "platform/src/features/idea-detail/components/MetricDrawer.tsx"
+        },
+        {
+          "label": "severityForInverted()",
+          "source_file": "platform/src/features/idea-detail/components/MetricDrawer.tsx"
+        },
+        {
+          "label": "MarkdownText()",
+          "source_file": "platform/src/features/idea-detail/components/MarkdownText.tsx"
+        },
+        {
+          "label": "SummaryModule()",
+          "source_file": "platform/src/features/idea-detail/components/modules/SummaryModule.tsx"
+        },
+        {
+          "label": "renderLink()",
+          "source_file": "platform/src/features/idea-detail/components/MarkdownText.tsx"
+        },
+        {
+          "label": "ComponentRow()",
+          "source_file": "platform/src/features/idea-detail/components/MetricDrawer.tsx"
+        },
+        {
+          "label": "makeComponents()",
+          "source_file": "platform/src/features/idea-detail/components/modules/SummaryModule.tsx"
+        },
+        {
+          "label": "ComponentCard()",
+          "source_file": "platform/src/features/ideas/components/MetricDetailModal.tsx"
+        },
+        {
+          "label": "makeInlineComponents()",
+          "source_file": "platform/src/features/idea-detail/components/MarkdownText.tsx"
+        },
+        {
+          "label": "makeBlockComponents()",
+          "source_file": "platform/src/features/idea-detail/components/MarkdownText.tsx"
+        },
+        {
+          "label": "MetricDrawer.tsx",
+          "source_file": "platform/src/features/idea-detail/components/MetricDrawer.tsx"
+        },
+        {
+          "label": "SummaryModule.tsx",
+          "source_file": "platform/src/features/idea-detail/components/modules/SummaryModule.tsx"
+        },
+        {
+          "label": "MetricDetailModal.tsx",
+          "source_file": "platform/src/features/ideas/components/MetricDetailModal.tsx"
+        },
+        {
+          "label": "MarkdownText.tsx",
+          "source_file": "platform/src/features/idea-detail/components/MarkdownText.tsx"
+        },
+        {
+          "label": "MetricDrawer()",
+          "source_file": "platform/src/features/idea-detail/components/MetricDrawer.tsx"
+        },
+        {
+          "label": "severityFor()",
+          "source_file": "platform/src/features/idea-detail/components/MetricDrawer.tsx"
+        }
+      ],
+      "relationship_count": 22,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "frontend_display"
+      }
+    },
+    {
+      "id": "mixed-nextjs-page-generated",
+      "class": "ambiguous-mixed",
+      "question": "How does Next.js generate this page?",
+      "expected_domain": "ambiguous",
+      "retrieval_gate": {
+        "intent": "explain",
+        "generation_intent": "unknown",
+        "target_domain_hint": "unknown"
+      },
+      "retrieval_strategy": "default",
+      "pack_token_count": 195,
+      "matched_nodes": [
+        {
+          "label": "nextConfig",
+          "source_file": "platform/next.config.performance.js"
+        },
+        {
+          "label": "next.config.js",
+          "source_file": "landing-page/next.config.js"
+        },
+        {
+          "label": "next.config.enhanced.js",
+          "source_file": "landing-page/next.config.enhanced.js"
+        },
+        {
+          "label": "nextConfig",
+          "source_file": "landing-page/next.config.js"
+        },
+        {
+          "label": "next.config.performance.js",
+          "source_file": "platform/next.config.performance.js"
+        },
+        {
+          "label": "nextConfig",
+          "source_file": "landing-page/next.config.enhanced.js"
+        }
+      ],
+      "relationship_count": 3,
+      "has_execution_slice": false,
+      "execution_slice_status": null,
+      "execution_slice_phase_coverage": null,
+      "execution_slice_steps": [],
+      "routing_judgment": {
+        "checks": {
+          "generation_intent": true,
+          "target_domain_hint": true,
+          "retrieval_strategy": true,
+          "execution_slice": true
+        },
+        "passed": true,
+        "failures": [],
+        "actual_domain": "ambiguous"
+      }
+    }
+  ]
+}

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/routing-validation.json
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/routing-validation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-23T23:51:43.283Z",
+  "generated_at": "2026-05-24T00:00:23.587Z",
   "graph_path": "<workspace-root>/out/graph.json",
   "workspace_root": "<workspace-root>",
   "budget": 4000,

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/routing-validation.json
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/routing-validation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-23T23:42:35.666Z",
+  "generated_at": "2026-05-23T23:51:43.283Z",
   "graph_path": "<workspace-root>/out/graph.json",
   "workspace_root": "<workspace-root>",
   "budget": 4000,

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/runtime-report-generated.native-agent.report.share-safe.json
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/runtime-report-generated.native-agent.report.share-safe.json
@@ -1,0 +1,129 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How idea report is being generated",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 16901,
+      "cache_creation_input_tokens": 60457,
+      "cache_read_input_tokens": 35902,
+      "output_tokens": 2416,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 60457,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 2,
+          "output_tokens": 1543,
+          "cache_read_input_tokens": 35902,
+          "cache_creation_input_tokens": 24555,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 24555
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 113260,
+    "uncached_input_tokens_anthropic_exact": 77358,
+    "cached_input_tokens_anthropic_exact": 35902,
+    "total_cost_usd": 1.0739026000000003,
+    "num_turns": 2,
+    "duration_ms": 176361,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 16833,
+      "cache_creation_input_tokens": 29524,
+      "cache_read_input_tokens": 71804,
+      "output_tokens": 2294,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 29524,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 2,
+          "output_tokens": 1566,
+          "cache_read_input_tokens": 35902,
+          "cache_creation_input_tokens": 29524,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 29524
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 118161,
+    "uncached_input_tokens_anthropic_exact": 46357,
+    "cached_input_tokens_anthropic_exact": 71804,
+    "total_cost_usd": 0.7722143000000001,
+    "num_turns": 2,
+    "duration_ms": 224951,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.96,
+    "num_turns": 1,
+    "duration_ms": 0.78,
+    "cost_usd": 1.39
+  },
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-23T18:39:17.733Z",
+  "completed_at": "2026-05-23T18:46:05.730Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/runtime-report-generated.pack-only.report.share-safe.json
+++ b/docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/runtime-report-generated.pack-only.report.share-safe.json
@@ -1,0 +1,5959 @@
+{
+  "question": "How idea report is being generated",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline_mode": "pack_only",
+  "baseline_prompt_tokens": 31982,
+  "madar_prompt_tokens": 32537,
+  "reduction_ratio": 1,
+  "baseline_effective_prompt_tokens": 31982,
+  "madar_effective_prompt_tokens": 32537,
+  "effective_reduction_ratio": 1,
+  "baseline_reused_context_tokens": 0,
+  "madar_reused_context_tokens": 0,
+  "baseline_total_tokens": null,
+  "madar_total_tokens": null,
+  "total_reduction_ratio": null,
+  "baseline_prompt_tokens_estimated": 31982,
+  "madar_prompt_tokens_estimated": 32537,
+  "reduction_ratio_estimated": 1,
+  "prompt_token_estimator": {
+    "source": "local_tokenizer",
+    "model": "cl100k_base",
+    "exact": false
+  },
+  "prompt_token_source": {
+    "baseline": "estimated_cl100k_base",
+    "madar": "estimated_cl100k_base"
+  },
+  "usage": {
+    "baseline": null,
+    "madar": null
+  },
+  "started_at": "2026-05-23T23:38:11.019Z",
+  "completed_at": "2026-05-23T23:38:27.426Z",
+  "elapsed_ms": {
+    "baseline": 14,
+    "madar": 7
+  },
+  "status": {
+    "baseline": "succeeded",
+    "madar": "succeeded"
+  },
+  "answer_paths": {
+    "baseline": "<artifact-root>/baseline-answer.txt",
+    "madar": "<artifact-root>/madar-answer.txt"
+  },
+  "exit_code": {
+    "baseline": 0,
+    "madar": 0
+  },
+  "stderr": {
+    "baseline": null,
+    "madar": null
+  },
+  "failure_reason": {
+    "baseline": null,
+    "madar": null
+  },
+  "evidence": {
+    "baseline": null,
+    "madar": null
+  },
+  "pack": {
+    "question": "How idea report is being generated",
+    "token_count": 927,
+    "matched_nodes": [
+      {
+        "label": ".generateFromProblem()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-generation.controller.ts",
+        "line_number": 75,
+        "source_domain": "production",
+        "snippet": "\n  @Post('analyze')\n  @UseGuards(AuthGuard, PlanEnforcementGuard)",
+        "relevance_band": "direct",
+        "community": 299,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route",
+        "node_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+        "match_score": 5.810626102292769
+      },
+      {
+        "label": ".generateScoringLedger()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 518,
+        "source_domain": "production",
+        "snippet": "\n  private generateScoringLedger(\n    metrics: Metric[],",
+        "relevance_band": "direct",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_generatescoringledger",
+        "match_score": 5.730769230769231
+      },
+      {
+        "label": ".generateSensitivityAnalysis()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 505,
+        "source_domain": "production",
+        "snippet": "\n  private generateSensitivityAnalysis(metrics: Metric[]): SensitivityAnalysis[] {\n    return metrics.map((m) => {",
+        "relevance_band": "direct",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_generatesensitivityanalysis",
+        "match_score": 5.7272727272727275
+      },
+      {
+        "label": ".generateSuggestedNextSteps()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 592,
+        "source_domain": "production",
+        "snippet": "\n  private generateSuggestedNextSteps(metrics: Metric[]): string[] {\n    const steps: string[] = [];",
+        "relevance_band": "direct",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_generatesuggestednextsteps",
+        "match_score": 5.618110236220472
+      },
+      {
+        "label": ".callLlm()",
+        "source_file": "backend/src/modules/pipeline/providers/llm-provider-resolver.service.ts",
+        "line_number": 100,
+        "source_domain": "production",
+        "snippet": "\n  async callLlm(resolved: ResolvedProvider, params: Omit<LlmChatParams, 'apiKey' | 'baseUrl'>): Promise<LlmChatResult> {\n    const client = this.getClient(resolved.clientType);",
+        "relevance_band": "related",
+        "community": 553,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+        "match_score": 7.82466913195796
+      },
+      {
+        "label": ".resolve()",
+        "source_file": "backend/src/modules/pipeline/providers/llm-provider-resolver.service.ts",
+        "line_number": 43,
+        "source_domain": "production",
+        "snippet": "\n  async resolve(userId: string, modelTier: ModelTier, modelOverride?: string): Promise<ResolvedProvider> {\n    const tierConfig = MODEL_TIER_DEFAULTS[modelTier];",
+        "relevance_band": "related",
+        "community": 550,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+        "match_score": 7.82466913195796
+      },
+      {
+        "label": ".addJob()",
+        "source_file": "backend/src/modules/pipeline/queues/queue-registry.service.ts",
+        "line_number": 59,
+        "source_domain": "production",
+        "snippet": "\n  async addJob<T>(\n    queueName: string,",
+        "relevance_band": "related",
+        "community": 181,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "queue_registry_service_queueregistryservice_addjob",
+        "match_score": 4.5
+      },
+      {
+        "label": ".scoreMetricBatch()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 298,
+        "source_domain": "production",
+        "snippet": "\n  private async scoreMetricBatch(\n    userId: string,",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+        "match_score": 5.5
+      },
+      {
+        "label": ".scoreMetrics()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 99,
+        "source_domain": "production",
+        "snippet": "   */\n  async scoreMetrics(\n    userId: string,",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+        "match_score": 5.5
+      },
+      {
+        "label": ".startPipeline()",
+        "source_file": "backend/src/modules/pipeline/api/pipeline-trigger.service.ts",
+        "line_number": 24,
+        "source_domain": "production",
+        "snippet": "\n  async startPipeline(userId: string, rawIdea: string, existingIdeaId?: string): Promise<{ ideaId: string; jobId: string }> {\n    const ideaId = existingIdeaId ?? randomUUID();",
+        "relevance_band": "related",
+        "community": 1284,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+        "match_score": 8.405313051146384
+      },
+      {
+        "label": ".retryPipeline()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-pipeline.controller.ts",
+        "line_number": 110,
+        "source_domain": "production",
+        "snippet": "   */\n  @Post(':id/retry-research')\n  @ApiOperation({ summary: 'Retry a failed v2 pipeline run' })",
+        "relevance_band": "related",
+        "community": 778,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route",
+        "node_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+        "match_score": 4.545117404410598
+      },
+      {
+        "label": ".enrichCompetitor()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts",
+        "line_number": 59,
+        "source_domain": "production",
+        "snippet": "\n  @Post(':id/competitors/:index/enrich')\n  @HttpCode(HttpStatus.ACCEPTED)",
+        "relevance_band": "related",
+        "community": 780,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route",
+        "node_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+        "match_score": 4.54483865914787
+      },
+      {
+        "label": ".proceedWithAnalysis()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-pipeline.controller.ts",
+        "line_number": 55,
+        "source_domain": "production",
+        "snippet": "\n  @Patch(':id/proceed-with-analysis')\n  @ApiOperation({",
+        "relevance_band": "related",
+        "community": 1178,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route",
+        "node_id": "idea_pipeline_controller_ideapipelinecontroller_proceedwithanalysis",
+        "match_score": 4.544291714394808
+      },
+      {
+        "label": ".retrySection()",
+        "source_file": "backend/src/modules/ideas/interface/http/idea-research.controller.ts",
+        "line_number": 149,
+        "source_domain": "production",
+        "snippet": "\n  @Post(':id/retry-section')\n  @HttpCode(HttpStatus.OK)",
+        "relevance_band": "related",
+        "community": 779,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route",
+        "node_id": "idea_research_controller_idearesearchcontroller_retrysection",
+        "match_score": 4.544023378582202
+      },
+      {
+        "label": "buildFallbackMetric()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 61,
+        "source_domain": "production",
+        "snippet": "/** Fallback metric when an individual call fails */\nfunction buildFallbackMetric(config: MetricConfig, reason: string): Metric {\n  const displayName = config.name.charAt(0).toUpperCase() + config.name.slice(1);",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_buildfallbackmetric",
+        "match_score": 4.5
+      },
+      {
+        "label": ".normalizeMetric()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 412,
+        "source_domain": "production",
+        "snippet": "\n  private normalizeMetric(parsed: Record<string, unknown>, config: MetricConfig): Metric {\n    const value = Math.max(0, Math.min(100, Math.round(Number(parsed.value) || 50)));",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_normalizemetric",
+        "match_score": 4.5
+      },
+      {
+        "label": "buildMetricHumanPrompt()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.prompts.ts",
+        "line_number": 15,
+        "source_domain": "production",
+        "snippet": " */\nexport function buildMetricHumanPrompt(\n  ideaTitle: string,",
+        "relevance_band": "related",
+        "community": 1218,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_prompts_buildmetrichumanprompt",
+        "match_score": 2.75
+      },
+      {
+        "label": ".startPipeline()",
+        "source_file": "backend/src/modules/pipeline/api/pipeline.controller.ts",
+        "line_number": 24,
+        "source_domain": "production",
+        "snippet": "\n  @Post('run')\n  async startPipeline(",
+        "relevance_band": "related",
+        "community": 1284,
+        "framework": "nestjs",
+        "framework_role": "nest_route",
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_kind": "route",
+        "node_id": "pipeline_controller_pipelinecontroller_startpipeline",
+        "match_score": 5.5
+      },
+      {
+        "label": ".deduplicateEvidenceRefs()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 570,
+        "source_domain": "production",
+        "snippet": "\n  private deduplicateEvidenceRefs(evidenceRefs: EvidenceRef[]): EvidenceRef[] {\n    const seen = new Map<string, EvidenceRef>();",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_deduplicateevidencerefs",
+        "match_score": 4.5
+      },
+      {
+        "label": ".mapCompositeToRecommendation()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 496,
+        "source_domain": "production",
+        "snippet": "\n  private mapCompositeToRecommendation(\n    compositeScore: number,",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_mapcompositetorecommendation",
+        "match_score": 4.5
+      },
+      {
+        "label": ".hasCollapsedMetricValues()",
+        "source_file": "backend/src/modules/pipeline/assembly/metrics-scoring.service.ts",
+        "line_number": 492,
+        "source_domain": "production",
+        "snippet": "\n  private hasCollapsedMetricValues(metrics: Metric[]): boolean {\n    return metrics.length >= 3 && metrics.every((metric) => metric.value === metric.weight);",
+        "relevance_band": "related",
+        "community": 55,
+        "representation_type": "detail",
+        "representation_reason": "explain detail preserved",
+        "node_id": "metrics_scoring_service_metricsscoringservice_hascollapsedmetricvalues",
+        "match_score": 4.5
+      }
+    ],
+    "relationships": [
+      {
+        "from": ".generateFromProblem()",
+        "to": ".startPipeline()",
+        "relation": "calls"
+      },
+      {
+        "from": ".generateScoringLedger()",
+        "to": ".scoreMetrics()",
+        "relation": "calls"
+      },
+      {
+        "from": ".generateSensitivityAnalysis()",
+        "to": ".scoreMetrics()",
+        "relation": "calls"
+      },
+      {
+        "from": ".startPipeline()",
+        "to": ".startPipeline()",
+        "relation": "calls"
+      },
+      {
+        "from": ".startPipeline()",
+        "to": ".addJob()",
+        "relation": "calls"
+      },
+      {
+        "from": ".startPipeline()",
+        "to": ".retryPipeline()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetrics()",
+        "to": "buildFallbackMetric()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetrics()",
+        "to": ".deduplicateEvidenceRefs()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetrics()",
+        "to": ".generateSuggestedNextSteps()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetrics()",
+        "to": ".mapCompositeToRecommendation()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetrics()",
+        "to": ".scoreMetricBatch()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetrics()",
+        "to": "buildMetricHumanPrompt()",
+        "relation": "calls"
+      },
+      {
+        "from": ".callLlm()",
+        "to": ".scoreMetricBatch()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetricBatch()",
+        "to": "buildFallbackMetric()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetricBatch()",
+        "to": ".hasCollapsedMetricValues()",
+        "relation": "calls"
+      },
+      {
+        "from": ".scoreMetricBatch()",
+        "to": ".normalizeMetric()",
+        "relation": "calls"
+      }
+    ],
+    "community_context": [
+      {
+        "id": 55,
+        "label": "Backend Metrics Scoring Service",
+        "node_count": 14
+      },
+      {
+        "id": 181,
+        "label": "Backend Research Agent Service",
+        "node_count": 8
+      },
+      {
+        "id": 299,
+        "label": "Backend Idea Generation Controller",
+        "node_count": 6
+      },
+      {
+        "id": 553,
+        "label": "Backend Llm Provider Resolver Service",
+        "node_count": 4
+      },
+      {
+        "id": 550,
+        "label": "Backend Lets Build Executor — Build",
+        "node_count": 4
+      },
+      {
+        "id": 778,
+        "label": "Backend Ideas Service — Pipeline",
+        "node_count": 3
+      },
+      {
+        "id": 780,
+        "label": "Backend Ideas Service — Competitor",
+        "node_count": 3
+      },
+      {
+        "id": 779,
+        "label": "Backend Idea Research Controller",
+        "node_count": 3
+      },
+      {
+        "id": 1284,
+        "label": "Backend Pipeline Controller — Pipeline",
+        "node_count": 2
+      },
+      {
+        "id": 1178,
+        "label": "Backend Idea Pipeline Controller — Analysis",
+        "node_count": 2
+      },
+      {
+        "id": 1218,
+        "label": "Backend Metrics Scoring Prompts",
+        "node_count": 2
+      }
+    ],
+    "graph_signals": {
+      "god_nodes": [],
+      "bridge_nodes": []
+    },
+    "shared_file_type": "code",
+    "retrieval_strategy": "slice-v1",
+    "slice": {
+      "mode": "explain",
+      "anchors": [
+        {
+          "node_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "label": ".generateFromProblem()",
+          "reason": "source path token match"
+        },
+        {
+          "node_id": "metrics_scoring_service_metricsscoringservice_generatescoringledger",
+          "label": ".generateScoringLedger()",
+          "reason": "generation core heuristic"
+        },
+        {
+          "node_id": "metrics_scoring_service_metricsscoringservice_generatesensitivityanalysis",
+          "label": ".generateSensitivityAnalysis()",
+          "reason": "generation core heuristic"
+        }
+      ],
+      "directions": [
+        "backward",
+        "forward"
+      ],
+      "selected_paths": [
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "from": ".startPipeline()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_getstatusmessage",
+          "from": ".getStatusMessage()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+          "from": ".releaseUnusedCreditReservation()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_createidea",
+          "from": ".createIdea()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+          "from": ".claimQueuedPipelineRun()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatetitle",
+          "from": ".updateTitle()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+          "from": ".releaseQueuedPipelineClaim()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller",
+          "from": "IdeaGenerationController",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "from": ".generateTitle()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_authenticated_request_requireideasuserid",
+          "from": "requireIdeasUserId",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "plan_enforcement_guard_planenforcement",
+          "from": "PlanEnforcement",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "to": ".generateFromProblem()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_generatescoringledger",
+          "to": ".generateScoringLedger()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice",
+          "from": "MetricsScoringService",
+          "to_id": "metrics_scoring_service_metricsscoringservice_generatescoringledger",
+          "to": ".generateScoringLedger()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_generatesensitivityanalysis",
+          "to": ".generateSensitivityAnalysis()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice",
+          "from": "MetricsScoringService",
+          "to_id": "metrics_scoring_service_metricsscoringservice_generatesensitivityanalysis",
+          "to": ".generateSensitivityAnalysis()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_controller_pipelinecontroller_startpipeline",
+          "from": ".startPipeline()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "to": ".startPipeline()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "from": ".retryPipeline()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "to": ".startPipeline()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "to": ".startPipeline()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice",
+          "from": "PipelineTriggerService",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "to": ".startPipeline()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_compensation_service_ideagenerationcompensationservice",
+          "from": "IdeaGenerationCompensationService",
+          "to_id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+          "to": ".releaseUnusedCreditReservation()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "credits_service_creditsservice_refundcredit",
+          "from": ".refundCredit()",
+          "to_id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+          "to": ".releaseUnusedCreditReservation()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_generatededupehash",
+          "from": ".generateDedupeHash()",
+          "to_id": "ideas_service_ideasservice_createidea",
+          "to": ".createIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice",
+          "from": "IdeasService",
+          "to_id": "ideas_service_ideasservice_createidea",
+          "to": ".createIdea()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "from": ".retryPipeline()",
+          "to_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+          "to": ".claimQueuedPipelineRun()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice",
+          "from": "IdeasService",
+          "to_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+          "to": ".claimQueuedPipelineRun()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice",
+          "from": "IdeasService",
+          "to_id": "ideas_service_ideasservice_updatetitle",
+          "to": ".updateTitle()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice",
+          "from": "IdeasService",
+          "to_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+          "to": ".releaseQueuedPipelineClaim()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_constructor",
+          "from": ".constructor()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller",
+          "to": "IdeaGenerationController",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_suggestimprovements",
+          "from": ".suggestImprovements()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller",
+          "to": "IdeaGenerationController",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_buildsystemprompt",
+          "from": ".buildSystemPrompt()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_builduserprompt",
+          "from": ".buildUserPrompt()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "from": ".resolve()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice",
+          "from": "TitleGenerationService",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+          "from": ".generateFallbackTitle()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "from": ".formatErrorForJson()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "from": ".retryPipeline()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "from": ".enrichCompetitor()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller_getpipelinestatus",
+          "from": ".getPipelineStatus()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller_proceedwithanalysis",
+          "from": ".proceedWithAnalysis()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_research_controller_idearesearchcontroller_retrysection",
+          "from": ".retrySection()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_suggestimprovements",
+          "from": ".suggestImprovements()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller_generatebuildperspective",
+          "from": ".generateBuildPerspective()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_generatesignedurl",
+          "from": ".generateSignedUrl()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller_generateletsbuild",
+          "from": ".generateLetsBuild()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller_publishidea",
+          "from": ".publishIdea()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller_getidea",
+          "from": ".getIdea()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller_listideas",
+          "from": ".listIdeas()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller_deleteidea",
+          "from": ".deleteIdea()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller_exportideatopdf",
+          "from": ".exportIdeaToPdf()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller_getbuildperspective",
+          "from": ".getBuildPerspective()",
+          "to_id": "ideas_authenticated_request_requireideasuserid",
+          "to": "requireIdeasUserId",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_generatesuggestednextsteps",
+          "from": ".generateSuggestedNextSteps()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_buildfallbackmetric",
+          "from": "buildFallbackMetric()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_deduplicateevidencerefs",
+          "from": ".deduplicateEvidenceRefs()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_mapcompositetorecommendation",
+          "from": ".mapCompositeToRecommendation()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_prompts_buildmetrichumanprompt",
+          "from": "buildMetricHumanPrompt()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_generatesuggestednextsteps",
+          "from": ".generateSuggestedNextSteps()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_normalizemetric",
+          "from": ".normalizeMetric()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_constructor",
+          "from": ".constructor()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_deduplicateevidencerefs",
+          "from": ".deduplicateEvidenceRefs()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_hascollapsedmetricvalues",
+          "from": ".hasCollapsedMetricValues()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_ismetricdecisiongrade",
+          "from": ".isMetricDecisionGrade()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_mapcompositetorecommendation",
+          "from": ".mapCompositeToRecommendation()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_parsejson",
+          "from": ".parseJson()",
+          "to_id": "metrics_scoring_service_metricsscoringservice",
+          "to": "MetricsScoringService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_controller_pipelinecontroller",
+          "from": "PipelineController",
+          "to_id": "pipeline_controller_pipelinecontroller_startpipeline",
+          "to": ".startPipeline()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_cancelpipeline",
+          "from": ".cancelPipeline()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "to": ".retryPipeline()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller",
+          "from": "IdeaPipelineController",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "to": ".retryPipeline()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatestatus",
+          "from": ".updateStatus()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "to": ".retryPipeline()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "to": ".retryPipeline()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "queue_registry_service_sanitizejobid",
+          "from": "sanitizeJobId()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice",
+          "from": "QueueRegistryService",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "from": ".checkAndDispatchNext()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "planner_service_plannerservice_dispatchwave",
+          "from": ".dispatchWave()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_broadcastevent",
+          "from": ".broadcastEvent()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "orchestrator_worker_orchestratorworker_broadcastrunfailed",
+          "from": ".broadcastRunFailed()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "orchestrator_worker_orchestratorworker_syncfailedstatus",
+          "from": ".syncFailedStatus()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastevent",
+          "from": ".broadcastEvent()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastsectionevent",
+          "from": ".broadcastSectionEvent()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "planner_service_plannerservice_broadcastrunstarted",
+          "from": ".broadcastRunStarted()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_dispatchdbsync",
+          "from": ".dispatchDbSync()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_dispatchdbsync",
+          "from": ".dispatchDbSync()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_cancelpipeline",
+          "from": ".cancelPipeline()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice",
+          "to": "PipelineTriggerService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_getstatus",
+          "from": ".getStatus()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice",
+          "to": "PipelineTriggerService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_constructor",
+          "from": ".constructor()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice",
+          "to": "PipelineTriggerService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_compensation_service_ideagenerationcompensationservice_constructor",
+          "from": ".constructor()",
+          "to_id": "idea_generation_compensation_service_ideagenerationcompensationservice",
+          "to": "IdeaGenerationCompensationService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_compensation_service_ideagenerationcompensationservice_attachconsumedcredit",
+          "from": ".attachConsumedCredit()",
+          "to_id": "idea_generation_compensation_service_ideagenerationcompensationservice",
+          "to": "IdeaGenerationCompensationService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_compensation_service_ideagenerationcompensationservice_restorecreditforterminalfailure",
+          "from": ".restoreCreditForTerminalFailure()",
+          "to_id": "idea_generation_compensation_service_ideagenerationcompensationservice",
+          "to": "IdeaGenerationCompensationService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "credits_service_creditsservice",
+          "from": "CreditsService",
+          "to_id": "credits_service_creditsservice_refundcredit",
+          "to": ".refundCredit()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "credit_refund_interceptor_creditrefundinterceptor_intercept",
+          "from": ".intercept()",
+          "to_id": "credits_service_creditsservice_refundcredit",
+          "to": ".refundCredit()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_update",
+          "from": ".update()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updateletsbuildstatus",
+          "from": ".updateLetsBuildStatus()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updateletsbuild",
+          "from": ".updateLetsBuild()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updateanalysis",
+          "from": ".updateAnalysis()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatebuildperspective",
+          "from": ".updateBuildPerspective()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatecompetitorenrichment",
+          "from": ".updateCompetitorEnrichment()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatecompetitorenrichmentstatus",
+          "from": ".updateCompetitorEnrichmentStatus()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatestatus",
+          "from": ".updateStatus()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_deleteidea",
+          "from": ".deleteIdea()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_markmetricsreviewed",
+          "from": ".markMetricsReviewed()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_constructor",
+          "from": ".constructor()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyuser",
+          "from": ".findByUser()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_getpublicstats",
+          "from": ".getPublicStats()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_verifydocumenthash",
+          "from": ".verifyDocumentHash()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_adddocumenthash",
+          "from": ".addDocumentHash()",
+          "to_id": "ideas_service_ideasservice",
+          "to": "IdeasService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_controller_logger_createideascontrollerlogger",
+          "from": "createIdeasControllerLogger",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_constructor",
+          "to": ".constructor()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "problem_suggestion_service_problemsuggestionservice_generatesuggestions",
+          "from": ".generateSuggestions()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_suggestimprovements",
+          "to": ".suggestImprovements()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "input_validation_service_inputvalidationservice_validateinput",
+          "from": ".validateInput()",
+          "to_id": "idea_generation_controller_ideagenerationcontroller_suggestimprovements",
+          "to": ".suggestImprovements()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_researchsection",
+          "from": ".researchSection()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "planner_service_plannerservice_classifyidea",
+          "from": ".classifyIdea()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "problem_suggestion_service_problemsuggestionservice_generatesuggestions",
+          "from": ".generateSuggestions()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_extractor_service_assemblyextractorservice_runrecovery",
+          "from": ".runRecovery()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_extractor_service_assemblyextractorservice_rununified",
+          "from": ".runUnified()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_run",
+          "from": ".run()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice",
+          "from": "LlmProviderResolverService",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_getclient",
+          "from": ".getClient()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "mvp_cost_estimation_service_mvpcostestimationservice_generateaimilestones",
+          "from": ".generateAIMilestones()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "business_model_proposal_service_businessmodelproposalservice_generateaiproposal",
+          "from": ".generateAIProposal()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "input_validation_service_inputvalidationservice_validateinput",
+          "from": ".validateInput()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "market_research_executor_marketresearchexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "lets_build_executor_letsbuildexecutor_executeforstrategy",
+          "from": ".executeForStrategy()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "tech_feasibility_executor_techfeasibilityexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "business_model_executor_businessmodelexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "user_personas_executor_userpersonasexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_researchsection",
+          "from": ".researchSection()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "planner_service_plannerservice_classifyidea",
+          "from": ".classifyIdea()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "problem_suggestion_service_problemsuggestionservice_generatesuggestions",
+          "from": ".generateSuggestions()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_run",
+          "from": ".run()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice",
+          "from": "LlmProviderResolverService",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "key_encryption_service_keyencryptionservice_decrypt",
+          "from": ".decrypt()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "mvp_cost_estimation_service_mvpcostestimationservice_generateaimilestones",
+          "from": ".generateAIMilestones()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "business_model_proposal_service_businessmodelproposalservice_generateaiproposal",
+          "from": ".generateAIProposal()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "input_validation_service_inputvalidationservice_validateinput",
+          "from": ".validateInput()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "market_research_executor_marketresearchexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "lets_build_executor_letsbuildexecutor_executeforstrategy",
+          "from": ".executeForStrategy()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "tech_feasibility_executor_techfeasibilityexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "business_model_executor_businessmodelexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "user_personas_executor_userpersonasexecutor_executeforstructurer",
+          "from": ".executeForStructurer()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "to": ".resolve()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+          "from": ".extractKeyPhrasesTitle()",
+          "to_id": "title_generation_service_titlegenerationservice",
+          "to": "TitleGenerationService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_constructor",
+          "from": ".constructor()",
+          "to_id": "title_generation_service_titlegenerationservice",
+          "to": "TitleGenerationService",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+          "from": ".extractKeyPhrasesTitle()",
+          "to_id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+          "to": ".generateFallbackTitle()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "problem_suggestion_service_problemsuggestionservice_generatesuggestions",
+          "from": ".generateSuggestions()",
+          "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "to": ".formatErrorForJson()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "validation_service_validationservice_validateidea",
+          "from": ".validateIdea()",
+          "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "to": ".formatErrorForJson()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "input_validation_service_inputvalidationservice_validateinput",
+          "from": ".validateInput()",
+          "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "to": ".formatErrorForJson()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "validation_service_validationservice_validateproblem",
+          "from": ".validateProblem()",
+          "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "to": ".formatErrorForJson()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "validation_service_validationservice_validatesolution",
+          "from": ".validateSolution()",
+          "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "to": ".formatErrorForJson()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "error_logger_util_errorloggerutil",
+          "from": "ErrorLoggerUtil",
+          "to_id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "to": ".formatErrorForJson()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_research_controller_idearesearchcontroller",
+          "from": "IdeaResearchController",
+          "to_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "to": ".enrichCompetitor()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatecompetitorenrichment",
+          "from": ".updateCompetitorEnrichment()",
+          "to_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "to": ".enrichCompetitor()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatecompetitorenrichmentstatus",
+          "from": ".updateCompetitorEnrichmentStatus()",
+          "to_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "to": ".enrichCompetitor()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "to": ".enrichCompetitor()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "competitor_enrichment_service_competitorenrichmentservice_enrich",
+          "from": ".enrich()",
+          "to_id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "to": ".enrichCompetitor()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller",
+          "from": "IdeaPipelineController",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_getpipelinestatus",
+          "to": ".getPipelineStatus()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_getstatus",
+          "from": ".getStatus()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_getpipelinestatus",
+          "to": ".getPipelineStatus()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pipeline_version_creatependinglivepipelinestatusresponse",
+          "from": "createPendingLivePipelineStatusResponse()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_getpipelinestatus",
+          "to": ".getPipelineStatus()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_getpipelinestatus",
+          "to": ".getPipelineStatus()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_pipeline_controller_ideapipelinecontroller",
+          "from": "IdeaPipelineController",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_proceedwithanalysis",
+          "to": ".proceedWithAnalysis()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_proceedwithanalysis",
+          "to": ".proceedWithAnalysis()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_markmetricsreviewed",
+          "from": ".markMetricsReviewed()",
+          "to_id": "idea_pipeline_controller_ideapipelinecontroller_proceedwithanalysis",
+          "to": ".proceedWithAnalysis()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_research_controller_idearesearchcontroller",
+          "from": "IdeaResearchController",
+          "to_id": "idea_research_controller_idearesearchcontroller_retrysection",
+          "to": ".retrySection()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "section_retry_service_sectionretryservice_retrysection",
+          "from": ".retrySection()",
+          "to_id": "idea_research_controller_idearesearchcontroller_retrysection",
+          "to": ".retrySection()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "build_perspective_service_buildperspectiveservice_generatebuildperspective",
+          "from": ".generateBuildPerspective()",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_generatebuildperspective",
+          "to": ".generateBuildPerspective()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_updatebuildperspective",
+          "from": ".updateBuildPerspective()",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_generatebuildperspective",
+          "to": ".generateBuildPerspective()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_generatebuildperspective",
+          "to": ".generateBuildPerspective()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller",
+          "from": "IdeaArtifactsController",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_generatebuildperspective",
+          "to": ".generateBuildPerspective()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_generatesignedurl",
+          "to": ".generateSignedUrl()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller",
+          "from": "IdeaLetsBuildDetailsController",
+          "to_id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_generatesignedurl",
+          "to": ".generateSignedUrl()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_signtoken",
+          "from": ".signToken()",
+          "to_id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_generatesignedurl",
+          "to": ".generateSignedUrl()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller",
+          "from": "IdeaArtifactsController",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_generateletsbuild",
+          "to": ".generateLetsBuild()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "lets_build_service_letsbuildservice_queueletsbuild",
+          "from": ".queueLetsBuild()",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_generateletsbuild",
+          "to": ".generateLetsBuild()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_update",
+          "from": ".update()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_publishidea",
+          "to": ".publishIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_publishidea",
+          "to": ".publishIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller",
+          "from": "IdeaLifecycleController",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_publishidea",
+          "to": ".publishIdea()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_getidea",
+          "to": ".getIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller",
+          "from": "IdeaLifecycleController",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_getidea",
+          "to": ".getIdea()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller",
+          "from": "IdeaLifecycleController",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_listideas",
+          "to": ".listIdeas()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyuser",
+          "from": ".findByUser()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_listideas",
+          "to": ".listIdeas()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_deleteidea",
+          "to": ".deleteIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_lifecycle_controller_idealifecyclecontroller",
+          "from": "IdeaLifecycleController",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_deleteidea",
+          "to": ".deleteIdea()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_deleteidea",
+          "from": ".deleteIdea()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_deleteidea",
+          "to": ".deleteIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "certification_service_certificationservice_revokebadge",
+          "from": ".revokeBadge()",
+          "to_id": "idea_lifecycle_controller_idealifecyclecontroller_deleteidea",
+          "to": ".deleteIdea()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller",
+          "from": "IdeaArtifactsController",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_exportideatopdf",
+          "to": ".exportIdeaToPdf()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "pdf_export_service_pdfexportservice_exportideatopdf",
+          "from": ".exportIdeaToPdf()",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_exportideatopdf",
+          "to": ".exportIdeaToPdf()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "ideas_service_ideasservice_findbyid",
+          "from": ".findById()",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_getbuildperspective",
+          "to": ".getBuildPerspective()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_artifacts_controller_ideaartifactscontroller",
+          "from": "IdeaArtifactsController",
+          "to_id": "idea_artifacts_controller_ideaartifactscontroller_getbuildperspective",
+          "to": ".getBuildPerspective()",
+          "relation": "method",
+          "direction": "backward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatecost",
+          "from": ".updateCost()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "to": ".scoreMetricBatch()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatesectionpromptio",
+          "from": ".updateSectionPromptIO()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "to": ".scoreMetricBatch()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "to": ".scoreMetricBatch()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "from": ".calculateTokenUsage()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "to": ".scoreMetricBatch()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "unified_metrics_prompts_buildgroupedmetricssystemprompt",
+          "from": "buildGroupedMetricsSystemPrompt()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "to": ".scoreMetricBatch()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "safe_input_safeusercontent",
+          "from": "safeUserContent()",
+          "to_id": "metrics_scoring_prompts_buildmetrichumanprompt",
+          "to": "buildMetricHumanPrompt()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "metrics_scoring_service_clampcredibilityscore",
+          "from": "clampCredibilityScore()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_normalizemetric",
+          "to": ".normalizeMetric()",
+          "relation": "calls",
+          "direction": "backward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "to": ".startPipeline()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+          "to": ".claimQueuedPipelineRun()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+          "to": ".releaseQueuedPipelineClaim()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+          "to": ".releaseUnusedCreditReservation()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "ideas_service_ideasservice_createidea",
+          "to": ".createIdea()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "ideas_service_ideasservice_updatetitle",
+          "to": ".updateTitle()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "title_generation_service_titlegenerationservice_generatetitle",
+          "to": ".generateTitle()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "from": ".generateFromProblem()",
+          "to_id": "plan_enforcement_guard_planenforcement",
+          "to": "PlanEnforcement",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_generatescoringledger",
+          "from": ".generateScoringLedger()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_generatesensitivityanalysis",
+          "from": ".generateSensitivityAnalysis()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "to": ".scoreMetrics()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "from": ".startPipeline()",
+          "to_id": "queue_registry_service_queueregistryservice_addjob",
+          "to": ".addJob()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_generatesuggestednextsteps",
+          "to": ".generateSuggestedNextSteps()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "to": ".scoreMetricBatch()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_buildfallbackmetric",
+          "to": "buildFallbackMetric()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_deduplicateevidencerefs",
+          "to": ".deduplicateEvidenceRefs()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_mapcompositetorecommendation",
+          "to": ".mapCompositeToRecommendation()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "from": ".scoreMetrics()",
+          "to_id": "metrics_scoring_prompts_buildmetrichumanprompt",
+          "to": "buildMetricHumanPrompt()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "queue_registry_service_sanitizejobid",
+          "to": "sanitizeJobId()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "to": ".handleQualityGateFailure()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "to": ".checkAndDispatchNext()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "planner_service_plannerservice_dispatchwave",
+          "to": ".dispatchWave()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "research_agent_service_researchagentservice_broadcastevent",
+          "to": ".broadcastEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "orchestrator_worker_orchestratorworker_broadcastrunfailed",
+          "to": ".broadcastRunFailed()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "orchestrator_worker_orchestratorworker_syncfailedstatus",
+          "to": ".syncFailedStatus()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastevent",
+          "to": ".broadcastEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastsectionevent",
+          "to": ".broadcastSectionEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "planner_service_plannerservice_broadcastrunstarted",
+          "to": ".broadcastRunStarted()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "assembly_service_assemblyservice_dispatchdbsync",
+          "to": ".dispatchDbSync()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_queueregistryservice_addjob",
+          "from": ".addJob()",
+          "to_id": "research_agent_service_researchagentservice_dispatchdbsync",
+          "to": ".dispatchDbSync()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "to": ".callLlm()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "index_manager_service_indexmanagerservice_updatecost",
+          "to": ".updateCost()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "index_manager_service_indexmanagerservice_updatesectionpromptio",
+          "to": ".updateSectionPromptIO()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "master_agent_service_masteragentservice_call",
+          "to": ".call()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "to": ".calculateTokenUsage()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_normalizemetric",
+          "to": ".normalizeMetric()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_hascollapsedmetricvalues",
+          "to": ".hasCollapsedMetricValues()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_ismetricdecisiongrade",
+          "to": ".isMetricDecisionGrade()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "metrics_scoring_service_metricsscoringservice_parsejson",
+          "to": ".parseJson()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "from": ".scoreMetricBatch()",
+          "to_id": "unified_metrics_prompts_buildgroupedmetricssystemprompt",
+          "to": "buildGroupedMetricsSystemPrompt()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_prompts_buildmetrichumanprompt",
+          "from": "buildMetricHumanPrompt()",
+          "to_id": "safe_input_safeusercontent",
+          "to": "safeUserContent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "queue_registry_service_sanitizejobid",
+          "from": "sanitizeJobId()",
+          "to_id": "queue_registry_service_queueregistryservice_removejob",
+          "to": ".removeJob()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "index_manager_service_indexmanagerservice_updateindex",
+          "to": ".updateIndex()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "index_manager_service_indexmanagerservice_updatemanifest",
+          "to": ".updateManifest()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "index_manager_service_indexmanagerservice_readindex",
+          "to": ".readIndex()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "file_storage_service_filestorageservice_writeraw",
+          "to": ".writeRaw()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "file_storage_service_filestorageservice_writesectionfile",
+          "to": ".writeSectionFile()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "assembly_service_assemblyservice_broadcastassemblysectionevent",
+          "to": ".broadcastAssemblySectionEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "from": ".handleQualityGateFailure()",
+          "to_id": "assembly_service_assemblyservice_broadcastevent",
+          "to": ".broadcastEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "from": ".checkAndDispatchNext()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "from": ".checkAndDispatchNext()",
+          "to_id": "index_manager_service_indexmanagerservice_allsectionsterminal",
+          "to": ".allSectionsTerminal()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "from": ".checkAndDispatchNext()",
+          "to_id": "index_manager_service_indexmanagerservice_getunblockedsections",
+          "to": ".getUnblockedSections()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "from": ".checkAndDispatchNext()",
+          "to_id": "section_state_helpers_shouldtreatsectionaspartial",
+          "to": "shouldTreatSectionAsPartial()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "planner_service_plannerservice_dispatchwave",
+          "from": ".dispatchWave()",
+          "to_id": "planner_service_plannerservice_plan",
+          "to": ".plan()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_broadcastevent",
+          "from": ".broadcastEvent()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_broadcastevent",
+          "from": ".broadcastEvent()",
+          "to_id": "research_agent_service_researchagentservice_broadcastcurrentevent",
+          "to": ".broadcastCurrentEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "orchestrator_worker_orchestratorworker_broadcastrunfailed",
+          "from": ".broadcastRunFailed()",
+          "to_id": "orchestrator_worker_orchestratorworker_process",
+          "to": ".process()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "orchestrator_worker_orchestratorworker_syncfailedstatus",
+          "from": ".syncFailedStatus()",
+          "to_id": "orchestrator_worker_orchestratorworker_process",
+          "to": ".process()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastevent",
+          "from": ".broadcastEvent()",
+          "to_id": "assembly_service_assemblyservice_broadcastevent",
+          "to": ".broadcastEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastevent",
+          "from": ".broadcastEvent()",
+          "to_id": "assembly_broadcaster_service_buildbaseprogressevent",
+          "to": "buildBaseProgressEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastsectionevent",
+          "from": ".broadcastSectionEvent()",
+          "to_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastassemblysectionevent",
+          "to": ".broadcastAssemblySectionEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastsectionevent",
+          "from": ".broadcastSectionEvent()",
+          "to_id": "assembly_broadcaster_service_buildbaseprogressevent",
+          "to": "buildBaseProgressEvent()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "planner_service_plannerservice_broadcastrunstarted",
+          "from": ".broadcastRunStarted()",
+          "to_id": "planner_service_plannerservice_plan",
+          "to": ".plan()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "research_agent_service_researchagentservice_dispatchdbsync",
+          "from": ".dispatchDbSync()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "planner_service_plannerservice_classifyidea",
+          "to": ".classifyIdea()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_runrecovery",
+          "to": ".runRecovery()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_rununified",
+          "to": ".runUnified()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_run",
+          "to": ".run()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "llm_provider_resolver_service_llmproviderresolverservice_getclient",
+          "to": ".getClient()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "market_research_executor_marketresearchexecutor_executeforstructurer",
+          "to": ".executeForStructurer()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "problem_suggestion_service_problemsuggestionservice_generatesuggestions",
+          "to": ".generateSuggestions()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "mvp_cost_estimation_service_mvpcostestimationservice_generateaimilestones",
+          "to": ".generateAIMilestones()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "business_model_proposal_service_businessmodelproposalservice_generateaiproposal",
+          "to": ".generateAIProposal()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "input_validation_service_inputvalidationservice_validateinput",
+          "to": ".validateInput()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "lets_build_executor_letsbuildexecutor_executeforstrategy",
+          "to": ".executeForStrategy()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "tech_feasibility_executor_techfeasibilityexecutor_executeforstructurer",
+          "to": ".executeForStructurer()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "business_model_executor_businessmodelexecutor_executeforstructurer",
+          "to": ".executeForStructurer()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "from": ".callLlm()",
+          "to_id": "user_personas_executor_userpersonasexecutor_executeforstructurer",
+          "to": ".executeForStructurer()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatecost",
+          "from": ".updateCost()",
+          "to_id": "index_manager_service_indexmanagerservice_updateindex",
+          "to": ".updateIndex()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatecost",
+          "from": ".updateCost()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatecost",
+          "from": ".updateCost()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_runrecovery",
+          "to": ".runRecovery()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatecost",
+          "from": ".updateCost()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_persistcostandio",
+          "to": ".persistCostAndIO()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatecost",
+          "from": ".updateCost()",
+          "to_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_persistcost",
+          "to": ".persistCost()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatesectionpromptio",
+          "from": ".updateSectionPromptIO()",
+          "to_id": "index_manager_service_indexmanagerservice_updateindex",
+          "to": ".updateIndex()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatesectionpromptio",
+          "from": ".updateSectionPromptIO()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_persistcostandio",
+          "to": ".persistCostAndIO()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "index_manager_service_indexmanagerservice_updatesectionpromptio",
+          "from": ".updateSectionPromptIO()",
+          "to_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_persistpromptio",
+          "to": ".persistPromptIO()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "planner_service_plannerservice_classifyidea",
+          "to": ".classifyIdea()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_runrecovery",
+          "to": ".runRecovery()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_rununified",
+          "to": ".runUnified()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_run",
+          "to": ".run()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "master_agent_service_serializetooloutputforprompt",
+          "to": "serializeToolOutputForPrompt()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "prompt_assembler_promptassembler_assemble",
+          "to": ".assemble()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "output_parser_outputparser_parse",
+          "to": ".parse()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "output_parser_outputparser_getformatinstructions",
+          "to": ".getFormatInstructions()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "tool_executor_toolexecutor_cancontinue",
+          "to": ".canContinue()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "master_agent_service_masteragentservice_call",
+          "from": ".call()",
+          "to_id": "tool_executor_toolexecutor_executetoolcall",
+          "to": ".executeToolCall()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "from": ".calculateTokenUsage()",
+          "to_id": "research_agent_service_researchagentservice_researchsection",
+          "to": ".researchSection()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "from": ".calculateTokenUsage()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_runrecovery",
+          "to": ".runRecovery()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "from": ".calculateTokenUsage()",
+          "to_id": "assembly_extractor_service_assemblyextractorservice_persistcostandio",
+          "to": ".persistCostAndIO()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "from": ".calculateTokenUsage()",
+          "to_id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_persistcost",
+          "to": ".persistCost()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "from": ".calculateTokenUsage()",
+          "to_id": "pricing_config_calculatecost",
+          "to": "calculateCost()",
+          "relation": "calls",
+          "direction": "forward"
+        },
+        {
+          "from_id": "metrics_scoring_service_metricsscoringservice_normalizemetric",
+          "from": ".normalizeMetric()",
+          "to_id": "metrics_scoring_service_clampcredibilityscore",
+          "to": "clampCredibilityScore()",
+          "relation": "calls",
+          "direction": "forward"
+        }
+      ]
+    },
+    "execution_slice": {
+      "status": "complete",
+      "steps": [
+        {
+          "label": ".generateFromProblem()",
+          "source_file": "idea-generation.controller.ts",
+          "line_number": 75
+        },
+        {
+          "label": ".startPipeline()",
+          "source_file": "pipeline-trigger.service.ts",
+          "line_number": 24
+        },
+        {
+          "label": ".addJob()",
+          "source_file": "queue-registry.service.ts",
+          "line_number": 59
+        },
+        {
+          "label": ".broadcastRunFailed()",
+          "source_file": "orchestrator.worker.ts",
+          "line_number": 60
+        },
+        {
+          "label": ".process()",
+          "source_file": "orchestrator.worker.ts",
+          "line_number": 93
+        }
+      ],
+      "primary_path": {
+        "steps": [
+          {
+            "label": ".generateFromProblem()",
+            "source_file": "idea-generation.controller.ts",
+            "line_number": 75
+          },
+          {
+            "label": ".startPipeline()",
+            "source_file": "pipeline-trigger.service.ts",
+            "line_number": 24
+          },
+          {
+            "label": ".addJob()",
+            "source_file": "queue-registry.service.ts",
+            "line_number": 59
+          },
+          {
+            "label": ".broadcastRunFailed()",
+            "source_file": "orchestrator.worker.ts",
+            "line_number": 60
+          },
+          {
+            "label": ".process()",
+            "source_file": "orchestrator.worker.ts",
+            "line_number": 93
+          }
+        ]
+      },
+      "side_effects": [
+        {
+          "steps": [
+            {
+              "label": ".releaseQueuedPipelineClaim()",
+              "source_file": "ideas.service.ts",
+              "line_number": 453
+            }
+          ]
+        },
+        {
+          "steps": [
+            {
+              "label": ".releaseUnusedCreditReservation()",
+              "source_file": "idea-generation-compensation.service.ts",
+              "line_number": 57
+            }
+          ]
+        },
+        {
+          "steps": [
+            {
+              "label": ".createIdea()",
+              "source_file": "ideas.service.ts",
+              "line_number": 78
+            }
+          ]
+        }
+      ],
+      "terminal_boundaries": [
+        {
+          "steps": [
+            {
+              "label": ".claimQueuedPipelineRun()",
+              "source_file": "ideas.service.ts",
+              "line_number": 418
+            }
+          ],
+          "boundary_reason": "branch terminates before rejoining the primary runtime path"
+        }
+      ],
+      "omitted_branches": [
+        {
+          "from": ".generateFromProblem()",
+          "to": ".updateTitle()",
+          "relation": "calls"
+        },
+        {
+          "from": ".generateFromProblem()",
+          "to": ".generateTitle()",
+          "relation": "calls"
+        },
+        {
+          "from": ".generateFromProblem()",
+          "to": "PlanEnforcement",
+          "relation": "calls",
+          "reason": "low-value branch omitted from compact execution slice"
+        },
+        {
+          "from": ".addJob()",
+          "to": "sanitizeJobId()",
+          "relation": "calls"
+        },
+        {
+          "from": ".addJob()",
+          "to": ".handleQualityGateFailure()",
+          "relation": "calls"
+        },
+        {
+          "from": ".addJob()",
+          "to": ".checkAndDispatchNext()",
+          "relation": "calls"
+        }
+      ],
+      "phase_coverage": {
+        "expected": [
+          "queue",
+          "worker"
+        ],
+        "observed": [
+          "controller",
+          "service",
+          "queue",
+          "worker"
+        ],
+        "missing": []
+      }
+    },
+    "retrieval_gate": {
+      "level": 3,
+      "reason": "runtime generation intent — behavior slice retrieval",
+      "skipped_retrieval": false,
+      "intent": "unknown",
+      "signals": {
+        "has_pr_diff": false,
+        "has_stack_trace": false,
+        "mentioned_paths": [],
+        "mentioned_symbols": [],
+        "generation_intent": "runtime_generation",
+        "target_domain_hint": "backend_runtime",
+        "generation_debug": {
+          "display_shaped": false,
+          "generic_generation_shaped": true,
+          "backend_runtime_shaped": false,
+          "report_generation_shaped": true,
+          "build_static_shaped": false,
+          "explanation_shaped": true
+        }
+      }
+    },
+    "claims": [
+      {
+        "evidence_class": "primary",
+        "text": "primary evidence: .getStatusMessage(), .updateTitle(), IdeaGenerationController",
+        "node_labels": [
+          ".getStatusMessage()",
+          ".updateTitle()",
+          "IdeaGenerationController"
+        ]
+      },
+      {
+        "evidence_class": "supporting",
+        "text": "supporting evidence: PlanEnforcement, MetricsScoringService, PipelineTriggerService",
+        "node_labels": [
+          "PlanEnforcement",
+          "MetricsScoringService",
+          "PipelineTriggerService"
+        ]
+      },
+      {
+        "evidence_class": "structural",
+        "text": "structural evidence: .generateFromProblem(), .generateScoringLedger(), .generateSensitivityAnalysis()",
+        "node_labels": [
+          ".generateFromProblem()",
+          ".generateScoringLedger()",
+          ".generateSensitivityAnalysis()"
+        ]
+      }
+    ],
+    "coverage": {
+      "required_evidence": [
+        "primary",
+        "supporting",
+        "structural"
+      ],
+      "semantic_required": [
+        "implementation",
+        "structure"
+      ],
+      "semantic_optional": [
+        "contracts",
+        "configuration",
+        "tests"
+      ],
+      "entries": [
+        {
+          "evidence_class": "primary",
+          "required": true,
+          "available_nodes": 12,
+          "selected_nodes": 12,
+          "status": "covered"
+        },
+        {
+          "evidence_class": "supporting",
+          "required": true,
+          "available_nodes": 22,
+          "selected_nodes": 22,
+          "status": "covered"
+        },
+        {
+          "evidence_class": "structural",
+          "required": true,
+          "available_nodes": 131,
+          "selected_nodes": 44,
+          "status": "covered"
+        }
+      ],
+      "semantic_entries": [
+        {
+          "category": "implementation",
+          "label": "implementation",
+          "required": true,
+          "available_nodes": 138,
+          "selected_nodes": 52,
+          "status": "covered"
+        },
+        {
+          "category": "structure",
+          "label": "structure",
+          "required": true,
+          "available_nodes": 131,
+          "selected_nodes": 44,
+          "status": "covered"
+        },
+        {
+          "category": "contracts",
+          "label": "contracts",
+          "required": false,
+          "available_nodes": 27,
+          "selected_nodes": 26,
+          "status": "covered"
+        },
+        {
+          "category": "configuration",
+          "label": "configuration",
+          "required": false,
+          "available_nodes": 0,
+          "selected_nodes": 0,
+          "status": "missing"
+        },
+        {
+          "category": "tests",
+          "label": "tests",
+          "required": false,
+          "available_nodes": 0,
+          "selected_nodes": 0,
+          "status": "missing"
+        }
+      ],
+      "missing_required": [],
+      "missing_semantic": [],
+      "available_relationships": 285,
+      "selected_relationships": 107
+    },
+    "selection_diagnostics": {
+      "selection_strategy": "value-per-token",
+      "budget": 3000,
+      "used_tokens": 2993,
+      "required_overflow": true,
+      "ranking": [
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller_getstatusmessage",
+          "label": ".getStatusMessage()",
+          "evidence_class": "primary",
+          "score": 12.75,
+          "token_cost": 42,
+          "density": 0.30357142857142855,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updatetitle",
+          "label": ".updateTitle()",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 47,
+          "density": 0.3191489361702128,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller",
+          "label": "IdeaGenerationController",
+          "evidence_class": "primary",
+          "score": 12.75,
+          "token_cost": 28,
+          "density": 0.45535714285714285,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_compensation_service_ideagenerationcompensationservice",
+          "label": "IdeaGenerationCompensationService",
+          "evidence_class": "primary",
+          "score": 13.587,
+          "token_cost": 32,
+          "density": 0.42459375,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice",
+          "label": "IdeasService",
+          "evidence_class": "primary",
+          "score": 10.891,
+          "token_cost": 25,
+          "density": 0.43564,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice",
+          "label": "TitleGenerationService",
+          "evidence_class": "primary",
+          "score": 15,
+          "token_cost": 28,
+          "density": 0.5357142857142857,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_pipeline_controller_ideapipelinecontroller",
+          "label": "IdeaPipelineController",
+          "evidence_class": "primary",
+          "score": 11.378,
+          "token_cost": 29,
+          "density": 0.3923448275862069,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_controller_logger_createideascontrollerlogger",
+          "label": "createIdeasControllerLogger",
+          "evidence_class": "primary",
+          "score": 10.852,
+          "token_cost": 37,
+          "density": 0.2932972972972973,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_research_controller_idearesearchcontroller",
+          "label": "IdeaResearchController",
+          "evidence_class": "primary",
+          "score": 11.377,
+          "token_cost": 29,
+          "density": 0.39231034482758625,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_artifacts_controller_ideaartifactscontroller",
+          "label": "IdeaArtifactsController",
+          "evidence_class": "primary",
+          "score": 9.868,
+          "token_cost": 30,
+          "density": 0.32893333333333336,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller",
+          "label": "IdeaLetsBuildDetailsController",
+          "evidence_class": "primary",
+          "score": 9.836,
+          "token_cost": 33,
+          "density": 0.2980606060606061,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lifecycle_controller_idealifecyclecontroller",
+          "label": "IdeaLifecycleController",
+          "evidence_class": "primary",
+          "score": 9.87,
+          "token_cost": 29,
+          "density": 0.3403448275862069,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "plan_enforcement_guard_planenforcement",
+          "label": "PlanEnforcement",
+          "evidence_class": "supporting",
+          "score": 11.66,
+          "token_cost": 34,
+          "density": 0.34294117647058825,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice",
+          "label": "MetricsScoringService",
+          "evidence_class": "supporting",
+          "score": 10.75,
+          "token_cost": 29,
+          "density": 0.3706896551724138,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "pipeline_trigger_service_pipelinetriggerservice",
+          "label": "PipelineTriggerService",
+          "evidence_class": "supporting",
+          "score": 12,
+          "token_cost": 25,
+          "density": 0.48,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller_constructor",
+          "label": ".constructor()",
+          "evidence_class": "supporting",
+          "score": 11.294,
+          "token_cost": 29,
+          "density": 0.389448275862069,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_constructor",
+          "label": ".constructor()",
+          "evidence_class": "supporting",
+          "score": 12,
+          "token_cost": 31,
+          "density": 0.3870967741935484,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pipeline_controller_pipelinecontroller",
+          "label": "PipelineController",
+          "evidence_class": "supporting",
+          "score": 12,
+          "token_cost": 26,
+          "density": 0.46153846153846156,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "queue_registry_service_queueregistryservice",
+          "label": "QueueRegistryService",
+          "evidence_class": "supporting",
+          "score": 12,
+          "token_cost": 35,
+          "density": 0.34285714285714286,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pipeline_trigger_service_pipelinetriggerservice_constructor",
+          "label": ".constructor()",
+          "evidence_class": "supporting",
+          "score": 12,
+          "token_cost": 29,
+          "density": 0.41379310344827586,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_compensation_service_ideagenerationcompensationservice_constructor",
+          "label": ".constructor()",
+          "evidence_class": "supporting",
+          "score": 13.529,
+          "token_cost": 28,
+          "density": 0.4831785714285714,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_compensation_service_ideagenerationcompensationservice_attachconsumedcredit",
+          "label": ".attachConsumedCredit()",
+          "evidence_class": "supporting",
+          "score": 13.529,
+          "token_cost": 34,
+          "density": 0.39791176470588235,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_compensation_service_ideagenerationcompensationservice_restorecreditforterminalfailure",
+          "label": ".restoreCreditForTerminalFailure()",
+          "evidence_class": "supporting",
+          "score": 13.511,
+          "token_cost": 49,
+          "density": 0.275734693877551,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "credits_service_creditsservice",
+          "label": "CreditsService",
+          "evidence_class": "supporting",
+          "score": 9.35,
+          "token_cost": 22,
+          "density": 0.425,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "ideas_service_ideasservice_updateletsbuildstatus",
+          "label": ".updateLetsBuildStatus()",
+          "evidence_class": "supporting",
+          "score": 13.041,
+          "token_cost": 33,
+          "density": 0.3951818181818182,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updateletsbuild",
+          "label": ".updateLetsBuild()",
+          "evidence_class": "supporting",
+          "score": 13.04,
+          "token_cost": 50,
+          "density": 0.2608,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updateanalysis",
+          "label": ".updateAnalysis()",
+          "evidence_class": "supporting",
+          "score": 13.04,
+          "token_cost": 29,
+          "density": 0.44965517241379305,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_constructor",
+          "label": ".constructor()",
+          "evidence_class": "supporting",
+          "score": 12.036,
+          "token_cost": 26,
+          "density": 0.4629230769230769,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_getpublicstats",
+          "label": ".getPublicStats()",
+          "evidence_class": "supporting",
+          "score": 12.036,
+          "token_cost": 66,
+          "density": 0.18236363636363637,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_verifydocumenthash",
+          "label": ".verifyDocumentHash()",
+          "evidence_class": "supporting",
+          "score": 12.035,
+          "token_cost": 44,
+          "density": 0.27352272727272725,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_adddocumenthash",
+          "label": ".addDocumentHash()",
+          "evidence_class": "supporting",
+          "score": 12.021,
+          "token_cost": 49,
+          "density": 0.2453265306122449,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "llm_provider_resolver_service_llmproviderresolverservice",
+          "label": "LlmProviderResolverService",
+          "evidence_class": "supporting",
+          "score": 12,
+          "token_cost": 32,
+          "density": 0.375,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_constructor",
+          "label": ".constructor()",
+          "evidence_class": "supporting",
+          "score": 13.511,
+          "token_cost": 34,
+          "density": 0.39738235294117646,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "error_logger_util_errorloggerutil",
+          "label": "ErrorLoggerUtil",
+          "evidence_class": "supporting",
+          "score": 8.75,
+          "token_cost": 39,
+          "density": 0.22435897435897437,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller_generatefromproblem",
+          "label": ".generateFromProblem()",
+          "evidence_class": "structural",
+          "score": 15.061,
+          "token_cost": 38,
+          "density": 0.3963421052631579,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_generatescoringledger",
+          "label": ".generateScoringLedger()",
+          "evidence_class": "structural",
+          "score": 15.731,
+          "token_cost": 35,
+          "density": 0.44945714285714283,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_generatesensitivityanalysis",
+          "label": ".generateSensitivityAnalysis()",
+          "evidence_class": "structural",
+          "score": 15.727,
+          "token_cost": 45,
+          "density": 0.3494888888888889,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pipeline_trigger_service_pipelinetriggerservice_startpipeline",
+          "label": ".startPipeline()",
+          "evidence_class": "structural",
+          "score": 16,
+          "token_cost": 63,
+          "density": 0.25396825396825395,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_generation_compensation_service_ideagenerationcompensationservice_releaseunusedcreditreservation",
+          "label": ".releaseUnusedCreditReservation()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 35,
+          "density": 0.5,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_createidea",
+          "label": ".createIdea()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 49,
+          "density": 0.35714285714285715,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_claimqueuedpipelinerun",
+          "label": ".claimQueuedPipelineRun()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 36,
+          "density": 0.4861111111111111,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_releasequeuedpipelineclaim",
+          "label": ".releaseQueuedPipelineClaim()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 34,
+          "density": 0.5147058823529411,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_generatetitle",
+          "label": ".generateTitle()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 31,
+          "density": 0.5645161290322581,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_authenticated_request_requireideasuserid",
+          "label": "requireIdeasUserId",
+          "evidence_class": "structural",
+          "score": 12.792,
+          "token_cost": 37,
+          "density": 0.3457297297297297,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_scoremetrics",
+          "label": ".scoreMetrics()",
+          "evidence_class": "structural",
+          "score": 14.25,
+          "token_cost": 30,
+          "density": 0.475,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "pipeline_controller_pipelinecontroller_startpipeline",
+          "label": ".startPipeline()",
+          "evidence_class": "structural",
+          "score": 15.5,
+          "token_cost": 27,
+          "density": 0.5740740740740741,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_pipeline_controller_ideapipelinecontroller_retrypipeline",
+          "label": ".retryPipeline()",
+          "evidence_class": "structural",
+          "score": 13.795,
+          "token_cost": 46,
+          "density": 0.29989130434782607,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "queue_registry_service_queueregistryservice_addjob",
+          "label": ".addJob()",
+          "evidence_class": "structural",
+          "score": 13.25,
+          "token_cost": 31,
+          "density": 0.4274193548387097,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "credits_service_creditsservice_refundcredit",
+          "label": ".refundCredit()",
+          "evidence_class": "structural",
+          "score": 13,
+          "token_cost": 42,
+          "density": 0.30952380952380953,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_generatededupehash",
+          "label": ".generateDedupeHash()",
+          "evidence_class": "structural",
+          "score": 12.782,
+          "token_cost": 55,
+          "density": 0.2324,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": [
+            "generated file penalty"
+          ]
+        },
+        {
+          "id": "idea_generation_controller_ideagenerationcontroller_suggestimprovements",
+          "label": ".suggestImprovements()",
+          "evidence_class": "structural",
+          "score": 13.775,
+          "token_cost": 33,
+          "density": 0.4174242424242424,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_buildsystemprompt",
+          "label": ".buildSystemPrompt()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 53,
+          "density": 0.330188679245283,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_builduserprompt",
+          "label": ".buildUserPrompt()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 45,
+          "density": 0.3888888888888889,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "llm_provider_resolver_service_llmproviderresolverservice_callllm",
+          "label": ".callLlm()",
+          "evidence_class": "structural",
+          "score": 14.75,
+          "token_cost": 68,
+          "density": 0.21691176470588236,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "llm_provider_resolver_service_llmproviderresolverservice_resolve",
+          "label": ".resolve()",
+          "evidence_class": "structural",
+          "score": 14.75,
+          "token_cost": 56,
+          "density": 0.26339285714285715,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_generatefallbacktitle",
+          "label": ".generateFallbackTitle()",
+          "evidence_class": "structural",
+          "score": 17.248,
+          "token_cost": 33,
+          "density": 0.5226666666666667,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "error_logger_util_errorloggerutil_formaterrorforjson",
+          "label": ".formatErrorForJson()",
+          "evidence_class": "structural",
+          "score": 14.275,
+          "token_cost": 42,
+          "density": 0.3398809523809524,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_research_controller_idearesearchcontroller_enrichcompetitor",
+          "label": ".enrichCompetitor()",
+          "evidence_class": "structural",
+          "score": 13.795,
+          "token_cost": 43,
+          "density": 0.3208139534883721,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_pipeline_controller_ideapipelinecontroller_getpipelinestatus",
+          "label": ".getPipelineStatus()",
+          "evidence_class": "structural",
+          "score": 13.795,
+          "token_cost": 37,
+          "density": 0.37283783783783786,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_pipeline_controller_ideapipelinecontroller_proceedwithanalysis",
+          "label": ".proceedWithAnalysis()",
+          "evidence_class": "structural",
+          "score": 13.794,
+          "token_cost": 35,
+          "density": 0.39411428571428575,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_research_controller_idearesearchcontroller_retrysection",
+          "label": ".retrySection()",
+          "evidence_class": "structural",
+          "score": 13.794,
+          "token_cost": 35,
+          "density": 0.39411428571428575,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_artifacts_controller_ideaartifactscontroller_generatebuildperspective",
+          "label": ".generateBuildPerspective()",
+          "evidence_class": "structural",
+          "score": 13.544,
+          "token_cost": 34,
+          "density": 0.3983529411764706,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_generatesignedurl",
+          "label": ".generateSignedUrl()",
+          "evidence_class": "structural",
+          "score": 13.54,
+          "token_cost": 50,
+          "density": 0.2708,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_artifacts_controller_ideaartifactscontroller_generateletsbuild",
+          "label": ".generateLetsBuild()",
+          "evidence_class": "structural",
+          "score": 13.536,
+          "token_cost": 33,
+          "density": 0.41018181818181815,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lifecycle_controller_idealifecyclecontroller_publishidea",
+          "label": ".publishIdea()",
+          "evidence_class": "structural",
+          "score": 12.53,
+          "token_cost": 36,
+          "density": 0.34805555555555556,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lifecycle_controller_idealifecyclecontroller_getidea",
+          "label": ".getIdea()",
+          "evidence_class": "structural",
+          "score": 12.39,
+          "token_cost": 39,
+          "density": 0.3176923076923077,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lifecycle_controller_idealifecyclecontroller_listideas",
+          "label": ".listIdeas()",
+          "evidence_class": "structural",
+          "score": 12.39,
+          "token_cost": 36,
+          "density": 0.3441666666666667,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lifecycle_controller_idealifecyclecontroller_deleteidea",
+          "label": ".deleteIdea()",
+          "evidence_class": "structural",
+          "score": 12.36,
+          "token_cost": 37,
+          "density": 0.33405405405405403,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_artifacts_controller_ideaartifactscontroller_exportideatopdf",
+          "label": ".exportIdeaToPdf()",
+          "evidence_class": "structural",
+          "score": 12.345,
+          "token_cost": 43,
+          "density": 0.287093023255814,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_artifacts_controller_ideaartifactscontroller_getbuildperspective",
+          "label": ".getBuildPerspective()",
+          "evidence_class": "structural",
+          "score": 12.287,
+          "token_cost": 34,
+          "density": 0.3613823529411765,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_generatesuggestednextsteps",
+          "label": ".generateSuggestedNextSteps()",
+          "evidence_class": "structural",
+          "score": 15.618,
+          "token_cost": 44,
+          "density": 0.35495454545454547,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_scoremetricbatch",
+          "label": ".scoreMetricBatch()",
+          "evidence_class": "structural",
+          "score": 14.25,
+          "token_cost": 32,
+          "density": 0.4453125,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "metrics_scoring_service_buildfallbackmetric",
+          "label": "buildFallbackMetric()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 63,
+          "density": 0.23015873015873015,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_deduplicateevidencerefs",
+          "label": ".deduplicateEvidenceRefs()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 50,
+          "density": 0.29,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_mapcompositetorecommendation",
+          "label": ".mapCompositeToRecommendation()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 36,
+          "density": 0.4027777777777778,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_prompts_buildmetrichumanprompt",
+          "label": "buildMetricHumanPrompt()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 36,
+          "density": 0.3541666666666667,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_normalizemetric",
+          "label": ".normalizeMetric()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 61,
+          "density": 0.23770491803278687,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_hascollapsedmetricvalues",
+          "label": ".hasCollapsedMetricValues()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 53,
+          "density": 0.27358490566037735,
+          "included": true,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_ismetricdecisiongrade",
+          "label": ".isMetricDecisionGrade()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 36,
+          "density": 0.4027777777777778,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "metrics_scoring_service_metricsscoringservice_parsejson",
+          "label": ".parseJson()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 37,
+          "density": 0.3918918918918919,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pipeline_trigger_service_pipelinetriggerservice_cancelpipeline",
+          "label": ".cancelPipeline()",
+          "evidence_class": "structural",
+          "score": 15.5,
+          "token_cost": 41,
+          "density": 0.3780487804878049,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updatestatus",
+          "label": ".updateStatus()",
+          "evidence_class": "structural",
+          "score": 15.539,
+          "token_cost": 29,
+          "density": 0.5358275862068965,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_findbyid",
+          "label": ".findById()",
+          "evidence_class": "structural",
+          "score": 13.64,
+          "token_cost": 36,
+          "density": 0.3788888888888889,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "queue_registry_service_sanitizejobid",
+          "label": "sanitizeJobId()",
+          "evidence_class": "structural",
+          "score": 14.566,
+          "token_cost": 42,
+          "density": 0.34680952380952385,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_service_assemblyservice_handlequalitygatefailure",
+          "label": ".handleQualityGateFailure()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 33,
+          "density": 0.4393939393939394,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "research_agent_service_researchagentservice_checkanddispatchnext",
+          "label": ".checkAndDispatchNext()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 33,
+          "density": 0.4393939393939394,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "planner_service_plannerservice_dispatchwave",
+          "label": ".dispatchWave()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 28,
+          "density": 0.5178571428571429,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "research_agent_service_researchagentservice_broadcastevent",
+          "label": ".broadcastEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 29,
+          "density": 0.5,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "orchestrator_worker_orchestratorworker_broadcastrunfailed",
+          "label": ".broadcastRunFailed()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 32,
+          "density": 0.453125,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "orchestrator_worker_orchestratorworker_syncfailedstatus",
+          "label": ".syncFailedStatus()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 32,
+          "density": 0.453125,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastevent",
+          "label": ".broadcastEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 31,
+          "density": 0.46774193548387094,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastsectionevent",
+          "label": ".broadcastSectionEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 33,
+          "density": 0.4393939393939394,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "planner_service_plannerservice_broadcastrunstarted",
+          "label": ".broadcastRunStarted()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 30,
+          "density": 0.48333333333333334,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_service_assemblyservice_dispatchdbsync",
+          "label": ".dispatchDbSync()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 50,
+          "density": 0.29,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "research_agent_service_researchagentservice_dispatchdbsync",
+          "label": ".dispatchDbSync()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 31,
+          "density": 0.46774193548387094,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pipeline_trigger_service_pipelinetriggerservice_getstatus",
+          "label": ".getStatus()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 39,
+          "density": 0.3717948717948718,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "credit_refund_interceptor_creditrefundinterceptor_intercept",
+          "label": ".intercept()",
+          "evidence_class": "structural",
+          "score": 11.25,
+          "token_cost": 46,
+          "density": 0.24456521739130435,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_update",
+          "label": ".update()",
+          "evidence_class": "structural",
+          "score": 15.638,
+          "token_cost": 46,
+          "density": 0.33995652173913044,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updatebuildperspective",
+          "label": ".updateBuildPerspective()",
+          "evidence_class": "structural",
+          "score": 15.54,
+          "token_cost": 33,
+          "density": 0.4709090909090909,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updatecompetitorenrichment",
+          "label": ".updateCompetitorEnrichment()",
+          "evidence_class": "structural",
+          "score": 15.54,
+          "token_cost": 37,
+          "density": 0.42,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_updatecompetitorenrichmentstatus",
+          "label": ".updateCompetitorEnrichmentStatus()",
+          "evidence_class": "structural",
+          "score": 15.539,
+          "token_cost": 39,
+          "density": 0.3984358974358974,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_deleteidea",
+          "label": ".deleteIdea()",
+          "evidence_class": "structural",
+          "score": 14.61,
+          "token_cost": 44,
+          "density": 0.33204545454545453,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_markmetricsreviewed",
+          "label": ".markMetricsReviewed()",
+          "evidence_class": "structural",
+          "score": 14.536,
+          "token_cost": 44,
+          "density": 0.33036363636363636,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "ideas_service_ideasservice_findbyuser",
+          "label": ".findByUser()",
+          "evidence_class": "structural",
+          "score": 14.536,
+          "token_cost": 28,
+          "density": 0.5191428571428571,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "problem_suggestion_service_problemsuggestionservice_generatesuggestions",
+          "label": ".generateSuggestions()",
+          "evidence_class": "structural",
+          "score": 16.014,
+          "token_cost": 31,
+          "density": 0.5165806451612903,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "input_validation_service_inputvalidationservice_validateinput",
+          "label": ".validateInput()",
+          "evidence_class": "structural",
+          "score": 14.51,
+          "token_cost": 31,
+          "density": 0.46806451612903227,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "research_agent_service_researchagentservice_researchsection",
+          "label": ".researchSection()",
+          "evidence_class": "structural",
+          "score": 13.35,
+          "token_cost": 50,
+          "density": 0.267,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "planner_service_plannerservice_classifyidea",
+          "label": ".classifyIdea()",
+          "evidence_class": "structural",
+          "score": 14.585,
+          "token_cost": 31,
+          "density": 0.47048387096774197,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_extractor_service_assemblyextractorservice_runrecovery",
+          "label": ".runRecovery()",
+          "evidence_class": "structural",
+          "score": 13.25,
+          "token_cost": 33,
+          "density": 0.4015151515151515,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "assembly_extractor_service_assemblyextractorservice_rununified",
+          "label": ".runUnified()",
+          "evidence_class": "structural",
+          "score": 13.25,
+          "token_cost": 31,
+          "density": 0.4274193548387097,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_run",
+          "label": ".run()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 28,
+          "density": 0.5178571428571429,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "llm_provider_resolver_service_llmproviderresolverservice_getclient",
+          "label": ".getClient()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 40,
+          "density": 0.3625,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "mvp_cost_estimation_service_mvpcostestimationservice_generateaimilestones",
+          "label": ".generateAIMilestones()",
+          "evidence_class": "structural",
+          "score": 14.395,
+          "token_cost": 41,
+          "density": 0.35109756097560973,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "business_model_proposal_service_businessmodelproposalservice_generateaiproposal",
+          "label": ".generateAIProposal()",
+          "evidence_class": "structural",
+          "score": 14.385,
+          "token_cost": 40,
+          "density": 0.359625,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "market_research_executor_marketresearchexecutor_executeforstructurer",
+          "label": ".executeForStructurer()",
+          "evidence_class": "structural",
+          "score": 14.257,
+          "token_cost": 40,
+          "density": 0.356425,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "lets_build_executor_letsbuildexecutor_executeforstrategy",
+          "label": ".executeForStrategy()",
+          "evidence_class": "structural",
+          "score": 12.756,
+          "token_cost": 36,
+          "density": 0.35433333333333333,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "tech_feasibility_executor_techfeasibilityexecutor_executeforstructurer",
+          "label": ".executeForStructurer()",
+          "evidence_class": "structural",
+          "score": 12.756,
+          "token_cost": 41,
+          "density": 0.3111219512195122,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "business_model_executor_businessmodelexecutor_executeforstructurer",
+          "label": ".executeForStructurer()",
+          "evidence_class": "structural",
+          "score": 12.756,
+          "token_cost": 38,
+          "density": 0.3356842105263158,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "user_personas_executor_userpersonasexecutor_executeforstructurer",
+          "label": ".executeForStructurer()",
+          "evidence_class": "structural",
+          "score": 12.756,
+          "token_cost": 39,
+          "density": 0.3270769230769231,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "key_encryption_service_keyencryptionservice_decrypt",
+          "label": ".decrypt()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 55,
+          "density": 0.2636363636363636,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "title_generation_service_titlegenerationservice_extractkeyphrasestitle",
+          "label": ".extractKeyPhrasesTitle()",
+          "evidence_class": "structural",
+          "score": 17.5,
+          "token_cost": 44,
+          "density": 0.3977272727272727,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "validation_service_validationservice_validateidea",
+          "label": ".validateIdea()",
+          "evidence_class": "structural",
+          "score": 11.852,
+          "token_cost": 27,
+          "density": 0.438962962962963,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "validation_service_validationservice_validateproblem",
+          "label": ".validateProblem()",
+          "evidence_class": "structural",
+          "score": 11.75,
+          "token_cost": 25,
+          "density": 0.47,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "validation_service_validationservice_validatesolution",
+          "label": ".validateSolution()",
+          "evidence_class": "structural",
+          "score": 11.75,
+          "token_cost": 25,
+          "density": 0.47,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "competitor_enrichment_service_competitorenrichmentservice_enrich",
+          "label": ".enrich()",
+          "evidence_class": "structural",
+          "score": 14.51,
+          "token_cost": 62,
+          "density": 0.23403225806451614,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pipeline_version_creatependinglivepipelinestatusresponse",
+          "label": "createPendingLivePipelineStatusResponse()",
+          "evidence_class": "structural",
+          "score": 15.261,
+          "token_cost": 39,
+          "density": 0.3913076923076923,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "section_retry_service_sectionretryservice_retrysection",
+          "label": ".retrySection()",
+          "evidence_class": "structural",
+          "score": 13.26,
+          "token_cost": 33,
+          "density": 0.4018181818181818,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "build_perspective_service_buildperspectiveservice_generatebuildperspective",
+          "label": ".generateBuildPerspective()",
+          "evidence_class": "structural",
+          "score": 15.722,
+          "token_cost": 36,
+          "density": 0.43672222222222223,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "idea_lets_build_details_controller_idealetsbuilddetailscontroller_signtoken",
+          "label": ".signToken()",
+          "evidence_class": "structural",
+          "score": 12.285,
+          "token_cost": 43,
+          "density": 0.28569767441860466,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "structure evidence",
+            "contracts evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "lets_build_service_letsbuildservice_queueletsbuild",
+          "label": ".queueLetsBuild()",
+          "evidence_class": "structural",
+          "score": 14.519,
+          "token_cost": 44,
+          "density": 0.32997727272727273,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "certification_service_certificationservice_revokebadge",
+          "label": ".revokeBadge()",
+          "evidence_class": "structural",
+          "score": 13,
+          "token_cost": 47,
+          "density": 0.2765957446808511,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pdf_export_service_pdfexportservice_exportideatopdf",
+          "label": ".exportIdeaToPdf()",
+          "evidence_class": "structural",
+          "score": 14.555,
+          "token_cost": 37,
+          "density": 0.39337837837837836,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence",
+            "source path match"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_updatecost",
+          "label": ".updateCost()",
+          "evidence_class": "structural",
+          "score": 15.5,
+          "token_cost": 26,
+          "density": 0.5961538461538461,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_updatesectionpromptio",
+          "label": ".updateSectionPromptIO()",
+          "evidence_class": "structural",
+          "score": 15.5,
+          "token_cost": 30,
+          "density": 0.5166666666666667,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "master_agent_service_masteragentservice_call",
+          "label": ".call()",
+          "evidence_class": "structural",
+          "score": 13.25,
+          "token_cost": 30,
+          "density": 0.44166666666666665,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "cost_aggregator_service_costaggregatorservice_calculatetokenusage",
+          "label": ".calculateTokenUsage()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 57,
+          "density": 0.2543859649122807,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "unified_metrics_prompts_buildgroupedmetricssystemprompt",
+          "label": "buildGroupedMetricsSystemPrompt()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 42,
+          "density": 0.30357142857142855,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "safe_input_safeusercontent",
+          "label": "safeUserContent()",
+          "evidence_class": "structural",
+          "score": 10,
+          "token_cost": 30,
+          "density": 0.3333333333333333,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "metrics_scoring_service_clampcredibilityscore",
+          "label": "clampCredibilityScore()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 57,
+          "density": 0.2543859649122807,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "queue_registry_service_queueregistryservice_removejob",
+          "label": ".removeJob()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 47,
+          "density": 0.30851063829787234,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_updateindex",
+          "label": ".updateIndex()",
+          "evidence_class": "structural",
+          "score": 14.25,
+          "token_cost": 26,
+          "density": 0.5480769230769231,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_updatemanifest",
+          "label": ".updateManifest()",
+          "evidence_class": "structural",
+          "score": 15.5,
+          "token_cost": 26,
+          "density": 0.5961538461538461,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_readindex",
+          "label": ".readIndex()",
+          "evidence_class": "structural",
+          "score": 13.25,
+          "token_cost": 49,
+          "density": 0.27040816326530615,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "file_storage_service_filestorageservice_writeraw",
+          "label": ".writeRaw()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 55,
+          "density": 0.2636363636363636,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "file_storage_service_filestorageservice_writesectionfile",
+          "label": ".writeSectionFile()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 43,
+          "density": 0.3372093023255814,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_service_assemblyservice_broadcastassemblysectionevent",
+          "label": ".broadcastAssemblySectionEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 32,
+          "density": 0.453125,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_service_assemblyservice_broadcastevent",
+          "label": ".broadcastEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 28,
+          "density": 0.5178571428571429,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_allsectionsterminal",
+          "label": ".allSectionsTerminal()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 40,
+          "density": 0.3625,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "index_manager_service_indexmanagerservice_getunblockedsections",
+          "label": ".getUnblockedSections()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 45,
+          "density": 0.32222222222222224,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "section_state_helpers_shouldtreatsectionaspartial",
+          "label": "shouldTreatSectionAsPartial()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 46,
+          "density": 0.27717391304347827,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "planner_service_plannerservice_plan",
+          "label": ".plan()",
+          "evidence_class": "structural",
+          "score": 13.25,
+          "token_cost": 50,
+          "density": 0.265,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": [
+            "hub node penalty"
+          ]
+        },
+        {
+          "id": "research_agent_service_researchagentservice_broadcastcurrentevent",
+          "label": ".broadcastCurrentEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 31,
+          "density": 0.46774193548387094,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "orchestrator_worker_orchestratorworker_process",
+          "label": ".process()",
+          "evidence_class": "structural",
+          "score": 15.5,
+          "token_cost": 49,
+          "density": 0.3163265306122449,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_broadcaster_service_buildbaseprogressevent",
+          "label": "buildBaseProgressEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 35,
+          "density": 0.4142857142857143,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_broadcaster_service_assemblybroadcasterservice_broadcastassemblysectionevent",
+          "label": ".broadcastAssemblySectionEvent()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 35,
+          "density": 0.4142857142857143,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_extractor_service_assemblyextractorservice_persistcostandio",
+          "label": ".persistCostAndIO()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 36,
+          "density": 0.4027777777777778,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_persistcost",
+          "label": ".persistCost()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 31,
+          "density": 0.46774193548387094,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "assembly_final_synthesis_service_assemblyfinalsynthesisservice_persistpromptio",
+          "label": ".persistPromptIO()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 33,
+          "density": 0.4393939393939394,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "master_agent_service_serializetooloutputforprompt",
+          "label": "serializeToolOutputForPrompt()",
+          "evidence_class": "structural",
+          "score": 14.5,
+          "token_cost": 42,
+          "density": 0.34523809523809523,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "prompt_assembler_promptassembler_assemble",
+          "label": ".assemble()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 40,
+          "density": 0.31875,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "output_parser_outputparser_parse",
+          "label": ".parse()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 46,
+          "density": 0.27717391304347827,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "output_parser_outputparser_getformatinstructions",
+          "label": ".getFormatInstructions()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 38,
+          "density": 0.3355263157894737,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "tool_executor_toolexecutor_cancontinue",
+          "label": ".canContinue()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 37,
+          "density": 0.34459459459459457,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "tool_executor_toolexecutor_executetoolcall",
+          "label": ".executeToolCall()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 56,
+          "density": 0.22767857142857142,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        },
+        {
+          "id": "pricing_config_calculatecost",
+          "label": "calculateCost()",
+          "evidence_class": "structural",
+          "score": 12.75,
+          "token_cost": 27,
+          "density": 0.4722222222222222,
+          "included": false,
+          "reasons": [
+            "match score",
+            "required evidence",
+            "implementation evidence",
+            "structure evidence"
+          ],
+          "penalties": []
+        }
+      ]
+    }
+  },
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "baseline_prompt": "<artifact-root>/baseline-prompt.txt",
+    "madar_prompt": "<artifact-root>/madar-prompt.txt",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": null,
+      "input_tokens_source": "estimated_cl100k_base",
+      "effective_tokens_source": "session_reuse_estimate",
+      "total_tokens_source": "not_available"
+    },
+    "madar": {
+      "provider": null,
+      "input_tokens_source": "estimated_cl100k_base",
+      "effective_tokens_source": "session_reuse_estimate",
+      "total_tokens_source": "not_available"
+    },
+    "reduction_basis": "estimated"
+  }
+}


### PR DESCRIPTION
## Summary
- add the dated v0.25.1 runtime-routing validation folder under docs/benchmarks
- include prompt expectations, a pack-based routing generator, committed routing records, and share-safe pack_only/native_agent artifacts
- document the mixed outcome conservatively: routing passes, cost can improve, but latency and manual quality can still regress

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- node docs/benchmarks/2026-05-23-v0.25.1-runtime-routing-validation/collect-routing-validation.mjs --graph /Users/mohammednaji/Desktop/projects/works/govalidate/out/graph.json

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive benchmark docs for v0.25.1 runtime-routing validation, including methodology, expected prompt classes, observed routing outcomes, reproduction commands, and a manual native-agent vs. madar quality note.
  * Reports now normalize/externalize source-file paths in published artifacts.

* **Tests**
  * Added deterministic routing-validation assets and reports covering 13 prompt scenarios (generation, pipeline, queue, frontend rendering) with all prompts marked passing and detailed execution-slice/coverage data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->