### PR TITLE
Add implementation-task context packs

### DIFF
--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -171,6 +171,47 @@ export interface ContextPackRuntimeGenerationAnswerContract {
   confidence?: 'high' | 'medium' | 'low'
 }
 
+export interface ImplementationPackFileHint {
+  path: string
+  why: string
+  matched_symbols: string[]
+}
+
+export interface ImplementationPackSurfaceHint {
+  label: string
+  source_file: string
+  line_number: number
+  kind: 'contract' | 'public_surface' | 'pattern'
+  why: string
+}
+
+export interface ImplementationPackRiskBoundary {
+  label: string
+  severity: 'high' | 'medium' | 'low'
+  reason: string
+  affected_files: string[]
+  affected_communities: string[]
+}
+
+export interface ImplementationPackRuntimeContext {
+  summary: string
+  execution_slice?: ContextPackExecutionSlice
+  answer_contract?: ContextPackRuntimeGenerationAnswerContract
+}
+
+export interface ImplementationPackGuidance {
+  summary: string
+  likely_edit_files: ImplementationPackFileHint[]
+  likely_test_files: ImplementationPackFileHint[]
+  contracts_and_public_surfaces: ImplementationPackSurfaceHint[]
+  existing_patterns: ImplementationPackSurfaceHint[]
+  risk_boundaries: ImplementationPackRiskBoundary[]
+  validation_commands: string[]
+  acceptance_criteria_summary: string[]
+  cautions: string[]
+  runtime_context_if_relevant?: ImplementationPackRuntimeContext
+}
+
 export type ContextRepresentationType =
   | 'detail'
   | 'summary'

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -4,6 +4,7 @@ import type {
   ContextPackCoverage,
   ContextPackEvidenceClass,
   ContextPackExpandableRef,
+  ImplementationPackGuidance,
   ContextPackNode,
   ContextPackRoutingDebug,
 } from '../contracts/context-pack.js'
@@ -19,6 +20,7 @@ import { analyzePrImpact, compactPrImpactResult, type PrImpactResult } from '../
 import { buildTaskContextPlan } from '../runtime/task-context-planner.js'
 import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
+import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
 
@@ -55,6 +57,7 @@ interface ContextPlaneMetadata {
 
 export interface ExplainPackPayload extends ContextPlaneMetadata {
   pack: ReturnType<typeof compactRetrieveResult>
+  implementation?: ImplementationPackGuidance
   routing?: ContextPackRoutingDebug
 }
 
@@ -99,9 +102,11 @@ export function buildExplainPackPayload(
     coverage: ContextPackCoverage
     retrieval_gate: RetrievalGateDecision
   }>,
+  implementation?: ImplementationPackGuidance,
 ): ExplainPackPayload {
   return {
     pack,
+    ...(implementation ? { implementation } : {}),
     ...contextMetadata(retrieval),
   }
 }
@@ -306,9 +311,15 @@ export async function runContextPackCommand(
       ? { retrievalStrategy: effectivePackRetrievalStrategy }
       : {}),
   })
+  const implementation = resolvedTask.task_kind === 'implement'
+    ? buildImplementationPackGuidance(graph, retrieval, {
+        budget: plannerBudget,
+        taskIntent: initialPlan.evidence.recipe_id,
+      })
+    : undefined
   return JSON.stringify({
     ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
-    ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval),
+    ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval, implementation),
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
   })
 }

--- a/src/runtime/feature-map.ts
+++ b/src/runtime/feature-map.ts
@@ -1,5 +1,7 @@
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef } from '../contracts/context-pack.js'
+import type { ContextPackTaskKind } from '../contracts/context-pack.js'
+import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
 import { relevantFiles, type RelevantFileEntry } from './relevant-files.js'
 import { retrieveContext, type RetrieveMatchedNode } from './retrieve.js'
@@ -10,6 +12,8 @@ export interface FeatureMapOptions {
   limit?: number
   community?: number
   fileType?: string
+  taskKind?: ContextPackTaskKind
+  taskIntent?: TaskIntentKind
 }
 
 export interface FeatureMapCommunity {
@@ -109,6 +113,8 @@ export function featureMap(graph: KnowledgeGraph, options: FeatureMapOptions): F
     budget: options.budget,
     ...(options.community !== undefined ? { community: options.community } : {}),
     ...(options.fileType ? { fileType: options.fileType } : {}),
+    ...(options.taskKind ? { taskKind: options.taskKind } : {}),
+    ...(options.taskIntent ? { taskIntent: options.taskIntent } : {}),
   })
   const limit = options.limit ?? 5
 
@@ -118,6 +124,8 @@ export function featureMap(graph: KnowledgeGraph, options: FeatureMapOptions): F
     limit,
     ...(options.community !== undefined ? { community: options.community } : {}),
     ...(options.fileType ? { fileType: options.fileType } : {}),
