### PR TITLE
Add explain-routing output for pack and compare

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -185,6 +185,7 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
       execTemplate: options.execTemplate,
       baselineMode: options.baselineMode,
       limit: options.limit,
+      ...(options.why ? { why: true } : {}),
     })
   },
   runReviewCompare: async ({ options }) => {
@@ -342,6 +343,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --budget N            cap context pack assembly at N tokens (default 3000)',
     '    --task KIND          explain|review|impact (default explain)',
     '    --graph <path>       path to graph.json (default out/graph.json)',
+    '    --why               include retrieval-routing debug metadata in the pack output',
     '  prompt "<prompt>"     compile a provider-ready prompt payload',
     '    --provider NAME      claude|gemini',
     '    --graph <path>       path to graph.json (default out/graph.json)',
@@ -379,6 +381,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
     '    --yes                 skip confirmation before running the paid prompt comparison',
     '    --limit N             cap processed prompts/questions for the comparison run',
+    '    --why                 include retrieval-routing debug metadata in the compare summary and reports',
     '  review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff',
     '    --exec TEMPLATE       required command template; supports {prompt_file}, {mode}, and {output_file}',
     '    --output-dir DIR      review compare output directory (default out/review-compare)',

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -28,6 +28,7 @@ export interface PackCliOptions {
   budget: number
   task: ContextPackTaskKind
   graphPath: string
+  why?: boolean
   /** #75 manual override for the retrieval gate. When set (0-5), the gate
    *  emits a decision with reason 'manual override' at the supplied level
    *  instead of running its heuristic classifier on the prompt. */
@@ -93,6 +94,7 @@ export interface CompareCliOptions {
   baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent'
   yes: boolean
   limit: number | null
+  why?: boolean
 }
 
 export interface ReviewCompareCliOptions {
@@ -421,6 +423,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
   let budget = 3000
   let task: ContextPackTaskKind = 'explain'
   let graphPath = 'out/graph.json'
+  let why = false
   let retrievalLevel: PackCliOptions['retrievalLevel'] | undefined
   let retrievalStrategy: PackCliOptions['retrievalStrategy'] | undefined
 
@@ -496,6 +499,11 @@ export function parsePackArgs(args: string[]): PackCliOptions {
       continue
     }
 
+    if (argument === '--why') {
+      why = true
+      continue
+    }
+
     throw new UsageError(`error: unknown option for pack: ${argument}`)
   }
 
@@ -504,6 +512,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
     budget,
     task,
     graphPath,
+    ...(why ? { why: true } : {}),
     ...(retrievalLevel !== undefined ? { retrievalLevel } : {}),
     ...(retrievalStrategy !== undefined ? { retrievalStrategy } : {}),
   }
@@ -908,6 +917,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   let baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent' = 'full'
   let yes = false
   let limit: number | null = null
+  let why = false
 
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index]
@@ -1008,6 +1018,11 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
       continue
     }
 
+    if (argument === '--why') {
+      why = true
+      continue
+    }
+
     throw new UsageError(`error: unknown option for compare: ${argument}`)
   }
 
@@ -1027,7 +1042,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
 
   outputDir = validateGraphOutputPath(outputDir)
 
