### PR TITLE
Add implement prompt guidance for context packs

### DIFF
--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -459,10 +459,10 @@ export const MCP_PROMPTS: McpPromptDefinition[] = [
   {
     name: 'context_pack_prompt',
     title: 'Context Pack Request',
-    description: 'Prepare a compact explain/review/impact context pack with expandable refs and missing-context hints.',
+    description: 'Prepare a compact explain/implement/review/impact context pack with expandable refs and missing-context hints.',
     arguments: [
       { name: 'prompt', description: 'Task prompt or question to gather context for', required: true },
-      { name: 'task', description: 'Pack mode: explain, review, or impact' },
+      { name: 'task', description: 'Pack mode: explain, implement, review, or impact' },
       { name: 'budget', description: 'Optional token budget for the pack' },
     ],
   },

--- a/src/runtime/stdio/prompts.ts
+++ b/src/runtime/stdio/prompts.ts
@@ -157,6 +157,18 @@ function graphSnapshotLines(context: PromptContext): string[] {
   ]
 }
 
+function contextPackPromptGuidance(task: string): string {
+  if (task === 'implement') {
+    return 'Include likely edit files, likely test files, contracts/public surfaces, existing patterns, runtime context when relevant, risk boundaries, validation commands, acceptance criteria, and missing-context hints.'
+  }
+
+  return 'Include coverage gaps, expandable references, and the minimum graph evidence a downstream agent needs to continue without re-scanning the repo.'
+}
+
+function formatContextPackPromptTaskLine(task: string, prompt: string): string {
+  return `Prepare a compact ${task} context pack for: ${prompt}${/[.!?]$/.test(prompt) ? '' : '.'}`
+}
+
 export function promptDefinitionsForGraph(graphPath: string): McpPromptDefinition[] {
   const context = loadPromptContext(graphPath)
   const exampleLabels = context.topGodNodes.slice(0, 3).map((node) => node.label)
@@ -188,7 +200,7 @@ export function promptDefinitionsForGraph(graphPath: string): McpPromptDefinitio
         return {
           ...prompt,
           description: exampleCommunities.length > 0
-            ? `Prepare a compact explain/review/impact pack for graph areas such as ${exampleCommunities.join(' or ')}.`
+            ? `Prepare a compact explain/implement/review/impact pack for graph areas such as ${exampleCommunities.join(' or ')}.`
             : prompt.description,
         }
       case 'context_prompt_prompt':
@@ -370,8 +382,8 @@ export function handlePromptGet(id: string | number | null, graphPath: string, p
                 'Suggested follow-up questions:',
                 suggestedQuestionsText,
                 '',
-                `Prepare a compact ${task} context pack for: ${prompt}.`,
-                'Include coverage gaps, expandable references, and the minimum graph evidence a downstream agent needs to continue without re-scanning the repo.',
+                formatContextPackPromptTaskLine(task, prompt),
+                contextPackPromptGuidance(task),
                 budget === null ? '' : `Target pack budget: ${budget} tokens.`,
               ].filter((line) => line.length > 0).join('\n'),
             },