+    ...(options.taskKind ? { taskKind: options.taskKind } : {}),
+    ...(options.taskIntent ? { taskIntent: options.taskIntent } : {}),
   }).relevant_files
 
   const communityContext = new Map(retrieveResult.community_context.map((community) => [community.id, community] as const))

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -1,0 +1,391 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import type {
+  ContextPackExecutionSlice,
+  ContextPackRuntimeGenerationAnswerContract,
+  ImplementationPackFileHint,
+  ImplementationPackGuidance,
+  ImplementationPackRiskBoundary,
+  ImplementationPackSurfaceHint,
+} from '../contracts/context-pack.js'
+import type { KnowledgeGraph } from '../contracts/graph.js'
+import type { TaskIntentKind } from '../contracts/task-intent.js'
+import { classifySourceDomain } from '../shared/source-discovery.js'
+import { relativizeSourceFile } from '../shared/source-path.js'
+import { riskMap } from './risk-map.js'
+import type { RetrieveMatchedNode, RetrieveResult } from './retrieve.js'
+
+const CONTRACT_PATH_PATTERN = /(?:^|\/)(?:contracts?|schemas?|dto|types?|interfaces?|openapi|graphql)(?:\/|$)|(?:^|\/)[^/]*\.d\.ts$/i
+const CONTRACT_NODE_KINDS = new Set(['interface', 'type', 'type_alias', 'typealias', 'enum', 'schema', 'contract'])
+const PUBLIC_SURFACE_NODE_KINDS = new Set(['route', 'router', 'controller', 'page', 'layout', 'middleware'])
+const PUBLIC_SURFACE_PATH_PATTERN = /(?:^|\/)(?:cli|stdio)(?:\/|$)|(?:^|\/)(?:http-server|definitions)\.ts$|(?:^|\/)(?:routes?|controllers?|interface\/http)(?:\/|$)/i
+
+type PackageScripts = Record<string, string>
+
+interface BuildImplementationPackOptions {
+  budget: number
+  taskIntent: TaskIntentKind
+  limit?: number
+}
+
+interface FileAggregate {
+  path: string
+  direct_symbols: string[]
+  related_symbols: string[]
+}
+
+function rootPathFromGraph(graph: KnowledgeGraph): string | undefined {
+  return typeof graph.graph.root_path === 'string' && graph.graph.root_path.trim().length > 0
+    ? graph.graph.root_path.trim()
+    : undefined
+}
+
+function groupFiles(
+  nodes: readonly RetrieveMatchedNode[],
+  rootPath?: string,
+): ImplementationPackFileHint[] {
+  const byPath = new Map<string, FileAggregate>()
+
+  for (const node of nodes) {
+    if (node.source_file.length === 0 || node.relevance_band === 'peripheral') {
+      continue
+    }
+
+    const path = relativizeSourceFile(node.source_file, rootPath)
+    const existing = byPath.get(path) ?? {
+      path,
+      direct_symbols: [],
+      related_symbols: [],
+    }
+    if (node.relevance_band === 'direct') {
+      if (!existing.direct_symbols.includes(node.label)) {
+        existing.direct_symbols.push(node.label)
+      }
+    } else if (!existing.related_symbols.includes(node.label)) {
+      existing.related_symbols.push(node.label)
+    }
+    byPath.set(path, existing)
+  }
+
+  return [...byPath.values()].map((entry) => ({
+    path: entry.path,
+    why: entry.direct_symbols.length > 0
+      ? `Direct evidence via ${entry.direct_symbols.slice(0, 3).join(', ')}.`
+      : `Supporting context via ${entry.related_symbols.slice(0, 2).join(', ')}.`,
+    matched_symbols: [...entry.direct_symbols, ...entry.related_symbols],
+  }))
+}
+
+function coveredTestNodes(
+  graph: KnowledgeGraph,
+  retrieval: RetrieveResult,
+  rootPath?: string,
+): RetrieveMatchedNode[] {
+  const derived = new Map<string, RetrieveMatchedNode>()
+
+  for (const node of retrieval.matched_nodes) {
+    if (!node.node_id || node.relevance_band === 'peripheral') {
+      continue
+    }
+    if (classifySourceDomain(node.source_file, rootPath) === 'test') {
+      continue
+    }
+
+    for (const successorId of graph.successors(node.node_id)) {
+      const edge = graph.edgeAttributes(node.node_id, successorId)
+      if (String(edge.relation ?? '') !== 'covered_by') {
+        continue
+      }
+
+      const attributes = graph.nodeAttributes(successorId)
+      const sourceFile = String(attributes.source_file ?? '')
+      if (classifySourceDomain(sourceFile, rootPath) !== 'test') {
+        continue
+      }
+
+      const label = String(attributes.label ?? successorId)
+      const key = `${sourceFile}:${label}`
+      if (derived.has(key)) {
+        continue
+      }
+
+      derived.set(key, {
+        node_id: successorId,
+        label,
+        source_file: sourceFile,
+        line_number: 0,
+        node_kind: String(attributes.node_kind ?? ''),
+        file_type: String(attributes.file_type ?? 'code'),
+        snippet: null,
+        match_score: Math.max(0.1, node.match_score - 0.1),
+        relevance_band: 'related',
+        community: typeof attributes.community === 'number' ? attributes.community : null,
+        community_label: null,
+      })
+    }
+  }
+
+  return [...derived.values()]
+}
+
+function isContractNode(node: RetrieveMatchedNode): boolean {
+  return CONTRACT_PATH_PATTERN.test(node.source_file)
+    || (typeof node.node_kind === 'string' && CONTRACT_NODE_KINDS.has(node.node_kind.toLowerCase()))
+}
+
+function isPublicSurfaceNode(node: RetrieveMatchedNode): boolean {
+  const nodeKind = node.node_kind?.toLowerCase() ?? ''
+  const frameworkRole = node.framework_role?.toLowerCase() ?? ''
+  return PUBLIC_SURFACE_NODE_KINDS.has(nodeKind)
+    || frameworkRole.includes('route')
+    || frameworkRole.includes('controller')
+    || frameworkRole.includes('page')
+    || frameworkRole.includes('layout')
+    || frameworkRole.includes('middleware')
+    || PUBLIC_SURFACE_PATH_PATTERN.test(node.source_file)
+}
+
+function pushSurfaceHint(
+  seen: Set<string>,
+  target: ImplementationPackSurfaceHint[],
+  node: RetrieveMatchedNode,
+  kind: ImplementationPackSurfaceHint['kind'],
+  why: string,
+  rootPath?: string,
+): void {
+  const sourceFile = relativizeSourceFile(node.source_file, rootPath)
+  const key = `${kind}:${sourceFile}:${node.label}:${node.line_number}`
+  if (seen.has(key)) {
+    return
+  }
+  seen.add(key)
+  target.push({
+    label: node.label,
+    source_file: sourceFile,
+    line_number: node.line_number,
+    kind,
+    why,
+  })
+}
+
+function buildSurfaceHints(
+  retrieval: RetrieveResult,
+  editPaths: ReadonlySet<string>,
+  rootPath?: string,
+): {
+  contracts_and_public_surfaces: ImplementationPackSurfaceHint[]
+  existing_patterns: ImplementationPackSurfaceHint[]
+} {
+  const contracts_and_public_surfaces: ImplementationPackSurfaceHint[] = []
+  const existing_patterns: ImplementationPackSurfaceHint[] = []
+  const surfaceSeen = new Set<string>()
+  const patternSeen = new Set<string>()
+
+  for (const node of retrieval.matched_nodes) {
+    if (node.relevance_band === 'peripheral') {
+      continue
+    }
+
+    const sourceFile = relativizeSourceFile(node.source_file, rootPath)
+    const sourceDomain = classifySourceDomain(node.source_file, rootPath)
+    if (sourceDomain === 'test' || sourceDomain === 'docs' || sourceDomain === 'build_artifact') {
+      continue
+    }
+
+    if (isContractNode(node)) {
+      pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, node, 'contract', 'Changing this contract can affect implementation callers.', rootPath)
+      continue
+    }
+
+    if (isPublicSurfaceNode(node)) {
+      pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, node, 'public_surface', 'This is part of the public entry surface touched by the task.', rootPath)
+      continue
+    }
+
+    if (!editPaths.has(sourceFile)) {
+      pushSurfaceHint(patternSeen, existing_patterns, node, 'pattern', 'Existing implementation context worth checking before editing.', rootPath)
+    }
+  }
+
+  return {
+    contracts_and_public_surfaces: contracts_and_public_surfaces.slice(0, 6),
+    existing_patterns: existing_patterns.slice(0, 5),
+  }
+}
+
+function readWorkspacePackageScripts(rootPath?: string): { scripts: PackageScripts; warnings: string[] } {
+  if (!rootPath) {
+    return { scripts: {}, warnings: ['No workspace root was recorded, so validation commands could not inspect package.json.'] }
+  }
+
+  const packageJsonPath = join(rootPath, 'package.json')
+  if (!existsSync(packageJsonPath)) {
+    return { scripts: {}, warnings: ['No package.json was found in the analyzed workspace root.'] }
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { scripts?: unknown }
+    if (!parsed.scripts || typeof parsed.scripts !== 'object' || Array.isArray(parsed.scripts)) {
+      return { scripts: {}, warnings: ['The analyzed workspace package.json does not define scripts for validation commands.'] }
+    }
+
+    const scripts = Object.fromEntries(
+      Object.entries(parsed.scripts)
+        .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].trim().length > 0),
+    )
+    return { scripts, warnings: [] }
+  } catch {
+    return { scripts: {}, warnings: ['Could not parse the analyzed workspace package.json to derive validation commands.'] }
+  }
+}
+
+function testCommandForScripts(scripts: PackageScripts, testFiles: readonly string[]): string[] {
+  const commands: string[] = []
+  if (testFiles.length > 0 && Object.hasOwn(scripts, 'test:run')) {
+    commands.push(`npm run test:run -- ${testFiles.slice(0, 5).join(' ')}`)
+  }
+  if (Object.hasOwn(scripts, 'test:run')) {
+    commands.push('npm run test:run')
+  } else if (Object.hasOwn(scripts, 'test')) {
+    commands.push('npm run test')
+  }
+  return commands
+}
+
+function validationCommands(rootPath: string | undefined, testFiles: readonly ImplementationPackFileHint[]): {
+  commands: string[]
+  warnings: string[]
+} {
+  const { scripts, warnings } = readWorkspacePackageScripts(rootPath)
+  const commands = [
+    ...(Object.hasOwn(scripts, 'typecheck') ? ['npm run typecheck'] : []),
+    ...(Object.hasOwn(scripts, 'build') ? ['npm run build'] : []),
+    ...testCommandForScripts(scripts, testFiles.map((entry) => entry.path)),
+  ]
+
+  return {
+    commands: [...new Set(commands)],
+    warnings,
+  }
+}
+
+function acceptanceCriteriaSummary(
+  prompt: string,
+  editFiles: readonly { path: string }[],
+  testFiles: readonly ImplementationPackFileHint[],
+  riskBoundaries: readonly ImplementationPackRiskBoundary[],
+  contractsAndPublicSurfaces: readonly ImplementationPackSurfaceHint[],
+): string[] {
+  const requestedChange = prompt.includes(':') ? prompt.split(':').slice(1).join(':').trim() : prompt.trim()
+  const summary = [`Implement the requested change: ${requestedChange}.`]
+
+  if (editFiles.length > 0) {
+    summary.push(`Update the likely edit surface starting with ${editFiles[0]!.path}.`)
+  }
+  if (testFiles.length > 0) {
+    summary.push(`Keep related tests aligned, including ${testFiles.slice(0, 2).map((entry) => entry.path).join(' and ')}.`)
+  }
+  if (contractsAndPublicSurfaces.length > 0) {
+    summary.push('Keep contracts and public surfaces aligned with the implementation change.')
+  }
+  if (riskBoundaries.length > 0) {
+    summary.push(`Avoid regressions around ${riskBoundaries[0]!.label}.`)
+  }
+
+  return summary
+}
+
+function cautionMessages(
+  retrieval: RetrieveResult,
+  riskBoundaries: readonly ImplementationPackRiskBoundary[],
+  validationWarnings: readonly string[],
+  testFiles: readonly ImplementationPackFileHint[],
+): string[] {
+  const cautions: string[] = []
+
+  if ((retrieval.coverage?.missing_required.length ?? 0) > 0) {
+    cautions.push(`Missing required context: ${retrieval.coverage!.missing_required.join(', ')}.`)
+  }
+  if ((retrieval.coverage?.missing_semantic.length ?? 0) > 0) {
+    cautions.push(`Missing semantic coverage: ${retrieval.coverage!.missing_semantic.join(', ')}.`)
+  }
+  for (const risk of riskBoundaries.filter((entry) => entry.severity === 'high').slice(0, 2)) {
+    cautions.push(`High-risk shared boundary: ${risk.label} affects ${risk.affected_files.length} files.`)
+  }
+  if (testFiles.length === 0) {
+    cautions.push('No related tests were retrieved; validate regression coverage manually.')
+  }
+
+  return [...new Set([...cautions, ...validationWarnings])]
+}
+
+function runtimeContext(
+  executionSlice: ContextPackExecutionSlice | undefined,
+  answerContract: ContextPackRuntimeGenerationAnswerContract | undefined,
+): ImplementationPackGuidance['runtime_context_if_relevant'] | undefined {
+  if (!executionSlice && !answerContract) {
+    return undefined
+  }
+
+  return {
+    summary: 'Runtime flow context was included because the retrieved implementation surface contains execution-path evidence.',
+    ...(executionSlice ? { execution_slice: executionSlice } : {}),
+    ...(answerContract ? { answer_contract: answerContract } : {}),
+  }
+}
+
+export function buildImplementationPackGuidance(
+  graph: KnowledgeGraph,
+  retrieval: RetrieveResult,
+  options: BuildImplementationPackOptions,
+): ImplementationPackGuidance {
+  const rootPath = rootPathFromGraph(graph)
+  const risk = riskMap(graph, {
+    question: retrieval.question,
+    budget: options.budget,
+    limit: options.limit ?? 5,
+    fileType: 'code',
+    taskKind: 'implement',
+    taskIntent: options.taskIntent,
+  })
+  const relatedTestNodes = coveredTestNodes(graph, retrieval, rootPath)
+  const likely_test_files = groupFiles(
+    [
+      ...retrieval.matched_nodes.filter((node) => classifySourceDomain(node.source_file, rootPath) === 'test'),
+      ...relatedTestNodes,
+    ],
+    rootPath,
+  ).slice(0, options.limit ?? 5)
+  const editPaths = new Set(risk.starter_files.map((entry) => entry.path))
+  const { contracts_and_public_surfaces, existing_patterns } = buildSurfaceHints(retrieval, editPaths, rootPath)
+  const validation = validationCommands(rootPath, likely_test_files)
+  const risk_boundaries: ImplementationPackRiskBoundary[] = risk.top_risks
+  const summary = risk.starter_files[0]
+    ? `Start with ${risk.starter_files[0].path}, then validate the highest-risk shared boundaries before finishing.`
+    : risk.summary
+  const runtimeContextIfRelevant = runtimeContext(retrieval.execution_slice, retrieval.answer_contract)
+
+  return {
+    summary,
+    likely_edit_files: risk.starter_files.slice(0, options.limit ?? 5).map((entry) => ({
+      path: entry.path,
+      why: entry.why,
+      matched_symbols: entry.matched_symbols,
+    })),
+    likely_test_files,
+    contracts_and_public_surfaces,
+    existing_patterns,
+    risk_boundaries,
+    validation_commands: validation.commands,
+    acceptance_criteria_summary: acceptanceCriteriaSummary(
+      retrieval.question,
+      risk.starter_files,
+      likely_test_files,
+      risk_boundaries,
+      contracts_and_public_surfaces,
+    ),
+    cautions: cautionMessages(retrieval, risk_boundaries, validation.warnings, likely_test_files),
+    ...(runtimeContextIfRelevant ? { runtime_context_if_relevant: runtimeContextIfRelevant } : {}),
+  }
+}

