### PR TITLE
Add pack quality fixture regressions

### DIFF
--- a/tests/fixtures/pack-quality/api-route-schema-service/fixture.json
+++ b/tests/fixtures/pack-quality/api-route-schema-service/fixture.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "add displayName validation to the create user API route",
+  "expected_workflow_centers": [
+    "src/routes/user-routes.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/routes/user-routes.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/user-routes.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/user-routes.test.ts"
+  ],
+  "expected_negative_guidance": []
+}

--- a/tests/fixtures/pack-quality/api-route-schema-service/workspace/package.json
+++ b/tests/fixtures/pack-quality/api-route-schema-service/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-api-route-schema-service",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/api-route-schema-service/workspace/src/routes/user-routes.ts
+++ b/tests/fixtures/pack-quality/api-route-schema-service/workspace/src/routes/user-routes.ts
@@ -1,0 +1,7 @@
+import { validateCreateUser } from '../schemas/create-user.schema.js'
+import { createUser } from '../services/user-service.js'
+
+export function createUserRoute(input: { email: string; displayName: string }) {
+  validateCreateUser(input)
+  return createUser(input)
+}

--- a/tests/fixtures/pack-quality/api-route-schema-service/workspace/src/schemas/create-user.schema.ts
+++ b/tests/fixtures/pack-quality/api-route-schema-service/workspace/src/schemas/create-user.schema.ts
@@ -1,0 +1,5 @@
+export function validateCreateUser(input: { email: string; displayName: string }) {
+  if (!input.displayName) {
+    throw new Error('displayName is required')
+  }
+}

--- a/tests/fixtures/pack-quality/api-route-schema-service/workspace/src/services/user-service.ts
+++ b/tests/fixtures/pack-quality/api-route-schema-service/workspace/src/services/user-service.ts
@@ -1,0 +1,3 @@
+export function createUser(input: { email: string; displayName: string }) {
+  return { id: input.email, displayName: input.displayName }
+}

--- a/tests/fixtures/pack-quality/api-route-schema-service/workspace/tests/unit/user-routes.test.ts
+++ b/tests/fixtures/pack-quality/api-route-schema-service/workspace/tests/unit/user-routes.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { createUserRoute } from '../../src/routes/user-routes.js'
+
+describe('createUserRoute', () => {
+  it('creates a user after schema validation', () => {
+    expect(createUserRoute({ email: 'sam@example.test', displayName: 'Sam' })).toEqual({
+      id: 'sam@example.test',
+      displayName: 'Sam',
+    })
+  })
+})

--- a/tests/fixtures/pack-quality/api-route-schema-service/workspace/tests/unit/user-routes.test.ts
+++ b/tests/fixtures/pack-quality/api-route-schema-service/workspace/tests/unit/user-routes.test.ts
@@ -9,4 +9,8 @@ describe('createUserRoute', () => {
       displayName: 'Sam',
     })
   })
+
+  it('throws when displayName is missing', () => {
+    expect(() => createUserRoute({ email: 'sam@example.test', displayName: '' })).toThrow('displayName is required')
+  })
 })

--- a/tests/fixtures/pack-quality/cli-command-implementation/fixture.json
+++ b/tests/fixtures/pack-quality/cli-command-implementation/fixture.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "add dry run support to the sync command",
+  "expected_workflow_centers": [
+    "src/commands/sync-command.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/commands/sync-command.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/sync-command.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/sync-command.test.ts"
+  ],
+  "expected_negative_guidance": []
+}

--- a/tests/fixtures/pack-quality/cli-command-implementation/workspace/package.json
+++ b/tests/fixtures/pack-quality/cli-command-implementation/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-cli-command-implementation",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/cli-command-implementation/workspace/src/cli/parser.ts
+++ b/tests/fixtures/pack-quality/cli-command-implementation/workspace/src/cli/parser.ts
@@ -1,0 +1,5 @@
+import { runSyncCommand } from '../commands/sync-command.js'
+
+export function parseSyncArgs(args: string[]) {
+  return runSyncCommand(args.includes('--dry-run'))
+}

