### PR TITLE
Triage Socket dependency alerts

### DIFF
--- a/docs/security/socket-alerts-0.26.0.md
+++ b/docs/security/socket-alerts-0.26.0.md
@@ -1,0 +1,82 @@
+# Socket dependency review for `@lubab/madar@0.26.0`
+
+## Scope
+
+This review covers the production dependency surface for `@lubab/madar@0.26.0` as installed from `package.json` / `package-lock.json` on the `0.26.0` line.
+
+Commands used during triage:
+
+- `npm ls --omit=dev --all --json`
+- `npm audit --omit=dev`
+- `npx license-checker --production --json`
+- `npm explain protobufjs`
+- `npm explain onnxruntime-node`
+- `npm explain sharp`
+- targeted source review in `src/runtime/*.ts` and the relevant `node_modules/*/package.json` / install scripts
+
+## Executive summary
+
+- **Fixed now:** the only `npm audit --omit=dev` finding was `protobufjs` and it has been updated in `package-lock.json` from `7.5.6` to `7.6.1`.
+- **Main remaining risk theme:** most of the noisy Socket-style alerts come from the optional semantic retrieval stack behind `@huggingface/transformers`.
+- **Default runtime behavior:** Madar only loads the semantic stack when semantic retrieval or reranking is explicitly enabled. The lexical/default path returns early without loading it.
+- **Follow-up required:** issue **#290** tracks making the semantic runtime dependencies optional so default installs do not pull the native/image/onnx stack for users who never enable semantic retrieval.
+
+## Direct production dependencies
+
+| Package | Version | Notes |
+| --- | --- | --- |
+| `@huggingface/transformers` | `4.2.0` | Direct dependency; lazy-loaded only from the semantic retrieval path |
+| `@vscode/tree-sitter-wasm` | `0.3.1` | Parser/grammar support |
+| `fflate` | `0.8.3` | Compression helper |
+| `gpt-tokenizer` | `3.4.0` | Local token counting |
+| `neo4j-driver` | `6.0.1` | Optional Neo4j push/runtime integration |
+| `typescript` | `6.0.3` | Parser/compiler dependency |
+| `web-tree-sitter` | `0.26.9` | Tree-sitter runtime |
+
+## Alert classification
+
+| Alert category | Package(s) | Direct / transitive | Decision | Notes |
+| --- | --- | --- | --- | --- |
+| Vulnerable dependency | `protobufjs` via `@huggingface/transformers -> onnxruntime-web` | Transitive | **fix** | `npm audit --omit=dev` originally reported `protobufjs <=7.5.7`. `npm audit fix --omit=dev` updated the lockfile to `protobufjs@7.6.1` and cleared the audit. |
+| Install script | `onnxruntime-node` | Transitive | **needs follow-up** | `onnxruntime-node` runs `node ./script/install` during install and its installer can download missing platform binaries, honoring proxy/env settings. This is part of the semantic stack and is tracked in **#290** because it lands in default installs today. |
+| Install script | `sharp` | Transitive | **needs follow-up** | `sharp` runs an install-time check/build path and brings in optional platform image binaries. This is also part of the semantic/image stack tracked in **#290**. |
+| Install script | `protobufjs` | Transitive | **false positive / scanner noise** | `protobufjs` does have `postinstall`, but the script only inspects nearby `package.json` files and emits a compatibility warning. It does not download code or spawn shells. |
+| Network access | `@huggingface/transformers`, `onnxruntime-node` | Direct + transitive | **acceptable and documented** | `@huggingface/transformers` supports model/hub fetches and `onnxruntime-node` can fetch binaries during install. In Madar this stack is only reached from semantic retrieval/rerank, not from the default lexical path. The install-time part is still tracked in **#290**. |
+| Shell access | `onnxruntime-node`, `sharp` | Transitive | **acceptable and documented** | Both packages use native build / binary-install tooling (`child_process`, `spawnSync`, `pkg-config`, `cmake`). This is expected for native Node dependencies. |
+| Dynamic require | `onnxruntime-node`, `sharp` | Transitive | **acceptable and documented** | These packages dynamically load platform-specific native binaries. This is standard native-addon behavior, not app-level command execution. |
+| Filesystem access | `web-tree-sitter`, `sharp`, `protobufjs` | Direct + transitive | **acceptable and documented** | Madar is a local code-analysis CLI and parser pipeline, so filesystem reads are expected. The transitive packages use local file access for wasm, native binaries, or proto loading helpers. |
+| Environment variable access | `@huggingface/transformers`, `onnxruntime-node`, `sharp` | Direct + transitive | **acceptable and documented** | These packages read env vars for tokens, proxy settings, install flags, or native build configuration. This is expected for local ML/runtime tooling. |
+| Copyleft / non-permissive license | `@img/sharp-libvips-*`, `@img/sharp-win32-*`, `@img/sharp-wasm32` | Transitive optional | **needs follow-up** | These LGPL-bearing packages are optional platform-specific binaries pulled in through `sharp`. They are not direct Madar dependencies, but they do enlarge the default install surface and are tracked in **#290**. |
+| Obfuscated / minified code | `@huggingface/transformers`, `onnxruntime-web`, `neo4j-driver`, `protobufjs` browser/dist bundles | Direct + transitive | **acceptable and documented** | Upstream packages ship minified browser/runtime bundles alongside readable source and non-minified entry points. Madar is not introducing new obfuscated artifacts in its own package. |
+| Eval-like code generation | `@protobufjs/codegen` via `protobufjs` | Transitive | **acceptable and documented** | `@protobufjs/codegen` uses the `Function` constructor to generate fast protobuf encode/decode helpers. This is real code generation, not evidence of hidden remote execution. |
+
+## Why the semantic stack is not part of the default runtime path
+
+Two repo-level checks matter here:
+
+1. `src/runtime/retrieve.ts` returns the lexical result immediately unless `options.semantic === true` or `options.rerank === true`.
+2. `src/runtime/semantic.ts` lazy-loads `@huggingface/transformers` with `await import('@huggingface/transformers')` only inside the semantic helper.
+
+That means normal lexical retrieval does **not** load the transformer/onnx/image stack at runtime. The remaining concern is **install-time** exposure, not default execution.
+
+## Risk posture
+
+### Resolved in this issue
+
+- `protobufjs` audit finding fixed in `package-lock.json`
+- `npm audit --omit=dev` now reports **0 vulnerabilities**
+
+### Acceptable with documentation
+
+- local filesystem access from parser/runtime dependencies
+- env-var and network access in the optional semantic model stack
+- native binary loading / shell usage in `onnxruntime-node` and `sharp`
+- minified upstream bundles and protobuf code-generation helpers
+
+### Still worth follow-up
+
+- default installs still pull the semantic dependency chain even though semantic retrieval is opt-in at runtime
+- optional `sharp` platform binaries bring the LGPL alerts that corporate scanners will keep flagging
+
+Tracked in: **#290 — Make semantic runtime dependencies optional**
+