-  return { question, graphPath, execTemplate, questionsPath, outputDir, baselineMode, yes, limit }
+  return { question, graphPath, execTemplate, questionsPath, outputDir, baselineMode, yes, limit, ...(why ? { why: true } : {}) }
 }
 
 export function parseReviewCompareArgs(args: string[]): ReviewCompareCliOptions {

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -1,5 +1,13 @@
-import type { RetrievalGateDecision } from './retrieval-gate.js'
+import type {
+  RetrievalExcludedDomain,
+  RetrievalGateDecision,
+  RetrievalGenerationIntent,
+  RetrievalIntent,
+  RetrievalLevel,
+  RetrievalTargetDomainHint,
+} from './retrieval-gate.js'
 import type { TaskIntentKind } from './task-intent.js'
+import type { ContextPackDiagnosticWarning } from './context-pack-diagnostics.js'
 import type { SourceDomain } from '../shared/source-discovery.js'
 
 export type ContextPackTaskKind = 'explain' | 'review' | 'impact'
@@ -36,6 +44,29 @@ export interface ContextPackSelectionDiagnostics {
 }
 
 export type ContextPackRetrievalStrategy = 'default' | 'slice-v1'
+
+export interface ContextPackRoutingDebugAnchor {
+  label: string
+  reason: string
+}
+
+export interface ContextPackRoutingDebugExclusions {
+  domains: RetrievalExcludedDomain[]
+  terms: string[]
+  path_hints: string[]
+}
+
+export interface ContextPackRoutingDebug {
+  detected_intent: RetrievalIntent
+  generation_intent: RetrievalGenerationIntent
+  target_domain_hint: RetrievalTargetDomainHint
+  retrieval_level: RetrievalLevel
+  effective_retrieval_strategy: ContextPackRetrievalStrategy
+  reason: string
+  top_anchors: ContextPackRoutingDebugAnchor[]
+  exclusions: ContextPackRoutingDebugExclusions
+  warnings: ContextPackDiagnosticWarning[]
+}
 
 export interface ContextPackSliceAnchor {
   node_id?: string

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -473,6 +473,7 @@ function shouldSanitizeCompareShareSafePath(path: readonly string[]): boolean {
     key === 'result_path' ||
     key === 'source_file' ||
     key === 'focus_files' ||
+    (parentKey === 'exclusions' && key === 'path_hints') ||
     parentKey === 'paths' ||
     parentKey === 'answer_paths'
   )

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
+import type { ContextPackRoutingDebug } from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
@@ -12,6 +13,7 @@ import { loadBenchmarkQuestions } from './benchmark/questions.js'
 import { parsePromptRunnerJsonRecord, parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner.js'
 import { classifyRetrievalLevel } from '../runtime/retrieval-gate.js'
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
+import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
 import { sanitizeShareSafeText, toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
@@ -168,6 +170,7 @@ export interface ComparePromptReport {
   provider_proof?: ComparePromptProviderProof
   madar_trace?: CompareMadarTrace
   pack?: CompareReportPack
+  routing?: ContextPackRoutingDebug
   paths: ComparePromptArtifactPaths
 }
 
@@ -178,6 +181,7 @@ export interface GenerateCompareArtifactsInput {
   outputDir: string
   execTemplate: string
   baselineMode: CompareBaselineMode
+  why?: boolean
   corpusText?: string
   limit?: number | null
   retrievalBudget?: number
@@ -670,6 +674,17 @@ function compareReportPackFromRetrieveResult(retrieval: RetrieveResult): Compare
     ...(retrieval.claims ? { claims: retrieval.claims } : {}),
     ...(retrieval.coverage ? { coverage: retrieval.coverage } : {}),
     ...(retrieval.selection_diagnostics ? { selection_diagnostics: retrieval.selection_diagnostics } : {}),
+  }
+}
+
+function appendRoutingSummary(lines: string[], reports: readonly ComparePromptReport[]): void {
+  const routedReports = reports.filter((report): report is ComparePromptReport & { routing: ContextPackRoutingDebug } => report.routing !== undefined)
+  for (const report of routedReports) {
+    const prefix = routedReports.length === 1 ? '' : ` (${report.question})`
+    lines.push(
+      `- Routing${prefix}: ${report.routing.detected_intent} · ${report.routing.generation_intent} · ${report.routing.target_domain_hint} · level ${report.routing.retrieval_level} · ${report.routing.effective_retrieval_strategy}`,
+    )
+    lines.push(`- Routing reason${prefix}: ${report.routing.reason}`)
   }
 }
 
@@ -1361,6 +1376,7 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
         madar: null,
       },
       ...(comparePack ? { pack: comparePack } : {}),
+      ...(input.why ? { routing: buildRoutingDebug(retrieval) } : {}),
       paths,
     }
 
@@ -1641,6 +1657,7 @@ export function formatCompareSummary(result: GenerateCompareArtifactsResult): st
   if (madarTraceSummary !== null) {
     lines.push(`- ${madarTraceSummary}`)
   }
+  appendRoutingSummary(lines, result.reports)
 
   return lines.join('\n')
 }

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -1,5 +1,12 @@
 import { buildCommunityLabels } from '../pipeline/community-naming.js'