--- a/tests/fixtures/pack-quality/cli-command-implementation/workspace/src/commands/sync-command.ts
+++ b/tests/fixtures/pack-quality/cli-command-implementation/workspace/src/commands/sync-command.ts
@@ -1,0 +1,5 @@
+import { syncProject } from '../runtime/sync-project.js'
+
+export function runSyncCommand(dryRun: boolean) {
+  return syncProject({ dryRun })
+}

--- a/tests/fixtures/pack-quality/cli-command-implementation/workspace/src/runtime/sync-project.ts
+++ b/tests/fixtures/pack-quality/cli-command-implementation/workspace/src/runtime/sync-project.ts
@@ -1,0 +1,3 @@
+export function syncProject(options: { dryRun: boolean }) {
+  return options
+}

--- a/tests/fixtures/pack-quality/cli-command-implementation/workspace/tests/unit/sync-command.test.ts
+++ b/tests/fixtures/pack-quality/cli-command-implementation/workspace/tests/unit/sync-command.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseSyncArgs } from '../../src/cli/parser.js'
+
+describe('parseSyncArgs', () => {
+  it('passes the dry run flag into the sync command', () => {
+    expect(parseSyncArgs(['--dry-run'])).toEqual({ dryRun: true })
+  })
+})

--- a/tests/fixtures/pack-quality/cli-command-implementation/workspace/tests/unit/sync-command.test.ts
+++ b/tests/fixtures/pack-quality/cli-command-implementation/workspace/tests/unit/sync-command.test.ts
@@ -6,4 +6,8 @@ describe('parseSyncArgs', () => {
   it('passes the dry run flag into the sync command', () => {
     expect(parseSyncArgs(['--dry-run'])).toEqual({ dryRun: true })
   })
+
+  it('keeps dry run disabled when flag is absent', () => {
+    expect(parseSyncArgs([])).toEqual({ dryRun: false })
+  })
 })

--- a/tests/fixtures/pack-quality/controller-service-test-flow/fixture.json
+++ b/tests/fixtures/pack-quality/controller-service-test-flow/fixture.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "change login session creation flow in AuthService.login",
+  "expected_workflow_centers": [
+    "src/services/auth-service.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/services/auth-service.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/auth-service.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/auth-service.test.ts"
+  ],
+  "expected_negative_guidance": []
+}

--- a/tests/fixtures/pack-quality/controller-service-test-flow/workspace/package.json
+++ b/tests/fixtures/pack-quality/controller-service-test-flow/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-controller-service-test-flow",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/controller-service-test-flow/workspace/src/controllers/auth-controller.ts
+++ b/tests/fixtures/pack-quality/controller-service-test-flow/workspace/src/controllers/auth-controller.ts
@@ -1,0 +1,9 @@
+import { AuthService } from '../services/auth-service.js'
+
+export class AuthController {
+  constructor(private readonly authService = new AuthService()) {}
+
+  async login(input: { email: string }) {
+    return this.authService.login(input)
+  }
+}

--- a/tests/fixtures/pack-quality/controller-service-test-flow/workspace/src/persistence/session-store.ts
+++ b/tests/fixtures/pack-quality/controller-service-test-flow/workspace/src/persistence/session-store.ts
@@ -1,0 +1,3 @@
+export function createSession(email: string) {
+  return { sessionId: `session:${email}` }
+}

--- a/tests/fixtures/pack-quality/controller-service-test-flow/workspace/src/services/auth-service.ts
+++ b/tests/fixtures/pack-quality/controller-service-test-flow/workspace/src/services/auth-service.ts
@@ -1,0 +1,7 @@
+import { createSession } from '../persistence/session-store.js'
+
+export class AuthService {
+  async login(input: { email: string }) {
+    return createSession(input.email)
+  }
+}

--- a/tests/fixtures/pack-quality/controller-service-test-flow/workspace/tests/unit/auth-service.test.ts
+++ b/tests/fixtures/pack-quality/controller-service-test-flow/workspace/tests/unit/auth-service.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { AuthService } from '../../src/services/auth-service.js'
+
+describe('AuthService.login', () => {
+  it('creates a session for the login flow', async () => {
+    const service = new AuthService()
+
+    await expect(service.login({ email: 'sam@example.test' })).resolves.toEqual({
+      sessionId: 'session:sam@example.test',
+    })
+  })
+})