--- a/src/runtime/relevant-files.ts
+++ b/src/runtime/relevant-files.ts
@@ -1,5 +1,7 @@
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextPackClaim, ContextPackCoverage, ContextPackEvidenceClass, ContextPackExpandableRef } from '../contracts/context-pack.js'
+import type { ContextPackTaskKind } from '../contracts/context-pack.js'
+import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
 import { retrieveContext } from './retrieve.js'
 
@@ -9,6 +11,8 @@ export interface RelevantFilesOptions {
   limit?: number
   community?: number
   fileType?: string
+  taskKind?: ContextPackTaskKind
+  taskIntent?: TaskIntentKind
 }
 
 export interface RelevantFileEntry {
@@ -82,6 +86,8 @@ export function relevantFiles(graph: KnowledgeGraph, options: RelevantFilesOptio
     budget: options.budget,
     ...(options.community !== undefined ? { community: options.community } : {}),
     ...(options.fileType ? { fileType: options.fileType } : {}),
+    ...(options.taskKind ? { taskKind: options.taskKind } : {}),
+    ...(options.taskIntent ? { taskIntent: options.taskIntent } : {}),
   })
 
   const byPath = new Map<string, FileAggregate>()

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -793,6 +793,16 @@ function normalizeIdentifier(value: string): string {
   return normalizeSeedText(value.replace(/\(\)$/, ''))
 }
 