--- a/docs/security/socket-alerts-0.26.0.md
+++ b/docs/security/socket-alerts-0.26.0.md
@@ -23,7 +23,11 @@ Commands used during triage:
 
 ## Direct production dependencies
 
-| Package | Version | Notes |
+The table below records the resolved versions installed in the reviewed production
+tree (`package-lock.json` / `node_modules`), not the semver ranges declared in
+`package.json`.
+
+| Package | Installed version | Notes |
 | --- | --- | --- |
 | `@huggingface/transformers` | `4.2.0` | Direct dependency; lazy-loaded only from the semantic retrieval path |
 | `@vscode/tree-sitter-wasm` | `0.3.1` | Parser/grammar support |
@@ -79,4 +83,3 @@ That means normal lexical retrieval does **not** load the transformer/onnx/image
 - optional `sharp` platform binaries bring the LGPL alerts that corporate scanners will keep flagging
 
 Tracked in: **#290 — Make semantic runtime dependencies optional**
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "@lubab/madar",
             "version": "0.26.0",
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^4.2.0",
@@ -148,12 +147,6 @@
             "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
             "license": "Apache-2.0"
         },
-        "node_modules/@huggingface/transformers/node_modules/long": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/@huggingface/transformers/node_modules/onnxruntime-common": {
             "version": "1.24.3",
             "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
@@ -196,30 +189,6 @@
             "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
             "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
             "license": "MIT"
-        },
-        "node_modules/@huggingface/transformers/node_modules/protobufjs": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
-            "hasInstallScript": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.1",
-                "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
         },
         "node_modules/@huggingface/transformers/node_modules/sharp": {
             "version": "0.34.5",
@@ -800,19 +769,18 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
@@ -822,9 +790,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1944,6 +1912,12 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2110,6 +2084,30 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/protobufjs": {
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+            "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.2",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
+                "@types/node": ">=13.7.0",
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/roarr": {


### PR DESCRIPTION
Closes #285
Refs #290

## Summary
- fix the transitive `protobufjs` audit finding by refreshing the production lockfile
- add `docs/security/socket-alerts-0.26.0.md` with per-alert triage decisions for the 0.26.0 package surface
- open and reference follow-up issue #290 to make semantic runtime dependencies optional

## Verification
- npm audit --omit=dev
- npm pack --dry-run
- npm run typecheck
- npm run build
- CI=1 npm run test:run