--- a/tests/fixtures/pack-quality/monorepo-package-boundary/fixture.json
+++ b/tests/fixtures/pack-quality/monorepo-package-boundary/fixture.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "add invite expiration support across the invite workflow",
+  "expected_workflow_centers": [
+    "packages/app/src/commands/invite-user.ts"
+  ],
+  "expected_likely_edit_files": [
+    "packages/app/src/commands/invite-user.ts"
+  ],
+  "expected_likely_test_files": [
+    "packages/app/tests/unit/invite-user.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- packages/app/tests/unit/invite-user.test.ts"
+  ],
+  "expected_negative_guidance": []
+}

--- a/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/package.json
+++ b/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-monorepo-package-boundary",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/app/src/commands/invite-user.ts
+++ b/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/app/src/commands/invite-user.ts
@@ -1,0 +1,5 @@
+import { createInvite } from '../../../domain/src/invite-service.js'
+
+export function inviteUser(email: string) {
+  return createInvite(email)
+}

--- a/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/app/tests/unit/invite-user.test.ts
+++ b/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/app/tests/unit/invite-user.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { inviteUser } from '../../src/commands/invite-user.js'
+
+describe('inviteUser', () => {
+  it('creates an invite across package boundaries', () => {
+    expect(inviteUser('sam@example.test')).toEqual({
+      email: 'sam@example.test',
+      expiresInMinutes: 30,
+    })
+  })
+})

--- a/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/domain/src/invite-service.ts
+++ b/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/domain/src/invite-service.ts
@@ -1,0 +1,5 @@
+import { createInviteContract } from '../../shared/src/contracts/invite.js'
+
+export function createInvite(email: string) {
+  return createInviteContract(email)
+}

--- a/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/shared/src/contracts/invite.ts
+++ b/tests/fixtures/pack-quality/monorepo-package-boundary/workspace/packages/shared/src/contracts/invite.ts
@@ -1,0 +1,3 @@
+export function createInviteContract(email: string) {
+  return { email, expiresInMinutes: 30 }
+}

--- a/tests/fixtures/pack-quality/noisy-helper-distractor/fixture.json
+++ b/tests/fixtures/pack-quality/noisy-helper-distractor/fixture.json
@@ -1,0 +1,20 @@
+{
+  "prompt": "add retry when invoice generation fails",
+  "expected_workflow_centers": [
+    "src/invoices/invoice-generation-service.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/invoices/invoice-generation-service.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/invoice-generation-service.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/invoice-generation-service.test.ts"
+  ],
+  "expected_negative_guidance": [
+    "src/invoices/retry-helper.ts"
+  ]
+}

--- a/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/package.json
+++ b/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-noisy-helper-distractor",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/src/invoices/invoice-controller.ts
+++ b/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/src/invoices/invoice-controller.ts
@@ -1,0 +1,5 @@
+import { generateInvoice } from './invoice-generation-service.js'
+
+export function submitInvoiceRetry(invoiceId: string) {
+  return generateInvoice(invoiceId)
+}

--- a/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/src/invoices/invoice-generation-service.ts
+++ b/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/src/invoices/invoice-generation-service.ts
@@ -1,0 +1,5 @@
+import { retryWhenInvoiceGenerationFails } from './retry-helper.js'
+
+export function generateInvoice(invoiceId: string) {
+  return retryWhenInvoiceGenerationFails(invoiceId)
+}

--- a/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/src/invoices/retry-helper.ts
+++ b/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/src/invoices/retry-helper.ts
@@ -1,0 +1,3 @@
+export function retryWhenInvoiceGenerationFails(invoiceId: string) {
+  return { invoiceId, retried: true }
+}

--- a/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/tests/unit/invoice-generation-service.test.ts
+++ b/tests/fixtures/pack-quality/noisy-helper-distractor/workspace/tests/unit/invoice-generation-service.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateInvoice } from '../../src/invoices/invoice-generation-service.js'
+
+describe('generateInvoice', () => {
+  it('keeps retry logic behind the service workflow owner', () => {
+    expect(generateInvoice('inv-1')).toEqual({ invoiceId: 'inv-1', retried: true })
+  })
+})

