### PR TITLE
Add budget-aware pack compression guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,15 @@ For `--task implement`, `workflow_centers` are scored workflow-owner candidates 
 
 The implement brief also keeps `recommended_first_read` separate from ranked `likely_edit_files` and `likely_test_files`. The edit/test sections now carry explicit `score` and `reason` fields so agents can tell orientation reads apart from the files most likely to change or validate.
 
+`negative_guidance` is also task-aware now: implementation packs can explicitly call out helper-like or generated files as supporting context instead of silently letting lexical matches drift into the default edit path.
+
 Use `--format json` when another tool or script will consume the pack directly. Use `--format text` when you want the same schema rendered as a short human/agent-readable execution brief.
 
 ### Adaptive context-pack representations
 
 Compiled context packs now have a first-pass **rendering-only** adaptive layer. Retrieval still selects the same nodes and paths first; the runtime only changes how those already-selected nodes are emitted for the task.
+
+That renderer is now budget-aware: tighter budgets compress already-selected nodes down toward summary/signature views, while explain packs only preserve full detail when the budget is large enough to justify it.
 
 The current deterministic core modes are:
 

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -30,6 +30,7 @@ import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
 
 const DEFAULT_IMPACT_DEPTH = 3
+const IMPLEMENTATION_DISTRACTOR_PATTERN = /(?:helper|util|formatter|serializer|mapper|constant|generated|dist\/|build\/|lockfile|migration)/i
 
 export interface ContextPackCommandDependencies {
   loadGraph: (graphPath: string) => KnowledgeGraph
@@ -441,6 +442,12 @@ function negativeGuidance(
   }
   if ('uncovered_hotspots' in pack && Array.isArray(pack.uncovered_hotspots) && pack.uncovered_hotspots.length > 0) {
     guidance.push(`Do not treat the compact review bundle as complete for uncovered hotspots: ${pack.uncovered_hotspots.slice(0, 3).map((entry) => entry.label).join(', ')}.`)
+  }
+  for (const pattern of implementation?.existing_patterns ?? []) {
+    if (!IMPLEMENTATION_DISTRACTOR_PATTERN.test(`${pattern.label} ${pattern.source_file}`)) {
+      continue
+    }
+    guidance.push(`Treat ${pattern.source_file} as supporting context first, not the default edit path, unless the task explicitly targets that helper or artifact.`)
   }
 
   return [...new Set(guidance)]

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -996,6 +996,28 @@ function tokenCountForRenderedNodes(nodes: readonly Pick<ContextPackNode, 'label
   )
 }
 
+function resolutionForTaskBudget(
+  taskContract: ContextPackTaskContract,
+  nodes: readonly ContextPackNode[],
+): 'summary' | 'signature' | 'sketch' {
+  const budgetPerNode = taskContract.budget / Math.max(1, nodes.length)
+  if (budgetPerNode < 18) {
+    return 'summary'
+  }
+  if (budgetPerNode < 28) {
+    return 'signature'
+  }
+  return 'sketch'
+}
+
+function canPreserveExplainDetail(
+  taskContract: ContextPackTaskContract,
+  nodes: readonly ContextPackNode[],
+): boolean {
+  return taskContract.task_kind === 'explain'
+    && resolutionForTaskBudget(taskContract, nodes) === 'sketch'
+}
+
 export function renderCompiledContextPackNodes<
   TNode extends ContextPackNode = ContextPackNode,
   TRelationship extends ContextPackRelationship = ContextPackRelationship,
