### PR TITLE
Add workflow-center scoring to implementation packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ When the agent says "tell me more," it expands a stable `handle_id` inside the s
 
 `madar pack` now emits a stable **Pack Schema v1** envelope around the compiled evidence bundle. In JSON mode (`--format json`), the response includes `schema_version`, `task`, `task_intent`, `workflow_centers`, `recommended_first_read`, `likely_edit_files`, `likely_test_files`, `public_contracts`, `risk_boundaries`, `validation_commands`, `negative_guidance`, `confidence_score`, and `why_explanation`, alongside the existing `pack`, `coverage`, and planner metadata.
 
+For `--task implement`, `workflow_centers` are scored workflow-owner candidates with a `path`, numeric `score`, and structural `reasons`, so orchestration files can outrank lexically louder helpers when the brief recommends where to start editing.
+
 Use `--format json` when another tool or script will consume the pack directly. Use `--format text` when you want the same schema rendered as a short human/agent-readable execution brief.
 
 ### Adaptive context-pack representations

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -203,6 +203,7 @@ export interface ImplementationPackRuntimeContext {
 
 export interface ImplementationPackGuidance {
   summary: string
+  workflow_centers: ContextPackWorkflowCenter[]
   likely_edit_files: ImplementationPackFileHint[]
   likely_test_files: ImplementationPackFileHint[]
   contracts_and_public_surfaces: ImplementationPackSurfaceHint[]
@@ -217,6 +218,10 @@ export interface ImplementationPackGuidance {
 export interface ContextPackWorkflowCenter {
   label: string
   node_count?: number
+  path?: string
+  score?: number
+  reasons?: string[]
+  matched_symbols?: string[]
   reason: string
 }
 

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -247,6 +247,7 @@ function workflowCenters(
   task: TaskContextPlan['task_kind'],
   pack: PackPayload,
   plan: TaskContextPlan,
+  implementation?: ImplementationPackGuidance,
 ): ContextPackWorkflowCenter[] {
   const fromCommunityContext = (
     entries: Array<{ label: string; node_count?: number }>,
@@ -256,6 +257,10 @@ function workflowCenters(
     ...(typeof entry.node_count === 'number' ? { node_count: entry.node_count } : {}),
     reason,
   }))
+
+  if (task === 'implement' && implementation?.workflow_centers.length) {
+    return implementation.workflow_centers.slice(0, 4)
+  }
 
   if (
     (task === 'review' || task === 'impact')
@@ -478,7 +483,7 @@ function buildPackSchemaV1<TPack extends PackPayload>(
     target?: string
   },
 ): PackSchemaEnvelope<TPack> {
-  const centers = workflowCenters(response.task, response.pack, response.plan)
+  const centers = workflowCenters(response.task, response.pack, response.plan, response.implementation)
   const firstRead = recommendedFirstRead(response.task, response.pack, response.implementation)
   const contracts = publicContracts(response.implementation)
   const guidance = negativeGuidance(response.coverage, response.pack, response.implementation)
@@ -529,7 +534,13 @@ function renderPackSchemaText(schema: PackSchemaEnvelope): string {
     `Graph path: ${schema.graph_path}`,
     `Confidence score: ${schema.confidence_score.toFixed(2)}`,
     '',
-    ...renderTextSection('Workflow centers', schema.workflow_centers.map((entry) => `- ${entry.label}: ${entry.reason}`)),
+    ...renderTextSection('Workflow centers', schema.workflow_centers.map((entry) => {
+      const location = entry.path
+        ? `${entry.path}${typeof entry.score === 'number' ? ` [${entry.score.toFixed(2)}]` : ''}`
+        : entry.label
+      const label = entry.path && entry.label !== entry.path ? ` (${entry.label})` : ''
+      return `- ${location}${label}: ${entry.reason}`
+    })),
     ...renderTextSection('Recommended first read', schema.recommended_first_read.map((entry) => formatFileHint(entry.path, entry.reason, entry.label))),
     ...renderTextSection('Likely edit files', schema.likely_edit_files.map((entry) => formatFileHint(entry.path, entry.why, entry.matched_symbols[0]))),
     ...renderTextSection('Likely test files', schema.likely_test_files.map((entry) => formatFileHint(entry.path, entry.why, entry.matched_symbols[0]))),

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type {
   ContextPackExecutionSlice,
   ContextPackRuntimeGenerationAnswerContract,
+  ContextPackWorkflowCenter,
   ImplementationPackFileHint,
   ImplementationPackGuidance,
   ImplementationPackRiskBoundary,
@@ -20,6 +21,10 @@ const CONTRACT_PATH_PATTERN = /(?:^|\/)(?:contracts?|schemas?|dto|types?|interfa
 const CONTRACT_NODE_KINDS = new Set(['interface', 'type', 'type_alias', 'typealias', 'enum', 'schema', 'contract'])
 const PUBLIC_SURFACE_NODE_KINDS = new Set(['route', 'router', 'controller', 'page', 'layout', 'middleware'])
 const PUBLIC_SURFACE_PATH_PATTERN = /(?:^|\/)(?:cli|stdio)(?:\/|$)|(?:^|\/)(?:http-server|definitions)\.ts$|(?:^|\/)(?:routes?|controllers?|interface\/http)(?:\/|$)/i
+const WORKFLOW_OWNER_PATTERN = /(?:service|controller|handler|worker|queue|job|workflow|orchestrator|planner|command|route|router|processor|consumer|producer|pipeline)/i
+const HELPER_PATTERN = /(?:helper|util|format|formatter|presenter|serializer|mapper|constant|type|schema|dto)/i
+const SIDE_EFFECT_PATTERN = /(?:save|create|update|delete|persist|write|enqueue|publish|dispatch|emit|send|store|cache|repository|queue|session|database|db)/i
+const WORKFLOW_EDGE_RELATIONS = new Set(['calls', 'controller_route', 'depends_on', 'imports_from', 'enqueues_job'])
 
 type PackageScripts = Record<string, string>
 
@@ -35,10 +40,420 @@ interface FileAggregate {
   related_symbols: string[]
 }
 
+interface WorkflowNodeCandidate {
+  node_id: string
+  label: string
+  source_file: string
+  node_kind?: string
+  framework_role?: string
+  match_score: number
+  relevance_band: 'direct' | 'related'
+}
+
+interface WorkflowScoreDetails {
+  score: number
+  reasons: string[]
+  helperLike: boolean
+}
+
+interface WorkflowCenterAggregate {
+  path: string
+  label: string
+  score: number
+  direct_matches: number
+  matched_symbols: string[]
+  reasons: string[]
+  reasonSet: Set<string>
+  matchedSymbolSet: Set<string>
+  bestNodeScore: number
+  bestNonHelperLabel?: string
+  bestNonHelperScore: number
+}
+
 function rootPathFromGraph(graph: KnowledgeGraph): string | undefined {
   return typeof graph.graph.root_path === 'string' && graph.graph.root_path.trim().length > 0
     ? graph.graph.root_path.trim()
     : undefined
+}
+
+function pushUnique(values: string[], seen: Set<string>, value: string | undefined): void {
+  if (!value || value.length === 0 || seen.has(value)) {
+    return
+  }
+  seen.add(value)
+  values.push(value)
+}
+
+function isWorkflowEntryPoint(node: {
+  label?: string
+  source_file: string
+  node_kind?: string
+  framework_role?: string
+}): boolean {
+  const nodeKind = node.node_kind?.toLowerCase() ?? ''
+  const frameworkRole = node.framework_role?.toLowerCase() ?? ''
+  return PUBLIC_SURFACE_NODE_KINDS.has(nodeKind)
+    || frameworkRole.includes('route')
+    || frameworkRole.includes('controller')
+    || frameworkRole.includes('page')
+    || frameworkRole.includes('layout')
+    || frameworkRole.includes('middleware')
+    || frameworkRole.includes('handler')
+    || PUBLIC_SURFACE_PATH_PATTERN.test(node.source_file)
+    || /(?:^|\/)[^/]*(?:route|router|controller|handler)\.[^/]+$/i.test(node.source_file)
+}
+
+function graphNodeFile(graph: KnowledgeGraph, nodeId: string): string {
+  return String(graph.nodeAttributes(nodeId).source_file ?? '')
+}
+
+function classifyWorkflowDomain(graph: KnowledgeGraph, nodeId: string, rootPath?: string): ReturnType<typeof classifySourceDomain> {
+  return classifySourceDomain(graphNodeFile(graph, nodeId), rootPath)
+}
+
+function graphRelation(graph: KnowledgeGraph, sourceId: string, targetId: string): string {
+  return String(graph.edgeAttributes(sourceId, targetId).relation ?? '')
+}
+
+function workflowCandidates(
+  graph: KnowledgeGraph,
+  retrieval: RetrieveResult,
+  rootPath?: string,
+): WorkflowNodeCandidate[] {
+  const byNodeId = new Map<string, WorkflowNodeCandidate>()
+
+  for (const node of retrieval.matched_nodes) {
+    if (!node.node_id || node.relevance_band === 'peripheral') {
+      continue
+    }
+    const sourceDomain = classifySourceDomain(node.source_file, rootPath)
+    if (sourceDomain === 'test' || sourceDomain === 'docs' || sourceDomain === 'build_artifact') {
+      continue
+    }
+    byNodeId.set(node.node_id, {
+      node_id: node.node_id,
+      label: node.label,
+      source_file: node.source_file,
+      ...(node.node_kind ? { node_kind: node.node_kind } : {}),
+      ...(node.framework_role ? { framework_role: node.framework_role } : {}),
+      match_score: node.match_score,
+      relevance_band: node.relevance_band === 'direct' ? 'direct' : 'related',
+    })
+  }
+
+  for (const node of retrieval.matched_nodes) {
+    if (!node.node_id || node.relevance_band !== 'direct') {
+      continue
+    }
+
+    for (const predecessorId of graph.predecessors(node.node_id)) {
+      const relation = graphRelation(graph, predecessorId, node.node_id)
+      if (!WORKFLOW_EDGE_RELATIONS.has(relation) || byNodeId.has(predecessorId)) {
+        continue
+      }
+      if (classifyWorkflowDomain(graph, predecessorId, rootPath) !== 'production') {
+        continue
+      }
+      const attributes = graph.nodeAttributes(predecessorId)
+      byNodeId.set(predecessorId, {
+        node_id: predecessorId,
+        label: String(attributes.label ?? predecessorId),
+        source_file: String(attributes.source_file ?? ''),
+        ...(attributes.node_kind ? { node_kind: String(attributes.node_kind) } : {}),
+        ...(attributes.framework_role ? { framework_role: String(attributes.framework_role) } : {}),
+        match_score: Math.max(0.1, node.match_score * 0.35),
+        relevance_band: 'related',
+      })
+    }
+
+    for (const successorId of graph.successors(node.node_id)) {
+      const relation = graphRelation(graph, node.node_id, successorId)
+      if (!WORKFLOW_EDGE_RELATIONS.has(relation) || byNodeId.has(successorId)) {
+        continue
+      }
+      if (classifyWorkflowDomain(graph, successorId, rootPath) !== 'production') {
+        continue
+      }
+      const attributes = graph.nodeAttributes(successorId)
+      byNodeId.set(successorId, {
+        node_id: successorId,
+        label: String(attributes.label ?? successorId),
+        source_file: String(attributes.source_file ?? ''),
+        ...(attributes.node_kind ? { node_kind: String(attributes.node_kind) } : {}),
+        ...(attributes.framework_role ? { framework_role: String(attributes.framework_role) } : {}),
+        match_score: Math.max(0.1, node.match_score * 0.25),
+        relevance_band: 'related',
+      })
+    }
+  }
+
+  return [...byNodeId.values()]
+}
+
+function nearestEntryPointDistance(
+  graph: KnowledgeGraph,
+  nodeId: string,
+  rootPath?: string,
+  maxHops = 3,
+): number | null {
+  const queue = [{ nodeId, distance: 0 }]
+  const seen = new Set<string>()
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current || seen.has(current.nodeId)) {
+      continue
+    }
+    seen.add(current.nodeId)
+
+    const attributes = graph.nodeAttributes(current.nodeId)
+    if (isWorkflowEntryPoint({
+      label: String(attributes.label ?? current.nodeId),
+      source_file: String(attributes.source_file ?? ''),
+      ...(attributes.node_kind ? { node_kind: String(attributes.node_kind) } : {}),
+      ...(attributes.framework_role ? { framework_role: String(attributes.framework_role) } : {}),
+    })) {
+      return current.distance
+    }
+
+    if (current.distance >= maxHops) {
+      continue
+    }
+
+    for (const predecessorId of graph.predecessors(current.nodeId)) {
+      const relation = graphRelation(graph, predecessorId, current.nodeId)
+      if (!WORKFLOW_EDGE_RELATIONS.has(relation) || classifyWorkflowDomain(graph, predecessorId, rootPath) !== 'production') {
+        continue
+      }
+      queue.push({ nodeId: predecessorId, distance: current.distance + 1 })
+    }
+  }
+
+  return null
+}
+
+function nonTestDegrees(
+  graph: KnowledgeGraph,
+  nodeId: string,
+  rootPath?: string,
+): { incoming: number; outgoing: number; coveredByTests: number; sideEffectTargets: string[] } {
+  let incoming = 0
+  let outgoing = 0
+  let coveredByTests = 0
+  const sideEffectTargets: string[] = []
+  const seenSideEffects = new Set<string>()
+
+  for (const predecessorId of graph.predecessors(nodeId)) {
+    const relation = graphRelation(graph, predecessorId, nodeId)
+    if (relation === 'covered_by') {
+      continue
+    }
+    if (classifyWorkflowDomain(graph, predecessorId, rootPath) !== 'production') {
+      continue
+    }
+    incoming += 1
+  }
+
+  for (const successorId of graph.successors(nodeId)) {
+    const relation = graphRelation(graph, nodeId, successorId)
+    const successorAttributes = graph.nodeAttributes(successorId)
+    const successorLabel = String(successorAttributes.label ?? successorId)
+    const successorFile = String(successorAttributes.source_file ?? '')
+    const successorDomain = classifySourceDomain(successorFile, rootPath)
+    if (relation === 'covered_by') {
+      if (successorDomain === 'test') {
+        coveredByTests += 1
+      }
+      continue
+    }
+    if (successorDomain !== 'production') {
+      continue
+    }
+    outgoing += 1
+    if (
+      SIDE_EFFECT_PATTERN.test(relation)
+      || SIDE_EFFECT_PATTERN.test(successorLabel)
+      || SIDE_EFFECT_PATTERN.test(successorFile)
+    ) {
+      pushUnique(sideEffectTargets, seenSideEffects, successorLabel)
+    }
+  }
+
+  return { incoming, outgoing, coveredByTests, sideEffectTargets }
+}
+
+function scoreWorkflowCandidate(
+  graph: KnowledgeGraph,
+  candidate: WorkflowNodeCandidate,
+  rootPath?: string,
+): WorkflowScoreDetails {
+  const reasons: string[] = []
+  let score = candidate.match_score * 0.75
+
+  if (candidate.relevance_band === 'direct') {
+    score += 0.75
+    reasons.push('Direct task evidence anchors this file in the implementation brief.')
+  }
+
+  const entryPointDistance = nearestEntryPointDistance(graph, candidate.node_id, rootPath)
+  if (entryPointDistance === 0) {
+    score += 6
+    reasons.push('Owns the route/controller entry point for the workflow.')
+  } else if (entryPointDistance === 1) {
+    score += 5
+    reasons.push('One hop from the route/controller entry point.')
+  } else if (entryPointDistance === 2) {
+    score += 3.5
+    reasons.push('Sits close to the route/controller chain that starts the flow.')
+  } else if (entryPointDistance === 3) {
+    score += 2
+    reasons.push('Still structurally close to the main workflow entry path.')
+  }
+
+  const workflowOwnerLabel = `${candidate.label} ${candidate.source_file} ${candidate.node_kind ?? ''} ${candidate.framework_role ?? ''}`
+  if (WORKFLOW_OWNER_PATTERN.test(workflowOwnerLabel)) {
+    score += 2.5
+    reasons.push('Looks like a workflow-owning surface such as a service, controller, worker, queue, or command.')
+  }
+
+  const degrees = nonTestDegrees(graph, candidate.node_id, rootPath)
+  if (degrees.incoming > 0 || degrees.outgoing > 0) {
+    score += Math.min(4, (degrees.incoming * 0.8) + (degrees.outgoing * 1.1))
+    if (degrees.incoming > 0 && degrees.outgoing > 0) {
+      reasons.push(`Call-graph centrality shows fan-in ${degrees.incoming} and fan-out ${degrees.outgoing}.`)
+    } else if (degrees.outgoing > 0) {
+      reasons.push(`Fan-out ${degrees.outgoing} suggests this node orchestrates downstream work.`)
+    } else {
+      reasons.push(`Fan-in ${degrees.incoming} shows multiple upstream callers converge here.`)
+    }
+  }
+
+  if (degrees.sideEffectTargets.length > 0) {
+    score += 2.5
+    reasons.push(`Touches side-effect boundaries via ${degrees.sideEffectTargets.slice(0, 2).join(' and ')}.`)
+  }
+
+  if (degrees.coveredByTests > 0) {
+    score += 1
+    reasons.push('Covered by nearby tests, which makes it a strong edit-and-validate anchor.')
+  }
+
+  const helperLike = HELPER_PATTERN.test(workflowOwnerLabel)
+  if (helperLike && entryPointDistance === null && degrees.outgoing <= 1 && degrees.sideEffectTargets.length === 0) {
+    score -= 3.5
+    reasons.push('Mostly looks like a leaf helper rather than the owning workflow surface.')
+  }
+
+  return { score, reasons, helperLike }
+}
+
+function workflowCenters(
+  graph: KnowledgeGraph,
+  retrieval: RetrieveResult,
+  rootPath: string | undefined,
+  limit: number,
+): ContextPackWorkflowCenter[] {
+  const centers = new Map<string, WorkflowCenterAggregate>()
+
+  for (const candidate of workflowCandidates(graph, retrieval, rootPath)) {
+    const path = relativizeSourceFile(candidate.source_file, rootPath)
+    const scoreDetails = scoreWorkflowCandidate(graph, candidate, rootPath)
+    const current = centers.get(path) ?? {
+      path,
+      label: candidate.label,
+      score: 0,
+      direct_matches: 0,
+      matched_symbols: [],
+      reasons: [],
+      reasonSet: new Set<string>(),
+      matchedSymbolSet: new Set<string>(),
+      bestNodeScore: Number.NEGATIVE_INFINITY,
+      bestNonHelperScore: Number.NEGATIVE_INFINITY,
+    }
+
+    current.score += scoreDetails.score
+    if (candidate.relevance_band === 'direct') {
+      current.direct_matches += 1
+    }
+    pushUnique(current.matched_symbols, current.matchedSymbolSet, candidate.label)
+    for (const reason of scoreDetails.reasons) {
+      pushUnique(current.reasons, current.reasonSet, reason)
+    }
+    const scoreDelta = scoreDetails.score - current.bestNodeScore
+    if (scoreDelta > 1e-9 || (Math.abs(scoreDelta) <= 1e-9 && !scoreDetails.helperLike)) {
+      current.bestNodeScore = scoreDetails.score
+      current.label = candidate.label
+    }
+    if (!scoreDetails.helperLike && scoreDetails.score > current.bestNonHelperScore) {
+      current.bestNonHelperScore = scoreDetails.score
+      current.bestNonHelperLabel = candidate.label
+    }
+    centers.set(path, current)
+  }
+
+  return [...centers.values()]
+    .map((entry) => {
+      if (entry.direct_matches > 1) {
+        entry.score += 0.5
+        pushUnique(entry.reasons, entry.reasonSet, `Multiple direct matches converge in ${entry.path}.`)
+      }
+      const reason = entry.reasons.slice(0, 3).join(' ')
+      return {
+        label: entry.bestNonHelperLabel ?? entry.label,
+        path: entry.path,
+        score: Math.round(entry.score * 100) / 100,
+        reasons: entry.reasons.slice(0, 4),
+        matched_symbols: entry.matched_symbols,
+        reason: reason.length > 0 ? reason : 'Structural and lexical signals both point to this file.',
+      } satisfies ContextPackWorkflowCenter
+    })
+    .sort((left, right) => (right.score ?? 0) - (left.score ?? 0)
+      || (right.reasons?.length ?? 0) - (left.reasons?.length ?? 0)
+      || left.path!.localeCompare(right.path!))
+    .slice(0, limit)
+}
+
+function mergeLikelyEditFiles(
+  workflowCentersValue: readonly ContextPackWorkflowCenter[],
+  starterFiles: readonly ImplementationPackFileHint[],
+  limit: number,
+): ImplementationPackFileHint[] {
+  const results: ImplementationPackFileHint[] = []
+  const seen = new Set<string>()
+  const starterByPath = new Map(starterFiles.map((entry) => [entry.path, entry] as const))
+
+  for (const center of workflowCentersValue) {
+    if (!center.path || seen.has(center.path)) {
+      continue
+    }
+    const existing = starterByPath.get(center.path)
+    const matchedSymbols = [...new Set([
+      ...(center.matched_symbols ?? []),
+      ...(existing?.matched_symbols ?? []),
+    ])]
+    results.push({
+      path: center.path,
+      why: center.reason,
+      matched_symbols: matchedSymbols.length > 0 ? matchedSymbols : [center.label],
+    })
+    seen.add(center.path)
+    if (results.length >= limit) {
+      return results
+    }
+  }
+
+  for (const entry of starterFiles) {
+    if (seen.has(entry.path)) {
+      continue
+    }
+    results.push(entry)
+    seen.add(entry.path)
+    if (results.length >= limit) {
+      break
+    }
+  }
+
+  return results
 }
 
 function groupFiles(
@@ -341,14 +756,25 @@ export function buildImplementationPackGuidance(
   options: BuildImplementationPackOptions,
 ): ImplementationPackGuidance {
   const rootPath = rootPathFromGraph(graph)
+  const limit = options.limit ?? 5
   const risk = riskMap(graph, {
     question: retrieval.question,
     budget: options.budget,
-    limit: options.limit ?? 5,
+    limit,
     fileType: 'code',
     taskKind: 'implement',
     taskIntent: options.taskIntent,
   })
+  const workflow_centers = workflowCenters(graph, retrieval, rootPath, limit)
+  const likely_edit_files = mergeLikelyEditFiles(
+    workflow_centers,
+    risk.starter_files.map((entry) => ({
+      path: entry.path,
+      why: entry.why,
+      matched_symbols: entry.matched_symbols,
+    })),
+    limit,
+  )
   const relatedTestNodes = coveredTestNodes(graph, retrieval, rootPath)
   const likely_test_files = groupFiles(
     [
@@ -356,23 +782,20 @@ export function buildImplementationPackGuidance(
       ...relatedTestNodes,
     ],
     rootPath,
-  ).slice(0, options.limit ?? 5)
-  const editPaths = new Set(risk.starter_files.map((entry) => entry.path))
+  ).slice(0, limit)
+  const editPaths = new Set(likely_edit_files.map((entry) => entry.path))
   const { contracts_and_public_surfaces, existing_patterns } = buildSurfaceHints(retrieval, editPaths, rootPath)
   const validation = validationCommands(rootPath, likely_test_files)
   const risk_boundaries: ImplementationPackRiskBoundary[] = risk.top_risks
-  const summary = risk.starter_files[0]
-    ? `Start with ${risk.starter_files[0].path}, then validate the highest-risk shared boundaries before finishing.`
+  const summary = likely_edit_files[0]
+    ? `Start with ${likely_edit_files[0].path}, then validate the highest-risk shared boundaries before finishing.`
     : risk.summary
   const runtimeContextIfRelevant = runtimeContext(retrieval.execution_slice, retrieval.answer_contract)
 
   return {
     summary,
-    likely_edit_files: risk.starter_files.slice(0, options.limit ?? 5).map((entry) => ({
-      path: entry.path,
-      why: entry.why,
-      matched_symbols: entry.matched_symbols,
-    })),
+    workflow_centers,
+    likely_edit_files,
     likely_test_files,
     contracts_and_public_surfaces,
     existing_patterns,
@@ -380,7 +803,7 @@ export function buildImplementationPackGuidance(
     validation_commands: validation.commands,
     acceptance_criteria_summary: acceptanceCriteriaSummary(
       retrieval.question,
-      risk.starter_files,
+      likely_edit_files,
       likely_test_files,
       risk_boundaries,
       contracts_and_public_surfaces,

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -619,7 +619,12 @@ describe('context-pack-command', () => {
       schema_version?: number
       task?: string
       task_intent?: string
-      workflow_centers?: Array<{ label?: string }>
+      workflow_centers?: Array<{
+        label?: string
+        path?: string
+        score?: number
+        reasons?: string[]
+      }>
       recommended_first_read?: Array<{ path?: string }>
       likely_edit_files?: Array<{ path?: string }>
       likely_test_files?: Array<{ path?: string }>
@@ -637,7 +642,12 @@ describe('context-pack-command', () => {
       task: 'implement',
       task_intent: 'implement',
       workflow_centers: expect.arrayContaining([
-        expect.objectContaining({ label: expect.any(String) }),
+        expect.objectContaining({
+          label: expect.any(String),
+          path: expect.stringMatching(/^src\//),
+          score: expect.any(Number),
+          reasons: expect.arrayContaining([expect.any(String)]),
+        }),
       ]),
       recommended_first_read: expect.arrayContaining([
         expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts' }),

--- a/tests/unit/implementation-pack.test.ts
+++ b/tests/unit/implementation-pack.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { build } from '../../src/pipeline/build.js'
+import { buildImplementationPackGuidance } from '../../src/runtime/implementation-pack.js'
+
+const tempFixtureRoots: string[] = []
+
+afterEach(() => {
+  while (tempFixtureRoots.length > 0) {
+    const root = tempFixtureRoots.pop()
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+})
+
+function buildWorkflowCenterGraph() {
+  const root = mkdtempSync(join(tmpdir(), 'madar-workflow-center-'))
+  tempFixtureRoots.push(root)
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'madar-workflow-center-fixture',
+    private: true,
+    scripts: {
+      typecheck: 'tsc --noEmit',
+      build: 'tsc -p tsconfig.build.json',
+      'test:run': 'vitest run',
+    },
+  }))
+
+  const graph = build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'invoice_route', label: 'POST /invoices/generate', file_type: 'code', source_file: `${root}/src/http/invoice-routes.ts`, source_location: 'L10', node_kind: 'route', framework: 'express', framework_role: 'express_route', community: 0 },
+          { id: 'invoice_controller', label: 'InvoiceController.generate', file_type: 'code', source_file: `${root}/src/invoices/controller.ts`, source_location: 'L20', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_controller', community: 0 },
+          { id: 'invoice_service', label: 'InvoiceGenerationService.generateInvoice', file_type: 'code', source_file: `${root}/src/invoices/generation-service.ts`, source_location: 'L30', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+          { id: 'invoice_retry_helper', label: 'retryWhenInvoiceGenerationFails', file_type: 'code', source_file: `${root}/src/invoices/retry-helper.ts`, source_location: 'L12', node_kind: 'function', community: 1 },
+          { id: 'invoice_queue', label: 'InvoiceJobQueue.enqueueRetry', file_type: 'code', source_file: `${root}/src/invoices/queue.ts`, source_location: 'L18', node_kind: 'method', community: 2 },
+          { id: 'invoice_repository', label: 'InvoiceRepository.saveRetryRecord', file_type: 'code', source_file: `${root}/src/invoices/repository.ts`, source_location: 'L16', node_kind: 'method', community: 2 },
+          { id: 'invoice_presenter', label: 'formatInvoiceFailureNotice', file_type: 'code', source_file: `${root}/src/invoices/presenter.ts`, source_location: 'L8', node_kind: 'function', community: 3 },
+          { id: 'invoice_service_test', label: 'InvoiceGenerationService.generateInvoice.spec', file_type: 'code', source_file: `${root}/tests/unit/invoice-generation-service.test.ts`, source_location: 'L1', node_kind: 'function', community: 4 },
+        ],
+        edges: [
+          { source: 'invoice_route', target: 'invoice_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: `${root}/src/http/invoice-routes.ts` },
+          { source: 'invoice_controller', target: 'invoice_service', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/controller.ts` },
+          { source: 'invoice_service', target: 'invoice_retry_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/generation-service.ts` },
+          { source: 'invoice_service', target: 'invoice_queue', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/generation-service.ts` },
+          { source: 'invoice_service', target: 'invoice_repository', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/generation-service.ts` },
+          { source: 'invoice_service', target: 'invoice_presenter', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/generation-service.ts` },
+          { source: 'invoice_service', target: 'invoice_service_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/generation-service.ts` },
+          { source: 'invoice_queue', target: 'invoice_repository', relation: 'enqueues_job', confidence: 'EXTRACTED', source_file: `${root}/src/invoices/queue.ts` },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+
+  graph.graph.root_path = root
+  return graph
+}
+
+describe('buildImplementationPackGuidance workflow-center scoring (#295)', () => {
+  it('ranks the workflow owner above a lexically stronger helper', () => {
+    const graph = buildWorkflowCenterGraph()
+    const retrieval = {
+      question: 'add retry when invoice generation fails',
+      token_count: 180,
+      matched_nodes: [
+        {
+          node_id: 'invoice_retry_helper',
+          label: 'retryWhenInvoiceGenerationFails',
+          source_file: `${graph.graph.root_path}/src/invoices/retry-helper.ts`,
+          line_number: 12,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'export function retryWhenInvoiceGenerationFails() {}',
+          match_score: 0.98,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Invoice workflow',
+        },
+        {
+          node_id: 'invoice_service',
+          label: 'InvoiceGenerationService.generateInvoice',
+          source_file: `${graph.graph.root_path}/src/invoices/generation-service.ts`,
+          line_number: 30,
+          node_kind: 'method',
+          framework_role: 'nest_provider',
+          file_type: 'code',
+          snippet: 'export class InvoiceGenerationService { async generateInvoice() {} }',
+          match_score: 0.62,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Invoice workflow',
+        },
+        {
+          node_id: 'invoice_controller',
+          label: 'InvoiceController.generate',
+          source_file: `${graph.graph.root_path}/src/invoices/controller.ts`,
+          line_number: 20,
+          node_kind: 'method',
+          framework_role: 'nest_controller',
+          file_type: 'code',
+          snippet: 'export class InvoiceController { async generate() {} }',
+          match_score: 0.58,
+          relevance_band: 'related' as const,
+          community: 0,
+          community_label: 'HTTP surface',
+        },
+        {
+          node_id: 'invoice_route',
+          label: 'POST /invoices/generate',
+          source_file: `${graph.graph.root_path}/src/http/invoice-routes.ts`,
+          line_number: 10,
+          node_kind: 'route',
+          framework_role: 'express_route',
+          file_type: 'code',
+          snippet: 'router.post("/invoices/generate", controller.generate)',
+          match_score: 0.41,
+          relevance_band: 'related' as const,
+          community: 0,
+          community_label: 'HTTP surface',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['contracts', 'configuration', 'tests', 'impact'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 2400,
+      taskIntent: 'implement',
+    })
+
+    expect(guidance.workflow_centers[0]).toEqual(expect.objectContaining({
+      label: 'InvoiceGenerationService.generateInvoice',
+      path: 'src/invoices/generation-service.ts',
+      score: expect.any(Number),
+      reasons: expect.arrayContaining([
+        expect.stringMatching(/entry point|route|controller/i),
+        expect.stringMatching(/fan-in|fan-out|call graph|central/i),
+      ]),
+    }))
+    expect(guidance.workflow_centers[0]!.score ?? 0).toBeGreaterThan(guidance.workflow_centers[1]!.score ?? 0)
+    expect(guidance.likely_edit_files[0]).toEqual(expect.objectContaining({
+      path: 'src/invoices/generation-service.ts',
+    }))
+    expect(guidance.likely_edit_files[0]!.path).not.toBe('src/invoices/retry-helper.ts')
+  })
+
+  it('keeps the workflow-owner label when a helper ties inside the same file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-workflow-center-tie-'))
+    tempFixtureRoots.push(root)
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'madar-workflow-center-tie-fixture',
+      private: true,
+      scripts: {
+        typecheck: 'tsc --noEmit',
+        build: 'tsc -p tsconfig.build.json',
+        'test:run': 'vitest run',
+      },
+    }))
+
+    const graph = build(
+      [
+        {
+          schema_version: 1,
+          nodes: [
+            { id: 'workflow_owner', label: 'InvoiceWorkflow.run', file_type: 'code', source_file: `${root}/src/invoices/billing.ts`, source_location: 'L10', node_kind: 'function', community: 1 },
+            { id: 'workflow_helper', label: 'formatInvoiceRetryMessage', file_type: 'code', source_file: `${root}/src/invoices/billing.ts`, source_location: 'L30', node_kind: 'function', community: 1 },
+          ],
+          edges: [],
+        },
+      ],
+      { directed: true },
+    )
+    graph.graph.root_path = root
+
+    const retrieval = {
+      question: 'update invoice retry workflow',
+      token_count: 80,
+      matched_nodes: [
+        {
+          node_id: 'workflow_owner',
+          label: 'InvoiceWorkflow.run',
+          source_file: `${root}/src/invoices/billing.ts`,
+          line_number: 10,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'export function InvoiceWorkflowRun() {}',
+          match_score: 0.8,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Invoice workflow',
+        },
+        {
+          node_id: 'workflow_helper',
+          label: 'formatInvoiceRetryMessage',
+          source_file: `${root}/src/invoices/billing.ts`,
+          line_number: 30,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'export function formatInvoiceRetryMessage() {}',
+          match_score: 8.8,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Invoice workflow',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary'] as const,
+        semantic_required: ['implementation'] as const,
+        semantic_optional: [] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 1200,
+      taskIntent: 'implement',
+    })
+
+    expect(guidance.workflow_centers[0]).toEqual(expect.objectContaining({
+      label: 'InvoiceWorkflow.run',
+      path: 'src/invoices/billing.ts',
+    }))
+    expect(guidance.workflow_centers[0]!.matched_symbols).toEqual(expect.arrayContaining([
+      'InvoiceWorkflow.run',
+      'formatInvoiceRetryMessage',
+    ]))
+  })
+})


### PR DESCRIPTION
## Summary
- add structural workflow-center scoring for implementation packs so owner files rank ahead of helper-heavy lexical matches
- expose scored workflow centers in Pack Schema v1 JSON/text output and use them to order likely edit files
- add regression coverage for helper-vs-owner ranking, same-file helper ties, and implement-pack schema output

Closes #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow center detection now intelligently ranks suggested files by relevance, prioritizing orchestration files over helper utilities.
  * Enhanced output displays file paths and confidence scores for recommended edit starting points.

* **Documentation**
  * Updated schema documentation to clarify workflow center prioritization and scoring behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->