@@ -529,7 +541,7 @@ export function handleCompletion(id: string | number | null, graphPath: string, 
       if (argumentName !== 'task') {
         return helpers.failure(id, helpers.jsonrpcInvalidParams, `Unsupported completion argument for ${refName}: ${argumentName}`)
       }
-      values = completionValuesForPrefix(['explain', 'impact', 'review'], argumentValue, helpers.maxCompletionValues)
+      values = completionValuesForPrefix(['explain', 'impact', 'implement', 'review'], argumentValue, helpers.maxCompletionValues)
       break
     case 'context_prompt_prompt':
       if (argumentName !== 'provider') {

--- a/tests/unit/stdio-prompts.test.ts
+++ b/tests/unit/stdio-prompts.test.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
-import { handleCompletion, promptDefinitionsForGraph } from '../../src/runtime/stdio/prompts.js'
+import { handleCompletion, handlePromptGet, promptDefinitionsForGraph } from '../../src/runtime/stdio/prompts.js'
+import { MCP_PROMPTS } from '../../src/runtime/stdio/definitions.js'
 
 function createGraphFixtureRoot(): string {
   const parentDir = resolve('out', 'test-runtime')
@@ -104,10 +105,15 @@ describe('stdio prompt helpers', () => {
       const contextPackPrompt = prompts.find((prompt) => prompt.name === 'context_pack_prompt')
       const contextPrompt = prompts.find((prompt) => prompt.name === 'context_prompt_prompt')
       const contextSessionPrompt = prompts.find((prompt) => prompt.name === 'context_session_reset_prompt')
+      const staticContextPackPrompt = MCP_PROMPTS.find((prompt) => prompt.name === 'context_pack_prompt')
+      const staticContextPackTaskArgument = staticContextPackPrompt?.arguments?.find((argument) => argument.name === 'task')
 
       expect(explainPrompt?.description).toContain('AuthService')
       expect(communityPrompt?.description).toContain('Auth Services')
       expect(contextPackPrompt?.description).toContain('Auth Services')
+      expect(contextPackPrompt?.description).toContain('implement')
+      expect(staticContextPackPrompt?.description).toContain('implement')
+      expect(staticContextPackTaskArgument?.description).toContain('implement')
       expect(contextPrompt?.description).toContain('claude')
       expect(contextSessionPrompt?.description).toContain('session')
       expect(completion).toMatchObject({
@@ -125,7 +131,7 @@ describe('stdio prompt helpers', () => {
         id: 2,
         result: {
           completion: {
-            values: ['explain', 'impact', 'review'],
+            values: ['explain', 'impact', 'implement', 'review'],
           },
         },
       })
@@ -138,6 +144,163 @@ describe('stdio prompt helpers', () => {
           },
         },
       })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('renders implement context_pack prompts with implementation guidance sections', () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const helpers = {
+        ok: (id: string | number | null, result: unknown) => ({ jsonrpc: '2.0' as const, id, result }),
+        failure: (id: string | number | null, code: number, message: string) => ({ jsonrpc: '2.0' as const, id, error: { code, message } }),
+        stringParam: (params: unknown, key: string) => {
+          if (!params || typeof params !== 'object' || !(key in params)) {
+            return null
+          }
+          const value = (params as Record<string, unknown>)[key]
+          return typeof value === 'string' ? value : null
+        },
+        stringParamAlias: (params: unknown, keys: readonly string[]) => {
+          for (const key of keys) {
+            const value = helpers.stringParam(params, key)
+            if (value !== null) {
+              return value
+            }
+          }
+          return null
+        },
+        integerLikeParamAlias: (params: unknown, keys: readonly string[], options: { min?: number; max?: number } = {}) => {
+          for (const key of keys) {
+            if (!params || typeof params !== 'object' || !(key in params)) {
+              continue
+            }
+            const rawValue = (params as Record<string, unknown>)[key]
+            const numericValue = typeof rawValue === 'number' ? rawValue : typeof rawValue === 'string' && /^\d+$/.test(rawValue.trim()) ? Number(rawValue.trim()) : null
+            if (numericValue === null) {
+              continue
+            }
+            if (options.min !== undefined && numericValue < options.min) {
+              continue
+            }
+            if (options.max !== undefined && numericValue > options.max) {
+              continue
+            }
+            return numericValue
+          }
+          return null
+        },
+        recordParam: (params: unknown, key: string) => {
+          if (!params || typeof params !== 'object' || !(key in params)) {
+            return null
+          }
+          const value = (params as Record<string, unknown>)[key]
+          return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+        },
+        jsonrpcInvalidParams: -32602,
+        maxStdioTextLength: 512,
+        maxCompletionValues: 25,
+      }
+
+      const response = handlePromptGet(4, graphPath, {
+        name: 'context_pack_prompt',
+        arguments: {
+          task: 'implement',
+          prompt: 'Implement workflow-centric retrieval for business capability prompts.',
+          budget: 1800,
+        },
+      }, helpers)
+
+      expect(response).toMatchObject({
+        jsonrpc: '2.0',
+        id: 4,
+        result: {
+          description: 'Prepare a compact context pack with expandable refs and missing-context hints.',
+        },
+      })
+      const text = (
+        (response.result as { messages: Array<{ content: { text: string } }> }).messages[0]?.content.text
+      )
+      expect(text).toContain('Prepare a compact implement context pack for: Implement workflow-centric retrieval for business capability prompts.')
+      expect(text).not.toContain('prompts..')
+      expect(text).toContain('Include likely edit files, likely test files, contracts/public surfaces, existing patterns, runtime context when relevant, risk boundaries, validation commands, acceptance criteria, and missing-context hints.')
+      expect(text).toContain('Target pack budget: 1800 tokens.')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('renders non-implement context_pack prompts with default coverage guidance', () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const helpers = {
+        ok: (id: string | number | null, result: unknown) => ({ jsonrpc: '2.0' as const, id, result }),
+        failure: (id: string | number | null, code: number, message: string) => ({ jsonrpc: '2.0' as const, id, error: { code, message } }),
+        stringParam: (params: unknown, key: string) => {
+          if (!params || typeof params !== 'object' || !(key in params)) {
+            return null
+          }
+          const value = (params as Record<string, unknown>)[key]
+          return typeof value === 'string' ? value : null
+        },
+        stringParamAlias: (params: unknown, keys: readonly string[]) => {
+          for (const key of keys) {
+            const value = helpers.stringParam(params, key)
+            if (value !== null) {
+              return value
+            }
+          }
+          return null
+        },
+        integerLikeParamAlias: (params: unknown, keys: readonly string[], options: { min?: number; max?: number } = {}) => {
+          for (const key of keys) {
+            if (!params || typeof params !== 'object' || !(key in params)) {
+              continue
+            }
+            const rawValue = (params as Record<string, unknown>)[key]
+            const numericValue = typeof rawValue === 'number' ? rawValue : typeof rawValue === 'string' && /^\d+$/.test(rawValue.trim()) ? Number(rawValue.trim()) : null
+            if (numericValue === null) {
+              continue
+            }
+            if (options.min !== undefined && numericValue < options.min) {
+              continue
+            }
+            if (options.max !== undefined && numericValue > options.max) {
+              continue
+            }
+            return numericValue
+          }
+          return null
+        },
+        recordParam: (params: unknown, key: string) => {
+          if (!params || typeof params !== 'object' || !(key in params)) {
+            return null
+          }
+          const value = (params as Record<string, unknown>)[key]
+          return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+        },
+        jsonrpcInvalidParams: -32602,
+        maxStdioTextLength: 512,
+        maxCompletionValues: 25,
+      }
+
+      const response = handlePromptGet(5, graphPath, {
+        name: 'context_pack_prompt',
+        arguments: {
+          task: 'explain',
+          prompt: 'How does AuthService reach Transport?',
+        },
+      }, helpers)
+
+      const text = (
+        (response.result as { messages: Array<{ content: { text: string } }> }).messages[0]?.content.text
+      )
+      expect(text).toContain('Prepare a compact explain context pack for: How does AuthService reach Transport?')
+      expect(text).toContain('Include coverage gaps, expandable references, and the minimum graph evidence a downstream agent needs to continue without re-scanning the repo.')
+      expect(text).not.toContain('Include likely edit files')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- advertise implement mode consistently across MCP context-pack prompt descriptions and completions
- render compact implementation guidance in implement-mode context_pack prompts without double punctuation
- add prompt-helper coverage for implement and non-implement guidance branches

Closes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context pack prompts now support the "implement" mode, offering task-specific guidance alongside existing explain, review, and impact modes for comprehensive workflow support.

* **Tests**
  * Expanded test coverage to validate the new implement mode and verify correct prompt generation across all supported task types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->