### PR TITLE
[P1] Add context-pack answer contract for runtime-generation prompts

### DIFF
--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -109,6 +109,18 @@ export interface ContextPackExecutionSlice {
   phase_coverage?: ContextPackExecutionSlicePhaseCoverage
 }
 
+export interface ContextPackRuntimeGenerationAnswerContract {
+  version: 1
+  answer_focus: 'runtime_generation'
+  entrypoint_scope: 'setup_context'
+  required_elements: string[]
+  do_not_claim: string[]
+  observed_phases: string[]
+  missing_phases: string[]
+  uncertainty_notes?: string[]
+  confidence?: 'high' | 'medium' | 'low'
+}
+
 export type ContextRepresentationType =
   | 'detail'
   | 'summary'
@@ -261,6 +273,7 @@ export interface CompiledContextPack<
   retrieval_strategy?: ContextPackRetrievalStrategy
   slice?: ContextPackSliceMetadata
   execution_slice?: ContextPackExecutionSlice
+  answer_contract?: ContextPackRuntimeGenerationAnswerContract
   /**
    * Retrieval-gate decision (#75) attached when the caller invoked the
    * gate before building the pack. Carries `level`, `reason`, `intent`,

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -242,7 +242,63 @@ function promptWantsReportGenerationCore(prompt: string): boolean {
   return /\b(?:report(?:\s+generation)?|generated\s+report|validation\s+report|final\s+report|assembly|assemble|synthesis|renderer|render|planner|research|metrics?|scor(?:e|ing)|quality(?:\s|-)?gate)\b/i.test(prompt)
 }
 
+function answerContractInstructions(retrieval: RetrieveResult): string[] {
+  const answerContract = retrieval.answer_contract
+  if (!answerContract) {
+    return []
+  }
+
+  const instructions = [
+    'Treat HTTP/controller entrypoints as trigger context, not the full answer.',
+  ]
+
+  const requiredElements = new Set(answerContract.required_elements)
+  const phaseLabels = [
+    ['planner_phase', 'planner'],
+    ['research_phase', 'research'],
+    ['assembly_phase', 'assembly'],
+    ['scoring_phase', 'scoring'],
+    ['report_builder_phase', 'rendering'],
+  ] as const satisfies ReadonlyArray<readonly [string, string]>
+  const selectedPhaseLabels: string[] = phaseLabels.flatMap(([key, label]) => requiredElements.has(key) ? [label] : [])
+  if (selectedPhaseLabels.length > 0 || requiredElements.has('persistence_or_artifact_storage')) {
+    const segments = [...selectedPhaseLabels]
+    if (requiredElements.has('persistence_or_artifact_storage')) {
+      segments.push('persistence')
+    }
+    instructions.push(`Follow ${segments.join(', ')} evidence before concluding the flow.`)
+  } else if (requiredElements.has('main_pipeline_phases')) {
+    instructions.push('Cover the main runtime pipeline phases instead of stopping at the entrypoint.')
+  }
+
+  if (requiredElements.has('queue_worker_handoff')) {
+    instructions.push('Describe queue-to-worker handoffs explicitly when the flow crosses an enqueues_job boundary.')
+  }
+
+  if (answerContract.do_not_claim.includes('direct_producer_to_worker_calls_without_enqueues_boundary')) {
+    instructions.push('Do not collapse producer-to-worker handoffs into direct calls when the evidence is an enqueues_job boundary.')
+  }
+
+  if (
+    answerContract.uncertainty_notes?.includes('mention missing or uncertain phases when the execution slice is partial')
+    || answerContract.do_not_claim.includes('full_runtime_certainty_when_slice_is_partial')
+  ) {
+    instructions.push('Mention missing or uncertain phases when the execution slice is partial.')
+  }
+
+  if (answerContract.do_not_claim.includes('irrelevant_model_or_provider_details')) {
+    instructions.push('Do not mention model or provider details unless they are directly relevant to the question.')
+  }
+
+  return instructions
+}
+
 function generationCoreInstructions(question: string, retrieval: RetrieveResult): string[] {
+  const contractInstructions = answerContractInstructions(retrieval)
+  if (contractInstructions.length > 0) {
+    return contractInstructions
+  }
+
   if (
     retrieval.retrieval_gate?.signals.generation_intent !== 'runtime_generation'
     || retrieval.retrieval_gate?.signals.target_domain_hint !== 'backend_runtime'

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -7,6 +7,7 @@ import type {
   ContextPackExecutionSliceBranch,
   ContextPackExecutionSliceOmittedBranch,
   ContextPackExecutionSliceStep,
+  ContextPackRuntimeGenerationAnswerContract,
   CompiledContextPack,
   ContextPackClaim,
   ContextPackCoverage,
@@ -147,6 +148,7 @@ export interface RetrieveResult {
   retrieval_strategy?: ContextPackRetrievalStrategy
   slice?: ContextPackSliceMetadata
   execution_slice?: ContextPackExecutionSlice
+  answer_contract?: ContextPackRuntimeGenerationAnswerContract
 }
 
 export interface CompactRetrieveMatchedNode extends Omit<RetrieveMatchedNode, 'community_label' | 'file_type' | 'framework_boost'> {
@@ -2311,6 +2313,121 @@ function walkExecutionSlice(
   return orderedPathIds
 }
 
+function runtimeGenerationAnswerContractWantsReportGenerationCore(question: string): boolean {
+  return /\b(?:report(?:\s+generation)?|generated\s+report|validation\s+report|final\s+report|assembly|assemble|synthesis|renderer|render|planner|research|metrics?|scor(?:e|ing)|quality(?:\s|-)?gate)\b/i.test(question)
+}
+
+function runtimeGenerationStepText(
+  value: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): string {
+  return `${value.label} ${value.source_file} ${value.node_kind ?? ''} ${value.framework_role ?? ''}`.toLowerCase()
+}
+
+function runtimeGenerationContractPhaseElements(
+  question: string,
+  matchedNodes: readonly Pick<RetrieveMatchedNode, 'label' | 'source_file' | 'node_kind' | 'framework_role'>[],
+  executionSlice: ContextPackExecutionSlice,
+): string[] {
+  const elements = new Set<string>(['main_pipeline_phases'])
+  const evidenceText = [
+    ...matchedNodes.map((node) =>
+      `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase(),
+    ),
+    ...executionSlice.steps.map(runtimeGenerationStepText),
+  ].join('\n')
+
+  if (
+    executionSlice.primary_path?.boundaries?.some((boundary) => boundary.relation === 'enqueues_job')
+    || (executionSlice.phase_coverage?.observed.includes('queue') && executionSlice.phase_coverage?.observed.includes('worker'))
+  ) {
+    elements.add('queue_worker_handoff')
+  }
+
+  if (
+    executionSlice.phase_coverage?.observed.includes('persistence')
+    || executionSlice.phase_coverage?.missing.includes('persistence')
+    || /\b(?:persist|repository|database|db|storage|store|save|write|artifact)\b/i.test(evidenceText)
+  ) {
+    elements.add('persistence_or_artifact_storage')
+  }
+
+  if (executionSlice.status === 'partial') {
+    elements.add('missing_or_uncertain_phases')
+  }
+
+  if (runtimeGenerationAnswerContractWantsReportGenerationCore(question)) {
+    if (/\b(?:planner|\.plan\(|plan\(\)|planning)\b/i.test(evidenceText)) {
+      elements.add('planner_phase')
+    }
+    if (/\b(?:research|search\(\)|processsection|processsection\(\)|section[-_\s]?research)\b/i.test(evidenceText)) {
+      elements.add('research_phase')
+    }
+    if (/\b(?:assembly|assemble|synthesis)\b/i.test(evidenceText)) {
+      elements.add('assembly_phase')
+    }
+    if (/\b(?:score|scoring|metrics?)\b/i.test(evidenceText)) {
+      elements.add('scoring_phase')
+    }
+    if (/\b(?:render|renderer|report builder|reportbuilder|final report)\b/i.test(evidenceText)) {
+      elements.add('report_builder_phase')
+    }
+  }
+
+  return [...elements]
+}
+
+function executionSliceConfidence(
+  executionSlice: ContextPackExecutionSlice,
+): ContextPackRuntimeGenerationAnswerContract['confidence'] | undefined {
+  const value = (executionSlice as { confidence?: unknown }).confidence
+  return value === 'high' || value === 'medium' || value === 'low' ? value : undefined
+}
+
+function buildRuntimeGenerationAnswerContract(
+  taskContract: ContextPackTaskContract,
+  retrievalGate: RetrievalGateDecision,
+  question: string,
+  matchedNodes: readonly Pick<RetrieveMatchedNode, 'label' | 'source_file' | 'node_kind' | 'framework_role'>[],
+  executionSlice: ContextPackExecutionSlice | undefined,
+  sliceMetadata: ContextPackSliceMetadata | undefined,
+): ContextPackRuntimeGenerationAnswerContract | undefined {
+  if (!runtimeGenerationExecutionSliceApplies(taskContract, retrievalGate, sliceMetadata) || !executionSlice) {
+    return undefined
+  }
+
+  const doNotClaim = new Set<string>([
+    'direct_producer_to_worker_calls_without_enqueues_boundary',
+    'irrelevant_model_or_provider_details',
+  ])
+  const missingPhases = [...(executionSlice.phase_coverage?.missing ?? [])]
+  if (executionSlice.status === 'partial') {
+    doNotClaim.add('full_runtime_certainty_when_slice_is_partial')
+  }
+
+  const answerContract: ContextPackRuntimeGenerationAnswerContract = {
+    version: 1,
+    answer_focus: 'runtime_generation',
+    entrypoint_scope: 'setup_context',
+    required_elements: runtimeGenerationContractPhaseElements(question, matchedNodes, executionSlice),
+    do_not_claim: [...doNotClaim],
+    observed_phases: [...(executionSlice.phase_coverage?.observed ?? [])],
+    missing_phases: missingPhases,
+  }
+
+  if (executionSlice.status === 'partial' || missingPhases.length > 0) {
+    answerContract.uncertainty_notes = [
+      'mention missing or uncertain phases when the execution slice is partial',
+    ]
+  }
+
+  const confidence = executionSliceConfidence(executionSlice)
+  if (confidence) {
+    answerContract.confidence = confidence
+  }
+
+  return answerContract
+}
+
 function buildExecutionSlice(
   graph: KnowledgeGraph,
   taskContract: ContextPackTaskContract,
@@ -3094,11 +3211,20 @@ function buildRetrieveResultFromOrderedCandidates(
     selection_strategy: options.selectionStrategy ?? 'value-per-token',
     retrieval_gate: retrievalGate,
   })
+  const matchedNodes = pack.nodes as RetrieveMatchedNode[]
+  const answerContract = buildRuntimeGenerationAnswerContract(
+    taskContract,
+    retrievalGate,
+    options.question,
+    matchedNodes,
+    executionSlice,
+    sliceMetadata,
+  )
 
   return {
     question: options.question,
     token_count: pack.token_count,
-    matched_nodes: pack.nodes as RetrieveMatchedNode[],
+    matched_nodes: matchedNodes,
     relationships: pack.relationships,
     community_context: pack.community_context,
     graph_signals: pack.graph_signals ?? { god_nodes: [], bridge_nodes: [] },
@@ -3111,6 +3237,7 @@ function buildRetrieveResultFromOrderedCandidates(
     retrieval_strategy: options.retrievalStrategy ?? 'default',
     ...(sliceMetadata ? { slice: sliceMetadata } : {}),
     ...(executionSlice ? { execution_slice: executionSlice } : {}),
+    ...(answerContract ? { answer_contract: answerContract } : {}),
   }
 }
 
@@ -3874,6 +4001,7 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
     retrieval_strategy: result.retrieval_strategy ?? 'default',
     ...(result.slice ? { slice: result.slice } : {}),
     ...(executionSlice ? { execution_slice: executionSlice } : {}),
+    ...(result.answer_contract ? { answer_contract: result.answer_contract } : {}),
     ...(result.retrieval_gate ? { retrieval_gate: result.retrieval_gate } : {}),
   }
 }
@@ -3922,6 +4050,7 @@ export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveR
     retrieval_strategy: result.retrieval_strategy ?? 'default',
     ...(result.slice ? { slice: result.slice } : {}),
     ...(compactResult.execution_slice ? { execution_slice: compactResult.execution_slice } : {}),
+    ...(result.answer_contract ? { answer_contract: result.answer_contract } : {}),
     ...(result.retrieval_gate ? { retrieval_gate: result.retrieval_gate } : {}),
   }
 }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -3081,6 +3081,7 @@ export function contextPackFromRetrieveResult(
     ...(result.retrieval_strategy ? { retrieval_strategy: result.retrieval_strategy } : {}),
     ...(result.slice ? { slice: result.slice } : {}),
     ...(result.execution_slice ? { execution_slice: result.execution_slice } : {}),
+    ...(result.answer_contract ? { answer_contract: result.answer_contract } : {}),
     ...(result.retrieval_gate ? { retrieval_gate: result.retrieval_gate } : {}),
   }
 }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -889,11 +889,94 @@ describe('compare runtime', () => {
             target_domain_hint: 'backend_runtime',
           },
         },
-      },
+      } as any,
     })
 
     expect(pack.prompt).toContain('Treat HTTP/controller entrypoints as trigger context, not the full answer, when downstream generation-core evidence is present.')
     expect(pack.prompt).toContain('Follow planner, research, assembly, scoring, rendering, and persistence evidence before concluding the flow.')
+  })
+
+  it('includes a runtime-generation answer contract in the prompt core and tells partial slices to mention uncertainty', () => {
+    const pack = buildMadarPromptPack({
+      question: 'How idea report is being generated',
+      retrieval: {
+        question: 'How idea report is being generated',
+        token_count: 120,
+        matched_nodes: [],
+        relationships: [],
+        community_context: [],
+        graph_signals: {
+          god_nodes: [],
+          bridge_nodes: [],
+        },
+        retrieval_gate: {
+          level: 3,
+          reason: 'runtime generation intent — behavior slice retrieval',
+          skipped_retrieval: false,
+          intent: 'unknown',
+          signals: {
+            has_pr_diff: false,
+            has_stack_trace: false,
+            mentioned_paths: [],
+            mentioned_symbols: [],
+            generation_intent: 'runtime_generation',
+            target_domain_hint: 'backend_runtime',
+          },
+        },
+        execution_slice: {
+          status: 'partial',
+          boundary_reason: 'slice stops before expected persistence step',
+          steps: [
+            {
+              label: 'IdeaGenerationController.generateFromProblem',
+              source_file: 'src/modules/ideas/interface/http/idea-generation.controller.ts',
+              line_number: 58,
+              node_kind: 'method',
+            },
+            {
+              label: 'PipelineTriggerService.startPipeline',
+              source_file: 'src/modules/pipeline/infrastructure/pipeline-trigger.service.ts',
+              line_number: 24,
+              node_kind: 'method',
+            },
+            {
+              label: 'QueueRegistry.addJob',
+              source_file: 'src/modules/pipeline/infrastructure/queue-registry.service.ts',
+              line_number: 16,
+              node_kind: 'method',
+            },
+          ],
+          phase_coverage: {
+            expected: ['controller', 'queue', 'worker', 'persistence'],
+            observed: ['controller', 'service', 'queue'],
+            missing: ['worker', 'persistence'],
+          },
+        },
+        answer_contract: {
+          version: 1,
+          answer_focus: 'runtime_generation',
+          entrypoint_scope: 'setup_context',
+          required_elements: [
+            'main_pipeline_phases',
+            'queue_worker_handoff',
+            'missing_or_uncertain_phases',
+          ],
+          do_not_claim: [
+            'direct_producer_to_worker_calls_without_enqueues_boundary',
+            'full_runtime_certainty_when_slice_is_partial',
+          ],
+          observed_phases: ['controller', 'service', 'queue'],
+          missing_phases: ['worker', 'persistence'],
+        },
+      } as any,
+    })
+
+    expect(pack.prompt).toContain('"answer_contract"')
+    expect(pack.prompt).toContain('"entrypoint_scope": "setup_context"')
+    expect(pack.prompt).toContain('"missing_phases": [')
+    expect(pack.prompt).toContain('"worker"')
+    expect(pack.prompt).toContain('"persistence"')
+    expect(pack.prompt).toContain('Mention missing or uncertain phases when the execution slice is partial.')
   })
 
   it('computes prompt token counts from the exact prompt text', () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -30,6 +30,7 @@ import { sanitizeShareSafeText } from '../../src/shared/share-safe-artifacts.js'
 const PROJECT_FIXTURE_ROOT = resolve('out', 'test-runtime', 'compare-runtime-project')
 const GRAPH_FIXTURE_ROOT = join(PROJECT_FIXTURE_ROOT, 'out')
 const COMPARE_OUTPUT_ROOT = resolve('out', 'compare', 'test-runtime')
+type MadarPromptPackRetrieval = Parameters<typeof buildMadarPromptPack>[0]['retrieval']
 
 function makeGraph(): KnowledgeGraph {
   const graph = new KnowledgeGraph()
@@ -863,33 +864,35 @@ describe('compare runtime', () => {
   })
 
   it('tells broad runtime-generation answers not to stop at the HTTP trigger when downstream generation core evidence exists', () => {
+    const retrieval: MadarPromptPackRetrieval = {
+      question: 'How idea report is being generated',
+      token_count: 120,
+      matched_nodes: [],
+      relationships: [],
+      community_context: [],
+      graph_signals: {
+        god_nodes: [],
+        bridge_nodes: [],
+      },
+      retrieval_gate: {
+        level: 3,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        skipped_retrieval: false,
+        intent: 'unknown',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation',
+          target_domain_hint: 'backend_runtime',
+        },
+      },
+    }
+
     const pack = buildMadarPromptPack({
       question: 'How idea report is being generated',
-      retrieval: {
-        question: 'How idea report is being generated',
-        token_count: 120,
-        matched_nodes: [],
-        relationships: [],
-        community_context: [],
-        graph_signals: {
-          god_nodes: [],
-          bridge_nodes: [],
-        },
-        retrieval_gate: {
-          level: 3,
-          reason: 'runtime generation intent — behavior slice retrieval',
-          skipped_retrieval: false,
-          intent: 'unknown',
-          signals: {
-            has_pr_diff: false,
-            has_stack_trace: false,
-            mentioned_paths: [],
-            mentioned_symbols: [],
-            generation_intent: 'runtime_generation',
-            target_domain_hint: 'backend_runtime',
-          },
-        },
-      } as any,
+      retrieval,
     })
 
     expect(pack.prompt).toContain('Treat HTTP/controller entrypoints as trigger context, not the full answer, when downstream generation-core evidence is present.')
@@ -897,78 +900,80 @@ describe('compare runtime', () => {
   })
 
   it('includes a runtime-generation answer contract in the prompt core and tells partial slices to mention uncertainty', () => {
+    const retrieval: MadarPromptPackRetrieval = {
+      question: 'How idea report is being generated',
+      token_count: 120,
+      matched_nodes: [],
+      relationships: [],
+      community_context: [],
+      graph_signals: {
+        god_nodes: [],
+        bridge_nodes: [],
+      },
+      retrieval_gate: {
+        level: 3,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        skipped_retrieval: false,
+        intent: 'unknown',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation',
+          target_domain_hint: 'backend_runtime',
+        },
+      },
+      execution_slice: {
+        status: 'partial',
+        boundary_reason: 'slice stops before expected persistence step',
+        steps: [
+          {
+            label: 'IdeaGenerationController.generateFromProblem',
+            source_file: 'src/modules/ideas/interface/http/idea-generation.controller.ts',
+            line_number: 58,
+            node_kind: 'method',
+          },
+          {
+            label: 'PipelineTriggerService.startPipeline',
+            source_file: 'src/modules/pipeline/infrastructure/pipeline-trigger.service.ts',
+            line_number: 24,
+            node_kind: 'method',
+          },
+          {
+            label: 'QueueRegistry.addJob',
+            source_file: 'src/modules/pipeline/infrastructure/queue-registry.service.ts',
+            line_number: 16,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['controller', 'queue', 'worker', 'persistence'],
+          observed: ['controller', 'service', 'queue'],
+          missing: ['worker', 'persistence'],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: [
+          'main_pipeline_phases',
+          'queue_worker_handoff',
+          'missing_or_uncertain_phases',
+        ],
+        do_not_claim: [
+          'direct_producer_to_worker_calls_without_enqueues_boundary',
+          'full_runtime_certainty_when_slice_is_partial',
+        ],
+        observed_phases: ['controller', 'service', 'queue'],
+        missing_phases: ['worker', 'persistence'],
+      },
+    }
+
     const pack = buildMadarPromptPack({
       question: 'How idea report is being generated',
-      retrieval: {
-        question: 'How idea report is being generated',
-        token_count: 120,
-        matched_nodes: [],
-        relationships: [],
-        community_context: [],
-        graph_signals: {
-          god_nodes: [],
-          bridge_nodes: [],
-        },
-        retrieval_gate: {
-          level: 3,
-          reason: 'runtime generation intent — behavior slice retrieval',
-          skipped_retrieval: false,
-          intent: 'unknown',
-          signals: {
-            has_pr_diff: false,
-            has_stack_trace: false,
-            mentioned_paths: [],
-            mentioned_symbols: [],
-            generation_intent: 'runtime_generation',
-            target_domain_hint: 'backend_runtime',
-          },
-        },
-        execution_slice: {
-          status: 'partial',
-          boundary_reason: 'slice stops before expected persistence step',
-          steps: [
-            {
-              label: 'IdeaGenerationController.generateFromProblem',
-              source_file: 'src/modules/ideas/interface/http/idea-generation.controller.ts',
-              line_number: 58,
-              node_kind: 'method',
-            },
-            {
-              label: 'PipelineTriggerService.startPipeline',
-              source_file: 'src/modules/pipeline/infrastructure/pipeline-trigger.service.ts',
-              line_number: 24,
-              node_kind: 'method',
-            },
-            {
-              label: 'QueueRegistry.addJob',
-              source_file: 'src/modules/pipeline/infrastructure/queue-registry.service.ts',
-              line_number: 16,
-              node_kind: 'method',
-            },
-          ],
-          phase_coverage: {
-            expected: ['controller', 'queue', 'worker', 'persistence'],
-            observed: ['controller', 'service', 'queue'],
-            missing: ['worker', 'persistence'],
-          },
-        },
-        answer_contract: {
-          version: 1,
-          answer_focus: 'runtime_generation',
-          entrypoint_scope: 'setup_context',
-          required_elements: [
-            'main_pipeline_phases',
-            'queue_worker_handoff',
-            'missing_or_uncertain_phases',
-          ],
-          do_not_claim: [
-            'direct_producer_to_worker_calls_without_enqueues_boundary',
-            'full_runtime_certainty_when_slice_is_partial',
-          ],
-          observed_phases: ['controller', 'service', 'queue'],
-          missing_phases: ['worker', 'persistence'],
-        },
-      } as any,
+      retrieval,
     })
 
     expect(pack.prompt).toContain('"answer_contract"')

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -58,6 +58,15 @@ describe('context-pack-command', () => {
 
     const payload = JSON.parse(output) as {
       pack?: {
+        answer_contract?: {
+          version?: number
+          answer_focus?: string
+          entrypoint_scope?: string
+          required_elements?: string[]
+          do_not_claim?: string[]
+          observed_phases?: string[]
+          missing_phases?: string[]
+        }
         execution_slice?: {
           status?: string
           steps?: Array<{ label?: string }>
@@ -98,6 +107,22 @@ describe('context-pack-command', () => {
         observed: ['controller', 'service', 'queue', 'worker', 'persistence'],
         missing: [],
       },
+    }))
+    expect(payload.pack?.answer_contract).toEqual(expect.objectContaining({
+      version: 1,
+      answer_focus: 'runtime_generation',
+      entrypoint_scope: 'setup_context',
+      required_elements: expect.arrayContaining([
+        'main_pipeline_phases',
+        'queue_worker_handoff',
+        'persistence_or_artifact_storage',
+      ]),
+      do_not_claim: expect.arrayContaining([
+        'direct_producer_to_worker_calls_without_enqueues_boundary',
+        'irrelevant_model_or_provider_details',
+      ]),
+      observed_phases: ['controller', 'service', 'queue', 'worker', 'persistence'],
+      missing_phases: [],
     }))
   })
 

--- a/tests/unit/retrieve.test.ts
+++ b/tests/unit/retrieve.test.ts
@@ -2472,6 +2472,44 @@ describe('retrieve', () => {
       expect(compactReview.matched_nodes[0]).not.toHaveProperty('file_type')
     })
 
+    it('preserves answer_contract when materializing a compiled context pack', () => {
+      const result: Parameters<typeof contextPackFromRetrieveResult>[0] = {
+        question: 'How is the validation report generated?',
+        token_count: 64,
+        matched_nodes: [
+          {
+            node_id: 'idea_controller',
+            label: 'IdeaGenerationController.generateFromProblem',
+            source_file: '/src/modules/ideas/interface/http/idea-generation.controller.ts',
+            line_number: 58,
+            node_kind: 'method',
+            file_type: 'code',
+            snippet: null,
+            match_score: 9,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Pipeline',
+          },
+        ],
+        relationships: [],
+        community_context: [{ id: 0, label: 'Pipeline', node_count: 1 }],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+        answer_contract: {
+          version: 1,
+          answer_focus: 'runtime_generation',
+          entrypoint_scope: 'setup_context',
+          required_elements: ['main_pipeline_phases', 'queue_worker_handoff'],
+          do_not_claim: ['direct_producer_to_worker_calls_without_enqueues_boundary'],
+          observed_phases: ['controller', 'service', 'queue'],
+          missing_phases: ['worker', 'persistence'],
+        },
+      }
+
+      const pack = contextPackFromRetrieveResult(result)
+
+      expect(pack.answer_contract).toEqual(result.answer_contract)
+    })
+
     it('compacts repeated node metadata for default payloads', () => {
       const graph = buildTestGraph()
       graph.graph.community_labels = { 0: 'Auth', 1: 'Data', 2: 'Observability' }


### PR DESCRIPTION
## Summary
- add a runtime-generation answer_contract to retrieval and compact context-pack payloads
- derive compare prompt instructions from the answer contract, including partial-slice uncertainty guidance
- cover the new contract path and legacy fallback behavior with focused tests

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieval results now include a structured runtime answer contract that surfaces required elements, phase coverage, uncertainty, and confidence for generation tasks.

* **Refactor**
  * Instruction-generation now prefers contract-derived, phase-aware directives to produce clearer generation-core guidance when available.

* **Tests**
  * Added tests ensuring answer contracts are generated, embedded in prompts, and preserved in compiled outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->