-import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef, ContextPackNode } from '../contracts/context-pack.js'
+import type {
+  ContextPackClaim,
+  ContextPackCoverage,
+  ContextPackEvidenceClass,
+  ContextPackExpandableRef,
+  ContextPackNode,
+  ContextPackRoutingDebug,
+} from '../contracts/context-pack.js'
 import type { KnowledgeGraph } from '../contracts/graph.js'
 import type { TaskContextPlan } from '../contracts/task-context-plan.js'
 import type { PackCliOptions } from '../cli/parser.js'
@@ -11,6 +18,7 @@ import { analyzeImpact, compactImpactResult, type ImpactResult } from '../runtim
 import { analyzePrImpact, compactPrImpactResult, type PrImpactResult } from '../runtime/pr-impact.js'
 import { buildTaskContextPlan } from '../runtime/task-context-planner.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
+import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
 
 const DEFAULT_IMPACT_DEPTH = 3
@@ -46,6 +54,7 @@ interface ContextPlaneMetadata {
 
 export interface ExplainPackPayload extends ContextPlaneMetadata {
   pack: ReturnType<typeof compactRetrieveResult>
+  routing?: ContextPackRoutingDebug
 }
 
 function emptyCoverage(): ContextPackCoverage {
@@ -267,6 +276,7 @@ export async function runContextPackCommand(
       target: impactTarget,
       pack: impactPack,
       ...impactMetadata(impactResult, plannerBudget, options.prompt, initialPlan.evidence.recipe_id, options.retrievalLevel),
+      ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
     })
   }
 
@@ -285,5 +295,6 @@ export async function runContextPackCommand(
   return JSON.stringify({
     ...baseResponse(options, initialPlan, plannerBudget),
     ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval),
+    ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
   })
 }

