### PR TITLE
Add runtime-generation explain pack fixture

### DIFF
--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/fixture.json
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/fixture.json
@@ -1,0 +1,17 @@
+{
+  "task": "explain",
+  "prompt": "How idea report is being generated",
+  "expected_workflow_centers": [
+    "src/modules/ideas/interface/http/idea-generation.controller.ts",
+    "src/modules/pipeline/api/pipeline-trigger.service.ts",
+    "src/modules/pipeline/api/queue-registry.service.ts",
+    "src/modules/pipeline/workers/orchestrator.worker.ts"
+  ],
+  "expected_likely_edit_files": [],
+  "expected_likely_test_files": [],
+  "expected_validation_commands": [],
+  "expected_negative_guidance": [
+    "idea-report-status-message.helper.ts",
+    "idea-report-suggested-next-steps.helper.ts"
+  ]
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/package.json
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pack-quality-runtime-generation-explain-report-flow",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test:run": "vitest run"
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/ideas/application/helpers/idea-report-status-message.helper.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/ideas/application/helpers/idea-report-status-message.helper.ts
@@ -1,0 +1,3 @@
+export function getIdeaReportStatusMessage(status: string): string {
+  return `report:${status}`
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/ideas/application/helpers/idea-report-suggested-next-steps.helper.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/ideas/application/helpers/idea-report-suggested-next-steps.helper.ts
@@ -1,0 +1,3 @@
+export function generateIdeaReportSuggestedNextSteps(problem: string): string[] {
+  return [`review:${problem}`, 'share-report']
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/ideas/interface/http/idea-generation.controller.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/ideas/interface/http/idea-generation.controller.ts
@@ -1,0 +1,38 @@
+import { generateIdeaReportSuggestedNextSteps } from '../../application/helpers/idea-report-suggested-next-steps.helper.js'
+import { getIdeaReportStatusMessage } from '../../application/helpers/idea-report-status-message.helper.js'
+import { startIdeaReportPipeline } from '../../../pipeline/api/pipeline-trigger.service.js'
+
+function Controller(_path: string): any {
+  return () => {}
+}
+
+function Post(_path: string): any {
+  return () => {}
+}
+
+@Controller('ideas')
+export class IdeaGenerationController {
+  @Post('analyze')
+  async generateFromProblem(
+    dto: { problem: string; userId: string },
+  ): Promise<{ status: string; next_steps: string[]; jobId: string }> {
+    const pipelineRun = await startIdeaReportPipeline(
+      dto.userId,
+      dto.problem,
+      'idea-1',
+    )
+
+    return this.buildQueuedIdeaReportResponse(dto.problem, pipelineRun.jobId)
+  }
+
+  private buildQueuedIdeaReportResponse(
+    problem: string,
+    jobId: string,
+  ): { status: string; next_steps: string[]; jobId: string } {
+    return {
+      status: getIdeaReportStatusMessage('QUEUED'),
+      next_steps: generateIdeaReportSuggestedNextSteps(problem),
+      jobId,
+    }
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/api/pipeline-trigger.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/api/pipeline-trigger.service.ts
@@ -1,0 +1,9 @@
+import { enqueueIdeaReportJob } from './queue-registry.service.js'
+
+export async function startIdeaReportPipeline(
+  userId: string,
+  problem: string,
+  ideaId: string,
+): Promise<{ jobId: string }> {
+  return enqueueIdeaReportJob({ userId, problem, ideaId })
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/api/queue-registry.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/api/queue-registry.service.ts
@@ -1,0 +1,25 @@
+export type PipelineJobPayload = {
+  userId: string
+  problem: string
+  ideaId: string
+}
+
+class PipelineQueue {
+  async add(
+    jobName: string,
+    input: PipelineJobPayload,
+  ): Promise<{ id: string }> {
+    return {
+      id: `${input.userId}:${input.problem}:${input.ideaId}:${jobName}`,
+    }
+  }
+}
+
+const pipelineQueue = new PipelineQueue()
+
+export async function enqueueIdeaReportJob(input: PipelineJobPayload): Promise<{ jobId: string }> {
+  const job = await pipelineQueue.add('pipeline.orchestrator.process', input)
+  return {
+    jobId: job.id,
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/db-sync.worker.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/db-sync.worker.ts
@@ -1,0 +1,6 @@
+export async function saveStructuredReport(
+  ideaId: string,
+  report: { content: string },
+): Promise<{ saved: boolean }> {
+  return { saved: ideaId.length > 0 && report.content.length > 0 }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/orchestrator.worker.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/orchestrator.worker.ts
@@ -1,0 +1,28 @@
+import type { PipelineJobPayload } from '../api/queue-registry.service.js'
+import { planIdeaReport } from '../../planning/planner.service.js'
+import { processIdeaReportSection } from '../../research/workers/section-research.worker.js'
+import { assembleIdeaReport } from '../../reports/assembly.service.js'
+import { saveStructuredReport } from './db-sync.worker.js'
+
+type BullJob<T> = {
+  data: T
+}
+
+function Processor(_queueName: string): any {
+  return () => {}
+}
+
+function Process(_jobName: string): any {
+  return () => {}
+}
+
+@Processor('pipeline.orchestrator')
+export class OrchestratorWorker {
+  @Process('pipeline.orchestrator.process')
+  async process(job: BullJob<PipelineJobPayload>): Promise<{ saved: boolean }> {
+    const plan = await planIdeaReport(job.data.problem)
+    const researchedSection = await processIdeaReportSection(plan.sections[0] ?? 'summary')
+    const report = await assembleIdeaReport(plan.sections, researchedSection)
+    return saveStructuredReport(job.data.ideaId, report)
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/planning/planner.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/planning/planner.service.ts
@@ -1,0 +1,5 @@
+export async function planIdeaReport(problem: string): Promise<{ sections: string[] }> {
+  return {
+    sections: [`summary:${problem}`, 'evidence'],
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/reports/assembly.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/reports/assembly.service.ts
@@ -1,0 +1,8 @@
+export async function assembleIdeaReport(
+  sections: string[],
+  researchedSection: { findings: string },
+): Promise<{ content: string }> {
+  return {
+    content: `${sections.join('|')}:${researchedSection.findings}`,
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/research/research-agent.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/research/research-agent.service.ts
@@ -1,0 +1,7 @@
+export class ResearchAgentService {
+  async searchIdeaReportSources(section: string): Promise<{ summary: string }> {
+    return {
+      summary: `researched:${section}`,
+    }
+  }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/research/workers/section-research.worker.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/research/workers/section-research.worker.ts
@@ -1,0 +1,11 @@
+import { ResearchAgentService } from '../research-agent.service.js'
+
+const researchAgentService = new ResearchAgentService()
+
+export async function processIdeaReportSection(section: string): Promise<{ section: string; findings: string }> {
+  const research = await researchAgentService.searchIdeaReportSources(section)
+  return {
+    section,
+    findings: research.summary,
+  }
+}

--- a/tests/unit/helpers/pack-quality.ts
+++ b/tests/unit/helpers/pack-quality.ts
@@ -16,11 +16,13 @@ const PACK_QUALITY_FIXTURE_ORDER = [
   'source-test-adjacency',
   'noisy-helper-distractor',
   'indirect-seed-workflow-owner',
+  'runtime-generation-explain-report-flow',
 ] as const
 
 const PACK_QUALITY_FIXTURE_ROOT = resolve('tests/fixtures/pack-quality')
 
 interface PackQualityFixtureManifest {
+  task?: 'implement' | 'explain'
   prompt: string
   budget?: number
   expected_workflow_centers: string[]
@@ -33,6 +35,7 @@ interface PackQualityFixtureManifest {
 
 interface PackSchemaPayload {
   workflow_centers?: Array<{ path?: string }>
+  recommended_first_read?: Array<{ path?: string }>
   likely_edit_files?: Array<{ path?: string }>
   likely_test_files?: Array<{ path?: string }>
   validation_commands?: string[]
@@ -104,6 +107,9 @@ function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
   if (typeof parsed.prompt !== 'string' || parsed.prompt.trim().length === 0) {
     problems.push('"prompt" must be a non-empty string')
   }
+  if ('task' in parsed && parsed.task !== undefined && parsed.task !== 'implement' && parsed.task !== 'explain') {
+    problems.push('"task" must be either "implement" or "explain" when provided')
+  }
   if ('budget' in parsed && parsed.budget !== undefined && typeof parsed.budget !== 'number') {
     problems.push('"budget" must be a number when provided')
   }
@@ -135,6 +141,7 @@ function loadPackQualityFixture(name: string): PackQualityFixtureManifest {
     : undefined
 
   return {
+    ...(parsed.task === 'implement' || parsed.task === 'explain' ? { task: parsed.task } : {}),
     prompt,
     ...(typeof parsed.budget === 'number' ? { budget: parsed.budget } : {}),
     expected_workflow_centers: expectedWorkflowCenters,
@@ -152,6 +159,14 @@ function normalizePayload(payload: PackSchemaPayload): PackSchemaPayload {
     ...(payload.workflow_centers
       ? {
           workflow_centers: payload.workflow_centers.map((entry) => ({
+            ...entry,
+            ...(entry.path ? { path: normalizeAssertionPath(entry.path) } : {}),
+          })),
+        }
+      : {}),
+    ...(payload.recommended_first_read
+      ? {
+          recommended_first_read: payload.recommended_first_read.map((entry) => ({
             ...entry,
             ...(entry.path ? { path: normalizeAssertionPath(entry.path) } : {}),
           })),
@@ -194,7 +209,7 @@ export async function runPackQualityFixture(name: string): Promise<PackQualityFi
     const packOutput = await runContextPackCommand({
       prompt: fixture.prompt,
       budget: fixture.budget ?? 1800,
-      task: 'implement',
+      task: fixture.task ?? 'implement',
       taskExplicit: true,
       graphPath,
       format: 'json',

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -67,6 +67,17 @@ describe('pack-quality fixtures (#298)', () => {
     const result = await runPackQualityFixture('runtime-generation-explain-report-flow')
     const payload = result.payload as typeof result.payload & {
       recommended_first_read?: Array<{ path?: string }>
+      pack?: {
+        execution_slice?: {
+          steps?: Array<{ label?: string }>
+          phase_coverage?: {
+            expected?: string[]
+            observed?: string[]
+            missing?: string[]
+          }
+        }
+        matched_nodes?: Array<{ label?: string }>
+      }
     }
 
     expect(payload.workflow_centers?.map((entry) => entry.path)).toEqual(
@@ -94,5 +105,37 @@ describe('pack-quality fixtures (#298)', () => {
       expect.stringContaining('idea-report-status-message.helper.ts'),
       expect.stringContaining('idea-report-suggested-next-steps.helper.ts'),
     ]))
+    expect(payload.pack?.execution_slice?.steps?.map((entry) => entry.label)).toEqual(
+      expect.arrayContaining([
+        '.generateFromProblem()',
+        'startIdeaReportPipeline()',
+        'enqueueIdeaReportJob()',
+        '.process()',
+        'saveStructuredReport()',
+      ]),
+    )
+    expect(payload.pack?.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
+      expected: expect.arrayContaining([
+        'planner',
+        'external_research_or_api',
+        'report_builder',
+        'persistence',
+      ]),
+      observed: expect.arrayContaining([
+        'planner',
+        'external_research_or_api',
+        'report_builder',
+        'persistence',
+      ]),
+      missing: [],
+    }))
+    expect(payload.pack?.matched_nodes?.map((entry) => entry.label)).toEqual(
+      expect.arrayContaining([
+        'planIdeaReport()',
+        'processIdeaReportSection()',
+        'assembleIdeaReport()',
+        'saveStructuredReport()',
+      ]),
+    )
   })
 })

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { listPackQualityFixtures, runPackQualityFixture } from './helpers/pack-quality.js'
 
-const EXPECTED_FIXTURES = [
+const EXPECTED_IMPLEMENT_FIXTURES = [
   'controller-service-test-flow',
   'queue-job-retry-workflow',
   'cli-command-implementation',
@@ -13,12 +13,21 @@ const EXPECTED_FIXTURES = [
   'indirect-seed-workflow-owner',
 ] as const
 
+const EXPECTED_EXPLAIN_FIXTURES = [
+  'runtime-generation-explain-report-flow',
+] as const
+
+const EXPECTED_FIXTURES = [
+  ...EXPECTED_IMPLEMENT_FIXTURES,
+  ...EXPECTED_EXPLAIN_FIXTURES,
+] as const
+
 describe('pack-quality fixtures (#298)', () => {
   it('ships all listed pack-quality fixture categories', () => {
     expect(listPackQualityFixtures()).toEqual(EXPECTED_FIXTURES)
   })
 
-  for (const fixtureName of EXPECTED_FIXTURES) {
+  for (const fixtureName of EXPECTED_IMPLEMENT_FIXTURES) {
     it(`generates a deterministic implement pack for ${fixtureName}`, async () => {
       const result = await runPackQualityFixture(fixtureName)
 
@@ -53,4 +62,37 @@ describe('pack-quality fixtures (#298)', () => {
       }
     })
   }
+
+  it('generates a deterministic explain pack for runtime-generation-explain-report-flow', async () => {
+    const result = await runPackQualityFixture('runtime-generation-explain-report-flow')
+    const payload = result.payload as typeof result.payload & {
+      recommended_first_read?: Array<{ path?: string }>
+    }
+
+    expect(payload.workflow_centers?.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining([
+        'src/modules/ideas/interface/http/idea-generation.controller.ts',
+        'src/modules/pipeline/api/pipeline-trigger.service.ts',
+        'src/modules/pipeline/api/queue-registry.service.ts',
+        'src/modules/pipeline/workers/orchestrator.worker.ts',
+      ]),
+    )
+    expect(payload.recommended_first_read?.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining([
+        'src/modules/ideas/interface/http/idea-generation.controller.ts',
+        'src/modules/pipeline/api/pipeline-trigger.service.ts',
+        'src/modules/pipeline/api/queue-registry.service.ts',
+      ]),
+    )
+    expect(payload.recommended_first_read?.map((entry) => entry.path)).not.toEqual(
+      expect.arrayContaining([
+        'src/modules/ideas/application/helpers/idea-report-status-message.helper.ts',
+        'src/modules/ideas/application/helpers/idea-report-suggested-next-steps.helper.ts',
+      ]),
+    )
+    expect(payload.negative_guidance).toEqual(expect.arrayContaining([
+      expect.stringContaining('idea-report-status-message.helper.ts'),
+      expect.stringContaining('idea-report-suggested-next-steps.helper.ts'),
+    ]))
+  })
 })


### PR DESCRIPTION
## Summary
- extend the pack-quality fixture harness to support explain-task runs
- add a GoValidate-style runtime-generation explain fixture with queue, worker, planner, research, assembly, and db-sync flow
- lock workflow centers, recommended first-read ordering, and helper demotion for that explain pack

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "explain" report generation workflow for analyzing ideas, queuing background processing, and producing structured reports.
  * New /ideas/analyze endpoint accepts a problem, returns queued status, recommended next steps, and a job ID for tracking.

* **Tests**
  * Test framework extended to support the "explain" task and includes a fixture for the explain report flow.
  * Deterministic tests validate workflow centers, recommended first-read paths, negative guidance, execution slice labels, and phase coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->