### PR TITLE
Score likely edit and test files in packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ When the agent says "tell me more," it expands a stable `handle_id` inside the s
 
 For `--task implement`, `workflow_centers` are scored workflow-owner candidates with a `path`, numeric `score`, and structural `reasons`, so orchestration files can outrank lexically louder helpers when the brief recommends where to start editing.
 
+The implement brief also keeps `recommended_first_read` separate from ranked `likely_edit_files` and `likely_test_files`. The edit/test sections now carry explicit `score` and `reason` fields so agents can tell orientation reads apart from the files most likely to change or validate.
+
 Use `--format json` when another tool or script will consume the pack directly. Use `--format text` when you want the same schema rendered as a short human/agent-readable execution brief.
 
 ### Adaptive context-pack representations

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -175,7 +175,9 @@ export interface ContextPackRuntimeGenerationAnswerContract {
 
 export interface ImplementationPackFileHint {
   path: string
-  why: string
+  score: number
+  reason: string
+  why?: string
   matched_symbols: string[]
 }
 

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -292,11 +292,44 @@ function recommendedFirstRead(
   pack: PackPayload,
   implementation?: ImplementationPackGuidance,
 ): ContextPackRecommendedFirstRead[] {
+  if (task === 'implement' && implementation) {
+    const reads: ContextPackRecommendedFirstRead[] = []
+    const seen = new Set<string>()
+    const pushRead = (path: string, reason: string, label?: string) => {
+      if (seen.has(path) || reads.length >= 3) {
+        return
+      }
+      seen.add(path)
+      reads.push({
+        path,
+        ...(label ? { label } : {}),
+        reason,
+      })
+    }
+
+    for (const entry of implementation.contracts_and_public_surfaces.filter((item) => item.kind === 'public_surface')) {
+      pushRead(entry.source_file, entry.why, entry.label)
+    }
+    for (const entry of implementation.contracts_and_public_surfaces.filter((item) => item.kind === 'contract')) {
+      pushRead(entry.source_file, entry.why, entry.label)
+    }
+    for (const entry of implementation.existing_patterns) {
+      pushRead(entry.source_file, entry.why, entry.label)
+    }
+    for (const entry of implementation.likely_edit_files) {
+      pushRead(entry.path, entry.reason, entry.matched_symbols[0])
+    }
+
+    if (reads.length > 0) {
+      return reads
+    }
+  }
+
   if (implementation?.likely_edit_files.length) {
     return implementation.likely_edit_files.slice(0, 3).map((entry) => ({
       path: entry.path,
       ...(entry.matched_symbols[0] ? { label: entry.matched_symbols[0] } : {}),
-      reason: entry.why,
+      reason: entry.reason,
     }))
   }
 
@@ -469,6 +502,9 @@ function whyExplanation(
     firstRead[0]
       ? `Start with ${firstRead[0].path} because ${firstRead[0].reason.toLowerCase()}`
       : 'No first-read anchor was available, so the brief leaves that section intentionally empty.',
+    ...(implementation && implementation.likely_test_files.length === 0
+      ? ['No related tests were identified, so the brief keeps a manual validation caution visible.']
+      : []),
     `Confidence ${score.toFixed(2)} from ${requiredCovered}/${requiredEntries.length || 0} required evidence classes and ${semanticCovered}/${semanticEntries.length || 0} required semantic categories covered.`,
   ]
 
@@ -524,6 +560,10 @@ function formatFileHint(path: string, reason: string, label?: string): string {
   return `- ${path}${label ? ` (${label})` : ''}: ${reason}`
 }
 
+function formatScoredFileHint(entry: { path: string; score: number; reason: string; matched_symbols: string[] }): string {
+  return `- ${entry.path} [${entry.score.toFixed(2)}]${entry.matched_symbols[0] ? ` (${entry.matched_symbols[0]})` : ''}: ${entry.reason}`
+}
+
 function renderPackSchemaText(schema: PackSchemaEnvelope): string {
   const lines = [
     'Pack Schema v1',
@@ -542,8 +582,8 @@ function renderPackSchemaText(schema: PackSchemaEnvelope): string {
       return `- ${location}${label}: ${entry.reason}`
     })),
     ...renderTextSection('Recommended first read', schema.recommended_first_read.map((entry) => formatFileHint(entry.path, entry.reason, entry.label))),
-    ...renderTextSection('Likely edit files', schema.likely_edit_files.map((entry) => formatFileHint(entry.path, entry.why, entry.matched_symbols[0]))),
-    ...renderTextSection('Likely test files', schema.likely_test_files.map((entry) => formatFileHint(entry.path, entry.why, entry.matched_symbols[0]))),
+    ...renderTextSection('Likely edit files', schema.likely_edit_files.map((entry) => formatScoredFileHint(entry))),
+    ...renderTextSection('Likely test files', schema.likely_test_files.map((entry) => formatScoredFileHint(entry))),
     ...renderTextSection('Public contracts', schema.public_contracts.map((entry) => `- ${entry.source_file}:${entry.line_number} (${entry.kind}) ${entry.label} — ${entry.why}`)),
     ...renderTextSection('Risk boundaries', schema.risk_boundaries.map((entry) => `- ${entry.label} [${entry.severity}]: ${entry.reason}`)),
     ...renderTextSection('Validation commands', schema.validation_commands.map((entry) => `- ${entry}`)),

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import type {
   ContextPackExecutionSlice,
@@ -25,6 +25,13 @@ const WORKFLOW_OWNER_PATTERN = /(?:service|controller|handler|worker|queue|job|w
 const HELPER_PATTERN = /(?:helper|util|format|formatter|presenter|serializer|mapper|constant|type|schema|dto)/i
 const SIDE_EFFECT_PATTERN = /(?:save|create|update|delete|persist|write|enqueue|publish|dispatch|emit|send|store|cache|repository|queue|session|database|db)/i
 const WORKFLOW_EDGE_RELATIONS = new Set(['calls', 'controller_route', 'depends_on', 'imports_from', 'enqueues_job'])
+const TEST_EDIT_PATTERN = /\b(?:add|update|modify|change|fix|write|edit|refactor|rename|remove)\b.{0,24}\b(?:test|tests|spec|specs|e2e|integration)\b|\b(?:test|tests|spec|specs|e2e|integration)\b.{0,24}\b(?:add|update|modify|change|fix|write|edit|refactor|rename|remove)\b/i
+const E2E_TEST_PATTERN = /(?:^|\/)(?:e2e|integration)(?:\/|$)|\.(?:e2e|integration)\.[^/]+$/i
+const GENERIC_MODULE_TOKENS = new Set([
+  'src', 'test', 'tests', 'unit', 'spec', 'specs', 'e2e', 'integration',
+  'app', 'apps', 'lib', 'libs', 'packages', 'package', 'modules', 'module',
+  'feature', 'features', 'http', 'api',
+])
 
 type PackageScripts = Record<string, string>
 
@@ -36,8 +43,27 @@ interface BuildImplementationPackOptions {
 
 interface FileAggregate {
   path: string
+  score: number
   direct_symbols: string[]
   related_symbols: string[]
+}
+
+interface RankedFileAccumulator {
+  path: string
+  score: number
+  matched_symbols: string[]
+  matchedSymbolSet: Set<string>
+  reasons: string[]
+  reasonSet: Set<string>
+}
+
+interface IndexedTestFile {
+  path: string
+  labels: string[]
+  labelSet: Set<string>
+  name_tokens: string[]
+  module_tokens: string[]
+  entry_surface_like: boolean
 }
 
 interface WorkflowNodeCandidate {
@@ -76,12 +102,118 @@ function rootPathFromGraph(graph: KnowledgeGraph): string | undefined {
     : undefined
 }
 
+function roundFileScore(value: number): number {
+  return Math.round(Math.max(0, value) * 100) / 100
+}
+
+function finalizeReason(reason: string): string {
+  const trimmed = reason.trim()
+  if (trimmed.length === 0) {
+    return 'Relevant file for this task.'
+  }
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`
+}
+
 function pushUnique(values: string[], seen: Set<string>, value: string | undefined): void {
   if (!value || value.length === 0 || seen.has(value)) {
     return
   }
   seen.add(value)
   values.push(value)
+}
+
+function createImplementationPackFileHint(
+  path: string,
+  score: number,
+  reason: string,
+  matchedSymbols: readonly string[],
+): ImplementationPackFileHint {
+  const finalReason = finalizeReason(reason)
+  return {
+    path,
+    score: roundFileScore(score),
+    reason: finalReason,
+    why: finalReason,
+    matched_symbols: [...new Set(matchedSymbols)],
+  }
+}
+
+function addRankedFileCandidate(
+  target: Map<string, RankedFileAccumulator>,
+  path: string,
+  score: number,
+  reason: string,
+  matchedSymbols: readonly string[],
+): void {
+  const entry = target.get(path) ?? {
+    path,
+    score: 0,
+    matched_symbols: [],
+    matchedSymbolSet: new Set<string>(),
+    reasons: [],
+    reasonSet: new Set<string>(),
+  }
+  entry.score += score
+  pushUnique(entry.reasons, entry.reasonSet, finalizeReason(reason))
+  for (const symbol of matchedSymbols) {
+    pushUnique(entry.matched_symbols, entry.matchedSymbolSet, symbol)
+  }
+  target.set(path, entry)
+}
+
+function rankedFileHints(
+  entries: Iterable<RankedFileAccumulator>,
+  limit: number,
+): ImplementationPackFileHint[] {
+  return [...entries]
+    .sort((left, right) => right.score - left.score
+      || right.reasons.length - left.reasons.length
+      || left.path.localeCompare(right.path))
+    .slice(0, limit)
+    .map((entry) => createImplementationPackFileHint(
+      entry.path,
+      entry.score,
+      entry.reasons[0] ?? 'Relevant file for this task.',
+      entry.matched_symbols,
+    ))
+}
+
+function tokenizePathValue(value: string): string[] {
+  return value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[\s_\\\-./,:;!?'"()[\]{}]+/)
+    .filter((token) => token.length > 1)
+}
+
+function fileNameTokens(path: string): string[] {
+  const fileName = basename(path)
+    .replace(/\.(?:test|spec|e2e|integration)(?=\.[^.]+$)/i, '')
+    .replace(/\.[^.]+$/, '')
+  return tokenizePathValue(fileName)
+}
+
+function moduleTokens(path: string): string[] {
+  return tokenizePathValue(dirname(path))
+    .filter((token) => !GENERIC_MODULE_TOKENS.has(token))
+}
+
+function overlapCount(left: readonly string[], right: readonly string[]): number {
+  if (left.length === 0 || right.length === 0) {
+    return 0
+  }
+  const rightSet = new Set(right)
+  let overlap = 0
+  for (const token of new Set(left)) {
+    if (rightSet.has(token)) {
+      overlap += 1
+    }
+  }
+  return overlap
+}
+
+function taskExplicitlyTargetsTests(question: string): boolean {
+  return TEST_EDIT_PATTERN.test(question)
 }
 
 function isWorkflowEntryPoint(node: {
@@ -416,14 +548,24 @@ function workflowCenters(
 function mergeLikelyEditFiles(
   workflowCentersValue: readonly ContextPackWorkflowCenter[],
   starterFiles: readonly ImplementationPackFileHint[],
+  rootPath: string | undefined,
+  allowTestFiles: boolean,
   limit: number,
 ): ImplementationPackFileHint[] {
   const results: ImplementationPackFileHint[] = []
   const seen = new Set<string>()
-  const starterByPath = new Map(starterFiles.map((entry) => [entry.path, entry] as const))
+  const starterByPath = new Map(
+    starterFiles
+      .filter((entry) => allowTestFiles || classifySourceDomain(entry.path, rootPath) !== 'test')
+      .map((entry) => [entry.path, entry] as const),
+  )
 
   for (const center of workflowCentersValue) {
-    if (!center.path || seen.has(center.path)) {
+    if (
+      !center.path
+      || seen.has(center.path)
+      || (!allowTestFiles && classifySourceDomain(center.path, rootPath) === 'test')
+    ) {
       continue
     }
     const existing = starterByPath.get(center.path)
@@ -433,6 +575,8 @@ function mergeLikelyEditFiles(
     ])]
     results.push({
       path: center.path,
+      score: roundFileScore((center.score ?? 0) + ((existing?.score ?? 0) * 0.25)),
+      reason: center.reason,
       why: center.reason,
       matched_symbols: matchedSymbols.length > 0 ? matchedSymbols : [center.label],
     })
@@ -443,7 +587,7 @@ function mergeLikelyEditFiles(
   }
 
   for (const entry of starterFiles) {
-    if (seen.has(entry.path)) {
+    if (seen.has(entry.path) || (!allowTestFiles && classifySourceDomain(entry.path, rootPath) === 'test')) {
       continue
     }
     results.push(entry)
@@ -470,26 +614,132 @@ function groupFiles(
     const path = relativizeSourceFile(node.source_file, rootPath)
     const existing = byPath.get(path) ?? {
       path,
+      score: 0,
       direct_symbols: [],
       related_symbols: [],
     }
     if (node.relevance_band === 'direct') {
+      existing.score += (node.match_score * 4) + 1
       if (!existing.direct_symbols.includes(node.label)) {
         existing.direct_symbols.push(node.label)
       }
     } else if (!existing.related_symbols.includes(node.label)) {
+      existing.score += (node.match_score * 2) + 0.5
       existing.related_symbols.push(node.label)
     }
     byPath.set(path, existing)
   }
 
-  return [...byPath.values()].map((entry) => ({
-    path: entry.path,
-    why: entry.direct_symbols.length > 0
-      ? `Direct evidence via ${entry.direct_symbols.slice(0, 3).join(', ')}.`
-      : `Supporting context via ${entry.related_symbols.slice(0, 2).join(', ')}.`,
-    matched_symbols: [...entry.direct_symbols, ...entry.related_symbols],
-  }))
+  return [...byPath.values()].map((entry) => {
+    const reason = entry.direct_symbols.length > 0
+      ? `Direct test evidence via ${entry.direct_symbols.slice(0, 3).join(', ')}`
+      : `Supporting test context via ${entry.related_symbols.slice(0, 2).join(', ')}`
+    return createImplementationPackFileHint(
+      entry.path,
+      entry.score,
+      reason,
+      [...entry.direct_symbols, ...entry.related_symbols],
+    )
+  })
+}
+
+function indexTestFiles(graph: KnowledgeGraph, rootPath?: string): IndexedTestFile[] {
+  const byPath = new Map<string, IndexedTestFile>()
+
+  for (const [, attributes] of graph.nodeEntries()) {
+    const sourceFile = String(attributes.source_file ?? '')
+    if (sourceFile.length === 0 || classifySourceDomain(sourceFile, rootPath) !== 'test') {
+      continue
+    }
+
+    const path = relativizeSourceFile(sourceFile, rootPath)
+    const existing = byPath.get(path) ?? {
+      path,
+      labels: [],
+      labelSet: new Set<string>(),
+      name_tokens: fileNameTokens(path),
+      module_tokens: moduleTokens(path),
+      entry_surface_like: E2E_TEST_PATTERN.test(path),
+    }
+    pushUnique(existing.labels, existing.labelSet, String(attributes.label ?? ''))
+    byPath.set(path, existing)
+  }
+
+  return [...byPath.values()]
+}
+
+function likelyTestFiles(
+  graph: KnowledgeGraph,
+  retrieval: RetrieveResult,
+  likelyEditFiles: readonly ImplementationPackFileHint[],
+  rootPath: string | undefined,
+  limit: number,
+): ImplementationPackFileHint[] {
+  const ranked = new Map<string, RankedFileAccumulator>()
+  const directAndCovered = groupFiles(
+    [
+      ...retrieval.matched_nodes.filter((node) => classifySourceDomain(node.source_file, rootPath) === 'test'),
+      ...coveredTestNodes(graph, retrieval, rootPath),
+    ],
+    rootPath,
+  )
+
+  for (const entry of directAndCovered) {
+    addRankedFileCandidate(ranked, entry.path, entry.score, entry.reason, entry.matched_symbols)
+  }
+
+  const indexedTests = indexTestFiles(graph, rootPath)
+  const publicSurfacePaths = retrieval.matched_nodes
+    .filter((node) => classifySourceDomain(node.source_file, rootPath) !== 'test')
+    .filter((node) => isPublicSurfaceNode(node))
+    .map((node) => relativizeSourceFile(node.source_file, rootPath))
+  const publicNameTokens = [...new Set(publicSurfacePaths.flatMap((path) => fileNameTokens(path)))]
+  const publicModuleTokens = [...new Set(publicSurfacePaths.flatMap((path) => moduleTokens(path)))]
+
+  for (const editFile of likelyEditFiles) {
+    const editNameTokens = fileNameTokens(editFile.path)
+    const editModuleTokens = moduleTokens(editFile.path)
+
+    for (const testFile of indexedTests) {
+      const nameOverlap = overlapCount(editNameTokens, testFile.name_tokens)
+      const moduleOverlap = overlapCount(editModuleTokens, testFile.module_tokens)
+      let score = 0
+      const reasons: string[] = []
+
+      if (nameOverlap > 0) {
+        score += 1.5 + (nameOverlap * 0.9)
+        reasons.push(`Naming overlaps with ${editFile.path}`)
+      }
+      if (moduleOverlap > 0) {
+        score += 1 + (moduleOverlap * 0.75)
+        reasons.push(`Lives in the same module area as ${editFile.path}`)
+      }
+      if (testFile.entry_surface_like) {
+        const publicOverlap = overlapCount(publicNameTokens, testFile.name_tokens) + overlapCount(publicModuleTokens, testFile.module_tokens)
+        if (publicOverlap > 0) {
+          score += 2.5
+          reasons.push('E2E/integration coverage sits near the public entry surface for this workflow')
+        }
+      }
+
+      if (score <= 0) {
+        continue
+      }
+
+      addRankedFileCandidate(
+        ranked,
+        testFile.path,
+        score,
+        reasons.join('. '),
+        [
+          ...(testFile.labels.length > 0 ? [testFile.labels[0]!] : []),
+          ...editFile.matched_symbols,
+        ],
+      )
+    }
+  }
+
+  return rankedFileHints(ranked.values(), limit)
 }
 
 function coveredTestNodes(
@@ -757,6 +1007,7 @@ export function buildImplementationPackGuidance(
 ): ImplementationPackGuidance {
   const rootPath = rootPathFromGraph(graph)
   const limit = options.limit ?? 5
+  const allowTestFilesInEditSet = taskExplicitlyTargetsTests(retrieval.question)
   const risk = riskMap(graph, {
     question: retrieval.question,
     budget: options.budget,
@@ -766,23 +1017,20 @@ export function buildImplementationPackGuidance(
     taskIntent: options.taskIntent,
   })
   const workflow_centers = workflowCenters(graph, retrieval, rootPath, limit)
+  const starterFiles = risk.starter_files.map((entry) => createImplementationPackFileHint(
+    entry.path,
+    entry.score,
+    entry.why,
+    entry.matched_symbols,
+  ))
   const likely_edit_files = mergeLikelyEditFiles(
     workflow_centers,
-    risk.starter_files.map((entry) => ({
-      path: entry.path,
-      why: entry.why,
-      matched_symbols: entry.matched_symbols,
-    })),
+    starterFiles,
+    rootPath,
+    allowTestFilesInEditSet,
     limit,
   )
-  const relatedTestNodes = coveredTestNodes(graph, retrieval, rootPath)
-  const likely_test_files = groupFiles(
-    [
-      ...retrieval.matched_nodes.filter((node) => classifySourceDomain(node.source_file, rootPath) === 'test'),
-      ...relatedTestNodes,
-    ],
-    rootPath,
-  ).slice(0, limit)
+  const likely_test_files = likelyTestFiles(graph, retrieval, likely_edit_files, rootPath, limit)
   const editPaths = new Set(likely_edit_files.map((entry) => entry.path))
   const { contracts_and_public_surfaces, existing_patterns } = buildSurfaceHints(retrieval, editPaths, rootPath)
   const validation = validationCommands(rootPath, likely_test_files)

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -76,6 +76,7 @@ function buildImplementationPackGraph() {
           { id: 'mcp_surface', label: 'context_pack', file_type: 'code', source_file: `${root}/src/runtime/stdio/definitions.ts`, source_location: 'L239', node_kind: 'function', community: 2 },
           { id: 'pack_test', label: 'context-pack-command.test', file_type: 'code', source_file: `${root}/tests/unit/context-pack-command.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
           { id: 'retrieve_test', label: 'retrieve-slice-v1.test', file_type: 'code', source_file: `${root}/tests/unit/retrieve-slice-v1.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
+          { id: 'pack_e2e_test', label: 'context-pack.e2e', file_type: 'code', source_file: `${root}/tests/e2e/context-pack.e2e.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
           { id: 'gate_test', label: 'retrieval-gate.test', file_type: 'code', source_file: `${root}/tests/unit/retrieval-gate.test.ts`, source_location: 'L1', node_kind: 'function', community: 3 },
           { id: 'prompt_pattern', label: 'runContextPromptCommand', file_type: 'code', source_file: `${root}/src/infrastructure/context-prompt-command.ts`, source_location: 'L1', node_kind: 'function', community: 4 },
           { id: 'review_template_pattern', label: 'renderReviewTemplate', file_type: 'code', source_file: `${root}/src/infrastructure/review-template.ts`, source_location: 'L10', node_kind: 'function', community: 4 },
@@ -90,6 +91,7 @@ function buildImplementationPackGraph() {
           { source: 'retrieve_context', target: 'retrieve_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/retrieve.ts` },
           { source: 'retrieve_context', target: 'gate_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/retrieve.ts` },
           { source: 'pack_command', target: 'pack_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'mcp_surface', target: 'pack_e2e_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/runtime/stdio/definitions.ts` },
           { source: 'pack_command', target: 'prompt_pattern', relation: 'related_to', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
           { source: 'pack_command', target: 'review_template_pattern', relation: 'related_to', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
         ],
@@ -552,8 +554,8 @@ describe('context-pack-command', () => {
     const payload = JSON.parse(output) as {
       task?: string
       implementation?: {
-        likely_edit_files?: Array<{ path?: string }>
-        likely_test_files?: Array<{ path?: string }>
+        likely_edit_files?: Array<{ path?: string; score?: number; reason?: string }>
+        likely_test_files?: Array<{ path?: string; score?: number; reason?: string }>
         contracts_and_public_surfaces?: Array<{ source_file?: string; kind?: string }>
         existing_patterns?: Array<{ source_file?: string; kind?: string }>
         validation_commands?: string[]
@@ -564,12 +566,12 @@ describe('context-pack-command', () => {
     expect(payload.task).toBe('implement')
     expect(payload.implementation).toEqual(expect.objectContaining({
       likely_edit_files: expect.arrayContaining([
-        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts' }),
-        expect.objectContaining({ path: 'src/runtime/retrieve.ts' }),
+        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts', score: expect.any(Number), reason: expect.any(String) }),
+        expect.objectContaining({ path: 'src/runtime/retrieve.ts', score: expect.any(Number), reason: expect.any(String) }),
       ]),
       likely_test_files: expect.arrayContaining([
-        expect.objectContaining({ path: 'tests/unit/context-pack-command.test.ts' }),
-        expect.objectContaining({ path: 'tests/unit/retrieve-slice-v1.test.ts' }),
+        expect.objectContaining({ path: 'tests/unit/context-pack-command.test.ts', score: expect.any(Number), reason: expect.any(String) }),
+        expect.objectContaining({ path: 'tests/e2e/context-pack.e2e.test.ts', score: expect.any(Number), reason: expect.stringMatching(/e2e|integration|entry/i) }),
       ]),
       contracts_and_public_surfaces: expect.arrayContaining([
         expect.objectContaining({ source_file: 'src/contracts/context-pack.ts', kind: 'contract' }),
@@ -590,6 +592,7 @@ describe('context-pack-command', () => {
         source_file: expect.stringMatching(/^src\//),
       }),
     ]))
+    expect(payload.implementation?.likely_edit_files?.every((entry) => !entry.path?.startsWith('tests/'))).toBe(true)
   })
 
   it('emits a pack schema v1 envelope for implement packs', async () => {
@@ -626,8 +629,8 @@ describe('context-pack-command', () => {
         reasons?: string[]
       }>
       recommended_first_read?: Array<{ path?: string }>
-      likely_edit_files?: Array<{ path?: string }>
-      likely_test_files?: Array<{ path?: string }>
+      likely_edit_files?: Array<{ path?: string; score?: number; reason?: string }>
+      likely_test_files?: Array<{ path?: string; score?: number; reason?: string }>
       public_contracts?: Array<{ source_file?: string; kind?: string }>
       risk_boundaries?: Array<{ label?: string }>
       validation_commands?: string[]
@@ -650,13 +653,16 @@ describe('context-pack-command', () => {
         }),
       ]),
       recommended_first_read: expect.arrayContaining([
-        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts' }),
+        expect.objectContaining({ path: 'src/cli/parser.ts' }),
+        expect.objectContaining({ path: 'src/runtime/stdio/definitions.ts' }),
+        expect.objectContaining({ path: 'src/contracts/context-pack.ts' }),
       ]),
       likely_edit_files: expect.arrayContaining([
-        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts' }),
+        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts', score: expect.any(Number), reason: expect.any(String) }),
       ]),
       likely_test_files: expect.arrayContaining([
-        expect.objectContaining({ path: 'tests/unit/context-pack-command.test.ts' }),
+        expect.objectContaining({ path: 'tests/unit/context-pack-command.test.ts', score: expect.any(Number), reason: expect.any(String) }),
+        expect.objectContaining({ path: 'tests/e2e/context-pack.e2e.test.ts', score: expect.any(Number), reason: expect.any(String) }),
       ]),
       public_contracts: expect.arrayContaining([
         expect.objectContaining({ source_file: 'src/contracts/context-pack.ts', kind: 'contract' }),
@@ -672,6 +678,7 @@ describe('context-pack-command', () => {
       confidence_score: expect.any(Number),
       why_explanation: expect.arrayContaining([expect.any(String)]),
     }))
+    expect(payload.likely_edit_files?.some((entry) => entry.path === 'src/contracts/context-pack.ts')).toBe(false)
   })
 
   it('renders pack schema v1 as a task-aware execution brief in text mode', async () => {

--- a/tests/unit/implementation-pack.test.ts
+++ b/tests/unit/implementation-pack.test.ts
@@ -63,6 +63,49 @@ function buildWorkflowCenterGraph() {
   return graph
 }
 
+function buildLikelyTargetsGraph() {
+  const root = mkdtempSync(join(tmpdir(), 'madar-likely-targets-'))
+  tempFixtureRoots.push(root)
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'madar-likely-targets-fixture',
+    private: true,
+    scripts: {
+      typecheck: 'tsc --noEmit',
+      build: 'tsc -p tsconfig.build.json',
+      'test:run': 'vitest run',
+    },
+  }))
+
+  const graph = build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'login_route', label: 'POST /login', file_type: 'code', source_file: `${root}/src/http/login-routes.ts`, source_location: 'L10', node_kind: 'route', framework_role: 'express_route', community: 0 },
+          { id: 'login_controller', label: 'LoginController.submit', file_type: 'code', source_file: `${root}/src/auth/login-controller.ts`, source_location: 'L20', node_kind: 'method', framework_role: 'nest_controller', community: 0 },
+          { id: 'login_service', label: 'LoginService.validate', file_type: 'code', source_file: `${root}/src/auth/login-service.ts`, source_location: 'L30', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+          { id: 'login_repository', label: 'LoginAuditRepository.saveAttempt', file_type: 'code', source_file: `${root}/src/auth/login-audit-repository.ts`, source_location: 'L40', node_kind: 'method', community: 1 },
+          { id: 'login_helper', label: 'normalizeLoginPayload', file_type: 'code', source_file: `${root}/src/auth/login-helper.ts`, source_location: 'L18', node_kind: 'function', community: 1 },
+          { id: 'login_unit_test', label: 'LoginService.validate.spec', file_type: 'code', source_file: `${root}/tests/unit/login-service.test.ts`, source_location: 'L1', node_kind: 'function', community: 2 },
+          { id: 'login_e2e_test', label: 'login flow e2e', file_type: 'code', source_file: `${root}/tests/e2e/login-flow.test.ts`, source_location: 'L1', node_kind: 'function', community: 2 },
+        ],
+        edges: [
+          { source: 'login_route', target: 'login_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: `${root}/src/http/login-routes.ts` },
+          { source: 'login_controller', target: 'login_service', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/auth/login-controller.ts` },
+          { source: 'login_service', target: 'login_repository', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/auth/login-service.ts` },
+          { source: 'login_service', target: 'login_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/auth/login-service.ts` },
+          { source: 'login_service', target: 'login_unit_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/auth/login-service.ts` },
+          { source: 'login_route', target: 'login_e2e_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/http/login-routes.ts` },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+
+  graph.graph.root_path = root
+  return graph
+}
+
 describe('buildImplementationPackGuidance workflow-center scoring (#295)', () => {
   it('ranks the workflow owner above a lexically stronger helper', () => {
     const graph = buildWorkflowCenterGraph()
@@ -255,5 +298,277 @@ describe('buildImplementationPackGuidance workflow-center scoring (#295)', () =>
       'InvoiceWorkflow.run',
       'formatInvoiceRetryMessage',
     ]))
+  })
+})
+
+describe('buildImplementationPackGuidance likely edit/test targets (#296)', () => {
+  it('scores likely edit files separately from likely test files', () => {
+    const graph = buildLikelyTargetsGraph()
+    const retrieval = {
+      question: 'change login validation behavior',
+      token_count: 180,
+      matched_nodes: [
+        {
+          node_id: 'login_helper',
+          label: 'normalizeLoginPayload',
+          source_file: `${graph.graph.root_path}/src/auth/login-helper.ts`,
+          line_number: 18,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'export function normalizeLoginPayload() {}',
+          match_score: 0.96,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Login workflow',
+        },
+        {
+          node_id: 'login_service',
+          label: 'LoginService.validate',
+          source_file: `${graph.graph.root_path}/src/auth/login-service.ts`,
+          line_number: 30,
+          node_kind: 'method',
+          framework_role: 'nest_provider',
+          file_type: 'code',
+          snippet: 'export class LoginService { validate() {} }',
+          match_score: 0.74,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Login workflow',
+        },
+        {
+          node_id: 'login_controller',
+          label: 'LoginController.submit',
+          source_file: `${graph.graph.root_path}/src/auth/login-controller.ts`,
+          line_number: 20,
+          node_kind: 'method',
+          framework_role: 'nest_controller',
+          file_type: 'code',
+          snippet: 'export class LoginController { submit() {} }',
+          match_score: 0.51,
+          relevance_band: 'related' as const,
+          community: 0,
+          community_label: 'Login HTTP surface',
+        },
+        {
+          node_id: 'login_route',
+          label: 'POST /login',
+          source_file: `${graph.graph.root_path}/src/http/login-routes.ts`,
+          line_number: 10,
+          node_kind: 'route',
+          framework_role: 'express_route',
+          file_type: 'code',
+          snippet: 'router.post("/login", controller.submit)',
+          match_score: 0.48,
+          relevance_band: 'related' as const,
+          community: 0,
+          community_label: 'Login HTTP surface',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 2200,
+      taskIntent: 'implement',
+    })
+
+    expect(guidance.likely_edit_files[0]).toEqual(expect.objectContaining({
+      path: 'src/auth/login-service.ts',
+      score: expect.any(Number),
+      reason: expect.stringMatching(/workflow|entry point|side-effect|call-graph|direct/i),
+    }))
+    expect(guidance.likely_edit_files.every((entry) => !entry.path.startsWith('tests/'))).toBe(true)
+    expect(guidance.likely_test_files).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: 'tests/unit/login-service.test.ts',
+        score: expect.any(Number),
+        reason: expect.stringMatching(/covered|unit|validation|test/i),
+      }),
+      expect.objectContaining({
+        path: 'tests/e2e/login-flow.test.ts',
+        score: expect.any(Number),
+        reason: expect.stringMatching(/e2e|integration|route|entry/i),
+      }),
+    ]))
+  })
+
+  it('keeps a clear caution when no related tests are discoverable', () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-no-tests-'))
+    tempFixtureRoots.push(root)
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'madar-no-tests-fixture',
+      private: true,
+      scripts: {
+        typecheck: 'tsc --noEmit',
+        build: 'tsc -p tsconfig.build.json',
+        'test:run': 'vitest run',
+      },
+    }))
+
+    const graph = build(
+      [
+        {
+          schema_version: 1,
+          nodes: [
+            { id: 'billing_service', label: 'BillingService.retry', file_type: 'code', source_file: `${root}/src/billing/service.ts`, source_location: 'L10', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+            { id: 'billing_helper', label: 'formatRetryWindow', file_type: 'code', source_file: `${root}/src/billing/helper.ts`, source_location: 'L20', node_kind: 'function', community: 1 },
+          ],
+          edges: [
+            { source: 'billing_service', target: 'billing_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/billing/service.ts` },
+          ],
+        },
+      ],
+      { directed: true },
+    )
+    graph.graph.root_path = root
+
+    const retrieval = {
+      question: 'adjust retry window logic',
+      token_count: 60,
+      matched_nodes: [
+        {
+          node_id: 'billing_service',
+          label: 'BillingService.retry',
+          source_file: `${root}/src/billing/service.ts`,
+          line_number: 10,
+          node_kind: 'method',
+          framework_role: 'nest_provider',
+          file_type: 'code',
+          snippet: 'export class BillingService { retry() {} }',
+          match_score: 0.72,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Billing workflow',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary'] as const,
+        semantic_required: ['implementation'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 1400,
+      taskIntent: 'implement',
+    })
+
+    expect(guidance.likely_test_files).toEqual([])
+    expect(guidance.cautions).toContain('No related tests were retrieved; validate regression coverage manually.')
+  })
+
+  it('does not leak matched test files into likely_edit_files when the task does not ask to modify tests', () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-edit-filter-'))
+    tempFixtureRoots.push(root)
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'madar-edit-filter-fixture',
+      private: true,
+      scripts: {
+        typecheck: 'tsc --noEmit',
+        build: 'tsc -p tsconfig.build.json',
+        'test:run': 'vitest run',
+      },
+    }))
+
+    const graph = build(
+      [
+        {
+          schema_version: 1,
+          nodes: [
+            { id: 'profile_service', label: 'ProfileService.update', file_type: 'code', source_file: `${root}/src/profile/service.ts`, source_location: 'L10', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+            { id: 'profile_service_test', label: 'ProfileService.update.spec', file_type: 'code', source_file: `${root}/tests/unit/profile-service.test.ts`, source_location: 'L1', node_kind: 'function', community: 2 },
+          ],
+          edges: [
+            { source: 'profile_service', target: 'profile_service_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/profile/service.ts` },
+          ],
+        },
+      ],
+      { directed: true },
+    )
+    graph.graph.root_path = root
+
+    const retrieval = {
+      question: 'change profile update validation',
+      token_count: 70,
+      matched_nodes: [
+        {
+          node_id: 'profile_service',
+          label: 'ProfileService.update',
+          source_file: `${root}/src/profile/service.ts`,
+          line_number: 10,
+          node_kind: 'method',
+          framework_role: 'nest_provider',
+          file_type: 'code',
+          snippet: 'export class ProfileService { update() {} }',
+          match_score: 0.78,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Profile workflow',
+        },
+        {
+          node_id: 'profile_service_test',
+          label: 'ProfileService.update.spec',
+          source_file: `${root}/tests/unit/profile-service.test.ts`,
+          line_number: 1,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'describe("ProfileService.update", () => {})',
+          match_score: 0.74,
+          relevance_band: 'direct' as const,
+          community: 2,
+          community_label: 'Profile tests',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary'] as const,
+        semantic_required: ['implementation'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 1200,
+      taskIntent: 'implement',
+      limit: 3,
+    })
+
+    expect(guidance.likely_edit_files.every((entry) => !entry.path.startsWith('tests/'))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add scored likely_edit_files and likely_test_files hints for implement packs with separate first-read guidance
- rank test targets from covered_by links plus naming/module/e2e heuristics while keeping tests out of edit files unless explicitly requested
- add regression coverage for scored pack output, test discovery, and test-file leakage prevention

Closes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced implementation pack guidance with explicit scoring and reasoning for recommended files
  * Improved test-file detection and ranking capabilities with better heuristics for identifying related test files
  * Clearer separation between recommended first reads and ranked file suggestions with dedicated score and reason fields

* **Documentation**
  * Updated pack schema documentation to clarify the structure and separation of ranked file recommendations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->