### PR TITLE
Add applicability gate for non-code tasks

### DIFF
--- a/src/contracts/task-applicability.ts
+++ b/src/contracts/task-applicability.ts
@@ -1,0 +1,25 @@
+export const TASK_APPLICABILITY_REASONS = [
+  'implement',
+  'explain',
+  'debug',
+  'test',
+  'review',
+  'refactor',
+  'external_url',
+  'github_project',
+  'package_registry',
+  'auth_setup',
+  'marketing_copy',
+  'general_research',
+] as const
+
+export type TaskApplicabilityReason = (typeof TASK_APPLICABILITY_REASONS)[number]
+
+export interface TaskApplicabilityClassification {
+  version: 1
+  prompt: string
+  normalized_prompt: string
+  needs_local_code_context: boolean
+  reason: TaskApplicabilityReason
+  matched_terms: string[]
+}

--- a/src/infrastructure/install-skill-templates.ts
+++ b/src/infrastructure/install-skill-templates.ts
@@ -295,6 +295,8 @@ function codexProfileSection(kind: PlatformKind): string {
 
   return `## Codex CLI profile
 
+Only use madar when the task needs local repository source-code context. Skip it for GitHub Projects board reviews, external URL/WebFetch-only tasks, ${CODE_SPAN_START}gh auth${CODE_SPAN_END} / ${CODE_SPAN_START}gh project${CODE_SPAN_END} setup, package-registry/security pages, and Product Hunt or marketing copy work.
+
 Use madar as a context-pack-first layer for Codex CLI. Before broad shell search, raw file reads, or ${CODE_SPAN_START}spawn_agent${CODE_SPAN_END} worker dispatch, generate or refresh the graph and compile the narrow task context:
 
 ${CODE_BLOCK_START}bash

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmdirSync, rmSync, statSync, unlin
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { getBuiltInSkillContent } from './install-skill-templates.js'
+import { buildPromptApplicabilityHookCommand } from '../runtime/task-applicability.js'
 import {
   findPackageRoot as resolvePackageRoot,
   readPackageName as resolvePackageName,
@@ -121,10 +122,35 @@ function hookCommandWithFallback(matchJson: string, missJson: string): string {
 }
 
 function decodeGeneratedHookPayloads(command: string): string[] {
-  return [...command.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)]
-    .map((match) => match[1])
-    .filter((value): value is string => typeof value === 'string')
-    .map((value) => Buffer.from(value, 'base64').toString('utf8'))
+  const decodedPayloads: string[] = []
+  const seen = new Set<string>()
+  const queue = [command]
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current) {
+      continue
+    }
+
+    for (const match of current.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)) {
+      const value = match[1]
+      if (typeof value !== 'string' || seen.has(value)) {
+        continue
+      }
+
+      seen.add(value)
+      const decoded = Buffer.from(value, 'base64').toString('utf8')
+      decodedPayloads.push(decoded)
+      queue.push(decoded)
+    }
+  }
+
+  return decodedPayloads
+}
+
+function hookCommandHasGraphCheck(command: string): boolean {
+  return command.includes("accessSync('out/graph.json')")
+    || decodeGeneratedHookPayloads(command).some((payload) => payload.includes("accessSync('out/graph.json')"))
 }
 
 function isMadarCodexHookPayload(payload: string): boolean {
@@ -153,14 +179,17 @@ function isMadarProjectHookPayload(payload: string): boolean {
 
 function isMadarProjectHookCommand(command: string): boolean {
   return (
-    command.includes("accessSync('out/graph.json')") &&
-    command.includes('process.stdout.write(Buffer.from(') &&
+    hookCommandHasGraphCheck(command) &&
     decodeGeneratedHookPayloads(command).some(isMadarProjectHookPayload)
   )
 }
 
-function isMadarProjectHook(hook: unknown, matcher: string): boolean {
-  if (!isRecord(hook) || hook.matcher !== matcher || !Array.isArray(hook.hooks)) {
+function isMadarProjectHook(hook: unknown, matcher?: string): boolean {
+  if (!isRecord(hook) || !Array.isArray(hook.hooks)) {
+    return false
+  }
+
+  if (matcher !== undefined && hook.matcher !== matcher) {
     return false
   }
 
@@ -268,41 +297,44 @@ const CLAUDE_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these rules:
 
-1. **BEFORE answering ANY codebase question**, start with the graph tool that matches the question:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
    - \`retrieve\` for "how does X work?" and other direct codebase questions
    - \`relevant_files\` for "which files should I open first?"
    - \`feature_map\` for "what parts of the codebase are involved?"
    - \`risk_map\` before editing to see likely hotspots
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for "what breaks if I change X?"
-2. **Do NOT use Glob, Grep, Bash, Read, or dispatch Agent/Explore subagents first** for codebase questions.
-3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
-4. **Do NOT dispatch Explore or research agents** for codebase questions — the knowledge graph already has the structural context they would spend tokens discovering.
+3. **Do NOT use Glob, Grep, Bash, Read, or dispatch Agent/Explore subagents first** for codebase questions.
+4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
+5. **Do NOT dispatch Explore or research agents** for codebase questions — the knowledge graph already has the structural context they would spend tokens discovering.
 `
 
 const STRICT_CLAUDE_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these strict compact MCP rules:
 
-1. **Call \`context_pack\` once for the task before broader exploration.**
-2. **Answer from the pack when coverage is complete.**
-3. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
-4. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`out/GRAPH_REPORT.md\` first.
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **Call \`context_pack\` once for the task before broader exploration.**
+3. **Answer from the pack when coverage is complete.**
+4. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
+5. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`out/GRAPH_REPORT.md\` first.
 `
 
 const AGENTS_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these rules:
 
-1. **BEFORE answering ANY codebase question**, start with the graph tool that matches the question:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
    - \`retrieve\` for "how does X work?" and other direct codebase questions
    - \`relevant_files\` for "which files should I open first?"
    - \`feature_map\` for "what parts of the codebase are involved?"
    - \`risk_map\` before editing to see likely hotspots
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for "what breaks if I change X?"
-2. **Do NOT search the codebase with other tools first** for codebase questions.
-3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
+3. **Do NOT search the codebase with other tools first** for codebase questions.
+4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
 `
 
 const AIDER_AGENTS_MD_SECTION = `${SECTION_MARKER}
@@ -311,14 +343,15 @@ const AIDER_AGENTS_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. Use a strict context-pack-first workflow:
 
-1. **Before broad code search or manual file expansion**, compile a task-specific context pack:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **Before broad code search or manual file expansion**, compile a task-specific context pack:
    - \`madar pack "<task or question>" --task explain\`
    - use \`--task review\`, \`--task debug\`, or \`--task impact\` when that better matches the work
-2. **Regenerate before expanding manually** when the pack is stale or missing:
+3. **Regenerate before expanding manually** when the pack is stale or missing:
    - run \`madar generate .\`
    - if you still need raw file reads, inspect \`out/GRAPH_REPORT.md\` first
-3. **This profile writes AGENTS.md only.** Aider does not get an auto-installed MCP server or hook from this installer, so the AGENTS.md rule plus explicit \`madar pack\` calls are the enforcement mechanism.
-4. **Uninstall behavior:** run \`madar aider uninstall\` to remove this AGENTS.md section while preserving unrelated content.
+4. **This profile writes AGENTS.md only.** Aider does not get an auto-installed MCP server or hook from this installer, so the AGENTS.md rule plus explicit \`madar pack\` calls are the enforcement mechanism.
+5. **Uninstall behavior:** run \`madar aider uninstall\` to remove this AGENTS.md section while preserving unrelated content.
 
 Manual verification:
 
@@ -337,19 +370,20 @@ const CODEX_AGENTS_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. Use a strict context-pack-first workflow:
 
-1. **Before broad code search, file reads, or worker dispatch**, compile a task-specific context pack:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **Before broad code search, file reads, or worker dispatch**, compile a task-specific context pack:
    - \`madar pack "<task or question>" --task explain\`
    - use \`--task review\`, \`--task debug\`, or \`--task impact\` when that better matches the work
-2. If MCP graph tools are available, use the focused tool that matches the question after the pack:
+3. If MCP graph tools are available, use the focused tool that matches the question after the pack:
    - \`retrieve\` for direct codebase questions
    - \`relevant_files\` for where to open first
    - \`feature_map\` for involved areas and entry points
    - \`risk_map\` before editing
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for blast radius
-3. **Only fall back to raw file tools** when the context pack or graph tools are missing, stale, or insufficient. In that case, read \`out/GRAPH_REPORT.md\` first.
-4. **Do not dispatch \`spawn_agent\` workers first** for codebase discovery. Let the context pack define likely entry files, risks, and missing context before parallel work.
-5. **Uninstall behavior:** run \`madar codex uninstall\` to remove this AGENTS.md section and the madar Codex hook from \`.codex/hooks.json\` while preserving unrelated content.
+4. **Only fall back to raw file tools** when the context pack or graph tools are missing, stale, or insufficient. In that case, read \`out/GRAPH_REPORT.md\` first.
+5. **Do not dispatch \`spawn_agent\` workers first** for codebase discovery. Let the context pack define likely entry files, risks, and missing context before parallel work.
+6. **Uninstall behavior:** run \`madar codex uninstall\` to remove this AGENTS.md section and the madar Codex hook from \`.codex/hooks.json\` while preserving unrelated content.
 
 Manual verification:
 
@@ -367,19 +401,20 @@ const OPENCODE_AGENTS_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. Use a strict context-pack-first workflow:
 
-1. **Before broad code search, bash-heavy exploration, or worker dispatch**, compile a task-specific context pack:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **Before broad code search, bash-heavy exploration, or worker dispatch**, compile a task-specific context pack:
    - \`madar pack "<task or question>" --task explain\`
    - use \`--task review\`, \`--task debug\`, or \`--task impact\` when that better matches the work
-2. After the pack, use MCP graph tools when available inside OpenCode:
+3. After the pack, use MCP graph tools when available inside OpenCode:
    - \`retrieve\` for direct codebase questions
    - \`relevant_files\` for where to open first
    - \`feature_map\` for involved areas and entry points
    - \`risk_map\` before editing
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for blast radius
-3. **Install artifacts:** this profile writes this AGENTS.md section, \`.opencode/plugins/madar.js\`, and the madar MCP server entry in \`opencode.json\` or \`opencode.jsonc\`.
-4. **Only fall back to raw file tools** when the context pack or graph tools are missing, stale, or insufficient. In that case, read \`out/GRAPH_REPORT.md\` first.
-5. **Uninstall behavior:** run \`madar opencode uninstall\` to remove the madar AGENTS.md section, plugin entry, plugin file, and madar MCP config while preserving unrelated content.
+4. **Install artifacts:** this profile writes this AGENTS.md section, \`.opencode/plugins/madar.js\`, and the madar MCP server entry in \`opencode.json\` or \`opencode.jsonc\`.
+5. **Only fall back to raw file tools** when the context pack or graph tools are missing, stale, or insufficient. In that case, read \`out/GRAPH_REPORT.md\` first.
+6. **Uninstall behavior:** run \`madar opencode uninstall\` to remove the madar AGENTS.md section, plugin entry, plugin file, and madar MCP config while preserving unrelated content.
 
 Manual verification:
 
@@ -396,25 +431,27 @@ const GEMINI_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these rules:
 
-1. **BEFORE answering ANY codebase question**, start with the graph tool that matches the question:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
    - \`retrieve\` for "how does X work?" and other direct codebase questions
    - \`relevant_files\` for "which files should I open first?"
    - \`feature_map\` for "what parts of the codebase are involved?"
    - \`risk_map\` before editing to see likely hotspots
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for "what breaks if I change X?"
-2. **Do NOT search the codebase with other tools first** for codebase questions.
-3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
+3. **Do NOT search the codebase with other tools first** for codebase questions.
+4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
 `
 
 const STRICT_GEMINI_MD_SECTION = `${SECTION_MARKER}
 
 IMPORTANT: This project has a madar knowledge graph. Use strict compact MCP guidance:
 
-1. **Call \`context_pack\` once for the task before broader exploration.**
-2. **Answer from the pack when coverage is complete.**
-3. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
-4. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`out/GRAPH_REPORT.md\` first.
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **Call \`context_pack\` once for the task before broader exploration.**
+3. **Answer from the pack when coverage is complete.**
+4. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
+5. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`out/GRAPH_REPORT.md\` first.
 `
 
 const SKILL_REGISTRATION_MARKER = '- **madar**'
@@ -457,15 +494,16 @@ alwaysApply: true
 
 IMPORTANT: This project has a madar knowledge graph.
 
-1. **BEFORE answering ANY codebase question**, start with the graph tool that matches the question:
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
    - \`retrieve\` for "how does X work?" and other direct codebase questions
    - \`relevant_files\` for "which files should I open first?"
    - \`feature_map\` for "what parts of the codebase are involved?"
    - \`risk_map\` before editing to see likely hotspots
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for "what breaks if I change X?"
-2. **Do NOT search the codebase with other tools first** for codebase questions.
-3. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
+3. **Do NOT search the codebase with other tools first** for codebase questions.
+4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. In that case, read out/GRAPH_REPORT.md first.
 `
 
 const STRICT_CURSOR_RULE = `---
@@ -475,10 +513,11 @@ alwaysApply: true
 
 IMPORTANT: This project has a madar knowledge graph. Use strict compact MCP guidance:
 
-1. **Call \`context_pack\` once for the task before broader exploration.**
-2. **Answer from the pack when coverage is complete.**
-3. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
-4. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`out/GRAPH_REPORT.md\` first.
+1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
+2. **Call \`context_pack\` once for the task before broader exploration.**
+3. **Answer from the pack when coverage is complete.**
+4. **Only expand with graph/search tools when diagnostics show missing evidence.** Use \`context_expand\` first, then focused graph tools such as \`retrieve\`, \`relevant_files\`, \`feature_map\`, \`risk_map\`, \`implementation_checklist\`, or \`impact\` only when the pack is insufficient.
+5. **Avoid raw file search unless the pack is insufficient.** If manual expansion is still required, read \`out/GRAPH_REPORT.md\` first.
 `
 
 function claudeMdSection(profile?: InstallProfile): string {
@@ -495,17 +534,17 @@ function cursorRule(profile?: InstallProfile): string {
 
 function settingsHook(profile?: InstallProfile): Record<string, unknown> {
   return {
-    matcher: 'Glob|Grep|Bash|Agent|Read',
     hooks: [
       {
         type: 'command',
-        command: hookCommand(
+        command: buildPromptApplicabilityHookCommand(
           JSON.stringify({
             hookSpecificOutput: {
-              hookEventName: 'PreToolUse',
+              hookEventName: 'UserPromptSubmit',
               additionalContext: profile === 'strict' ? STRICT_CONTEXT_PACK_MESSAGE : RETRIEVE_FIRST_MESSAGE,
             },
           }),
+          'UserPromptSubmit',
         ),
       },
     ],
@@ -1535,18 +1574,21 @@ function installClaudeHook(projectDir: string, profile?: InstallProfile): string
   const settingsPath = join(projectDir, '.claude', 'settings.json')
   const settings = readJsonObject(settingsPath)
   const hooks = ensureRecord(settings, 'hooks')
+  const userPromptSubmit = ensureArray(hooks, 'UserPromptSubmit')
   const preToolUse = ensureArray(hooks, 'PreToolUse')
 
-  const existingIndex = preToolUse.findIndex((hook) => isMadarProjectHook(hook, 'Glob|Grep|Bash|Agent|Read'))
+  const existingIndex = userPromptSubmit.findIndex((hook) => isMadarProjectHook(hook))
   if (existingIndex >= 0) {
-    preToolUse[existingIndex] = settingsHook(profile)
+    userPromptSubmit[existingIndex] = settingsHook(profile)
+    hooks.PreToolUse = preToolUse.filter((hook) => !isMadarProjectHook(hook, 'Glob|Grep|Bash|Agent|Read'))
     writeJson(settingsPath, settings)
     return '.claude/settings.json -> hook updated'
   }
 
-  preToolUse.push(settingsHook(profile))
+  userPromptSubmit.push(settingsHook(profile))
+  hooks.PreToolUse = preToolUse.filter((hook) => !isMadarProjectHook(hook, 'Glob|Grep|Bash|Agent|Read'))
   writeJson(settingsPath, settings)
-  return '.claude/settings.json -> PreToolUse hook registered'
+  return '.claude/settings.json -> UserPromptSubmit hook registered'
 }
 
 function uninstallClaudeHook(projectDir: string): string | undefined {
@@ -1557,16 +1599,19 @@ function uninstallClaudeHook(projectDir: string): string | undefined {
 
   const settings = readJsonObject(settingsPath)
   const hooks = ensureRecord(settings, 'hooks')
+  const userPromptSubmit = ensureArray(hooks, 'UserPromptSubmit')
   const preToolUse = ensureArray(hooks, 'PreToolUse')
-  const filtered = preToolUse.filter((hook) => !isMadarProjectHook(hook, 'Glob|Grep|Bash|Agent|Read'))
+  const filteredUserPromptSubmit = userPromptSubmit.filter((hook) => !isMadarProjectHook(hook))
+  const filteredPreToolUse = preToolUse.filter((hook) => !isMadarProjectHook(hook, 'Glob|Grep|Bash|Agent|Read'))
 
-  if (filtered.length === preToolUse.length) {
+  if (filteredUserPromptSubmit.length === userPromptSubmit.length && filteredPreToolUse.length === preToolUse.length) {
     return undefined
   }
 
-  hooks.PreToolUse = filtered
+  hooks.UserPromptSubmit = filteredUserPromptSubmit
+  hooks.PreToolUse = filteredPreToolUse
   writeJson(settingsPath, settings)
-  return '.claude/settings.json -> PreToolUse hook removed'
+  return '.claude/settings.json -> UserPromptSubmit hook removed'
 }
 
 function installGeminiHook(projectDir: string, profile?: InstallProfile): string {

--- a/src/runtime/task-applicability.ts
+++ b/src/runtime/task-applicability.ts
@@ -1,0 +1,553 @@
+import type {
+  TaskApplicabilityClassification,
+  TaskApplicabilityReason,
+} from '../contracts/task-applicability.js'
+
+const LOCAL_CODE_TERMS = [
+  'repo',
+  'repository',
+  'codebase',
+  'source code',
+  'code',
+  'file',
+  'files',
+  'module',
+  'function',
+  'class',
+  'symbol',
+  'runtime',
+  'stack trace',
+  'service',
+  'controller',
+  'component',
+  'pipeline',
+  'diff',
+  'pr',
+  'pull request',
+  'tests',
+  'test',
+  'bug',
+  'issue',
+  'auth',
+  'token',
+  'session',
+  'changed files',
+  'this repo',
+  'local repository',
+]
+
+const IMPLEMENT_TERMS = [
+  'implement',
+  'fix issue',
+  'fix bug',
+  'wire up',
+  'add support',
+  'build feature',
+  'create feature',
+  'write code',
+]
+
+const EXPLAIN_TERMS = [
+  'explain how',
+  'how does',
+  'where is',
+  'walk me through',
+  'help me understand',
+  'trace runtime path',
+  'find affected files',
+]
+
+const DEBUG_TERMS = [
+  'trace why',
+  'root cause',
+  'stack trace',
+  'why is',
+  'why does',
+  'debug',
+  'failing',
+  'failure',
+  'broken',
+  'error',
+  'bug',
+]
+
+const TEST_TERMS = [
+  'write tests',
+  'write regression tests',
+  'add tests',
+  'add regression tests',
+  'generate tests',
+  'create tests',
+  'unit test',
+  'integration test',
+  'regression test',
+]
+
+const REVIEW_TERMS = [
+  'review this pr',
+  'review the pr',
+  'review the diff',
+  'pr diff',
+  'review code',
+  'audit the',
+  'review the recent',
+]
+
+const REFACTOR_TERMS = [
+  'refactor',
+  'dead code',
+  'clean up module',
+  'cleanup module',
+  'simplify module',
+]
+
+const GITHUB_PROJECT_TERMS = [
+  'github project',
+  'github projects',
+  'project board',
+  'projects board',
+  'roadmap board',
+  'roadmap review',
+]
+
+const PACKAGE_REGISTRY_TERMS = [
+  'socket.dev',
+  'socket alert',
+  'npmjs.com',
+  'package registry',
+  'npm package',
+  'package security page',
+]
+
+const AUTH_SETUP_TERMS = [
+  'gh auth',
+  'gh project',
+  'auth login',
+  'login setup',
+  'device code',
+  'token setup',
+]
+
+const MARKETING_COPY_TERMS = [
+  'product hunt',
+  'marketing copy',
+  'launch copy',
+  'headline',
+  'tagline',
+  'positioning',
+  'landing page copy',
+]
+
+const GENERAL_RESEARCH_TERMS = [
+  'web research',
+  'market research',
+  'competitor research',
+  'general research',
+]
+
+const FILE_PATH_RE = /(?:^|\s)(?:[\w@./-]+\/)*[\w./@-]+\.[A-Za-z]{1,8}(?=\b|$)/i
+const URL_RE = /https?:\/\/\S+/i
+const GITHUB_PROJECT_URL_RE = /https?:\/\/github\.com\/.*\/projects\/\d+/i
+const PACKAGE_REGISTRY_URL_RE = /https?:\/\/(?:www\.)?(?:npmjs\.com|socket\.dev|snyk\.io|packagephobia\.com)\//i
+
+const TASK_APPLICABILITY_REASON_LABELS: Record<TaskApplicabilityReason, string> = {
+  implement: 'implementation task',
+  explain: 'codebase explanation task',
+  debug: 'debugging task',
+  test: 'test-writing task',
+  review: 'code review task',
+  refactor: 'refactor task',
+  external_url: 'external URL or web-only task',
+  github_project: 'GitHub Project roadmap review',
+  package_registry: 'package registry or security page review',
+  auth_setup: 'CLI auth or project setup',
+  marketing_copy: 'marketing copy review',
+  general_research: 'general research task',
+}
+
+interface TaskApplicabilityHookConfig {
+  local_code_terms: readonly string[]
+  implement_terms: readonly string[]
+  explain_terms: readonly string[]
+  debug_terms: readonly string[]
+  test_terms: readonly string[]
+  review_terms: readonly string[]
+  refactor_terms: readonly string[]
+  github_project_terms: readonly string[]
+  package_registry_terms: readonly string[]
+  auth_setup_terms: readonly string[]
+  marketing_copy_terms: readonly string[]
+  general_research_terms: readonly string[]
+  reason_labels: Record<TaskApplicabilityReason, string>
+}
+
+const HOOK_CONFIG: TaskApplicabilityHookConfig = {
+  local_code_terms: LOCAL_CODE_TERMS,
+  implement_terms: IMPLEMENT_TERMS,
+  explain_terms: EXPLAIN_TERMS,
+  debug_terms: DEBUG_TERMS,
+  test_terms: TEST_TERMS,
+  review_terms: REVIEW_TERMS,
+  refactor_terms: REFACTOR_TERMS,
+  github_project_terms: GITHUB_PROJECT_TERMS,
+  package_registry_terms: PACKAGE_REGISTRY_TERMS,
+  auth_setup_terms: AUTH_SETUP_TERMS,
+  marketing_copy_terms: MARKETING_COPY_TERMS,
+  general_research_terms: GENERAL_RESEARCH_TERMS,
+  reason_labels: TASK_APPLICABILITY_REASON_LABELS,
+}
+
+function normalizePrompt(prompt: string): string {
+  return prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+function containsTerm(normalizedPrompt: string, term: string): boolean {
+  const normalizedTerm = normalizePrompt(term)
+  if (normalizedPrompt.length === 0 || normalizedTerm.length === 0) {
+    return false
+  }
+
+  return ` ${normalizedPrompt} `.includes(` ${normalizedTerm} `)
+}
+
+function matchTerms(normalizedPrompt: string, terms: readonly string[]): string[] {
+  return [...new Set(terms.map(normalizePrompt).filter((term) => containsTerm(normalizedPrompt, term)))].sort()
+}
+
+function hasLocalCodeCue(prompt: string, normalizedPrompt: string): { matched_terms: string[]; detected: boolean } {
+  const matchedTerms = matchTerms(normalizedPrompt, LOCAL_CODE_TERMS)
+  const detected = matchedTerms.length > 0 || FILE_PATH_RE.test(prompt)
+  return {
+    matched_terms: FILE_PATH_RE.test(prompt) ? [...new Set([...matchedTerms, 'file path'])].sort() : matchedTerms,
+    detected,
+  }
+}
+
+function negativeClassification(
+  prompt: string,
+  normalizedPrompt: string,
+): { reason: TaskApplicabilityReason; matched_terms: string[] } | null {
+  if (GITHUB_PROJECT_URL_RE.test(prompt)) {
+    return { reason: 'github_project', matched_terms: ['github project url'] }
+  }
+
+  const githubProjectTerms = matchTerms(normalizedPrompt, GITHUB_PROJECT_TERMS)
+  if (githubProjectTerms.length > 0) {
+    return { reason: 'github_project', matched_terms: githubProjectTerms }
+  }
+
+  if (PACKAGE_REGISTRY_URL_RE.test(prompt)) {
+    return { reason: 'package_registry', matched_terms: ['package registry url'] }
+  }
+
+  const packageRegistryTerms = matchTerms(normalizedPrompt, PACKAGE_REGISTRY_TERMS)
+  if (packageRegistryTerms.length > 0) {
+    return { reason: 'package_registry', matched_terms: packageRegistryTerms }
+  }
+
+  const authSetupTerms = matchTerms(normalizedPrompt, AUTH_SETUP_TERMS)
+  if (authSetupTerms.length > 0) {
+    return { reason: 'auth_setup', matched_terms: authSetupTerms }
+  }
+
+  const marketingTerms = matchTerms(normalizedPrompt, MARKETING_COPY_TERMS)
+  if (marketingTerms.length > 0) {
+    return { reason: 'marketing_copy', matched_terms: marketingTerms }
+  }
+
+  if (URL_RE.test(prompt)) {
+    return { reason: 'external_url', matched_terms: ['external url'] }
+  }
+
+  const generalResearchTerms = matchTerms(normalizedPrompt, GENERAL_RESEARCH_TERMS)
+  if (generalResearchTerms.length > 0) {
+    return { reason: 'general_research', matched_terms: generalResearchTerms }
+  }
+
+  return null
+}
+
+function localClassification(
+  prompt: string,
+  normalizedPrompt: string,
+): { reason: TaskApplicabilityReason; matched_terms: string[] } | null {
+  const localCodeCue = hasLocalCodeCue(prompt, normalizedPrompt)
+
+  const implementTerms = matchTerms(normalizedPrompt, IMPLEMENT_TERMS)
+  if (implementTerms.length > 0) {
+    return { reason: 'implement', matched_terms: implementTerms }
+  }
+
+  const debugTerms = matchTerms(normalizedPrompt, DEBUG_TERMS)
+  if (debugTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'debug', matched_terms: [...new Set([...debugTerms, ...localCodeCue.matched_terms])].sort() }
+  }
+
+  const testTerms = matchTerms(normalizedPrompt, TEST_TERMS)
+  if (testTerms.length > 0) {
+    return { reason: 'test', matched_terms: testTerms }
+  }
+
+  const reviewTerms = matchTerms(normalizedPrompt, REVIEW_TERMS)
+  if (reviewTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'review', matched_terms: [...new Set([...reviewTerms, ...localCodeCue.matched_terms])].sort() }
+  }
+
+  const refactorTerms = matchTerms(normalizedPrompt, REFACTOR_TERMS)
+  if (refactorTerms.length > 0) {
+    return { reason: 'refactor', matched_terms: refactorTerms }
+  }
+
+  const explainTerms = matchTerms(normalizedPrompt, EXPLAIN_TERMS)
+  if (explainTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'explain', matched_terms: [...new Set([...explainTerms, ...localCodeCue.matched_terms])].sort() }
+  }
+
+  return localCodeCue.detected
+    ? { reason: 'explain', matched_terms: localCodeCue.matched_terms }
+    : null
+}
+
+export function classifyTaskApplicability(prompt: string): TaskApplicabilityClassification {
+  const normalizedPrompt = normalizePrompt(prompt)
+  const negative = negativeClassification(prompt, normalizedPrompt)
+  if (negative) {
+    return {
+      version: 1,
+      prompt,
+      normalized_prompt: normalizedPrompt,
+      needs_local_code_context: false,
+      reason: negative.reason,
+      matched_terms: negative.matched_terms,
+    }
+  }
+
+  const local = localClassification(prompt, normalizedPrompt)
+  if (local) {
+    return {
+      version: 1,
+      prompt,
+      normalized_prompt: normalizedPrompt,
+      needs_local_code_context: true,
+      reason: local.reason,
+      matched_terms: local.matched_terms,
+    }
+  }
+
+  return {
+    version: 1,
+    prompt,
+    normalized_prompt: normalizedPrompt,
+    needs_local_code_context: false,
+    reason: 'general_research',
+    matched_terms: [],
+  }
+}
+
+export function formatTaskApplicabilityDebugMessage(classification: TaskApplicabilityClassification): string {
+  if (classification.needs_local_code_context) {
+    return `Using Madar: task needs local codebase context (${TASK_APPLICABILITY_REASON_LABELS[classification.reason]}).`
+  }
+
+  return `Skipped Madar: task is ${TASK_APPLICABILITY_REASON_LABELS[classification.reason]}, not local codebase context.`
+}
+
+export function buildPromptApplicabilityHookCommand(
+  matchPayloadJson: string,
+  hookEventName: string,
+): string {
+  const b64MatchPayload = Buffer.from(matchPayloadJson).toString('base64')
+  const b64HookConfig = Buffer.from(JSON.stringify(HOOK_CONFIG)).toString('base64')
+  const source = `
+const fs = require('fs');
+const config = JSON.parse(Buffer.from('${b64HookConfig}', 'base64').toString('utf8'));
+const matchPayload = Buffer.from('${b64MatchPayload}', 'base64').toString('utf8');
+const filePathRe = /(?:^|\\s)(?:[\\w@./-]+\\/)*[\\w./@-]+\\.[A-Za-z]{1,8}(?=\\b|$)/i;
+const urlRe = /https?:\\/\\/\\S+/i;
+const githubProjectUrlRe = /https?:\\/\\/github\\.com\\/.*\\/projects\\/\\d+/i;
+const packageRegistryUrlRe = /https?:\\/\\/(?:www\\.)?(?:npmjs\\.com|socket\\.dev|snyk\\.io|packagephobia\\.com)\\//i;
+let input = '';
+
+function normalizePrompt(prompt) {
+  return String(prompt || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\\s+/g, ' ');
+}
+
+function containsTerm(normalizedPrompt, term) {
+  const normalizedTerm = normalizePrompt(term);
+  if (!normalizedPrompt || !normalizedTerm) {
+    return false;
+  }
+
+  return (' ' + normalizedPrompt + ' ').includes(' ' + normalizedTerm + ' ');
+}
+
+function matchTerms(normalizedPrompt, terms) {
+  return [...new Set(terms.map(normalizePrompt).filter((term) => containsTerm(normalizedPrompt, term)))].sort();
+}
+
+function hasLocalCodeCue(prompt, normalizedPrompt) {
+  const matchedTerms = matchTerms(normalizedPrompt, config.local_code_terms);
+  const hasFilePath = filePathRe.test(prompt);
+  return {
+    detected: matchedTerms.length > 0 || hasFilePath,
+    matched_terms: hasFilePath ? [...new Set([...matchedTerms, 'file path'])].sort() : matchedTerms,
+  };
+}
+
+function negativeClassification(prompt, normalizedPrompt) {
+  if (githubProjectUrlRe.test(prompt)) {
+    return { reason: 'github_project', matched_terms: ['github project url'] };
+  }
+
+  const githubProjectTerms = matchTerms(normalizedPrompt, config.github_project_terms);
+  if (githubProjectTerms.length > 0) {
+    return { reason: 'github_project', matched_terms: githubProjectTerms };
+  }
+
+  if (packageRegistryUrlRe.test(prompt)) {
+    return { reason: 'package_registry', matched_terms: ['package registry url'] };
+  }
+
+  const packageRegistryTerms = matchTerms(normalizedPrompt, config.package_registry_terms);
+  if (packageRegistryTerms.length > 0) {
+    return { reason: 'package_registry', matched_terms: packageRegistryTerms };
+  }
+
+  const authSetupTerms = matchTerms(normalizedPrompt, config.auth_setup_terms);
+  if (authSetupTerms.length > 0) {
+    return { reason: 'auth_setup', matched_terms: authSetupTerms };
+  }
+
+  const marketingTerms = matchTerms(normalizedPrompt, config.marketing_copy_terms);
+  if (marketingTerms.length > 0) {
+    return { reason: 'marketing_copy', matched_terms: marketingTerms };
+  }
+
+  if (urlRe.test(prompt)) {
+    return { reason: 'external_url', matched_terms: ['external url'] };
+  }
+
+  const researchTerms = matchTerms(normalizedPrompt, config.general_research_terms);
+  if (researchTerms.length > 0) {
+    return { reason: 'general_research', matched_terms: researchTerms };
+  }
+
+  return null;
+}
+
+function localClassification(prompt, normalizedPrompt) {
+  const localCodeCue = hasLocalCodeCue(prompt, normalizedPrompt);
+
+  const implementTerms = matchTerms(normalizedPrompt, config.implement_terms);
+  if (implementTerms.length > 0) {
+    return { reason: 'implement', matched_terms: implementTerms };
+  }
+
+  const debugTerms = matchTerms(normalizedPrompt, config.debug_terms);
+  if (debugTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'debug', matched_terms: [...new Set([...debugTerms, ...localCodeCue.matched_terms])].sort() };
+  }
+
+  const testTerms = matchTerms(normalizedPrompt, config.test_terms);
+  if (testTerms.length > 0) {
+    return { reason: 'test', matched_terms: testTerms };
+  }
+
+  const reviewTerms = matchTerms(normalizedPrompt, config.review_terms);
+  if (reviewTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'review', matched_terms: [...new Set([...reviewTerms, ...localCodeCue.matched_terms])].sort() };
+  }
+
+  const refactorTerms = matchTerms(normalizedPrompt, config.refactor_terms);
+  if (refactorTerms.length > 0) {
+    return { reason: 'refactor', matched_terms: refactorTerms };
+  }
+
+  const explainTerms = matchTerms(normalizedPrompt, config.explain_terms);
+  if (explainTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'explain', matched_terms: [...new Set([...explainTerms, ...localCodeCue.matched_terms])].sort() };
+  }
+
+  if (localCodeCue.detected) {
+    return { reason: 'explain', matched_terms: localCodeCue.matched_terms };
+  }
+
+  return null;
+}
+
+function classifyTaskApplicability(prompt) {
+  const normalizedPrompt = normalizePrompt(prompt);
+  const negative = negativeClassification(prompt, normalizedPrompt);
+  if (negative) {
+    return {
+      needs_local_code_context: false,
+      reason: negative.reason,
+    };
+  }
+
+  const local = localClassification(prompt, normalizedPrompt);
+  if (local) {
+    return {
+      needs_local_code_context: true,
+      reason: local.reason,
+    };
+  }
+
+  return {
+    needs_local_code_context: false,
+    reason: 'general_research',
+  };
+}
+
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    fs.accessSync('out/graph.json');
+  } catch (error) {
+    return;
+  }
+
+  let prompt = '';
+  try {
+    const payload = input.length > 0 ? JSON.parse(input) : {};
+    if (typeof payload.prompt === 'string') {
+      prompt = payload.prompt;
+    }
+  } catch (error) {
+    prompt = '';
+  }
+
+  const classification = classifyTaskApplicability(prompt);
+  const debugEnabled = /^(1|true|yes)$/i.test(String(process.env.MADAR_HOOK_DEBUG || ''));
+  if (!classification.needs_local_code_context) {
+    if (!debugEnabled) {
+      return;
+    }
+
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: '${hookEventName}',
+        additionalContext: 'Skipped Madar: task is ' + config.reason_labels[classification.reason] + ', not local codebase context.',
+      },
+    }));
+    return;
+  }
+
+  process.stdout.write(matchPayload);
+});
+`
+
+  const b64Source = Buffer.from(source, 'utf8').toString('base64')
+  return `node -e "eval(Buffer.from('${b64Source}','base64').toString('utf8'))"`
+}

--- a/tests/unit/install-templates.test.ts
+++ b/tests/unit/install-templates.test.ts
@@ -20,19 +20,41 @@ function withTempDir(callback: (dir: string) => void): void {
 
 function decodeHookPayload(settingsJson: string): string {
   const parsed = JSON.parse(settingsJson) as {
-    hooks?: { PreToolUse?: Array<{ hooks?: Array<{ command?: string }> }> }
+    hooks?: {
+      PreToolUse?: Array<{ hooks?: Array<{ command?: string }> }>
+      UserPromptSubmit?: Array<{ hooks?: Array<{ command?: string }> }>
+    }
   }
-  const command = parsed.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command ?? ''
+  const command = parsed.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command
+    ?? parsed.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command
+    ?? ''
   // Hook command embeds the payload as a base64 literal inside a node -e wrapper.
   // Extract every base64-looking chunk and decode each, concatenating the results
   // so we capture both the match and miss payloads when present.
-  const base64Matches = [...command.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)]
-    .map((match) => match[1])
-    .filter((value): value is string => typeof value === 'string')
-  if (base64Matches.length === 0) {
-    return ''
+  const decodedPayloads: string[] = []
+  const seen = new Set<string>()
+  const queue = [command]
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current) {
+      continue
+    }
+
+    for (const match of current.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)) {
+      const value = match[1]
+      if (typeof value !== 'string' || seen.has(value)) {
+        continue
+      }
+
+      seen.add(value)
+      const decoded = Buffer.from(value, 'base64').toString('utf8')
+      decodedPayloads.push(decoded)
+      queue.push(decoded)
+    }
   }
-  return base64Matches.map((b64) => Buffer.from(b64, 'base64').toString('utf8')).join('\n')
+
+  return decodedPayloads.join('\n')
 }
 
 describe('install hook payload', () => {
@@ -103,5 +125,6 @@ describe('built-in install templates', () => {
     expect(content).toContain('Codex limitations')
     expect(content).toContain('spawn_agent')
     expect(content).toContain('npx --yes madar --help')
+    expect(content).toContain('Only use madar when the task needs local repository source-code context.')
   })
 })

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -227,6 +227,7 @@ describe('install helpers', () => {
       const scriptPath = shell.args[3]
       if (scriptPath) {
         rmSync(scriptPath, { force: true })
+        rmSync(dirname(scriptPath), { recursive: true, force: true })
       }
     }
   })

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -149,13 +149,31 @@ function extractHookCommand(settingsJson: string, eventName: string): string {
   return parsed.hooks?.[eventName]?.[0]?.hooks?.[0]?.command ?? ''
 }
 
+function shellCommandForPlatform(
+  platform: NodeJS.Platform,
+  command: string,
+): { command: string; args: string[] } {
+  if (platform === 'win32') {
+    return {
+      command: process.env.ComSpec ?? 'cmd.exe',
+      args: ['/d', '/s', '/c', command],
+    }
+  }
+
+  return {
+    command: '/bin/sh',
+    args: ['-lc', command],
+  }
+}
+
 function runHookCommand(
   command: string,
   cwd: string,
   input: Record<string, unknown>,
   env: Record<string, string> = {},
 ): string {
-  const result = spawnSync('/bin/sh', ['-lc', command], {
+  const shell = shellCommandForPlatform(process.platform, command)
+  const result = spawnSync(shell.command, shell.args, {
     cwd,
     input: JSON.stringify(input),
     encoding: 'utf8',
@@ -170,6 +188,17 @@ function runHookCommand(
 }
 
 describe('install helpers', () => {
+  it('chooses a platform-appropriate shell for generated hook commands', () => {
+    expect(shellCommandForPlatform('darwin', 'node -e "console.log(1)"')).toEqual({
+      command: '/bin/sh',
+      args: ['-lc', 'node -e "console.log(1)"'],
+    })
+    expect(shellCommandForPlatform('win32', 'node -e "console.log(1)"')).toEqual({
+      command: process.env.ComSpec ?? 'cmd.exe',
+      args: ['/d', '/s', '/c', 'node -e "console.log(1)"'],
+    })
+  })
+
   it('chooses the default platform from the host OS', () => {
     expect(defaultInstallPlatform('win32')).toBe('windows')
     expect(defaultInstallPlatform('darwin')).toBe('claude')

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, relative } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 import * as ts from 'typescript'
 
 import {
@@ -152,11 +152,16 @@ function extractHookCommand(settingsJson: string, eventName: string): string {
 function shellCommandForPlatform(
   platform: NodeJS.Platform,
   command: string,
-): { command: string; args: string[] } {
+): { command: string; args: string[]; cleanupPath?: string } {
   if (platform === 'win32') {
+    const scriptDir = mkdtempSync(join(tmpdir(), 'madar-hook-'))
+    const scriptPath = join(scriptDir, 'run-hook.cmd')
+    writeFileSync(scriptPath, `@echo off\r\n${command}\r\n`, 'utf8')
+
     return {
       command: process.env.ComSpec ?? 'cmd.exe',
-      args: ['/d', '/s', '/c', command],
+      args: ['/d', '/s', '/c', scriptPath],
+      cleanupPath: scriptPath,
     }
   }
 
@@ -173,18 +178,25 @@ function runHookCommand(
   env: Record<string, string> = {},
 ): string {
   const shell = shellCommandForPlatform(process.platform, command)
-  const result = spawnSync(shell.command, shell.args, {
-    cwd,
-    input: JSON.stringify(input),
-    encoding: 'utf8',
-    env: { ...process.env, ...env },
-  })
+  try {
+    const result = spawnSync(shell.command, shell.args, {
+      cwd,
+      input: JSON.stringify(input),
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    })
 
-  if (result.status !== 0) {
-    throw new Error(result.stderr || `hook command failed with exit code ${result.status ?? 'unknown'}`)
+    if (result.status !== 0) {
+      throw new Error(result.stderr || `hook command failed with exit code ${result.status ?? 'unknown'}`)
+    }
+
+    return result.stdout
+  } finally {
+    if (shell.cleanupPath) {
+      rmSync(shell.cleanupPath, { force: true })
+      rmSync(dirname(shell.cleanupPath), { recursive: true, force: true })
+    }
   }
-
-  return result.stdout
 }
 
 describe('install helpers', () => {
@@ -193,10 +205,30 @@ describe('install helpers', () => {
       command: '/bin/sh',
       args: ['-lc', 'node -e "console.log(1)"'],
     })
-    expect(shellCommandForPlatform('win32', 'node -e "console.log(1)"')).toEqual({
-      command: process.env.ComSpec ?? 'cmd.exe',
-      args: ['/d', '/s', '/c', 'node -e "console.log(1)"'],
-    })
+  })
+
+  it('wraps Windows hook commands in a cmd script to avoid command-length limits', () => {
+    const longCommand = `node -e "${'console.log(1);'.repeat(1200)}"`
+    const shell = shellCommandForPlatform('win32', longCommand)
+
+    try {
+      expect(shell.command).toBe(process.env.ComSpec ?? 'cmd.exe')
+      expect(shell.args.slice(0, 3)).toEqual(['/d', '/s', '/c'])
+      const scriptPath = shell.args[3]
+      expect(scriptPath).toBeDefined()
+      if (!scriptPath) {
+        throw new Error('missing Windows hook script path')
+      }
+
+      expect(scriptPath).toMatch(/\.cmd$/i)
+      expect(scriptPath).not.toContain('console.log(1);')
+      expect(readFileSync(scriptPath, 'utf8')).toContain(longCommand)
+    } finally {
+      const scriptPath = shell.args[3]
+      if (scriptPath) {
+        rmSync(scriptPath, { force: true })
+      }
+    }
   })
 
   it('chooses the default platform from the host OS', () => {

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -115,11 +116,57 @@ function readJsoncConfig(filePath: string): OpenCodeConfig {
 }
 
 function decodeHookPayloads(content: string): string {
-  return [...content.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)]
-    .map((match) => match[1])
-    .filter((value): value is string => typeof value === 'string')
-    .map((b64) => Buffer.from(b64, 'base64').toString('utf8'))
-    .join('\n')
+  const decodedPayloads: string[] = []
+  const seen = new Set<string>()
+  const queue = [content]
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current) {
+      continue
+    }
+
+    for (const match of current.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)) {
+      const value = match[1]
+      if (typeof value !== 'string' || seen.has(value)) {
+        continue
+      }
+
+      seen.add(value)
+      const decoded = Buffer.from(value, 'base64').toString('utf8')
+      decodedPayloads.push(decoded)
+      queue.push(decoded)
+    }
+  }
+
+  return decodedPayloads.join('\n')
+}
+
+function extractHookCommand(settingsJson: string, eventName: string): string {
+  const parsed = JSON.parse(settingsJson) as {
+    hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>
+  }
+  return parsed.hooks?.[eventName]?.[0]?.hooks?.[0]?.command ?? ''
+}
+
+function runHookCommand(
+  command: string,
+  cwd: string,
+  input: Record<string, unknown>,
+  env: Record<string, string> = {},
+): string {
+  const result = spawnSync('/bin/sh', ['-lc', command], {
+    cwd,
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  })
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `hook command failed with exit code ${result.status ?? 'unknown'}`)
+  }
+
+  return result.stdout
 }
 
 describe('install helpers', () => {
@@ -298,6 +345,7 @@ describe('install helpers', () => {
           expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain('risk_map')
           expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain('implementation_checklist')
           expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain('impact')
+          expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain('Only use madar when the task needs local repository source-code context.')
           expect(readFileSync(join(projectDir, '.gemini', 'settings.json'), 'utf8')).toContain('out')
 
           const uninstallMessage = geminiUninstall(projectDir, { homeDir })
@@ -396,10 +444,66 @@ describe('install helpers', () => {
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('risk_map')
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('implementation_checklist')
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('impact')
+      expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('Only use madar when the task needs local repository source-code context.')
 
       const uninstallMessage = claudeUninstall(projectDir)
       expect(uninstallMessage).toMatch(/madar section removed|CLAUDE\.md was empty after removal/)
       expect(existsSync(join(projectDir, 'CLAUDE.md'))).toBe(false)
+    })
+  })
+
+  it('keeps the Claude prompt hook silent for GitHub Projects roadmap review prompts', () => {
+    withTempDir((projectDir) => {
+      mkdirSync(join(projectDir, 'out'), { recursive: true })
+      writeFileSync(join(projectDir, 'out', 'graph.json'), '{}', 'utf8')
+      claudeInstall(projectDir)
+
+      const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
+      const command = extractHookCommand(settings, 'UserPromptSubmit')
+      const output = runHookCommand(command, projectDir, {
+        prompt: 'I need you to access https://github.com/users/mohanagy/projects/9/views/3 and to review the roadmap, do not take any action for now',
+      })
+
+      expect(output).toBe('')
+    })
+  })
+
+  it('injects Claude prompt guidance only for local code tasks', () => {
+    withTempDir((projectDir) => {
+      mkdirSync(join(projectDir, 'out'), { recursive: true })
+      writeFileSync(join(projectDir, 'out', 'graph.json'), '{}', 'utf8')
+      claudeInstall(projectDir)
+
+      const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
+      const command = extractHookCommand(settings, 'UserPromptSubmit')
+      const output = runHookCommand(command, projectDir, {
+        prompt: 'Implement issue #275 by collecting implementation context for changed files',
+      })
+
+      expect(output).toContain('retrieve')
+      expect(output).toContain('3x fewer turns')
+    })
+  })
+
+  it('emits the Claude skip reason in debug mode', () => {
+    withTempDir((projectDir) => {
+      mkdirSync(join(projectDir, 'out'), { recursive: true })
+      writeFileSync(join(projectDir, 'out', 'graph.json'), '{}', 'utf8')
+      claudeInstall(projectDir)
+
+      const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
+      const command = extractHookCommand(settings, 'UserPromptSubmit')
+      const output = runHookCommand(
+        command,
+        projectDir,
+        {
+          prompt: 'Review the Product Hunt launch copy and marketing headline for tomorrow',
+        },
+        { MADAR_HOOK_DEBUG: '1' },
+      )
+
+      expect(output).toContain('Skipped Madar:')
+      expect(output).toContain('marketing copy review')
     })
   })
 
@@ -700,7 +804,7 @@ describe('install helpers', () => {
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toBe(firstClaudeMd)
       expect(readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')).toBe(firstSettings)
       expect(countOccurrences(firstClaudeMd, '## madar')).toBe(1)
-      expect(countOccurrences(firstSettings, 'out')).toBeGreaterThan(0)
+      expect(countOccurrences(firstSettings, 'UserPromptSubmit')).toBeGreaterThan(0)
     })
   })
 

--- a/tests/unit/task-applicability.test.ts
+++ b/tests/unit/task-applicability.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyTaskApplicability,
+  formatTaskApplicabilityDebugMessage,
+} from '../../src/runtime/task-applicability.js'
+
+describe('task-applicability', () => {
+  it('skips GitHub Projects roadmap review prompts', () => {
+    const classification = classifyTaskApplicability(
+      'I need you to access https://github.com/users/mohanagy/projects/9/views/3 and to review the roadmap, do not take any action for now',
+    )
+
+    expect(classification.needs_local_code_context).toBe(false)
+    expect(classification.reason).toBe('github_project')
+  })
+
+  it('skips external setup and package-registry tasks', () => {
+    expect(classifyTaskApplicability('Help me run gh auth login and gh project view setup').reason)
+      .toBe('auth_setup')
+    expect(classifyTaskApplicability('Review the Socket.dev alert for @lubab/madar').reason)
+      .toBe('package_registry')
+  })
+
+  it('keeps Madar enabled for local code explain, implement, debug, test, review, and refactor tasks', () => {
+    expect(classifyTaskApplicability('Explain how the context pack is assembled in this repo'))
+      .toEqual(expect.objectContaining({ needs_local_code_context: true, reason: 'explain' }))
+    expect(classifyTaskApplicability('Implement issue #275 by collecting implementation context for changed files'))
+      .toEqual(expect.objectContaining({ needs_local_code_context: true, reason: 'implement' }))
+    expect(classifyTaskApplicability('Trace why refresh token rotation started failing after the latest auth change'))
+      .toEqual(expect.objectContaining({ needs_local_code_context: true, reason: 'debug' }))
+    expect(classifyTaskApplicability('Write regression tests for parseConfig and session expiry'))
+      .toEqual(expect.objectContaining({ needs_local_code_context: true, reason: 'test' }))
+    expect(classifyTaskApplicability('Review this PR diff for risky auth regressions before merge'))
+      .toEqual(expect.objectContaining({ needs_local_code_context: true, reason: 'review' }))
+    expect(classifyTaskApplicability('Refactor the session cache module without changing behavior'))
+      .toEqual(expect.objectContaining({ needs_local_code_context: true, reason: 'refactor' }))
+  })
+
+  it('formats a human-readable debug skip message', () => {
+    const classification = classifyTaskApplicability(
+      'Review the Product Hunt launch copy and marketing headline for tomorrow',
+    )
+
+    expect(formatTaskApplicabilityDebugMessage(classification))
+      .toBe('Skipped Madar: task is marketing copy review, not local codebase context.')
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable task applicability classifier for local-code vs external/non-code tasks
- move the Claude install hook to a prompt-stage gate that skips Madar silently by default and exposes skip reasons in debug mode
- update install guidance/tests so Claude and Codex-facing instructions only recommend Madar when local repository source-code context is needed

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

Closes #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent task applicability detection to decide when prompts need local repository context and to suppress local-context actions when not needed.

* **Improvements**
  * Hook commands now recursively decode embedded payloads and handle installation/uninstallation across hook events.
  * In-product guidance strengthened: "Only use madar when the task needs local repository source-code context."

* **Tests**
  * Added and expanded tests for applicability classification, hook behavior, payload decoding, and command execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->