--- a/src/runtime/routing-debug.ts
+++ b/src/runtime/routing-debug.ts
@@ -7,6 +7,9 @@ import type {
 import { computeContextPackDiagnostics } from './context-pack-diagnostics.js'
 import { contextPackFromRetrieveResult, type RetrieveResult } from './retrieve.js'
 
+// Treat obvious path-shaped strings as private-ish anchor candidates so
+// safeAnchorLabel can collapse them to a basename: absolute paths, any value
+// containing a slash, or bare filenames with short extensions.
 const PATH_LIKE_PATTERN = /^(?:\/|[A-Za-z]:[\\/])|[\\/]|(?:^|[\\/])[^\\/]+\.[A-Za-z0-9]{1,8}$/
 
 function safeAnchorLabel(value: string): string {
@@ -56,11 +59,11 @@ function topAnchors(retrieval: RetrieveResult): ContextPackRoutingDebugAnchor[] 
   }
 
   return dedupeAnchors(
-    retrieval.matched_nodes.slice(0, 3).map((node) => ({
+    retrieval.matched_nodes.slice(0, 10).map((node) => ({
       label: safeAnchorLabel(node.label),
       reason: 'top retrieval match',
     })),
-  )
+  ).slice(0, 3)
 }
 
 export function buildRoutingDebug(retrieval: RetrieveResult): ContextPackRoutingDebug {

--- a/src/runtime/routing-debug.ts
+++ b/src/runtime/routing-debug.ts
@@ -1,0 +1,85 @@
+import { basename } from 'node:path'
+
+import type {
+  ContextPackRoutingDebug,
+  ContextPackRoutingDebugAnchor,
+} from '../contracts/context-pack.js'
+import { computeContextPackDiagnostics } from './context-pack-diagnostics.js'
+import { contextPackFromRetrieveResult, type RetrieveResult } from './retrieve.js'
+
+const PATH_LIKE_PATTERN = /^(?:\/|[A-Za-z]:[\\/])|[\\/]|(?:^|[\\/])[^\\/]+\.[A-Za-z0-9]{1,8}$/
+
+function safeAnchorLabel(value: string): string {
+  const trimmed = value.trim()
+  if (/^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+\//i.test(trimmed)) {
+    return trimmed
+  }
+  if (!PATH_LIKE_PATTERN.test(trimmed)) {
+    return trimmed
+  }
+  return basename(trimmed.replaceAll('\\', '/'))
+}
+
+function dedupeAnchors(anchors: ContextPackRoutingDebugAnchor[]): ContextPackRoutingDebugAnchor[] {
+  const seen = new Set<string>()
+  return anchors.filter((anchor) => {
+    const key = `${anchor.label}\u0000${anchor.reason}`
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+}
+
+function topAnchors(retrieval: RetrieveResult): ContextPackRoutingDebugAnchor[] {
+  const sliceAnchors = retrieval.slice?.anchors.map((anchor) => ({
+    label: safeAnchorLabel(anchor.label),
+    reason: anchor.reason,
+  })) ?? []
+  if (sliceAnchors.length > 0) {
+    return dedupeAnchors(sliceAnchors).slice(0, 3)
+  }
+
+  const signalAnchors: ContextPackRoutingDebugAnchor[] = [
+    ...(retrieval.retrieval_gate?.signals.mentioned_symbols ?? []).map((label) => ({
+      label: safeAnchorLabel(label),
+      reason: 'symbol mention',
+    })),
+    ...(retrieval.retrieval_gate?.signals.mentioned_paths ?? []).map((label) => ({
+      label: safeAnchorLabel(label),
+      reason: 'path mention',
+    })),
+  ]
+  if (signalAnchors.length > 0) {
+    return dedupeAnchors(signalAnchors).slice(0, 3)
+  }
+
+  return dedupeAnchors(
+    retrieval.matched_nodes.slice(0, 3).map((node) => ({
+      label: safeAnchorLabel(node.label),
+      reason: 'top retrieval match',
+    })),
+  )
+}
+
+export function buildRoutingDebug(retrieval: RetrieveResult): ContextPackRoutingDebug {
+  const gate = retrieval.retrieval_gate
+  const diagnostics = computeContextPackDiagnostics(contextPackFromRetrieveResult(retrieval))
+
+  return {
+    detected_intent: gate?.intent ?? 'unknown',
+    generation_intent: gate?.signals.generation_intent ?? 'unknown',
+    target_domain_hint: gate?.signals.target_domain_hint ?? 'unknown',
+    retrieval_level: gate?.level ?? 1,
+    effective_retrieval_strategy: retrieval.retrieval_strategy ?? 'default',
+    reason: gate?.reason ?? 'retrieval gate unavailable',
+    top_anchors: topAnchors(retrieval),
+    exclusions: {
+      domains: [...(gate?.signals.excluded_domains ?? [])],
+      terms: [...(gate?.signals.excluded_terms ?? [])],
+      path_hints: [...(gate?.signals.excluded_path_hints ?? [])],
+    },
+    warnings: diagnostics.warnings,
+  }
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -260,6 +260,16 @@ describe('cli parser', () => {
     })
   })
 
+  it('parses pack args with --why', () => {
+    expect(parsePackArgs(['how does auth work', '--why'])).toEqual({
+      prompt: 'how does auth work',
+      budget: 3000,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      why: true,
+    })
+  })
+
   it('rejects invalid pack args', () => {
     expect(() => parsePackArgs([])).toThrow('Usage: madar pack')
     expect(() => parsePackArgs(['how does auth work', '--budget', '0'])).toThrow('error: --budget must be a positive integer')
@@ -507,6 +517,27 @@ describe('cli parser', () => {
       baselineMode: 'pack_only',
       yes: false,
       limit: null,
+    })
+  })
+
+  it('parses compare args with --why', () => {
+    expect(
+    parseCompareArgs([
+      'how does login work',
+      '--exec',
+      'claude -p "$(cat {prompt_file})"',
+      '--why',
+    ]),
+    ).toEqual({
+    question: 'how does login work',
+    graphPath: 'out/graph.json',
+    execTemplate: 'claude -p "$(cat {prompt_file})"',
+    questionsPath: null,
+    outputDir: resolve('out/compare'),
+    baselineMode: 'full',
+    yes: false,
+    limit: null,
+    why: true,
     })
   })
 
@@ -921,6 +952,7 @@ describe('cli main', () => {
     expect(help).toContain('    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)')
     expect(help).toContain('    --yes                 skip confirmation before running the paid prompt comparison')
     expect(help).toContain('    --limit N             cap processed prompts/questions for the comparison run')
+    expect(help).toContain('    --why                 include retrieval-routing debug metadata in the compare summary and reports')
     expect(help).toContain('review-compare [graph.json] compare full vs compact pr_impact review prompts on the current git diff')
     expect(help).toContain('    --output-dir DIR      review compare output directory (default out/review-compare)')
     expect(help).toContain('time-travel <from> <to> compare two refs using on-demand cached graph snapshots')
@@ -975,9 +1007,10 @@ describe('cli main', () => {
         '--yes',
         '--limit',
         '5',
-      ],
-      io,
-      dependencies,
+        '--why',
+        ],
+        io,
+        dependencies,
     )
 
     expect(exitCode).toBe(0)
@@ -997,6 +1030,7 @@ describe('cli main', () => {
       baselineMode: 'bounded',
       yes: true,
       limit: 5,
+      why: true,
     })
     expect(compareRequest.io).toBe(io)
     await expect(compareRequest.confirm('Proceed?')).resolves.toBe(true)
@@ -1272,7 +1306,7 @@ describe('cli main', () => {
       runContextPack,
     }
 
-    await expect(executeCli(['pack', 'how does auth work', '--budget', '1800', '--task', 'explain'], io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['pack', 'how does auth work', '--budget', '1800', '--task', 'explain', '--why'], io, dependencies)).resolves.toBe(0)
 
     expect(runContextPack).toHaveBeenCalledWith({
       options: {
@@ -1280,6 +1314,7 @@ describe('cli main', () => {
         budget: 1800,
         task: 'explain',
         graphPath: 'out/graph.json',
+        why: true,
       },
       io,
     })

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -867,6 +867,7 @@ describe('compare runtime', () => {
     const graph = makeGraph()
     writeProjectFiles()
     const graphPath = writeGraphFixture(graph)
+    const absolutePathHint = join(PROJECT_FIXTURE_ROOT, 'src', 'routes.ts')
     const retrieveSpy = vi.spyOn(retrieveRuntime, 'retrieveContext').mockReturnValue({
       question: 'Explain the runtime path for login session creation excluding tests',
       token_count: 180,
@@ -947,7 +948,7 @@ describe('compare runtime', () => {
           target_domain_hint: 'backend_runtime',
           excluded_domains: ['test'],
           excluded_terms: ['tests'],
-          excluded_path_hints: ['test'],
+          excluded_path_hints: [absolutePathHint, '../private/secret.ts'],
         },
       },
       retrieval_strategy: 'slice-v1',
@@ -991,6 +992,13 @@ describe('compare runtime', () => {
           warnings?: Array<{ kind?: string; severity?: string }>
         }
       }
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as {
+        routing?: {
+          exclusions?: {
+            path_hints?: string[]
+          }
+        }
+      }
 
       expect(savedReport.routing).toEqual(expect.objectContaining({
         detected_intent: 'explain',
@@ -1006,7 +1014,7 @@ describe('compare runtime', () => {
         exclusions: {
           domains: ['test'],
           terms: ['tests'],
-          path_hints: ['test'],
+          path_hints: [absolutePathHint, '../private/secret.ts'],
         },
         warnings: expect.arrayContaining([
           expect.objectContaining({
@@ -1015,8 +1023,29 @@ describe('compare runtime', () => {
           }),
         ]),
       }))
+      expect(shareSafeReport.routing?.exclusions?.path_hints).toEqual([
+        '<project-root>/src/routes.ts',
+        'secret.ts',
+      ])
       expect(formatCompareSummary(result)).toContain('Routing: explain · runtime_generation · backend_runtime · level 3 · slice-v1')
       expect(formatCompareSummary(result)).toContain('Routing reason: runtime generation intent — behavior slice retrieval')
+
+      const defaultResult = generateCompareArtifacts({
+        graphPath,
+        question: 'Explain the runtime path for login session creation excluding tests',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+        baselineMode: 'pack_only',
+        now: new Date('2026-04-24T19:31:00.000Z'),
+      })
+      const defaultReport = defaultResult.reports[0]!
+      const defaultSavedReport = JSON.parse(readFileSync(defaultReport.paths.report, 'utf8')) as {
+        routing?: unknown
+      }
+
+      expect(defaultSavedReport.routing).toBeUndefined()
+      expect(formatCompareSummary(defaultResult)).not.toContain('Routing: explain · runtime_generation · backend_runtime · level 3 · slice-v1')
+      expect(formatCompareSummary(defaultResult)).not.toContain('Routing reason: runtime generation intent — behavior slice retrieval')
     } finally {
       retrieveSpy.mockRestore()
     }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -863,6 +863,165 @@ describe('compare runtime', () => {
     }
   })
 
+  it('adds routing debug metadata to compare reports and summaries when --why is enabled', () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+    const retrieveSpy = vi.spyOn(retrieveRuntime, 'retrieveContext').mockReturnValue({
+      question: 'Explain the runtime path for login session creation excluding tests',
+      token_count: 180,
+      matched_nodes: [
+        {
+          label: 'POST /login',
+          source_file: 'src/routes.ts',
+          line_number: 10,
+          file_type: 'code',
+          snippet: 'app.post("/login", authenticateUser)',
+          match_score: 0.95,
+          relevance_band: 'direct',
+          community: 0,
+          community_label: null,
+        },
+        {
+          label: 'authenticateUser',
+          source_file: 'src/auth.ts',
+          line_number: 1,
+          file_type: 'code',
+          snippet: 'return new SessionManager().createSession(credentials.userId)',
+          match_score: 0.91,
+          relevance_band: 'direct',
+          community: 0,
+          community_label: null,
+        },
+        {
+          label: 'authenticateUser.spec',
+          source_file: 'tests/auth.spec.ts',
+          line_number: 1,
+          file_type: 'code',
+          snippet: 'expect(authenticateUser()).toBeDefined()',
+          match_score: 0.41,
+          relevance_band: 'related',
+          community: 1,
+          community_label: null,
+          source_domain: 'test',
+        },
+      ],
+      relationships: [
+        { from: 'POST /login', to: 'authenticateUser', relation: 'calls' },
+        { from: 'authenticateUser', to: 'authenticateUser.spec', relation: 'covered_by' },
+      ],
+      community_context: [],
+      graph_signals: {
+        god_nodes: [],
+        bridge_nodes: [],
+      },
+      claims: [
+        {
+          evidence_class: 'primary',
+          text: 'authenticateUser executes the runtime login path.',
+          node_labels: ['authenticateUser'],
+        },
+      ],
+      coverage: {
+        required_evidence: ['primary'],
+        semantic_required: ['implementation'],
+        semantic_optional: ['tests'],
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 2,
+        selected_relationships: 2,
+      },
+      retrieval_gate: {
+        level: 3,
+        skipped_retrieval: false,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        intent: 'explain',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: ['authenticateUser'],
+          generation_intent: 'runtime_generation',
+          target_domain_hint: 'backend_runtime',
+          excluded_domains: ['test'],
+          excluded_terms: ['tests'],
+          excluded_path_hints: ['test'],
+        },
+      },
+      retrieval_strategy: 'slice-v1',
+      slice: {
+        mode: 'explain',
+        anchors: [
+          { label: 'authenticateUser', reason: 'symbol mention' },
+          { label: 'POST /login', reason: 'route mention' },
+        ],
+        directions: ['forward'],
+        selected_paths: [],
+      },
+    })
+
+    try {
+      const result = generateCompareArtifacts({
+        graphPath,
+        question: 'Explain the runtime path for login session creation excluding tests',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+        baselineMode: 'pack_only',
+        why: true,
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      })
+
+      const report = result.reports[0]!
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as {
+        routing?: {
+          detected_intent?: string
+          generation_intent?: string
+          target_domain_hint?: string
+          retrieval_level?: number
+          effective_retrieval_strategy?: string
+          reason?: string
+          top_anchors?: Array<{ label?: string; reason?: string }>
+          exclusions?: {
+            domains?: string[]
+            terms?: string[]
+            path_hints?: string[]
+          }
+          warnings?: Array<{ kind?: string; severity?: string }>
+        }
+      }
+
+      expect(savedReport.routing).toEqual(expect.objectContaining({
+        detected_intent: 'explain',
+        generation_intent: 'runtime_generation',
+        target_domain_hint: 'backend_runtime',
+        retrieval_level: 3,
+        effective_retrieval_strategy: 'slice-v1',
+        reason: 'runtime generation intent — behavior slice retrieval',
+        top_anchors: [
+          { label: 'authenticateUser', reason: 'symbol mention' },
+          { label: 'POST /login', reason: 'route mention' },
+        ],
+        exclusions: {
+          domains: ['test'],
+          terms: ['tests'],
+          path_hints: ['test'],
+        },
+        warnings: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'excluded_domain_selected',
+            severity: 'warn',
+          }),
+        ]),
+      }))
+      expect(formatCompareSummary(result)).toContain('Routing: explain · runtime_generation · backend_runtime · level 3 · slice-v1')
+      expect(formatCompareSummary(result)).toContain('Routing reason: runtime generation intent — behavior slice retrieval')
+    } finally {
+      retrieveSpy.mockRestore()
+    }
+  })
+
   it('tells broad runtime-generation answers not to stop at the HTTP trigger when downstream generation core evidence exists', () => {
     const retrieval: MadarPromptPackRetrieval = {
       question: 'How idea report is being generated',

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -172,6 +172,163 @@ describe('context-pack-command', () => {
     expect(payload.pack?.execution_slice?.status).toBe('complete')
   })
 
+  it('adds routing metadata only when --why is enabled', async () => {
+    const graph = new KnowledgeGraph()
+    const retrieval = {
+      question: 'Explain the runtime path for login session creation excluding tests',
+      token_count: 120,
+      matched_nodes: [
+        {
+          label: 'POST /login',
+          source_file: '/src/auth/routes.ts',
+          line_number: 10,
+          file_type: 'code',
+          snippet: 'app.post("/login", controller.login)',
+          match_score: 0.92,
+          relevance_band: 'direct' as const,
+          community: 0,
+        },
+        {
+          label: 'AuthService.login',
+          source_file: '/src/auth/service.ts',
+          line_number: 24,
+          file_type: 'code',
+          snippet: 'return sessionStore.createSession(userId)',
+          match_score: 0.88,
+          relevance_band: 'direct' as const,
+          community: 0,
+        },
+        {
+          label: 'AuthService.login.spec',
+          source_file: '/tests/auth.service.spec.ts',
+          line_number: 12,
+          file_type: 'code',
+          snippet: 'expect(login()).toEqual(...)',
+          match_score: 0.33,
+          relevance_band: 'related' as const,
+          community: 1,
+          source_domain: 'test' as const,
+        },
+      ],
+      relationships: [
+        { from: 'POST /login', to: 'AuthService.login', relation: 'calls' },
+        { from: 'AuthService.login', to: 'AuthService.login.spec', relation: 'covered_by' },
+      ],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [
+        {
+          evidence_class: 'primary' as const,
+          text: 'AuthService.login handles the login runtime path.',
+          node_labels: ['AuthService.login'],
+        },
+      ],
+      coverage: {
+        required_evidence: ['primary' as const],
+        semantic_required: ['implementation' as const],
+        semantic_optional: ['tests' as const],
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 2,
+        selected_relationships: 2,
+      },
+      retrieval_gate: {
+        level: 3 as const,
+        skipped_retrieval: false,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        intent: 'explain' as const,
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: ['AuthService.login'],
+          generation_intent: 'runtime_generation' as const,
+          target_domain_hint: 'backend_runtime' as const,
+          excluded_domains: ['test' as const],
+          excluded_terms: ['tests'],
+          excluded_path_hints: ['test'],
+        },
+      },
+      retrieval_strategy: 'slice-v1' as const,
+      slice: {
+        mode: 'explain' as const,
+        anchors: [
+          { label: 'AuthService.login', reason: 'symbol mention' },
+          { label: 'POST /login', reason: 'route mention' },
+        ],
+        directions: ['forward' as const],
+        selected_paths: [],
+      },
+    }
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const withoutWhy = JSON.parse(await runContextPackCommand({
+      prompt: retrieval.question,
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+    }, dependencies)) as Record<string, unknown>
+
+    const withWhy = JSON.parse(await runContextPackCommand({
+      prompt: retrieval.question,
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      why: true,
+    } as never, dependencies)) as {
+      routing?: {
+        detected_intent?: string
+        generation_intent?: string
+        target_domain_hint?: string
+        retrieval_level?: number
+        effective_retrieval_strategy?: string
+        reason?: string
+        top_anchors?: Array<{ label?: string; reason?: string }>
+        exclusions?: {
+          domains?: string[]
+          terms?: string[]
+          path_hints?: string[]
+        }
+        warnings?: Array<{ kind?: string; severity?: string }>
+      }
+    }
+
+    expect(withoutWhy).not.toHaveProperty('routing')
+    expect(withWhy.routing).toEqual(expect.objectContaining({
+      detected_intent: 'explain',
+      generation_intent: 'runtime_generation',
+      target_domain_hint: 'backend_runtime',
+      retrieval_level: 3,
+      effective_retrieval_strategy: 'slice-v1',
+      reason: 'runtime generation intent — behavior slice retrieval',
+      top_anchors: [
+        { label: 'AuthService.login', reason: 'symbol mention' },
+        { label: 'POST /login', reason: 'route mention' },
+      ],
+      exclusions: {
+        domains: ['test'],
+        terms: ['tests'],
+        path_hints: ['test'],
+      },
+      warnings: expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'excluded_domain_selected',
+          severity: 'warn',
+        }),
+      ]),
+    }))
+  })
+
   it('normalizes sub-minimum explain budgets before retrieving', async () => {
     const graph = new KnowledgeGraph()
     const dependencies: ContextPackCommandDependencies = {

--- a/tests/unit/routing-debug.test.ts
+++ b/tests/unit/routing-debug.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRoutingDebug } from '../../src/runtime/routing-debug.js'
+
+describe('buildRoutingDebug', () => {
+  it('dedupes matched-node fallback anchors before taking the top three', () => {
+    const routing = buildRoutingDebug({
+      question: 'Trace the runtime path',
+      token_count: 42,
+      retrieval_gate: {
+        level: 3,
+        skipped_retrieval: false,
+        reason: 'test routing fallback',
+        intent: 'explain',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation',
+          target_domain_hint: 'backend_runtime',
+          excluded_domains: [],
+          excluded_terms: [],
+          excluded_path_hints: [],
+        },
+      },
+      matched_nodes: [
+        {
+          node_id: '1',
+          label: 'src/foo.ts',
+          node_kind: 'file',
+          source_file: 'src/foo.ts',
+          line_number: 1,
+          snippet: null,
+          match_score: 0.9,
+          file_type: 'code',
+          relevance_band: 'direct',
+          community: 0,
+          community_label: null,
+        },
+        {
+          node_id: '2',
+          label: 'lib/foo.ts',
+          node_kind: 'file',
+          source_file: 'lib/foo.ts',
+          line_number: 1,
+          snippet: null,
+          match_score: 0.8,
+          file_type: 'code',
+          relevance_band: 'direct',
+          community: 0,
+          community_label: null,
+        },
+        {
+          node_id: '3',
+          label: 'app/foo.ts',
+          node_kind: 'file',
+          source_file: 'app/foo.ts',
+          line_number: 1,
+          snippet: null,
+          match_score: 0.7,
+          file_type: 'code',
+          relevance_band: 'direct',
+          community: 0,
+          community_label: null,
+        },
+        {
+          node_id: '4',
+          label: 'src/bar.ts',
+          node_kind: 'file',
+          source_file: 'src/bar.ts',
+          line_number: 1,
+          snippet: null,
+          match_score: 0.6,
+          file_type: 'code',
+          relevance_band: 'related',
+          community: 0,
+          community_label: null,
+        },
+        {
+          node_id: '5',
+          label: 'src/baz.ts',
+          node_kind: 'file',
+          source_file: 'src/baz.ts',
+          line_number: 1,
+          snippet: null,
+          match_score: 0.5,
+          file_type: 'code',
+          relevance_band: 'related',
+          community: 0,
+          community_label: null,
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: {
+        god_nodes: [],
+        bridge_nodes: [],
+      },
+    })
+
+    expect(routing.top_anchors).toEqual([
+      { label: 'foo.ts', reason: 'top retrieval match' },
+      { label: 'bar.ts', reason: 'top retrieval match' },
+      { label: 'baz.ts', reason: 'top retrieval match' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary\n- add an opt-in --why surface for pack and compare routing decisions\n- expose deterministic routing metadata from retrieval-gate signals, anchors, exclusions, and diagnostics\n- persist compare routing output in report artifacts and summary output\n\n## Testing\n- npm run typecheck\n- npm run build\n- CI=1 npm run test:run\n\nCloses #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--why` flag to `pack` and `compare` commands to include retrieval-routing debug metadata (detected/generation intent, target domain hints, retrieval level/strategy, top anchors, exclusions, and warnings) in outputs and reports.
* **Documentation**
  * CLI help updated to document the new `--why` option for both commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->