### PR TITLE
[P1] Add search-expand-refine retrieval pipeline for pack generation

### DIFF
--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -416,12 +416,6 @@ export interface CompiledContextPack<
   slice?: ContextPackSliceMetadata
   execution_slice?: ContextPackExecutionSlice
   answer_contract?: ContextPackRuntimeGenerationAnswerContract
-  /**
-   * Retrieval-gate decision (#75) attached when the caller invoked the
-   * gate before building the pack. Carries `level`, `reason`, `intent`,
-   * `skipped_retrieval`, and the underlying signals so consumers can
-   * audit why a retrieval depth was chosen.
-   */
   retrieval_gate?: RetrievalGateDecision
 }
 

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -173,12 +173,30 @@ export interface ContextPackRuntimeGenerationAnswerContract {
   confidence?: 'high' | 'medium' | 'low'
 }
 
+export type ImplementationPackPhase =
+  | 'seed'
+  | 'expand'
+  | 'promote'
+  | 'attach'
+  | 'refine'
+  | 'render'
+
+export interface ImplementationPackPipelinePhase {
+  phase: ImplementationPackPhase
+  summary: string
+}
+
+export interface ImplementationPackRetrievalPipeline {
+  phases: ImplementationPackPipelinePhase[]
+}
+
 export interface ImplementationPackFileHint {
   path: string
   score: number
   reason: string
   why?: string
   matched_symbols: string[]
+  phases?: ImplementationPackPhase[]
 }
 
 export interface ImplementationPackSurfaceHint {
@@ -187,6 +205,7 @@ export interface ImplementationPackSurfaceHint {
   line_number: number
   kind: 'contract' | 'public_surface' | 'pattern'
   why: string
+  phases?: ImplementationPackPhase[]
 }
 
 export interface ImplementationPackRiskBoundary {
@@ -205,6 +224,7 @@ export interface ImplementationPackRuntimeContext {
 
 export interface ImplementationPackGuidance {
   summary: string
+  retrieval_pipeline: ImplementationPackRetrievalPipeline
   workflow_centers: ContextPackWorkflowCenter[]
   likely_edit_files: ImplementationPackFileHint[]
   likely_test_files: ImplementationPackFileHint[]
@@ -225,6 +245,7 @@ export interface ContextPackWorkflowCenter {
   reasons?: string[]
   matched_symbols?: string[]
   reason: string
+  phases?: ImplementationPackPhase[]
 }
 
 export interface ContextPackRecommendedFirstRead {
@@ -239,6 +260,7 @@ export interface ContextPackPublicContract {
   line_number: number
   kind: 'contract' | 'public_surface'
   why: string
+  phases?: ImplementationPackPhase[]
 }
 
 export type ContextRepresentationType =
@@ -416,6 +438,7 @@ export interface ContextPackSchemaV1<TPack = unknown> {
   likely_edit_files: ImplementationPackFileHint[]
   likely_test_files: ImplementationPackFileHint[]
   public_contracts: ContextPackPublicContract[]
+  retrieval_pipeline?: ImplementationPackRetrievalPipeline
   risk_boundaries: ImplementationPackRiskBoundary[]
   validation_commands: string[]
   negative_guidance: string[]

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -419,6 +419,7 @@ function publicContracts(
       line_number: entry.line_number,
       kind: entry.kind,
       why: entry.why,
+      ...(entry.phases?.length ? { phases: entry.phases } : {}),
     })) ?? []
 }
 
@@ -540,6 +541,7 @@ function buildPackSchemaV1<TPack extends PackPayload>(
     likely_edit_files: response.implementation?.likely_edit_files ?? [],
     likely_test_files: response.implementation?.likely_test_files ?? [],
     public_contracts: contracts,
+    ...(response.implementation?.retrieval_pipeline ? { retrieval_pipeline: response.implementation.retrieval_pipeline } : {}),
     risk_boundaries: response.implementation?.risk_boundaries ?? [],
     validation_commands: response.implementation?.validation_commands ?? [],
     negative_guidance: guidance,
@@ -588,6 +590,7 @@ function renderPackSchemaText(schema: PackSchemaEnvelope): string {
       const label = entry.path && entry.label !== entry.path ? ` (${entry.label})` : ''
       return `- ${location}${label}: ${entry.reason}`
     })),
+    ...renderTextSection('Retrieval pipeline', schema.retrieval_pipeline?.phases.map((entry) => `- ${entry.phase}: ${entry.summary}`) ?? []),
     ...renderTextSection('Recommended first read', schema.recommended_first_read.map((entry) => formatFileHint(entry.path, entry.reason, entry.label))),
     ...renderTextSection('Likely edit files', schema.likely_edit_files.map((entry) => formatScoredFileHint(entry))),
     ...renderTextSection('Likely test files', schema.likely_test_files.map((entry) => formatScoredFileHint(entry))),

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -7,12 +7,15 @@ import type {
   ContextPackWorkflowCenter,
   ImplementationPackFileHint,
   ImplementationPackGuidance,
+  ImplementationPackPhase,
+  ImplementationPackRetrievalPipeline,
   ImplementationPackRiskBoundary,
   ImplementationPackSurfaceHint,
 } from '../contracts/context-pack.js'
 import type { KnowledgeGraph } from '../contracts/graph.js'
 import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { classifySourceDomain } from '../shared/source-discovery.js'
+import { lineNumberFromSourceLocation } from '../shared/source-location.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
 import { riskMap } from './risk-map.js'
 import type { RetrieveMatchedNode, RetrieveResult } from './retrieve.js'
@@ -25,6 +28,7 @@ const WORKFLOW_OWNER_PATTERN = /(?:service|controller|handler|worker|queue|job|w
 const HELPER_PATTERN = /(?:helper|util|format|formatter|presenter|serializer|mapper|constant|type|schema|dto)/i
 const SIDE_EFFECT_PATTERN = /(?:save|create|update|delete|persist|write|enqueue|publish|dispatch|emit|send|store|cache|repository|queue|session|database|db)/i
 const WORKFLOW_EDGE_RELATIONS = new Set(['calls', 'controller_route', 'depends_on', 'imports_from', 'enqueues_job'])
+const SURFACE_ATTACHMENT_RELATIONS = new Set(['calls', 'controller_route', 'depends_on', 'imports_from'])
 const TEST_EDIT_PATTERN = /\b(?:add|update|modify|change|fix|write|edit|refactor|rename|remove)\b.{0,24}\b(?:test|tests|spec|specs|e2e|integration)\b|\b(?:test|tests|spec|specs|e2e|integration)\b.{0,24}\b(?:add|update|modify|change|fix|write|edit|refactor|rename|remove)\b/i
 const E2E_TEST_PATTERN = /(?:^|\/)(?:e2e|integration)(?:\/|$)|\.(?:e2e|integration)\.[^/]+$/i
 const GENERIC_MODULE_TOKENS = new Set([
@@ -32,6 +36,14 @@ const GENERIC_MODULE_TOKENS = new Set([
   'app', 'apps', 'lib', 'libs', 'packages', 'package', 'modules', 'module',
   'feature', 'features', 'http', 'api',
 ])
+const IMPLEMENTATION_PIPELINE_PHASE_ORDER: ImplementationPackPhase[] = [
+  'seed',
+  'expand',
+  'promote',
+  'attach',
+  'refine',
+  'render',
+]
 
 type PackageScripts = Record<string, string>
 
@@ -55,6 +67,8 @@ interface RankedFileAccumulator {
   matchedSymbolSet: Set<string>
   reasons: string[]
   reasonSet: Set<string>
+  phases: ImplementationPackPhase[]
+  phaseSet: Set<ImplementationPackPhase>
 }
 
 interface IndexedTestFile {
@@ -74,6 +88,8 @@ interface WorkflowNodeCandidate {
   framework_role?: string
   match_score: number
   relevance_band: 'direct' | 'related'
+  phases: ImplementationPackPhase[]
+  phase_reasons: string[]
 }
 
 interface WorkflowScoreDetails {
@@ -90,7 +106,11 @@ interface WorkflowCenterAggregate {
   matched_symbols: string[]
   reasons: string[]
   reasonSet: Set<string>
+  phase_reasons: string[]
+  phaseReasonSet: Set<string>
   matchedSymbolSet: Set<string>
+  phases: ImplementationPackPhase[]
+  phaseSet: Set<ImplementationPackPhase>
   bestNodeScore: number
   bestNonHelperLabel?: string
   bestNonHelperScore: number
@@ -104,6 +124,16 @@ function rootPathFromGraph(graph: KnowledgeGraph): string | undefined {
 
 function roundFileScore(value: number): number {
   return Math.round(Math.max(0, value) * 100) / 100
+}
+
+function compareStableText(left: string, right: string): number {
+  if (left < right) {
+    return -1
+  }
+  if (left > right) {
+    return 1
+  }
+  return 0
 }
 
 function finalizeReason(reason: string): string {
@@ -122,11 +152,47 @@ function pushUnique(values: string[], seen: Set<string>, value: string | undefin
   values.push(value)
 }
 
+function pushUniquePhase(
+  values: ImplementationPackPhase[],
+  seen: Set<ImplementationPackPhase>,
+  value: ImplementationPackPhase | undefined,
+): void {
+  if (!value || seen.has(value)) {
+    return
+  }
+  seen.add(value)
+  values.push(value)
+}
+
+function orderedPhases(phases: readonly ImplementationPackPhase[]): ImplementationPackPhase[] {
+  const seen = new Set<ImplementationPackPhase>()
+  const ordered: ImplementationPackPhase[] = []
+  for (const phase of IMPLEMENTATION_PIPELINE_PHASE_ORDER) {
+    if (!phases.includes(phase) || seen.has(phase)) {
+      continue
+    }
+    seen.add(phase)
+    ordered.push(phase)
+  }
+  return ordered
+}
+
+function mergePhaseLists(
+  values: ImplementationPackPhase[],
+  seen: Set<ImplementationPackPhase>,
+  phases: readonly ImplementationPackPhase[],
+): void {
+  for (const phase of phases) {
+    pushUniquePhase(values, seen, phase)
+  }
+}
+
 function createImplementationPackFileHint(
   path: string,
   score: number,
   reason: string,
   matchedSymbols: readonly string[],
+  phases: readonly ImplementationPackPhase[] = [],
 ): ImplementationPackFileHint {
   const finalReason = finalizeReason(reason)
   return {
@@ -135,6 +201,7 @@ function createImplementationPackFileHint(
     reason: finalReason,
     why: finalReason,
     matched_symbols: [...new Set(matchedSymbols)],
+    ...(phases.length > 0 ? { phases: orderedPhases(phases) } : {}),
   }
 }
 
@@ -170,6 +237,7 @@ function addRankedFileCandidate(
   score: number,
   reason: string,
   matchedSymbols: readonly string[],
+  phases: readonly ImplementationPackPhase[] = [],
 ): void {
   const entry = target.get(path) ?? {
     path,
@@ -178,29 +246,34 @@ function addRankedFileCandidate(
     matchedSymbolSet: new Set<string>(),
     reasons: [],
     reasonSet: new Set<string>(),
+    phases: [],
+    phaseSet: new Set<ImplementationPackPhase>(),
   }
   entry.score += score
   pushUnique(entry.reasons, entry.reasonSet, finalizeReason(reason))
   for (const symbol of matchedSymbols) {
     pushUnique(entry.matched_symbols, entry.matchedSymbolSet, symbol)
   }
+  mergePhaseLists(entry.phases, entry.phaseSet, phases)
   target.set(path, entry)
 }
 
 function rankedFileHints(
   entries: Iterable<RankedFileAccumulator>,
   limit: number,
+  extraPhases: readonly ImplementationPackPhase[] = [],
 ): ImplementationPackFileHint[] {
   return [...entries]
     .sort((left, right) => right.score - left.score
       || right.reasons.length - left.reasons.length
-      || left.path.localeCompare(right.path))
+      || compareStableText(left.path, right.path))
     .slice(0, limit)
     .map((entry) => createImplementationPackFileHint(
       entry.path,
       entry.score,
       entry.reasons[0] ?? 'Relevant file for this task.',
       entry.matched_symbols,
+      [...entry.phases, ...extraPhases],
     ))
 }
 
@@ -273,6 +346,34 @@ function graphRelation(graph: KnowledgeGraph, sourceId: string, targetId: string
   return String(graph.edgeAttributes(sourceId, targetId).relation ?? '')
 }
 
+function upsertWorkflowCandidate(
+  target: Map<string, WorkflowNodeCandidate>,
+  candidate: WorkflowNodeCandidate,
+): void {
+  const existing = target.get(candidate.node_id)
+  if (!existing) {
+    target.set(candidate.node_id, {
+      ...candidate,
+      phases: orderedPhases(candidate.phases),
+      phase_reasons: [...new Set(candidate.phase_reasons)],
+    })
+    return
+  }
+
+  existing.match_score = Math.max(existing.match_score, candidate.match_score)
+  if (candidate.relevance_band === 'direct') {
+    existing.relevance_band = 'direct'
+  }
+  if (!existing.node_kind && candidate.node_kind) {
+    existing.node_kind = candidate.node_kind
+  }
+  if (!existing.framework_role && candidate.framework_role) {
+    existing.framework_role = candidate.framework_role
+  }
+  existing.phases = orderedPhases([...existing.phases, ...candidate.phases])
+  existing.phase_reasons = [...new Set([...existing.phase_reasons, ...candidate.phase_reasons])]
+}
+
 function workflowCandidates(
   graph: KnowledgeGraph,
   retrieval: RetrieveResult,
@@ -288,7 +389,7 @@ function workflowCandidates(
     if (sourceDomain === 'test' || sourceDomain === 'docs' || sourceDomain === 'build_artifact') {
       continue
     }
-    byNodeId.set(node.node_id, {
+    upsertWorkflowCandidate(byNodeId, {
       node_id: node.node_id,
       label: node.label,
       source_file: node.source_file,
@@ -296,6 +397,8 @@ function workflowCandidates(
       ...(node.framework_role ? { framework_role: node.framework_role } : {}),
       match_score: node.match_score,
       relevance_band: node.relevance_band === 'direct' ? 'direct' : 'related',
+      phases: ['seed'],
+      phase_reasons: ['Seed search matched this symbol directly from the task prompt.'],
     })
   }
 
@@ -306,14 +409,14 @@ function workflowCandidates(
 
     for (const predecessorId of graph.predecessors(node.node_id)) {
       const relation = graphRelation(graph, predecessorId, node.node_id)
-      if (!WORKFLOW_EDGE_RELATIONS.has(relation) || byNodeId.has(predecessorId)) {
+      if (!WORKFLOW_EDGE_RELATIONS.has(relation)) {
         continue
       }
       if (classifyWorkflowDomain(graph, predecessorId, rootPath) !== 'production') {
         continue
       }
       const attributes = graph.nodeAttributes(predecessorId)
-      byNodeId.set(predecessorId, {
+      upsertWorkflowCandidate(byNodeId, {
         node_id: predecessorId,
         label: String(attributes.label ?? predecessorId),
         source_file: String(attributes.source_file ?? ''),
@@ -321,19 +424,21 @@ function workflowCandidates(
         ...(attributes.framework_role ? { framework_role: String(attributes.framework_role) } : {}),
         match_score: Math.max(0.1, node.match_score * 0.35),
         relevance_band: 'related',
+        phases: ['expand'],
+        phase_reasons: [`Graph expansion followed ${relation} from ${node.label}.`],
       })
     }
 
     for (const successorId of graph.successors(node.node_id)) {
       const relation = graphRelation(graph, node.node_id, successorId)
-      if (!WORKFLOW_EDGE_RELATIONS.has(relation) || byNodeId.has(successorId)) {
+      if (!WORKFLOW_EDGE_RELATIONS.has(relation)) {
         continue
       }
       if (classifyWorkflowDomain(graph, successorId, rootPath) !== 'production') {
         continue
       }
       const attributes = graph.nodeAttributes(successorId)
-      byNodeId.set(successorId, {
+      upsertWorkflowCandidate(byNodeId, {
         node_id: successorId,
         label: String(attributes.label ?? successorId),
         source_file: String(attributes.source_file ?? ''),
@@ -341,6 +446,8 @@ function workflowCandidates(
         ...(attributes.framework_role ? { framework_role: String(attributes.framework_role) } : {}),
         match_score: Math.max(0.1, node.match_score * 0.25),
         relevance_band: 'related',
+        phases: ['expand'],
+        phase_reasons: [`Graph expansion followed ${relation} from ${node.label}.`],
       })
     }
   }
@@ -524,7 +631,11 @@ function workflowCenters(
       matched_symbols: [],
       reasons: [],
       reasonSet: new Set<string>(),
+      phase_reasons: [],
+      phaseReasonSet: new Set<string>(),
       matchedSymbolSet: new Set<string>(),
+      phases: [],
+      phaseSet: new Set<ImplementationPackPhase>(),
       bestNodeScore: Number.NEGATIVE_INFINITY,
       bestNonHelperScore: Number.NEGATIVE_INFINITY,
     }
@@ -534,9 +645,13 @@ function workflowCenters(
       current.direct_matches += 1
     }
     pushUnique(current.matched_symbols, current.matchedSymbolSet, candidate.label)
+    for (const reason of candidate.phase_reasons) {
+      pushUnique(current.phase_reasons, current.phaseReasonSet, reason)
+    }
     for (const reason of scoreDetails.reasons) {
       pushUnique(current.reasons, current.reasonSet, reason)
     }
+    mergePhaseLists(current.phases, current.phaseSet, candidate.phases)
     const scoreDelta = scoreDetails.score - current.bestNodeScore
     if (scoreDelta > 1e-9 || (Math.abs(scoreDelta) <= 1e-9 && !scoreDetails.helperLike)) {
       current.bestNodeScore = scoreDetails.score
@@ -551,23 +666,29 @@ function workflowCenters(
 
   return [...centers.values()]
     .map((entry) => {
+      const reasons = [...entry.reasons]
       if (entry.direct_matches > 1) {
         entry.score += 0.5
-        pushUnique(entry.reasons, entry.reasonSet, `Multiple direct matches converge in ${entry.path}.`)
+        reasons.push(`Multiple direct matches converge in ${entry.path}.`)
       }
-      const reason = entry.reasons.slice(0, 3).join(' ')
+      const reason = [
+        ...entry.phase_reasons,
+        'Workflow-center promotion preferred this file as the owning workflow surface.',
+        ...reasons,
+      ].slice(0, 3).join(' ')
       return {
         label: entry.bestNonHelperLabel ?? entry.label,
         path: entry.path,
         score: Math.round(entry.score * 100) / 100,
-        reasons: entry.reasons.slice(0, 4),
+        reasons: reasons.slice(0, 4),
         matched_symbols: entry.matched_symbols,
         reason: reason.length > 0 ? reason : 'Structural and lexical signals both point to this file.',
+        phases: orderedPhases([...entry.phases, 'promote']),
       } satisfies ContextPackWorkflowCenter
     })
     .sort((left, right) => (right.score ?? 0) - (left.score ?? 0)
       || (right.reasons?.length ?? 0) - (left.reasons?.length ?? 0)
-      || left.path!.localeCompare(right.path!))
+      || compareStableText(left.path ?? '', right.path ?? ''))
     .slice(0, limit)
 }
 
@@ -611,6 +732,7 @@ function mergeLikelyEditFiles(
       reason: center.reason,
       why: center.reason,
       matched_symbols: matchedSymbols.length > 0 ? matchedSymbols : [center.label],
+      phases: orderedPhases([...(center.phases ?? []), ...(existing?.phases ?? []), 'attach', 'refine']),
     })
     seen.add(center.path)
     if (results.length >= limit) {
@@ -628,7 +750,12 @@ function mergeLikelyEditFiles(
     ) {
       continue
     }
-    results.push(entry)
+    results.push({
+      ...entry,
+      ...(entry.phases?.length
+        ? { phases: orderedPhases([...entry.phases, 'attach', 'refine']) }
+        : { phases: ['attach', 'refine'] as ImplementationPackPhase[] }),
+    })
     seen.add(entry.path)
     if (results.length >= limit) {
       break
@@ -641,6 +768,7 @@ function mergeLikelyEditFiles(
 function groupFiles(
   nodes: readonly RetrieveMatchedNode[],
   rootPath?: string,
+  phases: readonly ImplementationPackPhase[] = [],
 ): ImplementationPackFileHint[] {
   const byPath = new Map<string, FileAggregate>()
 
@@ -677,6 +805,7 @@ function groupFiles(
       entry.score,
       reason,
       [...entry.direct_symbols, ...entry.related_symbols],
+      phases,
     )
   })
 }
@@ -720,10 +849,11 @@ function likelyTestFiles(
       ...coveredTestNodes(graph, retrieval, rootPath),
     ],
     rootPath,
+    ['attach'],
   )
 
   for (const entry of directAndCovered) {
-    addRankedFileCandidate(ranked, entry.path, entry.score, entry.reason, entry.matched_symbols)
+    addRankedFileCandidate(ranked, entry.path, entry.score, entry.reason, entry.matched_symbols, entry.phases ?? ['attach'])
   }
 
   const indexedTests = indexTestFiles(graph, rootPath)
@@ -773,11 +903,12 @@ function likelyTestFiles(
           ...(testFile.labels.length > 0 ? [testFile.labels[0]!] : []),
           ...editFile.matched_symbols,
         ],
+        ['attach'],
       )
     }
   }
 
-  return rankedFileHints(ranked.values(), limit)
+  return rankedFileHints(ranked.values(), limit, ['refine'])
 }
 
 function coveredTestNodes(
@@ -856,6 +987,7 @@ function pushSurfaceHint(
   kind: ImplementationPackSurfaceHint['kind'],
   why: string,
   rootPath?: string,
+  phases: readonly ImplementationPackPhase[] = [],
 ): void {
   const sourceFile = relativizeSourceFile(node.source_file, rootPath)
   const key = `${kind}:${sourceFile}:${node.label}:${node.line_number}`
@@ -869,12 +1001,47 @@ function pushSurfaceHint(
     line_number: node.line_number,
     kind,
     why,
+    ...(phases.length > 0 ? { phases: orderedPhases(phases) } : {}),
   })
 }
 
+function graphNodesForPath(
+  graph: KnowledgeGraph,
+  path: string,
+  rootPath?: string,
+): string[] {
+  return graph
+    .nodeEntries()
+    .filter(([, attributes]) => relativizeSourceFile(String(attributes.source_file ?? ''), rootPath) === path)
+    .map(([nodeId]) => nodeId)
+}
+
+function retrieveMatchedNodeFromGraph(
+  graph: KnowledgeGraph,
+  nodeId: string,
+): RetrieveMatchedNode {
+  const attributes = graph.nodeAttributes(nodeId)
+  return {
+    node_id: nodeId,
+    label: String(attributes.label ?? nodeId),
+    source_file: String(attributes.source_file ?? ''),
+    line_number: lineNumberFromSourceLocation(String(attributes.source_location ?? '')),
+    node_kind: String(attributes.node_kind ?? ''),
+    framework_role: typeof attributes.framework_role === 'string' ? attributes.framework_role : undefined,
+    file_type: String(attributes.file_type ?? 'code'),
+    snippet: null,
+    match_score: 0,
+    relevance_band: 'related',
+    community: typeof attributes.community === 'number' ? attributes.community : null,
+    community_label: null,
+  }
+}
+
 function buildSurfaceHints(
+  graph: KnowledgeGraph,
   retrieval: RetrieveResult,
   editPaths: ReadonlySet<string>,
+  workflowCentersValue: readonly ContextPackWorkflowCenter[],
   rootPath?: string,
 ): {
   contracts_and_public_surfaces: ImplementationPackSurfaceHint[]
@@ -897,12 +1064,12 @@ function buildSurfaceHints(
     }
 
     if (isContractNode(node)) {
-      pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, node, 'contract', 'Changing this contract can affect implementation callers.', rootPath)
+      pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, node, 'contract', 'Changing this contract can affect implementation callers.', rootPath, ['seed', 'attach'])
       continue
     }
 
     if (isPublicSurfaceNode(node)) {
-      pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, node, 'public_surface', 'This is part of the public entry surface touched by the task.', rootPath)
+      pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, node, 'public_surface', 'This is part of the public entry surface touched by the task.', rootPath, ['seed', 'attach'])
       continue
     }
 
@@ -911,9 +1078,97 @@ function buildSurfaceHints(
     }
   }
 
+  for (const center of workflowCentersValue) {
+    if (!center.path) {
+      continue
+    }
+
+    for (const nodeId of graphNodesForPath(graph, center.path, rootPath)) {
+      for (const predecessorId of graph.predecessors(nodeId)) {
+        const relation = graphRelation(graph, predecessorId, nodeId)
+        if (!SURFACE_ATTACHMENT_RELATIONS.has(relation)) {
+          continue
+        }
+        const neighbor = retrieveMatchedNodeFromGraph(graph, predecessorId)
+        if (classifySourceDomain(neighbor.source_file, rootPath) !== 'production') {
+          continue
+        }
+        if (isContractNode(neighbor)) {
+          pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, neighbor, 'contract', `Attachment stage pulled this nearby contract in from ${center.label} via ${relation}.`, rootPath, ['attach'])
+        } else if (isPublicSurfaceNode(neighbor)) {
+          pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, neighbor, 'public_surface', `Attachment stage pulled this nearby public surface in from ${center.label} via ${relation}.`, rootPath, ['attach'])
+        }
+      }
+
+      for (const successorId of graph.successors(nodeId)) {
+        const relation = graphRelation(graph, nodeId, successorId)
+        if (!SURFACE_ATTACHMENT_RELATIONS.has(relation)) {
+          continue
+        }
+        const neighbor = retrieveMatchedNodeFromGraph(graph, successorId)
+        if (classifySourceDomain(neighbor.source_file, rootPath) !== 'production') {
+          continue
+        }
+        if (isContractNode(neighbor)) {
+          pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, neighbor, 'contract', `Attachment stage pulled this nearby contract in from ${center.label} via ${relation}.`, rootPath, ['attach'])
+        } else if (isPublicSurfaceNode(neighbor)) {
+          pushSurfaceHint(surfaceSeen, contracts_and_public_surfaces, neighbor, 'public_surface', `Attachment stage pulled this nearby public surface in from ${center.label} via ${relation}.`, rootPath, ['attach'])
+        }
+      }
+    }
+  }
+
   return {
     contracts_and_public_surfaces: contracts_and_public_surfaces.slice(0, 6),
     existing_patterns: existing_patterns.slice(0, 5),
+  }
+}
+
+function retrievalPipeline(
+  retrieval: RetrieveResult,
+  workflowCentersValue: readonly ContextPackWorkflowCenter[],
+  likelyEditFiles: readonly ImplementationPackFileHint[],
+  likelyTestFiles: readonly ImplementationPackFileHint[],
+  contractsAndPublicSurfaces: readonly ImplementationPackSurfaceHint[],
+  existingPatterns: readonly ImplementationPackSurfaceHint[],
+  rootPath?: string,
+): ImplementationPackRetrievalPipeline {
+  const productionSeedCount = retrieval.matched_nodes.filter((node) => {
+    if (node.relevance_band === 'peripheral') {
+      return false
+    }
+    const sourceDomain = classifySourceDomain(node.source_file, rootPath)
+    return sourceDomain !== 'test' && sourceDomain !== 'docs' && sourceDomain !== 'build_artifact'
+  }).length
+  const expandedCenterCount = workflowCentersValue.filter((entry) => entry.phases?.includes('expand')).length
+
+  return {
+    phases: [
+      {
+        phase: 'seed',
+        summary: `Seed search matched ${productionSeedCount} production retrieval node${productionSeedCount === 1 ? '' : 's'}.`,
+      },
+      {
+        phase: 'expand',
+        summary: `Graph expansion added ${expandedCenterCount} promoted workflow candidate${expandedCenterCount === 1 ? '' : 's'} from structural neighbors.`,
+      },
+      {
+        phase: 'promote',
+        summary: `Workflow-center promotion ranked ${workflowCentersValue.length} owning file${workflowCentersValue.length === 1 ? '' : 's'} for the brief.`,
+      },
+      {
+        phase: 'attach',
+        summary: `Attachment linked ${likelyTestFiles.length} test file${likelyTestFiles.length === 1 ? '' : 's'} and ${contractsAndPublicSurfaces.length} contract/public surface file${contractsAndPublicSurfaces.length === 1 ? '' : 's'}.`,
+      },
+      {
+        phase: 'refine',
+        summary: `Refinement kept ${likelyEditFiles.length} edit file${likelyEditFiles.length === 1 ? '' : 's'}, ${likelyTestFiles.length} test file${likelyTestFiles.length === 1 ? '' : 's'}, and ${existingPatterns.length} supporting pattern${existingPatterns.length === 1 ? '' : 's'}.`,
+      },
+      {
+        phase: 'render',
+        summary: 'Pack Schema v1 renders the refined implementation guidance for downstream agents.',
+      },
+    ],
   }
 }
 
@@ -1060,6 +1315,7 @@ export function buildImplementationPackGuidance(
     entry.score,
     entry.why,
     entry.matched_symbols,
+    ['seed'],
   ))
   const likely_edit_files = mergeLikelyEditFiles(
     workflow_centers,
@@ -1071,9 +1327,24 @@ export function buildImplementationPackGuidance(
   )
   const likely_test_files = likelyTestFiles(graph, retrieval, likely_edit_files, rootPath, limit)
   const editPaths = new Set(likely_edit_files.map((entry) => entry.path))
-  const { contracts_and_public_surfaces, existing_patterns } = buildSurfaceHints(retrieval, editPaths, rootPath)
+  const { contracts_and_public_surfaces, existing_patterns } = buildSurfaceHints(
+    graph,
+    retrieval,
+    editPaths,
+    workflow_centers,
+    rootPath,
+  )
   const validation = validationCommands(rootPath, likely_test_files)
   const risk_boundaries: ImplementationPackRiskBoundary[] = risk.top_risks
+  const retrieval_pipeline = retrievalPipeline(
+    retrieval,
+    workflow_centers,
+    likely_edit_files,
+    likely_test_files,
+    contracts_and_public_surfaces,
+    existing_patterns,
+    rootPath,
+  )
   const summary = likely_edit_files[0]
     ? `Start with ${likely_edit_files[0].path}, then validate the highest-risk shared boundaries before finishing.`
     : risk.summary
@@ -1081,6 +1352,7 @@ export function buildImplementationPackGuidance(
 
   return {
     summary,
+    retrieval_pipeline,
     workflow_centers,
     likely_edit_files,
     likely_test_files,

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/fixture.json
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/fixture.json
@@ -1,0 +1,28 @@
+{
+  "prompt": "normalize payment aging retry window",
+  "expected_workflow_centers": [
+    "src/core/workflow-runner.ts"
+  ],
+  "expected_likely_edit_files": [
+    "src/core/workflow-runner.ts"
+  ],
+  "expected_likely_test_files": [
+    "tests/unit/workflow-runner.test.ts"
+  ],
+  "expected_validation_commands": [
+    "npm run typecheck",
+    "npm run build",
+    "npm run test:run -- tests/unit/workflow-runner.test.ts"
+  ],
+  "expected_negative_guidance": [
+    "src/core/payment-aging-helper.ts"
+  ],
+  "expected_retrieval_pipeline_phases": [
+    "seed",
+    "expand",
+    "promote",
+    "attach",
+    "refine",
+    "render"
+  ]
+}

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/package.json
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-indirect-seed-workflow-owner",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/payment-aging-helper.ts
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/payment-aging-helper.ts
@@ -1,0 +1,6 @@
+export function normalizePaymentAgingRetryWindow(paymentId: string) {
+  return {
+    paymentId,
+    retryWindowMinutes: 15,
+  }
+}

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/retry-ledger.ts
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/retry-ledger.ts
@@ -1,0 +1,6 @@
+export function storeRetryWindow(entry: { paymentId: string; retryWindowMinutes: number }) {
+  return {
+    ...entry,
+    stored: true,
+  }
+}

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/task-controller.ts
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/task-controller.ts
@@ -1,0 +1,5 @@
+import { runWorkflow } from './workflow-runner.js'
+
+export function handleTask(paymentId: string) {
+  return runWorkflow(paymentId)
+}

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/workflow-runner.ts
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/src/core/workflow-runner.ts
@@ -1,0 +1,7 @@
+import { normalizePaymentAgingRetryWindow } from './payment-aging-helper.js'
+import { storeRetryWindow } from './retry-ledger.js'
+
+export function runWorkflow(paymentId: string) {
+  const retryWindow = normalizePaymentAgingRetryWindow(paymentId)
+  return storeRetryWindow(retryWindow)
+}

--- a/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/tests/unit/workflow-runner.test.ts
+++ b/tests/fixtures/pack-quality/indirect-seed-workflow-owner/workspace/tests/unit/workflow-runner.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { runWorkflow } from '../../src/core/workflow-runner.js'
+
+describe('runWorkflow', () => {
+  it('stores the normalized retry window', () => {
+    expect(runWorkflow('pay-1')).toEqual({
+      paymentId: 'pay-1',
+      retryWindowMinutes: 15,
+      stored: true,
+    })
+  })
+})

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -679,6 +679,16 @@ describe('context-pack-command', () => {
       schema_version: 1,
       task: 'implement',
       task_intent: 'implement',
+      retrieval_pipeline: expect.objectContaining({
+        phases: [
+          expect.objectContaining({ phase: 'seed' }),
+          expect.objectContaining({ phase: 'expand' }),
+          expect.objectContaining({ phase: 'promote' }),
+          expect.objectContaining({ phase: 'attach' }),
+          expect.objectContaining({ phase: 'refine' }),
+          expect.objectContaining({ phase: 'render' }),
+        ],
+      }),
       workflow_centers: expect.arrayContaining([
         expect.objectContaining({
           label: expect.any(String),
@@ -693,7 +703,12 @@ describe('context-pack-command', () => {
         expect.objectContaining({ path: 'src/contracts/context-pack.ts' }),
       ]),
       likely_edit_files: expect.arrayContaining([
-        expect.objectContaining({ path: 'src/infrastructure/context-pack-command.ts', score: expect.any(Number), reason: expect.any(String) }),
+        expect.objectContaining({
+          path: 'src/infrastructure/context-pack-command.ts',
+          score: expect.any(Number),
+          reason: expect.any(String),
+          phases: expect.arrayContaining([expect.any(String)]),
+        }),
       ]),
       likely_test_files: expect.arrayContaining([
         expect.objectContaining({ path: 'tests/unit/context-pack-command.test.ts', score: expect.any(Number), reason: expect.any(String) }),
@@ -777,6 +792,7 @@ describe('context-pack-command', () => {
     expect(output).toContain('Workflow centers')
     expect(output).toContain('Recommended first read')
     expect(output).toContain('Likely edit files')
+    expect(output).toContain('Retrieval pipeline')
     expect(output).toContain('Validation commands')
     expect(output).toContain('Confidence score')
   })

--- a/tests/unit/helpers/pack-quality.ts
+++ b/tests/unit/helpers/pack-quality.ts
@@ -15,6 +15,7 @@ const PACK_QUALITY_FIXTURE_ORDER = [
   'monorepo-package-boundary',
   'source-test-adjacency',
   'noisy-helper-distractor',
+  'indirect-seed-workflow-owner',
 ] as const
 
 const PACK_QUALITY_FIXTURE_ROOT = resolve('tests/fixtures/pack-quality')
@@ -27,6 +28,7 @@ interface PackQualityFixtureManifest {
   expected_likely_test_files: string[]
   expected_validation_commands: string[]
   expected_negative_guidance: string[]
+  expected_retrieval_pipeline_phases?: string[]
 }
 
 interface PackSchemaPayload {
@@ -35,6 +37,9 @@ interface PackSchemaPayload {
   likely_test_files?: Array<{ path?: string }>
   validation_commands?: string[]
   negative_guidance?: string[]
+  retrieval_pipeline?: {
+    phases?: Array<{ phase?: string }>
+  }
 }
 
 export interface PackQualityFixtureRunResult {
@@ -102,6 +107,13 @@ function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
   if ('budget' in parsed && parsed.budget !== undefined && typeof parsed.budget !== 'number') {
     problems.push('"budget" must be a number when provided')
   }
+  if (
+    'expected_retrieval_pipeline_phases' in parsed
+    && parsed.expected_retrieval_pipeline_phases !== undefined
+    && !Array.isArray(parsed.expected_retrieval_pipeline_phases)
+  ) {
+    problems.push('"expected_retrieval_pipeline_phases" must be an array when provided')
+  }
   for (const field of requiredArrayFields) {
     if (!Array.isArray(parsed[field])) {
       problems.push(`"${field}" must be an array`)
@@ -118,6 +130,9 @@ function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
   const expectedLikelyTestFiles = parsed.expected_likely_test_files as string[]
   const expectedValidationCommands = parsed.expected_validation_commands as string[]
   const expectedNegativeGuidance = parsed.expected_negative_guidance as string[]
+  const expectedRetrievalPipelinePhases = Array.isArray(parsed.expected_retrieval_pipeline_phases)
+    ? parsed.expected_retrieval_pipeline_phases as string[]
+    : undefined
 
   return {
     prompt,
@@ -127,6 +142,7 @@ function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
     expected_likely_test_files: expectedLikelyTestFiles,
     expected_validation_commands: expectedValidationCommands,
     expected_negative_guidance: expectedNegativeGuidance,
+    ...(expectedRetrievalPipelinePhases ? { expected_retrieval_pipeline_phases: expectedRetrievalPipelinePhases } : {}),
   }
 }
 

--- a/tests/unit/implementation-pack.test.ts
+++ b/tests/unit/implementation-pack.test.ts
@@ -106,6 +106,49 @@ function buildLikelyTargetsGraph() {
   return graph
 }
 
+function buildIndirectSeedExpansionGraph() {
+  const root = mkdtempSync(join(tmpdir(), 'madar-indirect-seed-'))
+  tempFixtureRoots.push(root)
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'madar-indirect-seed-fixture',
+    private: true,
+    scripts: {
+      typecheck: 'tsc --noEmit',
+      build: 'tsc -p tsconfig.build.json',
+      'test:run': 'vitest run',
+    },
+  }))
+
+  const graph = build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'task_route', label: 'POST /tasks/apply', file_type: 'code', source_file: `${root}/src/http/task-routes.ts`, source_location: 'L10', node_kind: 'route', framework_role: 'express_route', community: 0 },
+          { id: 'task_controller', label: 'TaskController.handle', file_type: 'code', source_file: `${root}/src/core/task-controller.ts`, source_location: 'L20', node_kind: 'method', framework_role: 'nest_controller', community: 0 },
+          { id: 'workflow_runner', label: 'WorkflowRunner.run', file_type: 'code', source_file: `${root}/src/core/workflow-runner.ts`, source_location: 'L30', node_kind: 'method', framework_role: 'nest_provider', community: 1 },
+          { id: 'retry_helper', label: 'normalizePaymentAgingRetryWindow', file_type: 'code', source_file: `${root}/src/core/payment-aging-helper.ts`, source_location: 'L40', node_kind: 'function', community: 1 },
+          { id: 'retry_store', label: 'RetryLedger.store', file_type: 'code', source_file: `${root}/src/core/retry-ledger.ts`, source_location: 'L50', node_kind: 'method', community: 2 },
+          { id: 'retry_contract', label: 'RetryWindowConfig', file_type: 'code', source_file: `${root}/src/contracts/retry-window.ts`, source_location: 'L60', community: 3 },
+          { id: 'workflow_runner_test', label: 'WorkflowRunner.run.spec', file_type: 'code', source_file: `${root}/tests/unit/workflow-runner.test.ts`, source_location: 'L1', node_kind: 'function', community: 4 },
+        ],
+        edges: [
+          { source: 'task_route', target: 'task_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: `${root}/src/http/task-routes.ts` },
+          { source: 'task_controller', target: 'workflow_runner', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/core/task-controller.ts` },
+          { source: 'workflow_runner', target: 'retry_helper', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/core/workflow-runner.ts` },
+          { source: 'workflow_runner', target: 'retry_store', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/core/workflow-runner.ts` },
+          { source: 'workflow_runner', target: 'retry_contract', relation: 'depends_on', confidence: 'EXTRACTED', source_file: `${root}/src/core/workflow-runner.ts` },
+          { source: 'workflow_runner', target: 'workflow_runner_test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/core/workflow-runner.ts` },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+
+  graph.graph.root_path = root
+  return graph
+}
+
 describe('buildImplementationPackGuidance workflow-center scoring (#295)', () => {
   it('ranks the workflow owner above a lexically stronger helper', () => {
     const graph = buildWorkflowCenterGraph()
@@ -195,6 +238,7 @@ describe('buildImplementationPackGuidance workflow-center scoring (#295)', () =>
     expect(guidance.workflow_centers[0]).toEqual(expect.objectContaining({
       label: 'InvoiceGenerationService.generateInvoice',
       path: 'src/invoices/generation-service.ts',
+      phases: expect.arrayContaining(['seed', 'expand', 'promote']),
       score: expect.any(Number),
       reasons: expect.arrayContaining([
         expect.stringMatching(/entry point|route|controller/i),
@@ -648,5 +692,84 @@ describe('buildImplementationPackGuidance likely edit/test targets (#296)', () =
     })
 
     expect(guidance.likely_edit_files.every((entry) => !entry.path.startsWith('tests/'))).toBe(true)
+  })
+})
+
+describe('buildImplementationPackGuidance search-expand-refine pipeline (#299)', () => {
+  it('tracks explicit pipeline phases when graph expansion promotes the workflow owner from an indirect seed', () => {
+    const graph = buildIndirectSeedExpansionGraph()
+    const retrieval = {
+      question: 'normalize payment aging retry window',
+      token_count: 90,
+      matched_nodes: [
+        {
+          node_id: 'retry_helper',
+          label: 'normalizePaymentAgingRetryWindow',
+          source_file: `${graph.graph.root_path}/src/core/payment-aging-helper.ts`,
+          line_number: 40,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'export function normalizePaymentAgingRetryWindow() {}',
+          match_score: 0.97,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Task workflow',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['tests', 'contracts'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 2200,
+      taskIntent: 'implement',
+      limit: 5,
+    })
+
+    expect(guidance.retrieval_pipeline.phases.map((entry) => entry.phase)).toEqual([
+      'seed',
+      'expand',
+      'promote',
+      'attach',
+      'refine',
+      'render',
+    ])
+    expect(guidance.workflow_centers[0]).toEqual(expect.objectContaining({
+      path: 'src/core/workflow-runner.ts',
+      phases: expect.arrayContaining(['expand', 'promote']),
+      reason: expect.stringMatching(/expand|promot/i),
+    }))
+    expect(guidance.likely_edit_files[0]).toEqual(expect.objectContaining({
+      path: 'src/core/workflow-runner.ts',
+      phases: expect.arrayContaining(['expand', 'promote', 'attach', 'refine']),
+      reason: expect.stringMatching(/expand|promot/i),
+    }))
+    expect(guidance.contracts_and_public_surfaces).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        source_file: 'src/contracts/retry-window.ts',
+        kind: 'contract',
+        phases: expect.arrayContaining(['attach']),
+        why: expect.stringMatching(/attach|neighbor/i),
+      }),
+      expect.objectContaining({
+        source_file: 'src/core/task-controller.ts',
+        kind: 'public_surface',
+        phases: expect.arrayContaining(['attach']),
+      }),
+    ]))
   })
 })

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -10,6 +10,7 @@ const EXPECTED_FIXTURES = [
   'monorepo-package-boundary',
   'source-test-adjacency',
   'noisy-helper-distractor',
+  'indirect-seed-workflow-owner',
 ] as const
 
 describe('pack-quality fixtures (#298)', () => {
@@ -38,6 +39,12 @@ describe('pack-quality fixtures (#298)', () => {
       if (result.fixture.expected_validation_commands.length > 0) {
         expect(result.payload.validation_commands).toEqual(
           expect.arrayContaining(result.fixture.expected_validation_commands),
+        )
+      }
+
+      if ((result.fixture.expected_retrieval_pipeline_phases?.length ?? 0) > 0) {
+        expect(result.payload.retrieval_pipeline?.phases?.map((entry) => entry.phase)).toEqual(
+          expect.arrayContaining(result.fixture.expected_retrieval_pipeline_phases ?? []),
         )
       }
 


### PR DESCRIPTION
## Summary
- add an explicit seed/expand/promote/attach/refine/render pipeline for implement packs
- surface phase metadata and retrieval pipeline details through Pack Schema v1
- add an indirect-seed pack-quality fixture proving graph expansion promotes the workflow owner

Closes #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phase tracking to implementation guidance, capturing stages (seed, expand, promote, attach, refine, render) for selected items
  * Pack schema text now includes a "Retrieval pipeline" section and retrieval_pipeline metadata with ordered phase summaries
  * Phase annotations surface in workflow centers and likely-edit/test file listings

* **Tests**
  * Added new fixture for indirect workflow-owner scenarios
  * Expanded phase-tracking tests for the search–expand–refine pipeline and deterministic pack schema checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->