### PR TITLE
Add pack task classification

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -341,7 +341,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --file-type TYPE      limit traversal to one file type (for example code or document)',
     '  pack "<prompt>"       compile a compact context payload for automation',
     '    --budget N            cap context pack assembly at N tokens (default 3000)',
-    '    --task KIND          explain|review|impact (default explain)',
+    '    --task KIND          explain|implement|review|impact (default infer from prompt; fallback explain)',
     '    --graph <path>       path to graph.json (default out/graph.json)',
     '    --why               include retrieval-routing debug metadata in the pack output',
     '  prompt "<prompt>"     compile a provider-ready prompt payload',

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -27,6 +27,7 @@ export interface PackCliOptions {
   prompt: string
   budget: number
   task: ContextPackTaskKind
+  taskExplicit?: boolean
   graphPath: string
   why?: boolean
   /** #75 manual override for the retrieval gate. When set (0-5), the gate
@@ -287,10 +288,10 @@ function parseTimeTravelView(value: string): 'summary' | 'risk' | 'drift' | 'tim
 
 function parseContextPackTask(value: string): ContextPackTaskKind {
   const normalized = value.trim().toLowerCase()
-  if (normalized === 'explain' || normalized === 'review' || normalized === 'impact') {
+  if (normalized === 'explain' || normalized === 'implement' || normalized === 'review' || normalized === 'impact') {
     return normalized
   }
-  throw new UsageError('error: --task must be one of explain, review, impact')
+  throw new UsageError('error: --task must be one of explain, implement, review, impact')
 }
 
 function parsePromptProvider(value: string): PromptCliProvider {
@@ -422,6 +423,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
 
   let budget = 3000
   let task: ContextPackTaskKind = 'explain'
+  let taskExplicit = false
   let graphPath = 'out/graph.json'
   let why = false
   let retrievalLevel: PackCliOptions['retrievalLevel'] | undefined
@@ -453,6 +455,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
 
     if (argument === '--task') {
       task = parseContextPackTask(requireOptionValue('--task', args[index + 1]))
+      taskExplicit = true
       index += 1
       continue
     }
@@ -460,6 +463,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
     if (argument.startsWith('--task=')) {
       const [, value] = argument.split('=', 2)
       task = parseContextPackTask(requireOptionValue('--task', value))
+      taskExplicit = true
       continue
     }
 
@@ -511,6 +515,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
     prompt: normalizedPrompt,
     budget,
     task,
+    ...(taskExplicit ? { taskExplicit: true } : {}),
     graphPath,
     ...(why ? { why: true } : {}),
     ...(retrievalLevel !== undefined ? { retrievalLevel } : {}),

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -10,7 +10,7 @@ import type { TaskIntentKind } from './task-intent.js'
 import type { ContextPackDiagnosticWarning } from './context-pack-diagnostics.js'
 import type { SourceDomain } from '../shared/source-discovery.js'
 
-export type ContextPackTaskKind = 'explain' | 'review' | 'impact'
+export type ContextPackTaskKind = 'explain' | 'implement' | 'review' | 'impact'
 
 export type ContextPackEvidenceClass = 'primary' | 'supporting' | 'structural' | 'change' | 'impact'
 

--- a/src/contracts/retrieval-gate.ts
+++ b/src/contracts/retrieval-gate.ts
@@ -11,6 +11,9 @@ export type RetrievalLevel = 0 | 1 | 2 | 3 | 4 | 5
 export type RetrievalIntent =
   | 'rename'
   | 'explain'
+  | 'implement'
+  | 'migrate'
+  | 'document'
   | 'debug'
   | 'refactor'
   | 'test'

--- a/src/contracts/task-intent.ts
+++ b/src/contracts/task-intent.ts
@@ -1,7 +1,10 @@
 export const TASK_INTENT_KINDS = [
   'explain',
+  'implement',
   'review',
   'impact',
+  'migrate',
+  'document',
   'debug-flow',
   'pr-review-risk',
   'test-generation',
@@ -13,7 +16,7 @@ export const TASK_INTENT_KINDS = [
 
 export type TaskIntentKind = (typeof TASK_INTENT_KINDS)[number]
 
-export type TaskIntentContextKind = 'explain' | 'review' | 'impact'
+export type TaskIntentContextKind = 'explain' | 'implement' | 'review' | 'impact'
 
 export type TaskIntentConfidence = 'low' | 'medium' | 'high'
 
@@ -75,11 +78,38 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     ],
   },
   {
+    kind: 'implement',
+    label: 'Implement',
+    description: 'Build, fix, add, or wire code to change behavior.',
+    default_context_kind: 'implement',
+    priority: 1,
+    rules: [
+      {
+        id: 'implement-explicit',
+        score: 10,
+        any_keywords: ['implement'],
+      },
+      {
+        id: 'implement-phrases',
+        score: 9,
+        any_phrases: ['implement issue', 'fix issue', 'address issue', 'add support', 'wire up'],
+      },
+      {
+        id: 'implement-keywords',
+        score: 7,
+        keyword_groups: [
+          ['add', 'build', 'create', 'fix', 'support', 'wire'],
+          ['feature', 'flow', 'behavior', 'integration', 'context', 'command', 'pipeline', 'task', 'issue', 'support'],
+        ],
+      },
+    ],
+  },
+  {
     kind: 'review',
     label: 'Review',
     description: 'Inspect code or changes for quality concerns without a narrower specialty.',
     default_context_kind: 'review',
-    priority: 1,
+    priority: 2,
     rules: [
       {
         id: 'review-explicit',
@@ -98,7 +128,7 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     label: 'Impact',
     description: 'Estimate blast radius, downstream dependencies, or likely breakage.',
     default_context_kind: 'impact',
-    priority: 2,
+    priority: 3,
     rules: [
       {
         id: 'impact-explicit',
@@ -116,11 +146,52 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     ],
   },
   {
+    kind: 'migrate',
+    label: 'Migrate',
+    description: 'Migrate names, APIs, or integration surfaces from one shape to another.',
+    default_context_kind: 'implement',
+    priority: 4,
+    rules: [
+      {
+        id: 'migrate-explicit',
+        score: 10,
+        any_keywords: ['migrate', 'migration', 'port'],
+      },
+      {
+        id: 'migrate-phrases',
+        score: 8,
+        any_phrases: ['move from', 'move to', 'rename package', 'rebrand to'],
+      },
+    ],
+  },
+  {
+    kind: 'document',
+    label: 'Document',
+    description: 'Update README, changelog, or docs to reflect behavior and usage.',
+    default_context_kind: 'implement',
+    priority: 5,
+    rules: [
+      {
+        id: 'document-explicit',
+        score: 10,
+        any_phrases: ['document the', 'write docs', 'write documentation', 'update the readme', 'update readme', 'update the changelog', 'document how'],
+      },
+      {
+        id: 'document-keywords',
+        score: 7,
+        keyword_groups: [
+          ['document', 'docs', 'readme', 'changelog', 'documentation'],
+          ['write', 'update', 'refresh', 'capture'],
+        ],
+      },
+    ],
+  },
+  {
     kind: 'debug-flow',
     label: 'Debug flow',
     description: 'Trace failures, identify root causes, and follow error-producing paths.',
     default_context_kind: 'impact',
-    priority: 3,
+    priority: 6,
     rules: [
       {
         id: 'debug-explicit',
@@ -142,7 +213,7 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     label: 'PR review risk',
     description: 'Review a diff or pull request with explicit attention to merge risk.',
     default_context_kind: 'review',
-    priority: 4,
+    priority: 7,
     rules: [
       {
         id: 'pr-review-explicit',
@@ -163,8 +234,8 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     kind: 'test-generation',
     label: 'Test generation',
     description: 'Create or propose regression, unit, or integration tests.',
-    default_context_kind: 'review',
-    priority: 5,
+    default_context_kind: 'implement',
+    priority: 8,
     rules: [
       {
         id: 'test-generation-explicit',
@@ -185,8 +256,8 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     kind: 'refactor-module',
     label: 'Refactor module',
     description: 'Restructure a module or component while preserving behavior.',
-    default_context_kind: 'impact',
-    priority: 6,
+    default_context_kind: 'implement',
+    priority: 9,
     rules: [
       {
         id: 'refactor-explicit',
@@ -207,8 +278,8 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     kind: 'dead-code',
     label: 'Dead code',
     description: 'Find or remove unused, stale, or unreachable code.',
-    default_context_kind: 'impact',
-    priority: 7,
+    default_context_kind: 'implement',
+    priority: 10,
     rules: [
       {
         id: 'dead-code-explicit',
@@ -230,7 +301,7 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     label: 'Security review',
     description: 'Inspect attack surface, validation, and privilege boundaries.',
     default_context_kind: 'review',
-    priority: 8,
+    priority: 11,
     rules: [
       {
         id: 'security-explicit',
@@ -252,7 +323,7 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
     label: 'Performance review',
     description: 'Inspect latency, throughput, memory, or CPU behavior.',
     default_context_kind: 'impact',
-    priority: 9,
+    priority: 12,
     rules: [
       {
         id: 'performance-explicit',

--- a/src/contracts/task-intent.ts
+++ b/src/contracts/task-intent.ts
@@ -99,7 +99,7 @@ export const TASK_INTENT_DEFINITIONS: TaskIntentDefinition[] = [
         score: 7,
         keyword_groups: [
           ['add', 'build', 'create', 'fix', 'support', 'wire'],
-          ['feature', 'flow', 'behavior', 'integration', 'context', 'command', 'pipeline', 'task', 'issue', 'support'],
+          ['feature', 'flow', 'behavior', 'integration', 'context', 'command', 'pipeline', 'task', 'issue'],
         ],
       },
     ],

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -17,6 +17,7 @@ import { pickImpactTarget } from '../runtime/context-pack-target.js'
 import { analyzeImpact, compactImpactResult, type ImpactResult } from '../runtime/impact.js'
 import { analyzePrImpact, compactPrImpactResult, type PrImpactResult } from '../runtime/pr-impact.js'
 import { buildTaskContextPlan } from '../runtime/task-context-planner.js'
+import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
@@ -25,7 +26,7 @@ const DEFAULT_IMPACT_DEPTH = 3
 
 export interface ContextPackCommandDependencies {
   loadGraph: (graphPath: string) => KnowledgeGraph
-  retrieveContext: (graph: KnowledgeGraph, options: Pick<import('../runtime/retrieve.js').RetrieveOptions, 'question' | 'budget' | 'taskIntent' | 'retrievalLevel' | 'retrievalStrategy'>) => RetrieveResult
+  retrieveContext: (graph: KnowledgeGraph, options: Pick<import('../runtime/retrieve.js').RetrieveOptions, 'question' | 'budget' | 'taskKind' | 'taskIntent' | 'retrievalLevel' | 'retrievalStrategy'>) => RetrieveResult
   compactRetrieveResult: typeof compactRetrieveResult
   analyzePrImpact: (graph: KnowledgeGraph, projectDir?: string, options?: { baseBranch?: string; depth?: number; budget?: number; taskIntent?: TaskContextPlan['evidence']['recipe_id'] }) => PrImpactResult
   compactPrImpactResult: typeof compactPrImpactResult
@@ -192,9 +193,14 @@ function impactMetadata(
   return contextMetadata(pack)
 }
 
-function baseResponse(options: PackCliOptions, plan: TaskContextPlan, budget: number) {
+function baseResponse(
+  options: PackCliOptions,
+  plan: TaskContextPlan,
+  budget: number,
+  task: TaskContextPlan['task_kind'],
+) {
   return {
-    task: options.task,
+    task,
     task_intent: plan.evidence.recipe_id,
     prompt: options.prompt,
     budget,
@@ -203,7 +209,7 @@ function baseResponse(options: PackCliOptions, plan: TaskContextPlan, budget: nu
   }
 }
 
-function defaultExplainRetrievalStrategy(
+function defaultPackRetrievalStrategy(
   prompt: string,
 ): PackCliOptions['retrievalStrategy'] | undefined {
   const gate = classifyRetrievalLevel({
@@ -221,13 +227,19 @@ export async function runContextPackCommand(
 ): Promise<string> {
   const graph = dependencies.loadGraph(options.graphPath)
   const plannerBudget = Math.max(options.budget, 3)
+  const resolvedTask = resolveTaskSelection(
+    options.prompt,
+    options.task,
+    options.taskExplicit !== undefined ? { explicit: options.taskExplicit } : {},
+  )
   const initialPlan = buildTaskContextPlan({
-    task_kind: options.task,
+    task_kind: resolvedTask.task_kind,
     prompt: options.prompt,
     budget: plannerBudget,
+    task_intent: resolvedTask.task_intent,
   })
 
-  if (options.task === 'review') {
+  if (resolvedTask.task_kind === 'review') {
     if (options.retrievalStrategy !== undefined) {
       throw new Error('retrievalStrategy is not supported for task=review')
     }
@@ -249,16 +261,17 @@ export async function runContextPackCommand(
     })
 
     return JSON.stringify({
-      ...baseResponse(options, plan, plannerBudget),
+      ...baseResponse(options, plan, plannerBudget, resolvedTask.task_kind),
       pack: reviewPack,
       ...contextMetadata(reviewResult.review_bundle ?? {}),
     })
   }
 
-  if (options.task === 'impact') {
+  if (resolvedTask.task_kind === 'impact') {
     const retrieval = dependencies.retrieveContext(graph, {
       question: options.prompt,
       budget: plannerBudget,
+      taskKind: resolvedTask.task_kind,
       taskIntent: initialPlan.evidence.recipe_id,
       ...(options.retrievalLevel !== undefined ? { retrievalLevel: options.retrievalLevel } : {}),
       ...(options.retrievalStrategy !== undefined ? { retrievalStrategy: options.retrievalStrategy } : {}),
@@ -272,7 +285,7 @@ export async function runContextPackCommand(
     const impactPack = dependencies.compactImpactResult(impactResult)
 
     return JSON.stringify({
-      ...baseResponse(options, initialPlan, plannerBudget),
+      ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
       target: impactTarget,
       pack: impactPack,
       ...impactMetadata(impactResult, plannerBudget, options.prompt, initialPlan.evidence.recipe_id, options.retrievalLevel),
@@ -280,20 +293,21 @@ export async function runContextPackCommand(
     })
   }
 
-  const effectiveExplainRetrievalStrategy =
-    options.retrievalStrategy ?? defaultExplainRetrievalStrategy(options.prompt)
+  const effectivePackRetrievalStrategy =
+    options.retrievalStrategy ?? defaultPackRetrievalStrategy(options.prompt)
 
   const retrieval = dependencies.retrieveContext(graph, {
     question: options.prompt,
     budget: plannerBudget,
+    taskKind: resolvedTask.task_kind,
     taskIntent: initialPlan.evidence.recipe_id,
     ...(options.retrievalLevel !== undefined ? { retrievalLevel: options.retrievalLevel } : {}),
-    ...(effectiveExplainRetrievalStrategy !== undefined
-      ? { retrievalStrategy: effectiveExplainRetrievalStrategy }
+    ...(effectivePackRetrievalStrategy !== undefined
+      ? { retrievalStrategy: effectivePackRetrievalStrategy }
       : {}),
   })
   return JSON.stringify({
-    ...baseResponse(options, initialPlan, plannerBudget),
+    ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
     ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval),
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
   })

--- a/src/runtime/retrieval-gate.ts
+++ b/src/runtime/retrieval-gate.ts
@@ -30,6 +30,7 @@ import type {
   RetrievalLevel,
   RetrievalTargetDomainHint,
 } from '../contracts/retrieval-gate.js'
+import { classifyTaskIntent } from './task-intent.js'
 
 export type {
   RetrievalGateDecision,
@@ -173,6 +174,14 @@ function decideLevel(opts: {
       return { level: 0, reason: 'conversational prompt with no code intent — no retrieval' }
     case 'impact':
       return { level: 4, reason: 'impact intent without PR diff — cross-module impact' }
+    case 'implement':
+      return { level: 2, reason: 'implementation intent — direct dependencies' }
+    case 'migrate':
+      return { level: 2, reason: 'migration intent — direct dependencies' }
+    case 'document':
+      return mentions > 0
+        ? { level: 2, reason: 'documentation intent with explicit reference — direct dependencies' }
+        : { level: 1, reason: 'documentation intent without explicit reference — local context' }
     case 'debug':
       return { level: 3, reason: 'debug/why intent — behavior slice retrieval' }
     case 'review':
@@ -207,6 +216,11 @@ function decideLevel(opts: {
 }
 
 function detectIntent(prompt: string): RetrievalIntent {
+  const taskIntent = classifyTaskIntent(prompt).kind
+  if (taskIntent === 'implement' || taskIntent === 'migrate' || taskIntent === 'document') {
+    return taskIntent
+  }
+
   for (const { intent, re } of PATTERNS) {
     if (re.test(prompt)) return intent
   }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -21,6 +21,7 @@ import type {
   ContextPackSelectionDiagnostics,
   ContextPackSliceMetadata,
   ContextPackTaskContract,
+  ContextPackTaskKind,
 } from '../contracts/context-pack.js'
 import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
@@ -45,6 +46,7 @@ import {
 } from './context-pack.js'
 import type { RetrievalGateDecision, RetrievalLevel } from '../contracts/retrieval-gate.js'
 import { classifyRetrievalLevel } from './retrieval-gate.js'
+import { defaultContextKindForTaskIntent } from './task-intent.js'
 import {
   expansionPolicyForLevel,
   predecessorAllowedForPolicy,
@@ -78,6 +80,7 @@ const averageLabelLengthCache = new WeakMap<KnowledgeGraph, number>()
 export interface RetrieveOptions {
   question: string
   budget: number
+  taskKind?: ContextPackTaskKind
   taskIntent?: TaskIntentKind
   community?: number
   fileType?: string
@@ -93,6 +96,24 @@ export interface RetrieveOptions {
   /** Internal additive override for benchmarks/tests. */
   selectionStrategy?: ContextPackSelectionStrategy
   retrievalStrategy?: ContextPackRetrievalStrategy
+}
+
+function effectiveRetrieveTaskKind(options: RetrieveOptions): ContextPackTaskKind {
+  if (options.taskKind) {
+    return options.taskKind
+  }
+  if (options.taskIntent) {
+    return defaultContextKindForTaskIntent(options.taskIntent)
+  }
+  return 'explain'
+}
+
+function classifyRetrieveTaskContract(options: RetrieveOptions): ContextPackTaskContract {
+  return classifyTaskContract(effectiveRetrieveTaskKind(options), {
+    budget: options.budget,
+    prompt: options.question,
+    ...(options.taskIntent ? { task_intent: options.taskIntent } : {}),
+  })
 }
 
 export interface RetrieveMatchedNode {
@@ -3454,11 +3475,7 @@ function buildRetrieveResultFromOrderedCandidates(
   sliceMetadata?: ContextPackSliceMetadata,
 ): RetrieveResult {
   const snippetFileCache = new Map<string, string[] | null>()
-  const taskContract = classifyTaskContract('explain', {
-    budget: options.budget,
-    prompt: options.question,
-    ...(options.taskIntent ? { task_intent: options.taskIntent } : {}),
-  })
+  const taskContract = classifyRetrieveTaskContract(options)
   const orderedCandidateIds = new Set(orderedCandidates.map((node) => node.id))
   const orderedCommunities = new Set<number>(orderedCandidates.flatMap((node) => (node.community === null ? [] : [node.community])))
   const graphSignalLabels = {
@@ -3617,11 +3634,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
 
   if (questionTokens.length === 0) {
     const emptyPack = compileContextPack({
-      task_contract: classifyTaskContract('explain', {
-        budget,
-        prompt: question,
-        ...(options.taskIntent ? { task_intent: options.taskIntent } : {}),
-      }),
+      task_contract: classifyRetrieveTaskContract(options),
       nodes: [],
       relationships: [],
       community_context: [],
@@ -3647,11 +3660,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
 
   if (effectiveRetrievalLevel === 0) {
     const emptyPack = compileContextPack({
-      task_contract: classifyTaskContract('explain', {
-        budget,
-        prompt: question,
-        ...(options.taskIntent ? { task_intent: options.taskIntent } : {}),
-      }),
+      task_contract: classifyRetrieveTaskContract(options),
       nodes: [],
       relationships: [],
       community_context: [],

--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -238,13 +238,13 @@ export const MCP_TOOLS: McpToolDefinition[] = [
   {
     name: 'context_pack',
     description:
-      'Build a compact explain/review/impact context pack with expandable refs and coverage signals.',
+      'Build a compact explain/implement/review/impact pack with expandable refs and coverage.',
     inputSchema: {
       type: 'object',
       required: ['prompt'],
       properties: {
         prompt: { type: 'string', description: 'Task prompt or question to build context for' },
-        task: { type: 'string', enum: ['explain', 'review', 'impact'], description: 'Context-pack mode (default: explain)' },
+        task: { type: 'string', enum: ['explain', 'implement', 'review', 'impact'], description: 'Optional mode override (default: infer from prompt; fallback explain)' },
         budget: { type: 'number', description: 'Optional: maximum token budget for the pack (default 3000)' },
         delta_session_id: { type: 'string', description: 'Optional (#81): delta-pack session key for per-session dedup.' },
         verbose: { type: 'boolean', description: 'Optional: include extended selection diagnostics.' },

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -12,6 +12,7 @@ import type {
   ContextPackNode,
   ContextPackRetrievalStrategy,
   ContextPackRelationship,
+  ContextPackTaskKind,
   ContextRepresentationType,
 } from '../../contracts/context-pack.js'
 import type { ContextSessionState } from '../../contracts/context-session.js'
@@ -32,6 +33,7 @@ import { collectRelationships, compactRetrieveResult, contextPackFromRetrieveRes
 import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
 import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-delta.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
+import { resolveTaskSelection } from '../task-intent.js'
 import { riskMap } from '../risk-map.js'
 import { buildTaskContextPlan } from '../task-context-planner.js'
 import type { TimeTravelView } from '../time-travel.js'
@@ -107,7 +109,7 @@ interface ContextPlaneMetadata {
 
 interface StoredContextPackHandle {
   prompt: string
-  task: 'explain' | 'review' | 'impact'
+  task: ContextPackTaskKind
   task_intent: TaskContextPlan['evidence']['recipe_id']
   follow_up: ContextPackExpandableFollowUp
 }
@@ -173,8 +175,8 @@ function isContextPackEvidenceClass(value: unknown): value is ContextPackEvidenc
     || value === 'impact'
 }
 
-function isContextPackTaskKind(value: unknown): value is 'explain' | 'review' | 'impact' {
-  return value === 'explain' || value === 'review' || value === 'impact'
+function isContextPackTaskKind(value: unknown): value is ContextPackTaskKind {
+  return value === 'explain' || value === 'implement' || value === 'review' || value === 'impact'
 }
 
 function isExpandableSourceRange(value: unknown): value is ContextPackExpandableFollowUp['focus_ranges'][number] {
@@ -523,7 +525,7 @@ function relevanceBandForEvidenceClass(evidenceClass: ContextPackEvidenceClass):
 }
 
 function contextPackBasePayload(
-  task: 'explain' | 'review' | 'impact',
+  task: ContextPackTaskKind,
   prompt: string,
   budget: number,
   graphPath: string,
@@ -541,7 +543,7 @@ function contextPackBasePayload(
 
 function storeExpandableHandles(
   prompt: string,
-  task: 'explain' | 'review' | 'impact',
+  task: ContextPackTaskKind,
   taskIntent: TaskContextPlan['evidence']['recipe_id'],
   expandable: readonly ContextPackExpandableRef[],
   helpers: ToolHelpers,
@@ -953,10 +955,12 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         return helpers.failure(id, helpers.jsonrpcInvalidParams, `context_pack requires a string prompt parameter <= ${helpers.maxStdioTextLength} characters`)
       }
 
-      const task = helpers.stringParam(toolArguments, 'task') ?? 'explain'
-      if (task !== 'explain' && task !== 'review' && task !== 'impact') {
-        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'task must be one of explain, review, impact')
+      const rawTask = helpers.stringParam(toolArguments, 'task')
+      if (rawTask !== null && !isContextPackTaskKind(rawTask)) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'task must be one of explain, implement, review, impact')
       }
+      const resolvedTask = resolveTaskSelection(prompt, rawTask ?? 'explain', { explicit: rawTask !== null })
+      const task = resolvedTask.task_kind
       const budget = helpers.numberParamAlias(toolArguments, ['budget'], { min: 1, max: helpers.maxStdioTokenBudget })
       if (Object.hasOwn(toolArguments, 'budget') && budget === null) {
         return helpers.failure(id, helpers.jsonrpcInvalidParams, `budget must be a number between 1 and ${helpers.maxStdioTokenBudget}`)
@@ -967,6 +971,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         task_kind: task,
         prompt,
         budget: plannerBudget,
+        task_intent: resolvedTask.task_intent,
       })
 
       // CodeRabbit fix: validate resolution BEFORE the review/impact
@@ -1070,6 +1075,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const retrieval = retrieveContext(graph, {
         question: prompt,
         budget: resolvedBudget,
+        taskKind: task,
         taskIntent: initialPlan.evidence.recipe_id,
         ...(contextPackLevelTyped !== null ? { retrievalLevel: contextPackLevelTyped } : {}),
         ...(contextPackStrategy ? { retrievalStrategy: contextPackStrategy } : {}),

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -135,7 +135,7 @@ function isStoredContextPackHandle(value: unknown): value is StoredContextPackHa
   if (typeof candidate.prompt !== 'string') {
     return false
   }
-  if (candidate.task !== 'explain' && candidate.task !== 'review' && candidate.task !== 'impact') {
+  if (!isContextPackTaskKind(candidate.task)) {
     return false
   }
   if (typeof candidate.task_intent !== 'string') {
@@ -147,7 +147,7 @@ function isStoredContextPackHandle(value: unknown): value is StoredContextPackHa
 
   const followUp = candidate.follow_up as Record<string, unknown>
   return followUp.kind === 'context_pack'
-    && typeof followUp.task_kind === 'string'
+    && isContextPackTaskKind(followUp.task_kind)
     && typeof followUp.evidence_class === 'string'
     && Array.isArray(followUp.focus_files)
     && Array.isArray(followUp.focus_ranges)

--- a/src/runtime/task-context-planner.ts
+++ b/src/runtime/task-context-planner.ts
@@ -25,6 +25,10 @@ const TASK_PLANNER_SHAPES: Record<ContextPackTaskKind, TaskPlannerShape> = {
     budget_shares: [35, 40, 25],
     titles: ['Collect primary evidence', 'Expand supporting context', 'Assemble final context'],
   },
+  implement: {
+    budget_shares: [35, 40, 25],
+    titles: ['Collect implementation anchors', 'Expand implementation context', 'Assemble implementation context'],
+  },
   review: {
     budget_shares: [50, 30, 20],
     titles: ['Collect changed evidence', 'Expand review context', 'Assemble review context'],

--- a/src/runtime/task-evidence-recipes.ts
+++ b/src/runtime/task-evidence-recipes.ts
@@ -34,6 +34,19 @@ const TASK_EVIDENCE_RECIPES: Record<TaskIntentKind, TaskEvidenceRecipe> = {
       ['primary', 'supporting', 'structural'],
     ],
   },
+  implement: {
+    id: 'implement',
+    task_kind: 'implement',
+    required_evidence: ['primary', 'supporting', 'structural'],
+    preferred_evidence: ['primary', 'supporting', 'structural', 'impact', 'change'],
+    semantic_required: ['implementation', 'structure'],
+    semantic_optional: ['contracts', 'configuration', 'tests', 'impact'],
+    step_evidence: [
+      ['primary'],
+      ['supporting', 'structural', 'change'],
+      ['primary', 'supporting', 'structural'],
+    ],
+  },
   review: {
     id: 'review',
     task_kind: 'review',
@@ -88,7 +101,7 @@ const TASK_EVIDENCE_RECIPES: Record<TaskIntentKind, TaskEvidenceRecipe> = {
   },
   'test-generation': {
     id: 'test-generation',
-    task_kind: 'review',
+    task_kind: 'implement',
     required_evidence: ['primary', 'supporting', 'structural'],
     preferred_evidence: ['primary', 'structural', 'supporting', 'change', 'impact'],
     semantic_required: ['implementation', 'tests', 'structure'],
@@ -101,7 +114,7 @@ const TASK_EVIDENCE_RECIPES: Record<TaskIntentKind, TaskEvidenceRecipe> = {
   },
   'refactor-module': {
     id: 'refactor-module',
-    task_kind: 'impact',
+    task_kind: 'implement',
     required_evidence: ['primary', 'structural', 'impact'],
     preferred_evidence: ['primary', 'structural', 'impact', 'supporting', 'change'],
     semantic_required: ['implementation', 'structure', 'contracts'],
@@ -114,7 +127,7 @@ const TASK_EVIDENCE_RECIPES: Record<TaskIntentKind, TaskEvidenceRecipe> = {
   },
   'dead-code': {
     id: 'dead-code',
-    task_kind: 'impact',
+    task_kind: 'implement',
     required_evidence: ['impact', 'primary', 'structural'],
     preferred_evidence: ['impact', 'primary', 'structural', 'supporting', 'change'],
     semantic_required: ['impact', 'implementation', 'structure'],
@@ -149,6 +162,32 @@ const TASK_EVIDENCE_RECIPES: Record<TaskIntentKind, TaskEvidenceRecipe> = {
       ['impact', 'primary'],
       ['impact', 'structural', 'supporting'],
       ['impact', 'structural', 'primary'],
+    ],
+  },
+  migrate: {
+    id: 'migrate',
+    task_kind: 'implement',
+    required_evidence: ['primary', 'supporting', 'structural'],
+    preferred_evidence: ['primary', 'supporting', 'structural', 'change', 'impact'],
+    semantic_required: ['implementation', 'contracts', 'structure'],
+    semantic_optional: ['configuration', 'tests', 'impact'],
+    step_evidence: [
+      ['primary', 'structural'],
+      ['supporting', 'structural', 'change'],
+      ['primary', 'supporting', 'structural'],
+    ],
+  },
+  document: {
+    id: 'document',
+    task_kind: 'implement',
+    required_evidence: ['primary', 'supporting', 'structural'],
+    preferred_evidence: ['primary', 'supporting', 'structural', 'impact'],
+    semantic_required: ['implementation', 'structure'],
+    semantic_optional: ['contracts', 'configuration', 'tests'],
+    step_evidence: [
+      ['primary'],
+      ['supporting', 'structural'],
+      ['primary', 'supporting', 'structural'],
     ],
   },
 }

--- a/src/runtime/task-intent.ts
+++ b/src/runtime/task-intent.ts
@@ -2,11 +2,13 @@ import {
   TASK_INTENT_DEFINITIONS,
   type TaskIntentClassification,
   type TaskIntentConfidence,
+  type TaskIntentContextKind,
   type TaskIntentDefinition,
   type TaskIntentKind,
   type TaskIntentScore,
   type TaskIntentSignalRule,
 } from '../contracts/task-intent.js'
+import type { ContextPackTaskKind } from '../contracts/context-pack.js'
 
 interface RuleMatch {
   kind: TaskIntentKind
@@ -188,6 +190,14 @@ function compareDefinitions(left: TaskIntentDefinition, right: TaskIntentDefinit
   return left.kind.localeCompare(right.kind)
 }
 
+function taskIntentDefinition(kind: TaskIntentKind): TaskIntentDefinition {
+  const definition = VALIDATED_TASK_INTENT_DEFINITIONS.find((entry) => entry.kind === kind)
+  if (!definition) {
+    throw new Error(`Missing task intent definition for ${kind}`)
+  }
+  return definition
+}
+
 function compareScores(left: TaskIntentScore, right: TaskIntentScore): number {
   if (left.score !== right.score) {
     return right.score - left.score
@@ -216,6 +226,51 @@ export function normalizeTaskIntentPrompt(prompt: string): string {
   return normalizeTerm(prompt)
 }
 
+export function defaultContextKindForTaskIntent(kind: TaskIntentKind): TaskIntentContextKind {
+  return taskIntentDefinition(kind).default_context_kind
+}
+
+export function fallbackTaskIntentForContextKind(kind: TaskIntentContextKind): TaskIntentKind {
+  switch (kind) {
+    case 'implement':
+      return 'implement'
+    case 'review':
+      return 'review'
+    case 'impact':
+      return 'impact'
+    case 'explain':
+    default:
+      return 'explain'
+  }
+}
+
+export interface ResolvedTaskSelection {
+  classification: TaskIntentClassification
+  explicit: boolean
+  task_kind: ContextPackTaskKind
+  task_intent: TaskIntentKind
+}
+
+export function resolveTaskSelection(
+  prompt: string,
+  requestedTask: ContextPackTaskKind = 'explain',
+  options: { explicit?: boolean } = {},
+): ResolvedTaskSelection {
+  const classification = classifyTaskIntent(prompt)
+  const explicit = options.explicit === true || requestedTask !== 'explain'
+  const task_kind = explicit ? requestedTask : classification.default_context_kind
+  const task_intent = explicit && task_kind !== classification.default_context_kind
+    ? fallbackTaskIntentForContextKind(task_kind)
+    : classification.kind
+
+  return {
+    classification,
+    explicit,
+    task_kind,
+    task_intent,
+  }
+}
+
 export function classifyTaskIntent(prompt: string): TaskIntentClassification {
   const normalizedPrompt = normalizeTaskIntentPrompt(prompt)
   const tokens = promptTokens(normalizedPrompt)
@@ -233,10 +288,7 @@ export function classifyTaskIntent(prompt: string): TaskIntentClassification {
     .sort(compareScores)
 
   const winningKind = scores[0]?.kind ?? 'explain'
-  const winningDefinition = VALIDATED_TASK_INTENT_DEFINITIONS.find((definition) => definition.kind === winningKind)
-  if (!winningDefinition) {
-    throw new Error(`Missing task intent definition for ${winningKind}`)
-  }
+  const winningDefinition = taskIntentDefinition(winningKind)
 
   return {
     version: 1,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -256,6 +256,17 @@ describe('cli parser', () => {
       prompt: 'how does auth work',
       budget: 1800,
       task: 'explain',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+    })
+  })
+
+  it('parses explicit implement task selection for pack', () => {
+    expect(parsePackArgs(['implement auth session invalidation', '--task', 'implement'])).toEqual({
+      prompt: 'implement auth session invalidation',
+      budget: 3000,
+      task: 'implement',
+      taskExplicit: true,
       graphPath: 'out/graph.json',
     })
   })
@@ -274,7 +285,7 @@ describe('cli parser', () => {
     expect(() => parsePackArgs([])).toThrow('Usage: madar pack')
     expect(() => parsePackArgs(['how does auth work', '--budget', '0'])).toThrow('error: --budget must be a positive integer')
     expect(() => parsePackArgs(['how does auth work', '--budget', '100001'])).toThrow('error: --budget must be <= 100000')
-    expect(() => parsePackArgs(['how does auth work', '--task', 'summarize'])).toThrow('error: --task must be one of explain, review, impact')
+    expect(() => parsePackArgs(['how does auth work', '--task', 'summarize'])).toThrow('error: --task must be one of explain, implement, review, impact')
     expect(() => parsePackArgs(['how does auth work', '--wat'])).toThrow('error: unknown option for pack: --wat')
   })
 
@@ -299,6 +310,7 @@ describe('cli parser', () => {
         prompt: 'review current diff',
         budget: 3000,
         task: 'review',
+        taskExplicit: true,
         graphPath: resolvedGraphPath,
       })
 
@@ -1313,6 +1325,7 @@ describe('cli main', () => {
         prompt: 'how does auth work',
         budget: 1800,
         task: 'explain',
+        taskExplicit: true,
         graphPath: 'out/graph.json',
         why: true,
       },

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -86,6 +86,7 @@ describe('context-pack-command', () => {
     expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
       question: 'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
       budget: 1800,
+      taskKind: 'explain',
       taskIntent: 'explain',
       retrievalStrategy: 'slice-v1',
     })
@@ -165,6 +166,7 @@ describe('context-pack-command', () => {
     expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
       question: 'How `POST /login` reaches persistence in the backend runtime pipeline',
       budget: 1800,
+      taskKind: 'explain',
       taskIntent: 'explain',
       retrievalStrategy: 'slice-v1',
     })
@@ -365,10 +367,99 @@ describe('context-pack-command', () => {
     expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
       question: 'auth',
       budget: 3,
+      taskKind: 'explain',
       taskIntent: 'explain',
     })
     expect(JSON.parse(output)).toEqual(expect.objectContaining({
       budget: 3,
+    }))
+  })
+
+  it('infers implement packs from imperative prompts when --task is omitted', async () => {
+    const graph = new KnowledgeGraph()
+    const retrieval = {
+      question: 'Implement issue #275 by collecting implementation context for changed files',
+      token_count: 4,
+      matched_nodes: [],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    }
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult: vi.fn().mockReturnValue(retrieval),
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: retrieval.question,
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+    }, dependencies)
+
+    expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
+      question: retrieval.question,
+      budget: 1800,
+      taskIntent: 'implement',
+      taskKind: 'implement',
+    })
+    expect(JSON.parse(output)).toEqual(expect.objectContaining({
+      task: 'implement',
+      task_intent: 'implement',
+      plan: expect.objectContaining({
+        task_kind: 'implement',
+        evidence: expect.objectContaining({
+          recipe_id: 'implement',
+        }),
+      }),
+    }))
+  })
+
+  it('honors explicit --task implement even for explain-shaped prompts', async () => {
+    const graph = new KnowledgeGraph()
+    const retrieval = {
+      question: 'Explain how auth works',
+      token_count: 4,
+      matched_nodes: [],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    }
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult: vi.fn().mockReturnValue(retrieval),
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: retrieval.question,
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+    } as never, dependencies)
+
+    expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
+      question: retrieval.question,
+      budget: 1800,
+      taskIntent: 'implement',
+      taskKind: 'implement',
+    })
+    expect(JSON.parse(output)).toEqual(expect.objectContaining({
+      task: 'implement',
+      task_intent: 'implement',
+      plan: expect.objectContaining({
+        task_kind: 'implement',
+      }),
     }))
   })
 
@@ -618,12 +709,12 @@ describe('context-pack-command', () => {
     const payload = JSON.parse(output) as Record<string, unknown>
     expect(payload).toEqual(expect.objectContaining({
       task: 'review',
-      task_intent: 'test-generation',
+      task_intent: 'review',
       plan: expect.objectContaining({
         task_kind: 'review',
         evidence: expect.objectContaining({
-          recipe_id: 'test-generation',
-          semantic_required: ['implementation', 'tests', 'structure'],
+          recipe_id: 'review',
+          semantic_required: ['changes', 'impact'],
         }),
       }),
     }))
@@ -793,6 +884,7 @@ describe('context-pack-command', () => {
     expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
       question: 'auth',
       budget: 3,
+      taskKind: 'impact',
       taskIntent: 'impact',
     })
     expect(JSON.parse(output)).toEqual(expect.objectContaining({

--- a/tests/unit/context-pack.test.ts
+++ b/tests/unit/context-pack.test.ts
@@ -38,10 +38,16 @@ function renderedTokenCount(nodes: readonly ContextPackNode[]): number {
 
 describe('context-pack', () => {
   describe('classifyTaskContract', () => {
-    it('classifies explain, review, and impact task contracts with required evidence classes', () => {
+    it('classifies explain, implement, review, and impact task contracts with required evidence classes', () => {
       expect(classifyTaskContract('explain', { budget: 320, prompt: 'Explain auth flow' })).toEqual(expect.objectContaining({
         task_kind: 'explain',
         budget: 320,
+        required_evidence: ['primary', 'supporting', 'structural'],
+        semantic_required: ['implementation', 'structure'],
+      }))
+      expect(classifyTaskContract('implement', { budget: 420, prompt: 'Implement auth session invalidation' })).toEqual(expect.objectContaining({
+        task_kind: 'implement',
+        budget: 420,
         required_evidence: ['primary', 'supporting', 'structural'],
         semantic_required: ['implementation', 'structure'],
       }))
@@ -73,6 +79,20 @@ describe('context-pack', () => {
         preferred_evidence: ['change', 'impact', 'supporting', 'primary', 'structural'],
         semantic_required: ['changes', 'impact', 'configuration'],
         semantic_optional: ['tests', 'contracts'],
+      }))
+    })
+
+    it('accepts implementation-oriented task intents on implement contracts', () => {
+      expect(classifyTaskContract('implement', {
+        budget: 480,
+        prompt: 'Generate regression tests for token refresh and session expiry.',
+        task_intent: 'test-generation',
+      })).toEqual(expect.objectContaining({
+        task_kind: 'implement',
+        task_intent: 'test-generation',
+        evidence_recipe_id: 'test-generation',
+        required_evidence: ['primary', 'supporting', 'structural'],
+        semantic_required: ['implementation', 'tests', 'structure'],
       }))
     })
   })

--- a/tests/unit/retrieval-gate.test.ts
+++ b/tests/unit/retrieval-gate.test.ts
@@ -38,6 +38,27 @@ describe('classifyRetrievalLevel — example decisions from issue #75', () => {
     expect(decision.intent).toBe('explain')
   })
 
+  it('implement prompt → level 2 (direct dependencies)', () => {
+    const decision = classify({ prompt: 'Implement issue #275 by collecting implementation context for changed files' })
+    expect(decision.level).toBe(2)
+    expect(decision.intent).toBe('implement')
+    expect(decision.reason).toMatch(/direct dependencies/i)
+  })
+
+  it('migrate prompt → level 2 (direct dependencies)', () => {
+    const decision = classify({ prompt: 'Migrate the pack task inference to the new implementation taxonomy' })
+    expect(decision.level).toBe(2)
+    expect(decision.intent).toBe('migrate')
+    expect(decision.reason).toMatch(/direct dependencies/i)
+  })
+
+  it('document prompt → level 1 (local context)', () => {
+    const decision = classify({ prompt: 'Document the new pack task inference behavior' })
+    expect(decision.level).toBe(1)
+    expect(decision.intent).toBe('document')
+    expect(decision.reason).toMatch(/local context/i)
+  })
+
   it('debug "why" prompt → level 3 (behavior slice)', () => {
     const decision = classify({ prompt: 'Why is report generation slow?' })
     expect(decision.level).toBe(3)

--- a/tests/unit/retrieve-slice-surface.test.ts
+++ b/tests/unit/retrieve-slice-surface.test.ts
@@ -67,6 +67,7 @@ describe('slice-v1 context-pack command surface', () => {
     expect(dependencies.retrieveContext).toHaveBeenCalledWith(graph, {
       question: 'Explain auth',
       budget: 1000,
+      taskKind: 'explain',
       taskIntent: 'explain',
       retrievalStrategy: 'slice-v1',
     })

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -1218,6 +1218,60 @@ describe('stdio runtime', () => {
     }
   })
 
+  it('accepts implement context_pack handles in context_expand', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPackHandles: new Map<string, unknown>(),
+      }
+
+      const pack = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          arguments: {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'implement',
+            budget: 1,
+          },
+        },
+      }, sessionState))
+
+      const packPayload = JSON.parse((pack?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      expect(packPayload.expandable).toEqual(expect.arrayContaining([
+        expect.objectContaining({ handle_id: expect.any(String) }),
+      ]))
+
+      const expanded = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'context_expand',
+          arguments: {
+            handle_id: packPayload.expandable[0].handle_id,
+          },
+        },
+      }, sessionState))
+
+      const expandedPayload = JSON.parse((expanded?.result as { content: Array<{ text: string }> }).content[0]!.text)
+      expect(expandedPayload).toEqual(expect.objectContaining({
+        handle_id: packPayload.expandable[0].handle_id,
+        task: 'implement',
+        pack: expect.objectContaining({
+          matched_nodes: expect.any(Array),
+        }),
+      }))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('invalidates cached context_pack responses after graph.json changes', async () => {
     const root = createGraphFixtureRoot()
     try {

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -182,4 +182,26 @@ describe('stdio slice-v1 surface', () => {
 
     expect(JSON.stringify(contextPackResponse)).toContain('retrieval_strategy is not supported for task=review')
   })
+
+  it('infers implement task intent for context_pack when task is omitted', async () => {
+    const graphPath = createGraphPath()
+
+    const contextPackResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 5,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Implement support for login session audit trails',
+          budget: 1000,
+          verbose: true,
+        },
+      },
+    }))
+
+    const contextPackText = ((contextPackResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? ''
+
+    expect(contextPackText).toContain('"task":"implement"')
+    expect(contextPackText).toContain('"task_intent":"implement"')
+  })
 })

--- a/tests/unit/task-context-planner.test.ts
+++ b/tests/unit/task-context-planner.test.ts
@@ -203,9 +203,9 @@ describe('task-context-planner', () => {
     ])
   })
 
-  it('uses a test-generation evidence recipe instead of the generic review defaults', () => {
+  it('uses an implementation recipe for test-generation prompts', () => {
     const plan = buildTaskContextPlan({
-      task_kind: 'review',
+      task_kind: 'implement',
       prompt: 'Generate regression tests for token refresh and session expiry.',
       budget: 90,
       focus_paths: ['src/auth.ts', 'tests/auth.test.ts'],
@@ -214,21 +214,24 @@ describe('task-context-planner', () => {
     expect(plan.evidence).toEqual({
       recipe_id: 'test-generation',
       required: ['primary', 'supporting', 'structural'],
-      preferred: ['primary', 'structural', 'supporting', 'impact'],
+      preferred: ['primary', 'structural', 'supporting', 'change', 'impact'],
       semantic_required: ['implementation', 'tests', 'structure'],
       semantic_optional: ['contracts', 'configuration'],
     })
     expect(plan.steps).toEqual(expect.arrayContaining([
       expect.objectContaining({
         id: 'seed',
+        title: 'Collect implementation anchors',
         evidence: ['primary', 'structural'],
       }),
       expect.objectContaining({
         id: 'expand',
-        evidence: ['supporting', 'structural', 'primary'],
+        title: 'Expand implementation context',
+        evidence: ['supporting', 'structural', 'change'],
       }),
       expect.objectContaining({
         id: 'assemble',
+        title: 'Assemble implementation context',
         evidence: ['primary', 'supporting', 'structural'],
       }),
     ]))

--- a/tests/unit/task-intent.test.ts
+++ b/tests/unit/task-intent.test.ts
@@ -140,6 +140,13 @@ describe('task-intent', () => {
       ])
     })
 
+    it('does not let one support token satisfy both implement keyword groups', () => {
+      const classification = classifyTaskIntent('Need support')
+
+      expect(classification.kind).toBe('explain')
+      expect(classification.matched_rules).not.toContain('implement-keywords')
+    })
+
     it('falls back to explain when no roadmap signal matches', () => {
       const classification = classifyTaskIntent('Need help with the graph.')
 

--- a/tests/unit/task-intent.test.ts
+++ b/tests/unit/task-intent.test.ts
@@ -11,12 +11,20 @@ import {
   validateTaskIntentDefinitions,
 } from '../../src/runtime/task-intent.js'
 
-function defaultContextKindFor(kind: TaskIntentKind): 'explain' | 'review' | 'impact' {
+function defaultContextKindFor(kind: TaskIntentKind): 'explain' | 'implement' | 'review' | 'impact' {
   const definition = TASK_INTENT_DEFINITIONS.find((entry) => entry.kind === kind)
   if (!definition) {
     throw new Error(`Missing task intent definition for ${kind}`)
   }
   return definition.default_context_kind
+}
+
+function definitionByKind(kind: TaskIntentKind) {
+  const definition = TASK_INTENT_DEFINITIONS.find((entry) => entry.kind === kind)
+  if (!definition) {
+    throw new Error(`Missing task intent definition for ${kind}`)
+  }
+  return definition
 }
 
 function withTemporaryDefinitions(
@@ -37,8 +45,11 @@ describe('task-intent', () => {
     it('publishes a serializable roadmap taxonomy in stable order', () => {
       expect(TASK_INTENT_KINDS).toEqual([
         'explain',
+        'implement',
         'review',
         'impact',
+        'migrate',
+        'document',
         'debug-flow',
         'pr-review-risk',
         'test-generation',
@@ -49,6 +60,21 @@ describe('task-intent', () => {
       ])
 
       expect(TASK_INTENT_DEFINITIONS).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'implement',
+          default_context_kind: 'implement',
+          label: 'Implement',
+        }),
+        expect.objectContaining({
+          kind: 'migrate',
+          default_context_kind: 'implement',
+          label: 'Migrate',
+        }),
+        expect.objectContaining({
+          kind: 'document',
+          default_context_kind: 'implement',
+          label: 'Document',
+        }),
         expect.objectContaining({
           kind: 'debug-flow',
           default_context_kind: 'impact',
@@ -79,8 +105,11 @@ describe('task-intent', () => {
   describe('classifyTaskIntent', () => {
     it.each([
       ['Explain how the context pack is assembled for retrieve questions.', 'explain'],
+      ['Implement issue #275 by collecting implementation context for changed files.', 'implement'],
       ['Review the recent auth changes for anything suspicious.', 'review'],
       ['What breaks if we remove ContextPackTaskKind from the runtime?', 'impact'],
+      ['Migrate graphify-ts install docs to madar naming.', 'migrate'],
+      ['Document the new pack task inference behavior in the README.', 'document'],
       ['Trace why refresh token rotation started failing after the latest auth change.', 'debug-flow'],
       ['Review this PR diff for risky auth regressions before merge.', 'pr-review-risk'],
       ['Generate regression tests for token refresh and session expiry.', 'test-generation'],
@@ -125,7 +154,7 @@ describe('task-intent', () => {
         .toBe('impact')
 
       withTemporaryDefinitions((definitions) => {
-        definitions[1]!.rules = [
+        definitionByKind('review').rules = [
           {
             id: 'review-invalid-keywords',
             score: 7,
@@ -140,7 +169,7 @@ describe('task-intent', () => {
 
     it('rejects multi-word any_keywords entries after normalization', () => {
       withTemporaryDefinitions((definitions) => {
-        definitions[1]!.rules = [
+        definitionByKind('review').rules = [
           {
             id: 'review-invalid-keywords',
             score: 7,
@@ -155,7 +184,7 @@ describe('task-intent', () => {
 
     it('rejects multi-word keyword_groups entries after normalization', () => {
       withTemporaryDefinitions((definitions) => {
-        definitions[2]!.rules = [
+        definitionByKind('impact').rules = [
           {
             id: 'impact-invalid-keyword-groups',
             score: 6,


### PR DESCRIPTION
## Summary
- add implementation-oriented task classification and inferred pack task selection
- preserve explicit task overrides across CLI and MCP context-pack surfaces
- thread effective task kinds into retrieval, planning, and regression coverage

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "implement" task to pack flows and made task handling task-aware end-to-end
  * Automatic inference now recognizes implementation, migration, and documentation intents from prompts
  * Retrieval/planning behavior adapts based on the resolved task kind

* **Documentation**
  * Help text and tool descriptions updated to list supported task types and inference/default behavior

* **Tests**
  * Expanded tests to cover new task kinds and task-inference/handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->