### PR TITLE
Fix runtime-generation explain pack spine selection

### DIFF
--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -3,6 +3,7 @@ import type {
   ContextPackClaim,
   ContextPackCoverage,
   ContextPackEvidenceClass,
+  ContextPackExecutionSliceStep,
   ContextPackExpandableRef,
   ContextPackFormat,
   ImplementationPackGuidance,
@@ -31,6 +32,7 @@ import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
 
 const DEFAULT_IMPACT_DEPTH = 3
 const IMPLEMENTATION_DISTRACTOR_PATTERN = /(?:helper|util|formatter|serializer|mapper|constant|generated|dist\/|build\/|lockfile|migration)/i
+const RUNTIME_GENERATION_DISTRACTOR_PATTERN = /(?:helper|util|formatter|serializer|mapper|constant|status|display|render|renderer|summary|footer|header|view|score|scoring|suggest(?:ed)?|next[-_\s]?steps)/i
 
 export interface ContextPackCommandDependencies {
   loadGraph: (graphPath: string) => KnowledgeGraph
@@ -244,11 +246,37 @@ function defaultPackRetrievalStrategy(
     : undefined
 }
 
+function runtimeGenerationExecutionSpine(
+  task: TaskContextPlan['task_kind'],
+  pack: PackPayload,
+  retrieval?: RetrieveResult,
+): ContextPackExecutionSliceStep[] {
+  const retrievalGate = retrieval?.retrieval_gate ?? ('retrieval_gate' in pack ? pack.retrieval_gate : undefined)
+  const retrievalSteps = Array.isArray(retrieval?.execution_slice?.steps) ? retrieval.execution_slice.steps : []
+  if (
+    task !== 'explain'
+    || retrievalGate?.signals.generation_intent !== 'runtime_generation'
+  ) {
+    return []
+  }
+
+  if (retrievalSteps.length > 0) {
+    return retrievalSteps
+  }
+
+  if ('execution_slice' in pack && Array.isArray(pack.execution_slice?.steps) && pack.execution_slice.steps.length > 0) {
+    return pack.execution_slice.steps
+  }
+
+  return []
+}
+
 function workflowCenters(
   task: TaskContextPlan['task_kind'],
   pack: PackPayload,
   plan: TaskContextPlan,
   implementation?: ImplementationPackGuidance,
+  retrieval?: RetrieveResult,
 ): ContextPackWorkflowCenter[] {
   const fromCommunityContext = (
     entries: Array<{ label: string; node_count?: number }>,
@@ -261,6 +289,31 @@ function workflowCenters(
 
   if (task === 'implement' && implementation?.workflow_centers.length) {
     return implementation.workflow_centers.slice(0, 4)
+  }
+
+  const executionSpine = runtimeGenerationExecutionSpine(task, pack, retrieval)
+  if (executionSpine.length > 0) {
+    const centers: ContextPackWorkflowCenter[] = []
+    const seen = new Set<string>()
+    for (const [index, step] of executionSpine.entries()) {
+      if (seen.has(step.source_file)) {
+        continue
+      }
+      seen.add(step.source_file)
+      centers.push({
+        label: step.label,
+        path: step.source_file,
+        reason: index === 0
+          ? 'Runtime-generation execution spine enters here.'
+          : `Runtime-generation execution spine handoff ${index + 1} passes through this file.`,
+      })
+      if (centers.length >= 4) {
+        break
+      }
+    }
+    if (centers.length > 0) {
+      return centers
+    }
   }
 
   if (
@@ -292,6 +345,7 @@ function recommendedFirstRead(
   task: TaskContextPlan['task_kind'],
   pack: PackPayload,
   implementation?: ImplementationPackGuidance,
+  retrieval?: RetrieveResult,
 ): ContextPackRecommendedFirstRead[] {
   if (task === 'implement' && implementation) {
     const reads: ContextPackRecommendedFirstRead[] = []
@@ -321,6 +375,31 @@ function recommendedFirstRead(
       pushRead(entry.path, entry.reason, entry.matched_symbols[0])
     }
 
+    if (reads.length > 0) {
+      return reads
+    }
+  }
+
+  const executionSpine = runtimeGenerationExecutionSpine(task, pack, retrieval)
+  if (executionSpine.length > 0) {
+    const reads: ContextPackRecommendedFirstRead[] = []
+    const seen = new Set<string>()
+    for (const [index, step] of executionSpine.entries()) {
+      if (seen.has(step.source_file)) {
+        continue
+      }
+      seen.add(step.source_file)
+      reads.push({
+        path: step.source_file,
+        label: step.label,
+        reason: index === 0
+          ? 'Start with the runtime-generation entrypoint.'
+          : `Read this runtime-generation handoff after ${executionSpine[index - 1]?.label ?? 'the previous step'}.`,
+      })
+      if (reads.length >= 3) {
+        break
+      }
+    }
     if (reads.length > 0) {
       return reads
     }
@@ -424,9 +503,11 @@ function publicContracts(
 }
 
 function negativeGuidance(
+  task: TaskContextPlan['task_kind'],
   coverage: ContextPackCoverage,
   pack: PackPayload,
   implementation?: ImplementationPackGuidance,
+  retrieval?: RetrieveResult,
 ): string[] {
   const guidance = [...(implementation?.cautions ?? [])]
 
@@ -449,6 +530,27 @@ function negativeGuidance(
       continue
     }
     guidance.push(`Treat ${pattern.source_file} as supporting context first, not the default edit path, unless the task explicitly targets that helper or artifact.`)
+  }
+
+  const executionSpine = runtimeGenerationExecutionSpine(task, pack, retrieval)
+  if (executionSpine.length > 0) {
+    const spinePaths = new Set(executionSpine.map((step) => step.source_file))
+    const seenPaths = new Set<string>()
+    const matchedNodes = retrieval?.matched_nodes
+      ?? ('matched_nodes' in pack && Array.isArray(pack.matched_nodes) ? pack.matched_nodes : [])
+    for (const node of matchedNodes) {
+      if (spinePaths.has(node.source_file) || seenPaths.has(node.source_file)) {
+        continue
+      }
+      if (!RUNTIME_GENERATION_DISTRACTOR_PATTERN.test(`${node.label} ${node.source_file}`)) {
+        continue
+      }
+      seenPaths.add(node.source_file)
+      guidance.push(`Treat ${node.source_file} as supporting context first, not the primary runtime workflow spine, unless the question explicitly targets that helper or display/status surface.`)
+      if (seenPaths.size >= 3) {
+        break
+      }
+    }
   }
 
   return [...new Set(guidance)]
@@ -525,17 +627,19 @@ function buildPackSchemaV1<TPack extends PackPayload>(
     implementation?: ImplementationPackGuidance
     routing?: ContextPackRoutingDebug
     target?: string
+    retrieval?: RetrieveResult
   },
 ): PackSchemaEnvelope<TPack> {
-  const centers = workflowCenters(response.task, response.pack, response.plan, response.implementation)
-  const firstRead = recommendedFirstRead(response.task, response.pack, response.implementation)
+  const { retrieval, ...serializableResponse } = response
+  const centers = workflowCenters(response.task, response.pack, response.plan, response.implementation, retrieval)
+  const firstRead = recommendedFirstRead(response.task, response.pack, response.implementation, retrieval)
   const contracts = publicContracts(response.implementation)
-  const guidance = negativeGuidance(response.coverage, response.pack, response.implementation)
+  const guidance = negativeGuidance(response.task, response.coverage, response.pack, response.implementation, retrieval)
   const score = confidenceScore(response.coverage, response.pack, response.implementation)
 
   return {
     schema_version: 1,
-    ...response,
+    ...serializableResponse,
     workflow_centers: centers,
     recommended_first_read: firstRead,
     likely_edit_files: response.implementation?.likely_edit_files ?? [],
@@ -854,6 +958,7 @@ export async function runContextPackCommand(
   return renderContextPackOutput(options.format, buildPackSchemaV1({
     ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
     ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval, implementation),
+    retrieval,
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
   }))
 }

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -238,6 +238,222 @@ describe('context-pack-command', () => {
     }))
   })
 
+  it('derives runtime-generation explain workflow centers and first-read from the execution spine', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const retrieval = {
+      question: 'How idea report is being generated',
+      token_count: 220,
+      matched_nodes: [
+        {
+          node_id: 'status_helper',
+          label: 'getStatusMessage',
+          source_file: 'src/ideas/report-status.ts',
+          line_number: 18,
+          file_type: 'code',
+          snippet: 'export function getStatusMessage() {}',
+          match_score: 0.98,
+          relevance_band: 'direct' as const,
+          community: 2,
+          community_label: 'Idea report helpers',
+        },
+        {
+          node_id: 'next_steps_helper',
+          label: 'generateSuggestedNextSteps',
+          source_file: 'src/ideas/next-steps.ts',
+          line_number: 24,
+          file_type: 'code',
+          snippet: 'export function generateSuggestedNextSteps() {}',
+          match_score: 0.95,
+          relevance_band: 'direct' as const,
+          community: 2,
+          community_label: 'Idea report helpers',
+        },
+        {
+          node_id: 'controller_entry',
+          label: 'IdeasController.generateReport',
+          source_file: 'src/ideas/controller.ts',
+          line_number: 40,
+          file_type: 'code',
+          snippet: 'return this.reportService.generateReport(id)',
+          match_score: 0.74,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+        {
+          node_id: 'service_handoff',
+          label: 'IdeaReportService.generateReport',
+          source_file: 'src/ideas/report-service.ts',
+          line_number: 58,
+          file_type: 'code',
+          snippet: 'await queue.enqueue(reportJob)',
+          match_score: 0.72,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+      ],
+      relationships: [],
+      community_context: [
+        { id: 2, label: 'Idea report helpers', node_count: 8 },
+      ],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['contracts', 'configuration', 'tests'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+      retrieval_gate: {
+        level: 4,
+        skipped_retrieval: false,
+        reason: 'manual override',
+        intent: 'explain',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation' as const,
+          target_domain_hint: 'backend_runtime' as const,
+        },
+      },
+      retrieval_strategy: 'slice-v1' as const,
+      execution_slice: {
+        status: 'complete' as const,
+        confidence: 'high' as const,
+        steps: [
+          {
+            node_id: 'controller_entry',
+            label: 'IdeasController.generateReport',
+            source_file: 'src/ideas/controller.ts',
+            line_number: 40,
+            node_kind: 'method',
+            framework_role: 'nest_controller',
+          },
+          {
+            node_id: 'service_handoff',
+            label: 'IdeaReportService.generateReport',
+            source_file: 'src/ideas/report-service.ts',
+            line_number: 58,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'queue_boundary',
+            label: 'IdeaReportQueue.enqueue',
+            source_file: 'src/ideas/report-queue.ts',
+            line_number: 72,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'worker_entry',
+            label: 'IdeaReportWorker.process',
+            source_file: 'src/ideas/report-worker.ts',
+            line_number: 84,
+            node_kind: 'method',
+            framework_role: 'worker',
+          },
+          {
+            node_id: 'assembler',
+            label: 'IdeaReportAssembler.build',
+            source_file: 'src/ideas/report-assembler.ts',
+            line_number: 102,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'store',
+            label: 'IdeaReportStore.save',
+            source_file: 'src/ideas/report-store.ts',
+            line_number: 119,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['controller', 'service', 'queue', 'worker', 'report_builder', 'persistence'],
+          observed: ['controller', 'service', 'queue', 'worker', 'report_builder', 'persistence'],
+          missing: [],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation' as const,
+        entrypoint_scope: 'setup_context' as const,
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: ['irrelevant_model_or_provider_details'],
+        observed_phases: ['controller', 'service', 'queue', 'worker', 'report_builder', 'persistence'],
+        missing_phases: [],
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'How idea report is being generated',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      retrievalStrategy: 'slice-v1',
+      format: 'json',
+    }, dependencies)
+
+    const payload = JSON.parse(output) as {
+      workflow_centers?: Array<{ path?: string; label?: string }>
+      recommended_first_read?: Array<{ path?: string; label?: string }>
+      negative_guidance?: string[]
+    }
+
+    expect(payload.workflow_centers?.slice(0, 4)).toEqual([
+      expect.objectContaining({
+        path: 'src/ideas/controller.ts',
+        label: 'IdeasController.generateReport',
+      }),
+      expect.objectContaining({
+        path: 'src/ideas/report-service.ts',
+        label: 'IdeaReportService.generateReport',
+      }),
+      expect.objectContaining({
+        path: 'src/ideas/report-queue.ts',
+        label: 'IdeaReportQueue.enqueue',
+      }),
+      expect.objectContaining({
+        path: 'src/ideas/report-worker.ts',
+        label: 'IdeaReportWorker.process',
+      }),
+    ])
+    expect(payload.recommended_first_read).toEqual([
+      expect.objectContaining({
+        path: 'src/ideas/controller.ts',
+        label: 'IdeasController.generateReport',
+      }),
+      expect.objectContaining({
+        path: 'src/ideas/report-service.ts',
+        label: 'IdeaReportService.generateReport',
+      }),
+      expect.objectContaining({
+        path: 'src/ideas/report-queue.ts',
+        label: 'IdeaReportQueue.enqueue',
+      }),
+    ])
+    expect(payload.negative_guidance).toEqual(expect.arrayContaining([
+      expect.stringContaining('src/ideas/report-status.ts'),
+      expect.stringContaining('src/ideas/next-steps.ts'),
+    ]))
+  })
+
   it('defaults runtime-generation explain packs to slice-v1 retrieval', async () => {
     const graph = buildRuntimeGenerationGraph()
     const dependencies: ContextPackCommandDependencies = {


### PR DESCRIPTION
## Summary
- select explain-pack workflow centers from the runtime execution spine for runtime_generation retrievals
- prioritize first-read guidance from execution handoff files instead of helper-heavy matched-node order
- demote helper/status/display runtime distractors into negative guidance and add regression coverage

Closes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced context pack generation to improve workflow guidance and recommendations for runtime generation scenarios.
  * Updated schema rendering to better process and utilize retrieval context data.

* **Tests**
  * Added unit test coverage for runtime generation context pack workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->