--- a/tests/fixtures/pack-quality/queue-job-retry-workflow/fixture.json
+++ b/tests/fixtures/pack-quality/queue-job-retry-workflow/fixture.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "add retry handling when report generation job fails",
+  "expected_workflow_centers": [
+    "src/services/report-generation-service.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/services/report-generation-service.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/report-generation-service.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/report-generation-service.test.ts"
+  ],
+  "expected_negative_guidance": []
+}

--- a/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/package.json
+++ b/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-queue-job-retry-workflow",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/src/queue/report-job-queue.ts
+++ b/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/src/queue/report-job-queue.ts
@@ -1,0 +1,5 @@
+import { processReportRetry } from '../workers/report-worker.js'
+
+export function enqueueRetry(reportId: string) {
+  return processReportRetry(reportId)
+}

--- a/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/src/services/report-generation-service.ts
+++ b/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/src/services/report-generation-service.ts
@@ -1,0 +1,5 @@
+import { enqueueRetry } from '../queue/report-job-queue.js'
+
+export async function generateReportJob(reportId: string) {
+  return enqueueRetry(reportId)
+}

--- a/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/src/workers/report-worker.ts
+++ b/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/src/workers/report-worker.ts
@@ -1,0 +1,3 @@
+export function processReportRetry(reportId: string) {
+  return { queued: true, reportId }
+}

--- a/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/tests/unit/report-generation-service.test.ts
+++ b/tests/fixtures/pack-quality/queue-job-retry-workflow/workspace/tests/unit/report-generation-service.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateReportJob } from '../../src/services/report-generation-service.js'
+
+describe('generateReportJob', () => {
+  it('queues retry work for report generation', async () => {
+    await expect(generateReportJob('report-1')).resolves.toEqual({
+      queued: true,
+      reportId: 'report-1',
+    })
+  })
+})

--- a/tests/fixtures/pack-quality/source-test-adjacency/fixture.json
+++ b/tests/fixtures/pack-quality/source-test-adjacency/fixture.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "change profile update validation",
+  "expected_workflow_centers": [
+    "src/profile/update-profile.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/profile/update-profile.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/update-profile.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/update-profile.test.ts"
+  ],
+  "expected_negative_guidance": []
+}

--- a/tests/fixtures/pack-quality/source-test-adjacency/workspace/package.json
+++ b/tests/fixtures/pack-quality/source-test-adjacency/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-source-test-adjacency",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/source-test-adjacency/workspace/src/profile/update-profile.ts
+++ b/tests/fixtures/pack-quality/source-test-adjacency/workspace/src/profile/update-profile.ts
@@ -1,0 +1,7 @@
+export function updateProfile(input: { displayName: string }) {
+  if (!input.displayName.trim()) {
+    throw new Error('displayName is required')
+  }
+
+  return input
+}