+function compareStableText(left: string, right: string): number {
+  if (left < right) {
+    return -1
+  }
+  if (left > right) {
+    return 1
+  }
+  return 0
+}
+
 function parseSymbolReference(value: string): SymbolReference {
   const trimmed = value.trim().replace(/`/g, '')
   const withoutCall = trimmed.replace(/\(\)$/, '')
@@ -994,7 +1004,10 @@ function compareScoredNodes(graph: KnowledgeGraph, left: ScoredNode, right: Scor
     right.frameworkBoost - left.frameworkBoost ||
     right.score - left.score ||
     Number(left.fileNodeLike) - Number(right.fileNodeLike) ||
-    graph.degree(right.id) - graph.degree(left.id)
+    graph.degree(right.id) - graph.degree(left.id) ||
+    compareStableText(left.label, right.label) ||
+    compareStableText(left.sourceFile, right.sourceFile) ||
+    compareStableText(left.id, right.id)
   )
 }
 
@@ -1202,7 +1215,10 @@ function rankedSeedCandidateIds(
     .sort((left, right) => (
       scoreForCandidate(right) - scoreForCandidate(left) ||
       right.seedScore.total - left.seedScore.total ||
-      graph.degree(right.id) - graph.degree(left.id)
+      graph.degree(right.id) - graph.degree(left.id) ||
+      compareStableText(left.label, right.label) ||
+      compareStableText(left.sourceFile, right.sourceFile) ||
+      compareStableText(left.id, right.id)
     ))
     .map((candidate) => candidate.id)
 }

--- a/src/runtime/risk-map.ts
+++ b/src/runtime/risk-map.ts
@@ -1,4 +1,6 @@
 import { KnowledgeGraph } from '../contracts/graph.js'
+import type { ContextPackTaskKind } from '../contracts/context-pack.js'
+import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { godNodes, workspaceBridges } from '../pipeline/analyze.js'
 import { communitiesFromGraph } from './serve.js'
 import { analyzeImpact } from './impact.js'
@@ -6,7 +8,10 @@ import { featureMap, type FeatureMapOptions } from './feature-map.js'
 import { retrieveContext } from './retrieve.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
 
-export interface RiskMapOptions extends FeatureMapOptions {}
+export interface RiskMapOptions extends FeatureMapOptions {
+  taskKind?: ContextPackTaskKind
+  taskIntent?: TaskIntentKind
+}
 
 export type RiskSeverity = 'high' | 'medium' | 'low'
 
@@ -134,6 +139,8 @@ export function riskMap(graph: KnowledgeGraph, options: RiskMapOptions): RiskMap
     budget: options.budget,
     ...(options.community !== undefined ? { community: options.community } : {}),
     ...(options.fileType ? { fileType: options.fileType } : {}),
+    ...(options.taskKind ? { taskKind: options.taskKind } : {}),
+    ...(options.taskIntent ? { taskIntent: options.taskIntent } : {}),
   })
   const communities = communitiesFromGraph(graph)
   const communityLabels = storedCommunityLabels(graph)

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -33,6 +33,7 @@ import { collectRelationships, compactRetrieveResult, contextPackFromRetrieveRes
 import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
 import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-delta.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
+import { buildImplementationPackGuidance } from '../implementation-pack.js'
 import { resolveTaskSelection } from '../task-intent.js'
 import { riskMap } from '../risk-map.js'
 import { buildTaskContextPlan } from '../task-context-planner.js'
@@ -1105,6 +1106,12 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const fullPack = contextPackFromRetrieveResult(retrieval)
       const compactPack = compactRetrieveResult(retrieval)
       const metadata = contextMetadata(retrieval)
+      const implementation = task === 'implement'
+        ? buildImplementationPackGuidance(graph, retrieval, {
+            budget: resolvedBudget,
+            taskIntent: initialPlan.evidence.recipe_id,
+          })
+        : undefined
       storeExpandableHandles(prompt, task, initialPlan.evidence.recipe_id, metadata.expandable, helpers)
       // Slice #78: emit context-pack quality diagnostics so callers can
       // detect bad runs (missing required evidence, zero claims, weak
@@ -1188,6 +1195,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           ...(includeSelectionDiagnostics && deltaResult.delta_pack.selection_diagnostics
             ? { selection_diagnostics: deltaResult.delta_pack.selection_diagnostics }
             : {}),
+          ...(implementation ? { implementation } : {}),
           ...metadata,
         })))
       }
@@ -1206,6 +1214,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         ...(includeSelectionDiagnostics && fullPack.selection_diagnostics
           ? { selection_diagnostics: fullPack.selection_diagnostics }
           : {}),
+        ...(implementation ? { implementation } : {}),
         ...metadata,
       }
       if (!cacheKey || !cacheGraphVersion) {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -528,7 +528,7 @@ describe('context-pack-command', () => {
         likely_edit_files?: Array<{ path?: string }>
         likely_test_files?: Array<{ path?: string }>
         contracts_and_public_surfaces?: Array<{ source_file?: string; kind?: string }>
-        existing_patterns?: Array<{ source_file?: string }>
+        existing_patterns?: Array<{ source_file?: string; kind?: string }>
         validation_commands?: string[]
         risk_boundaries?: Array<{ label?: string }>
       }
@@ -548,9 +548,6 @@ describe('context-pack-command', () => {
         expect.objectContaining({ source_file: 'src/contracts/context-pack.ts', kind: 'contract' }),
         expect.objectContaining({ source_file: 'src/runtime/stdio/definitions.ts', kind: 'public_surface' }),
       ]),
-      existing_patterns: expect.arrayContaining([
-        expect.objectContaining({ source_file: 'src/infrastructure/context-prompt-command.ts' }),
-      ]),
       validation_commands: expect.arrayContaining([
         'npm run typecheck',
         'npm run build',
@@ -560,6 +557,15 @@ describe('context-pack-command', () => {
         expect.objectContaining({ label: 'retrieveContext' }),
       ]),
     }))
+    expect(payload.implementation?.existing_patterns).toEqual(expect.any(Array))
+    if ((payload.implementation?.existing_patterns?.length ?? 0) > 0) {
+      expect(payload.implementation?.existing_patterns).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'pattern',
+          source_file: expect.stringMatching(/^src\//),
+        }),
+      ]))
+    }
   })
 
   it('emits a compact deterministic review pack', async () => {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -35,6 +35,45 @@ function buildRuntimeGenerationGraph() {
   )
 }
 
+function buildImplementationPackGraph() {
+  const root = process.cwd()
+  const graph = build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'pack_parser', label: 'parsePackArgs', file_type: 'code', source_file: `${root}/src/cli/parser.ts`, source_location: 'L416', node_kind: 'function', community: 0 },
+          { id: 'pack_command', label: 'runContextPackCommand', file_type: 'code', source_file: `${root}/src/infrastructure/context-pack-command.ts`, source_location: 'L224', node_kind: 'function', community: 0 },
+          { id: 'retrieve_context', label: 'retrieveContext', file_type: 'code', source_file: `${root}/src/runtime/retrieve.ts`, source_location: 'L3601', node_kind: 'function', community: 1 },
+          { id: 'task_planner', label: 'buildTaskContextPlan', file_type: 'code', source_file: `${root}/src/runtime/task-context-planner.ts`, source_location: 'L151', node_kind: 'function', community: 1 },
+          { id: 'gate', label: 'classifyRetrievalLevel', file_type: 'code', source_file: `${root}/src/runtime/retrieval-gate.ts`, source_location: 'L1', node_kind: 'function', community: 1 },
+          { id: 'contract', label: 'ContextPackTaskKind', file_type: 'code', source_file: `${root}/src/contracts/context-pack.ts`, source_location: 'L13', community: 2 },
+          { id: 'mcp_surface', label: 'context_pack', file_type: 'code', source_file: `${root}/src/runtime/stdio/definitions.ts`, source_location: 'L239', node_kind: 'function', community: 2 },
+          { id: 'pack_test', label: 'context-pack-command.test', file_type: 'code', source_file: `${root}/tests/unit/context-pack-command.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
+          { id: 'retrieve_test', label: 'retrieve-slice-v1.test', file_type: 'code', source_file: `${root}/tests/unit/retrieve-slice-v1.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
+          { id: 'gate_test', label: 'retrieval-gate.test', file_type: 'code', source_file: `${root}/tests/unit/retrieval-gate.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
+          { id: 'prompt_pattern', label: 'runContextPromptCommand', file_type: 'code', source_file: `${root}/src/infrastructure/context-prompt-command.ts`, source_location: 'L1', node_kind: 'function', community: 4 },
+        ],
+        edges: [
+          { source: 'pack_parser', target: 'pack_command', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/cli/parser.ts` },
+          { source: 'pack_command', target: 'retrieve_context', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'task_planner', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'contract', relation: 'depends_on', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'mcp_surface', relation: 'depends_on', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'retrieve_context', target: 'gate', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/retrieve.ts` },
+          { source: 'retrieve_context', target: 'retrieve_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/retrieve.ts` },
+          { source: 'retrieve_context', target: 'gate_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/retrieve.ts` },
+          { source: 'pack_command', target: 'pack_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'prompt_pattern', relation: 'related_to', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+  graph.graph.root_path = root
+  return graph
+}
+
 describe('context-pack-command', () => {
   it('preserves execution_slice for runtime-generation explain packs', async () => {
     const graph = buildRuntimeGenerationGraph()
@@ -460,6 +499,66 @@ describe('context-pack-command', () => {
       plan: expect.objectContaining({
         task_kind: 'implement',
       }),
+    }))
+  })
+
+  it('adds implementation guidance sections for implement packs', async () => {
+    const graph = buildImplementationPackGraph()
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn((currentGraph, options) => retrieveContext(currentGraph, options as never)),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement issue #275: add implementation-task context packs with validation commands for context_pack',
+      budget: 2400,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+    } as never, dependencies)
+
+    const payload = JSON.parse(output) as {
+      task?: string
+      implementation?: {
+        likely_edit_files?: Array<{ path?: string }>
+        likely_test_files?: Array<{ path?: string }>
+        contracts_and_public_surfaces?: Array<{ source_file?: string; kind?: string }>
+        existing_patterns?: Array<{ source_file?: string }>
+        validation_commands?: string[]
+        risk_boundaries?: Array<{ label?: string }>
+      }
+    }
+
+    expect(payload.task).toBe('implement')
+    expect(payload.implementation).toEqual(expect.objectContaining({
+      likely_edit_files: expect.arrayContaining([
+        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts' }),
+        expect.objectContaining({ path: 'src/runtime/retrieve.ts' }),
+      ]),
+      likely_test_files: expect.arrayContaining([
+        expect.objectContaining({ path: 'tests/unit/context-pack-command.test.ts' }),
+        expect.objectContaining({ path: 'tests/unit/retrieve-slice-v1.test.ts' }),
+      ]),
+      contracts_and_public_surfaces: expect.arrayContaining([
+        expect.objectContaining({ source_file: 'src/contracts/context-pack.ts', kind: 'contract' }),
+        expect.objectContaining({ source_file: 'src/runtime/stdio/definitions.ts', kind: 'public_surface' }),
+      ]),
+      existing_patterns: expect.arrayContaining([
+        expect.objectContaining({ source_file: 'src/infrastructure/context-prompt-command.ts' }),
+      ]),
+      validation_commands: expect.arrayContaining([
+        'npm run typecheck',
+        'npm run build',
+        expect.stringMatching(/npm run test:run -- .*context-pack-command\.test\.ts/),
+      ]),
+      risk_boundaries: expect.arrayContaining([
+        expect.objectContaining({ label: 'retrieveContext' }),
+      ]),
     }))
   })
 

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
 import { build } from '../../src/pipeline/build.js'
 import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+
+const tempFixtureRoots: string[] = []
+
+afterEach(() => {
+  while (tempFixtureRoots.length > 0) {
+    const root = tempFixtureRoots.pop()
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+})
 
 function buildRuntimeGenerationGraph() {
   return build(
@@ -36,7 +51,17 @@ function buildRuntimeGenerationGraph() {
 }
 
 function buildImplementationPackGraph() {
-  const root = process.cwd()
+  const root = mkdtempSync(join(tmpdir(), 'madar-fixture-'))
+  tempFixtureRoots.push(root)
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'madar-fixture',
+    private: true,
+    scripts: {
+      typecheck: 'tsc --noEmit',
+      build: 'tsc -p tsconfig.build.json',
+      'test:run': 'vitest run',
+    },
+  }))
   const graph = build(
     [
       {
@@ -53,6 +78,7 @@ function buildImplementationPackGraph() {
           { id: 'retrieve_test', label: 'retrieve-slice-v1.test', file_type: 'code', source_file: `${root}/tests/unit/retrieve-slice-v1.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
           { id: 'gate_test', label: 'retrieval-gate.test', file_type: 'code', source_file: `${root}/tests/unit/retrieval-gate.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
           { id: 'prompt_pattern', label: 'runContextPromptCommand', file_type: 'code', source_file: `${root}/src/infrastructure/context-prompt-command.ts`, source_location: 'L1', node_kind: 'function', community: 4 },
+          { id: 'review_template_pattern', label: 'renderReviewTemplate', file_type: 'code', source_file: `${root}/src/infrastructure/review-template.ts`, source_location: 'L10', node_kind: 'function', community: 4 },
         ],
         edges: [
           { source: 'pack_parser', target: 'pack_command', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/cli/parser.ts` },
@@ -65,6 +91,7 @@ function buildImplementationPackGraph() {
           { source: 'retrieve_context', target: 'gate_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/retrieve.ts` },
           { source: 'pack_command', target: 'pack_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
           { source: 'pack_command', target: 'prompt_pattern', relation: 'related_to', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'review_template_pattern', relation: 'related_to', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
         ],
       },
     ],

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -557,15 +557,12 @@ describe('context-pack-command', () => {
         expect.objectContaining({ label: 'retrieveContext' }),
       ]),
     }))
-    expect(payload.implementation?.existing_patterns).toEqual(expect.any(Array))
-    if ((payload.implementation?.existing_patterns?.length ?? 0) > 0) {
-      expect(payload.implementation?.existing_patterns).toEqual(expect.arrayContaining([
-        expect.objectContaining({
-          kind: 'pattern',
-          source_file: expect.stringMatching(/^src\//),
-        }),
-      ]))
-    }
+    expect(payload.implementation?.existing_patterns).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'pattern',
+        source_file: expect.stringMatching(/^src\//),
+      }),
+    ]))
   })
 
   it('emits a compact deterministic review pack', async () => {

--- a/tests/unit/retrieve.test.ts
+++ b/tests/unit/retrieve.test.ts
@@ -2049,6 +2049,37 @@ describe('retrieve', () => {
       expect(result.matched_nodes.find((node) => node.label === 'SessionCoordinator')?.relevance_band).toBe('related')
     })
 
+    it('orders tied lexical seed matches deterministically instead of by insertion order', () => {
+      const graph = new KnowledgeGraph()
+      graph.addNode('zeta_login', {
+        label: 'ZetaLogin',
+        source_file: '/src/zeta-login.ts',
+        line_number: 1,
+        node_kind: 'function',
+        file_type: 'code',
+        community: 0,
+      })
+      graph.addNode('alpha_login', {
+        label: 'AlphaLogin',
+        source_file: '/src/alpha-login.ts',
+        line_number: 1,
+        node_kind: 'function',
+        file_type: 'code',
+        community: 0,
+      })
+
+      const result = retrieveContext(graph, {
+        question: 'login',
+        budget: 5000,
+        fileType: 'code',
+      })
+
+      expect(result.matched_nodes.slice(0, 2).map((node) => node.label)).toEqual([
+        'AlphaLogin',
+        'ZetaLogin',
+      ])
+    })
+
     it('includes neighbors of matched nodes', () => {
       const graph = buildTestGraph()
       const result = retrieveContext(graph, { question: 'auth', budget: 5000 })

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -1247,6 +1247,10 @@ describe('stdio runtime', () => {
       expect(packPayload.expandable).toEqual(expect.arrayContaining([
         expect.objectContaining({ handle_id: expect.any(String) }),
       ]))
+      expect(packPayload.implementation).toEqual(expect.objectContaining({
+        likely_edit_files: expect.any(Array),
+        validation_commands: expect.any(Array),
+      }))
 
       const expanded = await Promise.resolve(handleStdioRequest(graphPath, {
         id: 2,


### PR DESCRIPTION
## Summary
- add implementation-specific guidance sections to context packs for likely edits, tests, contracts/public surfaces, risks, validation, and cautions
- reuse the new guidance in both CLI and MCP stdio context_pack flows
- make relevant-files, feature-map, and risk-map task-aware so implement-mode packs use implement retrieval rather than explain defaults

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implementation guidance for "implement" tasks: likely edit/test files, contracts/public-surface hints, validation commands, risk boundaries, acceptance criteria, cautions, and optional runtime context.

* **Behavior**
  * Guidance included in explain/context-pack and tool responses for implement tasks; task-kind and task-intent can filter retrieval and influence results.
  * Retrieval ordering made deterministic for tied scores.

* **Tests**
  * Unit tests added/updated to verify presence, shape, and ordering of implementation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->