@@ -1017,7 +1039,7 @@ export function renderCompiledContextPackNodes<
   const renderedNodes = nodes.some((node) => typeof node.representation_type === 'string')
     ? [...nodes]
     : applyContextPackResolution(nodes, {
-        resolution: 'sketch',
+        resolution: resolutionForTaskBudget(taskContract, nodes),
         relationships,
         task_kind: taskContract.task_kind,
       }).nodes.map((node, index) => {
@@ -1036,7 +1058,7 @@ export function renderCompiledContextPackNodes<
         )
         const hasOriginalSnippet = typeof originalNode.snippet === 'string'
           && originalNode.snippet.length > 0
-        if (taskContract.task_kind === 'explain' && hasOriginalSnippet) {
+        if (canPreserveExplainDetail(taskContract, nodes) && hasOriginalSnippet) {
           return {
             ...node,
             representation_type: 'detail',

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -138,6 +138,14 @@ function createImplementationPackFileHint(
   }
 }
 
+function helperLikeFileContext(
+  path: string,
+  labelOrSymbols: readonly string[],
+  reason?: string,
+): boolean {
+  return HELPER_PATTERN.test([path, ...labelOrSymbols, reason ?? ''].join(' '))
+}
+
 function addRankedFileCandidate(
   target: Map<string, RankedFileAccumulator>,
   path: string,
@@ -554,6 +562,8 @@ function mergeLikelyEditFiles(
 ): ImplementationPackFileHint[] {
   const results: ImplementationPackFileHint[] = []
   const seen = new Set<string>()
+  const hasNonHelperWorkflowCenter = workflowCentersValue.some((center) => center.path
+    && !helperLikeFileContext(center.path, [center.label, ...(center.matched_symbols ?? [])], center.reason))
   const starterByPath = new Map(
     starterFiles
       .filter((entry) => allowTestFiles || classifySourceDomain(entry.path, rootPath) !== 'test')
@@ -565,6 +575,7 @@ function mergeLikelyEditFiles(
       !center.path
       || seen.has(center.path)
       || (!allowTestFiles && classifySourceDomain(center.path, rootPath) === 'test')
+      || (hasNonHelperWorkflowCenter && helperLikeFileContext(center.path, [center.label, ...(center.matched_symbols ?? [])], center.reason))
     ) {
       continue
     }
@@ -587,7 +598,11 @@ function mergeLikelyEditFiles(
   }
 
   for (const entry of starterFiles) {
-    if (seen.has(entry.path) || (!allowTestFiles && classifySourceDomain(entry.path, rootPath) === 'test')) {
+    if (
+      seen.has(entry.path)
+      || (!allowTestFiles && classifySourceDomain(entry.path, rootPath) === 'test')
+      || (hasNonHelperWorkflowCenter && helperLikeFileContext(entry.path, entry.matched_symbols, entry.reason))
+    ) {
       continue
     }
     results.push(entry)

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -146,6 +146,24 @@ function helperLikeFileContext(
   return HELPER_PATTERN.test([path, ...labelOrSymbols, reason ?? ''].join(' '))
 }
 
+function explicitlyTargetsPathOrSymbol(
+  question: string | undefined,
+  path: string,
+  symbols: readonly string[],
+): boolean {
+  if (!question) {
+    return false
+  }
+
+  const prompt = question.toLowerCase()
+  const normalizedPath = path.toLowerCase()
+  if (prompt.includes(normalizedPath) || prompt.includes(basename(normalizedPath))) {
+    return true
+  }
+
+  return symbols.some((symbol) => symbol.length > 0 && prompt.includes(symbol.toLowerCase()))
+}
+
 function addRankedFileCandidate(
   target: Map<string, RankedFileAccumulator>,
   path: string,
@@ -559,6 +577,7 @@ function mergeLikelyEditFiles(
   rootPath: string | undefined,
   allowTestFiles: boolean,
   limit: number,
+  question?: string,
 ): ImplementationPackFileHint[] {
   const results: ImplementationPackFileHint[] = []
   const seen = new Set<string>()
@@ -575,7 +594,9 @@ function mergeLikelyEditFiles(
       !center.path
       || seen.has(center.path)
       || (!allowTestFiles && classifySourceDomain(center.path, rootPath) === 'test')
-      || (hasNonHelperWorkflowCenter && helperLikeFileContext(center.path, [center.label, ...(center.matched_symbols ?? [])], center.reason))
+      || (hasNonHelperWorkflowCenter
+        && helperLikeFileContext(center.path, [center.label, ...(center.matched_symbols ?? [])], center.reason)
+        && !explicitlyTargetsPathOrSymbol(question, center.path, [center.label, ...(center.matched_symbols ?? [])]))
     ) {
       continue
     }
@@ -601,7 +622,9 @@ function mergeLikelyEditFiles(
     if (
       seen.has(entry.path)
       || (!allowTestFiles && classifySourceDomain(entry.path, rootPath) === 'test')
-      || (hasNonHelperWorkflowCenter && helperLikeFileContext(entry.path, entry.matched_symbols, entry.reason))
+      || (hasNonHelperWorkflowCenter
+        && helperLikeFileContext(entry.path, entry.matched_symbols, entry.reason)
+        && !explicitlyTargetsPathOrSymbol(question, entry.path, entry.matched_symbols))
     ) {
       continue
     }
@@ -1044,6 +1067,7 @@ export function buildImplementationPackGuidance(
     rootPath,
     allowTestFilesInEditSet,
     limit,
+    retrieval.question,
   )
   const likely_test_files = likelyTestFiles(graph, retrieval, likely_edit_files, rootPath, limit)
   const editPaths = new Set(likely_edit_files.map((entry) => entry.path))

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -103,6 +103,41 @@ function buildImplementationPackGraph() {
   return graph
 }
 
+function buildImplementationPackDistractorGraph() {
+  const root = mkdtempSync(join(tmpdir(), 'madar-fixture-'))
+  tempFixtureRoots.push(root)
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'madar-fixture',
+    private: true,
+    scripts: {
+      typecheck: 'tsc --noEmit',
+      build: 'tsc -p tsconfig.build.json',
+      'test:run': 'vitest run',
+    },
+  }))
+  const graph = build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'pack_command', label: 'runContextPackCommand', file_type: 'code', source_file: `${root}/src/infrastructure/context-pack-command.ts`, source_location: 'L224', node_kind: 'function', community: 0 },
+          { id: 'pack_helper', label: 'buildContextPackHelper', file_type: 'code', source_file: `${root}/src/infrastructure/context-pack-helper.ts`, source_location: 'L18', node_kind: 'function', community: 0 },
+          { id: 'pack_contract', label: 'ContextPackTaskKind', file_type: 'code', source_file: `${root}/src/contracts/context-pack.ts`, source_location: 'L13', community: 1 },
+          { id: 'pack_test', label: 'context-pack-command.test', file_type: 'code', source_file: `${root}/tests/unit/context-pack-command.test.ts`, source_location: 'L1', node_kind: 'function', community: 2 },
+        ],
+        edges: [
+          { source: 'pack_command', target: 'pack_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'pack_contract', relation: 'depends_on', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+          { source: 'pack_command', target: 'pack_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/infrastructure/context-pack-command.ts` },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+  graph.graph.root_path = root
+  return graph
+}
+
 describe('context-pack-command', () => {
   it('preserves execution_slice for runtime-generation explain packs', async () => {
     const graph = buildRuntimeGenerationGraph()
@@ -679,6 +714,41 @@ describe('context-pack-command', () => {
       why_explanation: expect.arrayContaining([expect.any(String)]),
     }))
     expect(payload.likely_edit_files?.some((entry) => entry.path === 'src/contracts/context-pack.ts')).toBe(false)
+  })
+
+  it('surfaces lexical helpers as negative guidance instead of edit targets for implementation packs', async () => {
+    const graph = buildImplementationPackDistractorGraph()
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn((currentGraph, options) => retrieveContext(currentGraph, options as never)),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement context pack command compression guidance',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'json',
+    } as never, dependencies)
+
+    const payload = JSON.parse(output) as {
+      likely_edit_files?: Array<{ path?: string }>
+      negative_guidance?: string[]
+    }
+
+    expect(payload.likely_edit_files).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts' }),
+    ]))
+    expect(payload.likely_edit_files?.some((entry) => entry.path === 'src/infrastructure/context-pack-helper.ts')).toBe(false)
+    expect(payload.negative_guidance).toEqual(expect.arrayContaining([
+      expect.stringContaining('src/infrastructure/context-pack-helper.ts'),
+    ]))
   })
 
   it('renders pack schema v1 as a task-aware execution brief in text mode', async () => {

--- a/tests/unit/context-pack.test.ts
+++ b/tests/unit/context-pack.test.ts
@@ -6,6 +6,7 @@ import {
   compactContextPack,
   compileContextPack,
   estimateContextPackEntryTokens,
+  renderCompiledContextPackNodes,
   type ContextPackNodeCandidate,
 } from '../../src/runtime/context-pack.js'
 
@@ -374,6 +375,75 @@ describe('context-pack', () => {
       expect(reviewPack.token_count).toBeLessThan(explainPack.token_count)
       expect(explainPack.token_count).toBe(renderedTokenCount(explainPack.nodes))
       expect(reviewPack.token_count).toBe(renderedTokenCount(reviewPack.nodes))
+    })
+
+    it('compresses selected explain nodes more aggressively when the token budget is tight', () => {
+      const nodes = [
+        nodeCandidate({
+          node_id: 'auth_controller',
+          label: 'AuthController.callback',
+          source_file: 'src/auth/controller.ts',
+          line_number: 12,
+          file_type: 'code',
+          snippet: [
+            'export class AuthController {',
+            '  async callback(input: LoginInput) {',
+            '    const normalized = normalizeCallback(input)',
+            '    const user = await this.authService.login(normalized)',
+            '    return this.sessionStore.create(user.id)',
+            '  }',
+            '}',
+          ].join('\n'),
+          match_score: 10,
+          relevance_band: 'direct',
+          community: 0,
+          community_label: 'Auth',
+        }, 'primary', 8),
+        nodeCandidate({
+          node_id: 'auth_service',
+          label: 'AuthService.login',
+          source_file: 'src/auth/service.ts',
+          line_number: 20,
+          file_type: 'code',
+          snippet: [
+            'export class AuthService {',
+            '  async login(input: LoginInput) {',
+            '    await this.validator.validate(input)',
+            '    const token = this.tokenService.sign(input.userId)',
+            '    return this.sessionStore.create(token)',
+            '  }',
+            '}',
+          ].join('\n'),
+          match_score: 8,
+          relevance_band: 'related',
+          community: 0,
+          community_label: 'Auth',
+        }, 'supporting', 8),
+      ]
+      const relationships = [
+        {
+          from_id: 'auth_controller',
+          from: 'AuthController.callback',
+          to_id: 'auth_service',
+          to: 'AuthService.login',
+          relation: 'calls',
+        },
+      ] as const
+
+      const generous = renderCompiledContextPackNodes(
+        classifyTaskContract('explain', { budget: 256, prompt: 'Explain the auth callback flow' }),
+        nodes.map((candidate) => candidate.build_entry()),
+        relationships,
+      )
+      const constrained = renderCompiledContextPackNodes(
+        classifyTaskContract('explain', { budget: 32, prompt: 'Explain the auth callback flow' }),
+        nodes.map((candidate) => candidate.build_entry()),
+        relationships,
+      )
+
+      expect(generous.nodes.find((node) => node.node_id === 'auth_controller')?.representation_type).toBe('detail')
+      expect(constrained.nodes.find((node) => node.node_id === 'auth_controller')?.representation_type).not.toBe('detail')
+      expect(constrained.token_count).toBeLessThan(generous.token_count)
     })
 
     it('does not materialize omitted entries when candidate metadata already covers previews and semantics', () => {

--- a/tests/unit/implementation-pack.test.ts
+++ b/tests/unit/implementation-pack.test.ts
@@ -407,6 +407,84 @@ describe('buildImplementationPackGuidance likely edit/test targets (#296)', () =
     ]))
   })
 
+  it('keeps an explicitly named helper target in likely_edit_files', () => {
+    const graph = buildLikelyTargetsGraph()
+    const retrieval = {
+      question: 'update normalizeLoginPayload in src/auth/login-helper.ts to preserve the new login validation behavior',
+      token_count: 180,
+      matched_nodes: [
+        {
+          node_id: 'login_helper',
+          label: 'normalizeLoginPayload',
+          source_file: `${graph.graph.root_path}/src/auth/login-helper.ts`,
+          line_number: 18,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'export function normalizeLoginPayload() {}',
+          match_score: 0.96,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Login workflow',
+        },
+        {
+          node_id: 'login_service',
+          label: 'LoginService.validate',
+          source_file: `${graph.graph.root_path}/src/auth/login-service.ts`,
+          line_number: 30,
+          node_kind: 'method',
+          framework_role: 'nest_provider',
+          file_type: 'code',
+          snippet: 'export class LoginService { validate() {} }',
+          match_score: 0.74,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Login workflow',
+        },
+        {
+          node_id: 'login_controller',
+          label: 'LoginController.submit',
+          source_file: `${graph.graph.root_path}/src/auth/login-controller.ts`,
+          line_number: 20,
+          node_kind: 'method',
+          framework_role: 'nest_controller',
+          file_type: 'code',
+          snippet: 'export class LoginController { submit() {} }',
+          match_score: 0.51,
+          relevance_band: 'related' as const,
+          community: 0,
+          community_label: 'Login HTTP surface',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 2200,
+      taskIntent: 'implement',
+      limit: 5,
+    })
+
+    expect(guidance.likely_edit_files).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'src/auth/login-helper.ts' }),
+      expect.objectContaining({ path: 'src/auth/login-service.ts' }),
+    ]))
+  })
+
   it('keeps a clear caution when no related tests are discoverable', () => {
     const root = mkdtempSync(join(tmpdir(), 'madar-no-tests-'))
     tempFixtureRoots.push(root)


### PR DESCRIPTION
## Summary
- make context-pack rendering compress selected nodes more aggressively under tight budgets
- keep helper-like lexical matches out of implement-pack edit targets and surface them in negative guidance
- document the new budget-aware compression and distractor guidance behavior

Closes #297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented task-aware handling of helper and generated files in implementation packs—these are now marked as supporting context rather than primary edit targets.
  * Added budget-aware rendering that dynamically adjusts detail levels based on available token budget.

* **Documentation**
  * Clarified format options: `--format json` for tool/script consumption, `--format text` for brief execution summaries.
  * Expanded guidance on adaptive context-pack representations and budget-aware compression.

* **Tests**
  * Added test coverage for helper file handling in implementation packs.
  * Added test coverage for budget-based representation selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->