--- a/tests/fixtures/pack-quality/source-test-adjacency/workspace/src/profile/update-profile.ts
+++ b/tests/fixtures/pack-quality/source-test-adjacency/workspace/src/profile/update-profile.ts
@@ -1,7 +1,8 @@
 export function updateProfile(input: { displayName: string }) {
-  if (!input.displayName.trim()) {
+  const displayName = input.displayName.trim()
+  if (!displayName) {
     throw new Error('displayName is required')
   }
 
-  return input
+  return { ...input, displayName }
 }

--- a/tests/fixtures/pack-quality/source-test-adjacency/workspace/tests/unit/update-profile.test.ts
+++ b/tests/fixtures/pack-quality/source-test-adjacency/workspace/tests/unit/update-profile.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { updateProfile } from '../../src/profile/update-profile.js'
+
+describe('updateProfile', () => {
+  it('keeps source and test adjacency obvious', () => {
+    expect(updateProfile({ displayName: 'Sam' })).toEqual({ displayName: 'Sam' })
+  })
+})

--- a/tests/fixtures/pack-quality/source-test-adjacency/workspace/tests/unit/update-profile.test.ts
+++ b/tests/fixtures/pack-quality/source-test-adjacency/workspace/tests/unit/update-profile.test.ts
@@ -6,4 +6,8 @@ describe('updateProfile', () => {
   it('keeps source and test adjacency obvious', () => {
     expect(updateProfile({ displayName: 'Sam' })).toEqual({ displayName: 'Sam' })
   })
+
+  it('returns a trimmed displayName after validation', () => {
+    expect(updateProfile({ displayName: '  Sam  ' })).toEqual({ displayName: 'Sam' })
+  })
 })

--- a/tests/unit/helpers/pack-quality.ts
+++ b/tests/unit/helpers/pack-quality.ts
@@ -1,0 +1,161 @@
+import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative, resolve, sep } from 'node:path'
+
+import { runContextPackCommand } from '../../../src/infrastructure/context-pack-command.js'
+import { generateGraph, type GenerateGraphResult } from '../../../src/infrastructure/generate.js'
+
+import { normalizeAssertionPath } from './platform.js'
+
+const PACK_QUALITY_FIXTURE_ORDER = [
+  'controller-service-test-flow',
+  'queue-job-retry-workflow',
+  'cli-command-implementation',
+  'api-route-schema-service',
+  'monorepo-package-boundary',
+  'source-test-adjacency',
+  'noisy-helper-distractor',
+] as const
+
+const PACK_QUALITY_FIXTURE_ROOT = resolve('tests/fixtures/pack-quality')
+
+interface PackQualityFixtureManifest {
+  prompt: string
+  budget?: number
+  expected_workflow_centers: string[]
+  expected_likely_edit_files: string[]
+  expected_likely_test_files: string[]
+  expected_validation_commands: string[]
+  expected_negative_guidance: string[]
+}
+
+interface PackSchemaPayload {
+  workflow_centers?: Array<{ path?: string }>
+  likely_edit_files?: Array<{ path?: string }>
+  likely_test_files?: Array<{ path?: string }>
+  validation_commands?: string[]
+  negative_guidance?: string[]
+}
+
+export interface PackQualityFixtureRunResult {
+  fixture: PackQualityFixtureManifest
+  graph: GenerateGraphResult
+  payload: PackSchemaPayload
+}
+
+function withTempDir<T>(callback: (tempDir: string) => T | Promise<T>): T | Promise<T> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'madar-pack-quality-'))
+  const finalize = () => rmSync(tempDir, { recursive: true, force: true })
+  try {
+    const result = callback(tempDir)
+    if (result && typeof (result as Promise<T>).then === 'function') {
+      return (result as Promise<T>).finally(finalize)
+    }
+    finalize()
+    return result
+  } catch (error) {
+    finalize()
+    throw error
+  }
+}
+
+function fixtureDir(name: string): string {
+  return join(PACK_QUALITY_FIXTURE_ROOT, name)
+}
+
+function fixtureManifestPath(name: string): string {
+  return join(fixtureDir(name), 'fixture.json')
+}
+
+function fixtureWorkspaceRoot(name: string): string {
+  return join(fixtureDir(name), 'workspace')
+}
+
+function copyFixtureWorkspace(name: string, tempDir: string): string {
+  const sourceRoot = fixtureWorkspaceRoot(name)
+  const targetRoot = join(tempDir, name)
+  cpSync(sourceRoot, targetRoot, {
+    recursive: true,
+    filter: (source) => {
+      const relativePath = relative(sourceRoot, source)
+      return relativePath !== 'out' && !relativePath.startsWith(`out${sep}`)
+    },
+  })
+  return targetRoot
+}
+
+function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
+  const manifestPath = fixtureManifestPath(name)
+  const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as Partial<PackQualityFixtureManifest>
+  return {
+    prompt: parsed.prompt ?? '',
+    ...(typeof parsed.budget === 'number' ? { budget: parsed.budget } : {}),
+    expected_workflow_centers: parsed.expected_workflow_centers ?? [],
+    expected_likely_edit_files: parsed.expected_likely_edit_files ?? [],
+    expected_likely_test_files: parsed.expected_likely_test_files ?? [],
+    expected_validation_commands: parsed.expected_validation_commands ?? [],
+    expected_negative_guidance: parsed.expected_negative_guidance ?? [],
+  }
+}
+
+function normalizePayload(payload: PackSchemaPayload): PackSchemaPayload {
+  return {
+    ...payload,
+    ...(payload.workflow_centers
+      ? {
+          workflow_centers: payload.workflow_centers.map((entry) => ({
+            ...entry,
+            ...(entry.path ? { path: normalizeAssertionPath(entry.path) } : {}),
+          })),
+        }
+      : {}),
+    ...(payload.likely_edit_files
+      ? {
+          likely_edit_files: payload.likely_edit_files.map((entry) => ({
+            ...entry,
+            ...(entry.path ? { path: normalizeAssertionPath(entry.path) } : {}),
+          })),
+        }
+      : {}),
+    ...(payload.likely_test_files
+      ? {
+          likely_test_files: payload.likely_test_files.map((entry) => ({
+            ...entry,
+            ...(entry.path ? { path: normalizeAssertionPath(entry.path) } : {}),
+          })),
+        }
+      : {}),
+  }
+}
+
+export function listPackQualityFixtures(): string[] {
+  const fixtureNames = readdirSync(PACK_QUALITY_FIXTURE_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+
+  return PACK_QUALITY_FIXTURE_ORDER.filter((name) =>
+    fixtureNames.includes(name) && existsSync(fixtureManifestPath(name)) && existsSync(fixtureWorkspaceRoot(name)))
+}
+
+export async function runPackQualityFixture(name: string): Promise<PackQualityFixtureRunResult> {
+  const fixture = loadPackQualityFixture(name)
+  return withTempDir(async (tempDir) => {
+    const workspaceRoot = copyFixtureWorkspace(name, tempDir)
+    const graph = generateGraph(workspaceRoot, { noHtml: true })
+    const graphPath = join(workspaceRoot, 'out', 'graph.json')
+    const packOutput = await runContextPackCommand({
+      prompt: fixture.prompt,
+      budget: fixture.budget ?? 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath,
+      format: 'json',
+    } as never)
+
+    return {
+      fixture,
+      graph,
+      payload: normalizePayload(JSON.parse(packOutput) as PackSchemaPayload),
+    }
+  })
+}

--- a/tests/unit/helpers/pack-quality.ts
+++ b/tests/unit/helpers/pack-quality.ts
@@ -87,14 +87,46 @@ function copyFixtureWorkspace(name: string, tempDir: string): string {
 function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
   const manifestPath = fixtureManifestPath(name)
   const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as Partial<PackQualityFixtureManifest>
+  const requiredArrayFields = [
+    'expected_workflow_centers',
+    'expected_likely_edit_files',
+    'expected_likely_test_files',
+    'expected_validation_commands',
+    'expected_negative_guidance',
+  ] as const
+  const problems: string[] = []
+
+  if (typeof parsed.prompt !== 'string' || parsed.prompt.trim().length === 0) {
+    problems.push('"prompt" must be a non-empty string')
+  }
+  if ('budget' in parsed && parsed.budget !== undefined && typeof parsed.budget !== 'number') {
+    problems.push('"budget" must be a number when provided')
+  }
+  for (const field of requiredArrayFields) {
+    if (!Array.isArray(parsed[field])) {
+      problems.push(`"${field}" must be an array`)
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(`Invalid fixture manifest at ${manifestPath}: ${problems.join('; ')}`)
+  }
+
+  const prompt = parsed.prompt as string
+  const expectedWorkflowCenters = parsed.expected_workflow_centers as string[]
+  const expectedLikelyEditFiles = parsed.expected_likely_edit_files as string[]
+  const expectedLikelyTestFiles = parsed.expected_likely_test_files as string[]
+  const expectedValidationCommands = parsed.expected_validation_commands as string[]
+  const expectedNegativeGuidance = parsed.expected_negative_guidance as string[]
+
   return {
-    prompt: parsed.prompt ?? '',
+    prompt,
     ...(typeof parsed.budget === 'number' ? { budget: parsed.budget } : {}),
-    expected_workflow_centers: parsed.expected_workflow_centers ?? [],
-    expected_likely_edit_files: parsed.expected_likely_edit_files ?? [],
-    expected_likely_test_files: parsed.expected_likely_test_files ?? [],
-    expected_validation_commands: parsed.expected_validation_commands ?? [],
-    expected_negative_guidance: parsed.expected_negative_guidance ?? [],
+    expected_workflow_centers: expectedWorkflowCenters,
+    expected_likely_edit_files: expectedLikelyEditFiles,
+    expected_likely_test_files: expectedLikelyTestFiles,
+    expected_validation_commands: expectedValidationCommands,
+    expected_negative_guidance: expectedNegativeGuidance,
   }
 }
 

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { listPackQualityFixtures, runPackQualityFixture } from './helpers/pack-quality.js'
+
+const EXPECTED_FIXTURES = [
+  'controller-service-test-flow',
+  'queue-job-retry-workflow',
+  'cli-command-implementation',
+  'api-route-schema-service',
+  'monorepo-package-boundary',
+  'source-test-adjacency',
+  'noisy-helper-distractor',
+] as const
+
+describe('pack-quality fixtures (#298)', () => {
+  it('ships all listed pack-quality fixture categories', () => {
+    expect(listPackQualityFixtures()).toEqual(EXPECTED_FIXTURES)
+  })
+
+  for (const fixtureName of EXPECTED_FIXTURES) {
+    it(`generates a deterministic implement pack for ${fixtureName}`, async () => {
+      const result = await runPackQualityFixture(fixtureName)
+
+      expect(result.graph.nodeCount).toBeGreaterThan(0)
+      expect(result.payload.workflow_centers?.map((entry) => entry.path)).toEqual(
+        expect.arrayContaining(result.fixture.expected_workflow_centers),
+      )
+      expect(result.payload.likely_edit_files?.map((entry) => entry.path)).toEqual(
+        expect.arrayContaining(result.fixture.expected_likely_edit_files),
+      )
+
+      if (result.fixture.expected_likely_test_files.length > 0) {
+        expect(result.payload.likely_test_files?.map((entry) => entry.path)).toEqual(
+          expect.arrayContaining(result.fixture.expected_likely_test_files),
+        )
+      }
+
+      if (result.fixture.expected_validation_commands.length > 0) {
+        expect(result.payload.validation_commands).toEqual(
+          expect.arrayContaining(result.fixture.expected_validation_commands),
+        )
+      }
+
+      for (const snippet of result.fixture.expected_negative_guidance) {
+        expect(result.payload.negative_guidance?.some((entry) => entry.includes(snippet))).toBe(true)
+      }
+    })
+  }
+})

--- a/tests/unit/pack-quality-helper.test.ts
+++ b/tests/unit/pack-quality-helper.test.ts
@@ -1,0 +1,31 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { runPackQualityFixture } from './helpers/pack-quality.js'
+
+const tempFixtureNames: string[] = []
+
+afterEach(() => {
+  while (tempFixtureNames.length > 0) {
+    const name = tempFixtureNames.pop()
+    if (name) {
+      rmSync(resolve('tests/fixtures/pack-quality', name), { recursive: true, force: true })
+    }
+  }
+})
+
+describe('pack-quality helper', () => {
+  it('throws when a fixture manifest is malformed', async () => {
+    const fixtureName = '__invalid-manifest-fixture'
+    const fixtureRoot = resolve('tests/fixtures/pack-quality', fixtureName)
+    tempFixtureNames.push(fixtureName)
+    mkdirSync(join(fixtureRoot, 'workspace'), { recursive: true })
+    writeFileSync(join(fixtureRoot, 'fixture.json'), JSON.stringify({
+      expected_workflow_centers: [],
+    }))
+
+    await expect(runPackQualityFixture(fixtureName)).rejects.toThrow(/fixture\.json|prompt|expected_likely_edit_files/i)
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable pack-quality fixture harness that copies real mini-repos, generates graphs, and runs implement packs
- cover all listed issue categories under tests/fixtures/pack-quality with deterministic expectations
- lock workflow centers, likely edit files, likely test files, validation commands, and helper distractor guidance into CI

Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added seven pack-quality test fixtures covering common software patterns: API route validation, CLI command implementation, service-controller flows, monorepo boundaries, invoice retry handling, report job queuing, and profile updates.
  * Added test utilities to load and execute pack-quality fixtures, enabling validation of code generation workflows across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->