### PR TITLE
Gate adapter directives on pack quality

### DIFF
--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -32,6 +32,7 @@ import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
 
 const DEFAULT_IMPACT_DEPTH = 3
 const IMPLEMENTATION_DISTRACTOR_PATTERN = /(?:helper|util|formatter|serializer|mapper|constant|generated|dist\/|build\/|lockfile|migration)/i
+const ADAPTER_DIRECTIVE_CONFIDENCE_THRESHOLD = 0.5
 const RUNTIME_GENERATION_DISTRACTOR_PATTERN = /(?:helper|util|formatter|serializer|mapper|constant|status|display|render|renderer|summary|footer|header|view|score|scoring|suggest(?:ed)?|next[-_\s]?steps)/i
 
 export interface ContextPackCommandDependencies {
@@ -709,6 +710,38 @@ function retrievalPipelineLines(schema: PackSchemaEnvelope): string[] {
   return schema.retrieval_pipeline?.phases.map((entry) => `- ${entry.phase}: ${entry.summary}`) ?? []
 }
 
+function hasGraphBackedWorkflowCenter(schema: PackSchemaEnvelope): boolean {
+  return schema.workflow_centers.some((entry) => typeof entry.path === 'string' && entry.path.trim().length > 0)
+}
+
+function hasGroundedFirstRead(schema: PackSchemaEnvelope): boolean {
+  const firstRead = schema.recommended_first_read[0]
+  if (!firstRead) {
+    return false
+  }
+
+  return schema.likely_edit_files.some((entry) => entry.path === firstRead.path)
+    || schema.public_contracts.some((entry) => entry.source_file === firstRead.path)
+    || schema.workflow_centers.some((entry) => entry.path === firstRead.path)
+}
+
+function useDirectiveAdapterGuidance(schema: PackSchemaEnvelope): boolean {
+  return schema.confidence_score >= ADAPTER_DIRECTIVE_CONFIDENCE_THRESHOLD
+    && schema.missing_context.length === 0
+    && hasGraphBackedWorkflowCenter(schema)
+    && hasGroundedFirstRead(schema)
+}
+
+function claudeSearchGuidanceLine(schema: PackSchemaEnvelope): string {
+  if (useDirectiveAdapterGuidance(schema)) {
+    return '- Do not start with a broad repo search. Use the listed files, contracts, and tests first.'
+  }
+
+  return schema.recommended_first_read.length > 0 || schema.workflow_centers.length > 0
+    ? '- Use targeted verification to confirm the listed starting points before widening the search.'
+    : '- Use targeted verification to identify the starting file before widening the search.'
+}
+
 function renderPackSchemaText(schema: PackSchemaEnvelope): string {
   const lines = [
     'Pack Schema v1',
@@ -775,7 +808,7 @@ function renderClaudePack(schema: PackSchemaEnvelope): string {
     ...(firstRead.length > 0
       ? firstRead
       : ['- No first-read anchor was identified; begin with the workflow centers below.']),
-    '- Do not start with a broad repo search. Use the listed files, contracts, and tests first.',
+    claudeSearchGuidanceLine(schema),
     '',
     ...renderMarkdownSection('Retrieval pipeline', retrievalPipelineLines(schema)),
     ...renderMarkdownSection('Workflow centers', workflowCenterLines(schema)),
@@ -796,11 +829,20 @@ function renderCopilotPlanSteps(schema: PackSchemaEnvelope): string[] {
   const firstRead = schema.recommended_first_read[0]
   const primaryEdit = schema.likely_edit_files[0]
   const primaryTest = schema.likely_test_files[0]
+  const directiveMode = useDirectiveAdapterGuidance(schema)
 
   steps.push(
-    firstRead
-      ? `Read \`${firstRead.path}\` first to anchor the change: ${firstRead.reason}`
-      : 'Start from the top workflow center before making edits.',
+    directiveMode
+      ? (
+          firstRead
+            ? `Read \`${firstRead.path}\` first to anchor the change: ${firstRead.reason}`
+            : 'Start from the top workflow center before making edits.'
+        )
+      : (
+          firstRead
+            ? 'Verify the suggested starting file against the prompt and workflow centers before editing.'
+            : 'Verify the top workflow center against the prompt before making edits.'
+        ),
   )
   steps.push(
     primaryEdit

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -728,6 +728,7 @@ function hasGroundedFirstRead(schema: PackSchemaEnvelope): boolean {
 function useDirectiveAdapterGuidance(schema: PackSchemaEnvelope): boolean {
   return schema.confidence_score >= ADAPTER_DIRECTIVE_CONFIDENCE_THRESHOLD
     && schema.missing_context.length === 0
+    && schema.missing_semantic.length === 0
     && hasGraphBackedWorkflowCenter(schema)
     && hasGroundedFirstRead(schema)
 }

--- a/tests/unit/context-pack-adapter-gating.test.ts
+++ b/tests/unit/context-pack-adapter-gating.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ContextPackCoverage, ImplementationPackGuidance } from '../../src/contracts/context-pack.js'
+import type { RetrievalGateDecision } from '../../src/contracts/retrieval-gate.js'
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
+import type { RetrieveResult } from '../../src/runtime/retrieve.js'
+
+const { buildImplementationPackGuidanceMock } = vi.hoisted(() => ({
+  buildImplementationPackGuidanceMock: vi.fn(),
+}))
+
+vi.mock('../../src/runtime/implementation-pack.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/runtime/implementation-pack.js')>('../../src/runtime/implementation-pack.js')
+  return {
+    ...actual,
+    buildImplementationPackGuidance: buildImplementationPackGuidanceMock,
+  }
+})
+
+beforeEach(() => {
+  buildImplementationPackGuidanceMock.mockReset()
+})
+
+function retrievalGate(): RetrievalGateDecision {
+  return {
+    level: 4,
+    skipped_retrieval: false,
+    reason: 'manual override',
+    intent: 'implement',
+    signals: {
+      has_pr_diff: false,
+      has_stack_trace: false,
+      mentioned_paths: ['src/infrastructure/context-pack-command.ts'],
+      mentioned_symbols: ['runContextPackCommand'],
+      generation_intent: 'unknown',
+      target_domain_hint: 'unknown',
+    },
+  }
+}
+
+function lowConfidenceCoverage(): ContextPackCoverage {
+  return {
+    required_evidence: ['primary', 'structural'],
+    semantic_required: ['implementation', 'structure'],
+    semantic_optional: ['tests'],
+    entries: [
+      { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 0, status: 'missing' },
+      { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 0, status: 'missing' },
+    ],
+    semantic_entries: [
+      { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 0, status: 'missing' },
+      { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 0, status: 'missing' },
+      { category: 'tests', label: 'tests', required: false, available_nodes: 0, selected_nodes: 0, status: 'missing' },
+    ],
+    missing_required: ['primary', 'structural'],
+    missing_semantic: ['implementation', 'structure'],
+    available_relationships: 1,
+    selected_relationships: 0,
+  }
+}
+
+function highConfidenceCoverage(): ContextPackCoverage {
+  return {
+    required_evidence: ['primary', 'structural'],
+    semantic_required: ['implementation', 'structure'],
+    semantic_optional: ['tests'],
+    entries: [
+      { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+      { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+    ],
+    semantic_entries: [
+      { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+      { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+      { category: 'tests', label: 'tests', required: false, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+    ],
+    missing_required: [],
+    missing_semantic: [],
+    available_relationships: 1,
+    selected_relationships: 1,
+  }
+}
+
+function lowConfidenceImplementation(): ImplementationPackGuidance {
+  return {
+    summary: 'Evidence is partial, so the starting file still needs targeted verification.',
+    retrieval_pipeline: {
+      phases: [
+        { phase: 'seed', summary: 'Seeded direct prompt matches.' },
+      ],
+    },
+    workflow_centers: [],
+    likely_edit_files: [],
+    likely_test_files: [],
+    contracts_and_public_surfaces: [],
+    existing_patterns: [],
+    risk_boundaries: [],
+    validation_commands: ['npm run typecheck'],
+    acceptance_criteria_summary: [],
+    cautions: ['Confirm the starting file before making edits.'],
+  }
+}
+
+function highConfidenceImplementation(): ImplementationPackGuidance {
+  return {
+    summary: 'Adapter rendering is isolated to the context pack command.',
+    retrieval_pipeline: {
+      phases: [
+        { phase: 'seed', summary: 'Seeded direct prompt matches.' },
+        { phase: 'render', summary: 'Promoted the adapter rendering surface.' },
+      ],
+    },
+    workflow_centers: [
+      {
+        label: 'runContextPackCommand',
+        path: 'src/infrastructure/context-pack-command.ts',
+        score: 0.91,
+        reasons: ['Adapter rendering is implemented here.'],
+        matched_symbols: ['runContextPackCommand'],
+        reason: 'Implementation guidance converges on the adapter renderer.',
+        phases: ['render'],
+      },
+    ],
+    likely_edit_files: [
+      {
+        path: 'src/infrastructure/context-pack-command.ts',
+        score: 0.91,
+        reason: 'Adapter wording is rendered here.',
+        matched_symbols: ['runContextPackCommand'],
+        phases: ['render'],
+      },
+    ],
+    likely_test_files: [
+      {
+        path: 'tests/unit/context-pack-command.test.ts',
+        score: 0.83,
+        reason: 'Adapter output is asserted here.',
+        matched_symbols: ['context-pack-command'],
+        phases: ['render'],
+      },
+    ],
+    contracts_and_public_surfaces: [
+      {
+        label: 'ContextPackSchemaV1',
+        source_file: 'src/contracts/context-pack.ts',
+        line_number: 422,
+        kind: 'contract',
+        why: 'Adapter wording is derived from schema fields.',
+      },
+    ],
+    existing_patterns: [],
+    risk_boundaries: [
+      {
+        label: 'runContextPackCommand',
+        severity: 'medium',
+        reason: 'Renderer changes affect the Claude and Copilot pack formats.',
+        affected_files: ['src/infrastructure/context-pack-command.ts'],
+        affected_communities: ['Context pack rendering'],
+      },
+    ],
+    validation_commands: ['npm run typecheck'],
+    acceptance_criteria_summary: [],
+    cautions: [],
+  }
+}
+
+function buildRetrieval(coverage: ContextPackCoverage): RetrieveResult {
+  return {
+    question: 'Implement issue #312 by gating directive adapter wording on pack quality',
+    token_count: 128,
+    matched_nodes: [
+      {
+        label: 'runContextPackCommand',
+        source_file: 'src/infrastructure/context-pack-command.ts',
+        line_number: 763,
+        node_kind: 'function',
+        file_type: 'code',
+        snippet: 'export async function runContextPackCommand(...)',
+        match_score: 0.91,
+        relevance_band: 'direct',
+        community: 0,
+        community_label: 'Context pack rendering',
+      },
+    ],
+    relationships: [],
+    community_context: [],
+    graph_signals: { god_nodes: [], bridge_nodes: [] },
+    claims: [],
+    expandable: [],
+    coverage,
+    retrieval_gate: retrievalGate(),
+  }
+}
+
+function buildCompactPack(coverage: ContextPackCoverage) {
+  return {
+    question: 'Implement issue #312 by gating directive adapter wording on pack quality',
+    token_count: 128,
+    matched_nodes: [
+      {
+        label: 'runContextPackCommand',
+        source_file: 'src/infrastructure/context-pack-command.ts',
+        line_number: 763,
+        node_kind: 'function',
+        file_type: 'code',
+        snippet: 'export async function runContextPackCommand(...)',
+        match_score: 0.91,
+        relevance_band: 'direct' as const,
+        community: 0,
+      },
+    ],
+    relationships: [],
+    community_context: [],
+    graph_signals: { god_nodes: [], bridge_nodes: [] },
+    claims: [],
+    expandable: [],
+    coverage,
+    retrieval_gate: retrievalGate(),
+  }
+}
+
+function buildDependencies(retrieval: RetrieveResult, compactPack: ReturnType<typeof buildCompactPack>): ContextPackCommandDependencies {
+  return {
+    loadGraph: vi.fn().mockReturnValue(new KnowledgeGraph()),
+    retrieveContext: vi.fn().mockReturnValue(retrieval),
+    compactRetrieveResult: vi.fn().mockReturnValue(compactPack),
+    analyzePrImpact: vi.fn(),
+    compactPrImpactResult: vi.fn(),
+    analyzeImpact: vi.fn(),
+    compactImpactResult: vi.fn(),
+  }
+}
+
+describe('context-pack adapter gating', () => {
+  it('suppresses claude anti-search guidance when implementation evidence is weak', async () => {
+    const coverage = lowConfidenceCoverage()
+    buildImplementationPackGuidanceMock.mockReturnValue(lowConfidenceImplementation())
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement issue #312 by gating directive adapter wording on pack quality',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'claude',
+    } as never, buildDependencies(buildRetrieval(coverage), buildCompactPack(coverage)))
+
+    expect(output).not.toContain('Do not start with a broad repo search.')
+    expect(output).toContain('Use targeted verification to confirm the listed starting points before widening the search.')
+  })
+
+  it('switches the copilot plan to cautious verification when first-read guidance is fallback-only', async () => {
+    const coverage = lowConfidenceCoverage()
+    buildImplementationPackGuidanceMock.mockReturnValue(lowConfidenceImplementation())
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement issue #312 by gating directive adapter wording on pack quality',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'copilot',
+    } as never, buildDependencies(buildRetrieval(coverage), buildCompactPack(coverage)))
+
+    expect(output).not.toContain('Read `src/infrastructure/context-pack-command.ts` first to anchor the change:')
+    expect(output).toContain('Verify the suggested starting file against the prompt and workflow centers before editing.')
+  })
+
+  it('keeps claude anti-search guidance for high-confidence implementation packs', async () => {
+    const coverage = highConfidenceCoverage()
+    buildImplementationPackGuidanceMock.mockReturnValue(highConfidenceImplementation())
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement issue #312 by gating directive adapter wording on pack quality',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'claude',
+    } as never, buildDependencies(buildRetrieval(coverage), buildCompactPack(coverage)))
+
+    expect(output).toContain('Do not start with a broad repo search.')
+  })
+})

--- a/tests/unit/context-pack-adapter-gating.test.ts
+++ b/tests/unit/context-pack-adapter-gating.test.ts
@@ -81,6 +81,27 @@ function highConfidenceCoverage(): ContextPackCoverage {
   }
 }
 
+function missingSemanticCoverage(): ContextPackCoverage {
+  return {
+    required_evidence: ['primary', 'structural'],
+    semantic_required: ['implementation', 'structure'],
+    semantic_optional: ['tests'],
+    entries: [
+      { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+      { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+    ],
+    semantic_entries: [
+      { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+      { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 0, status: 'missing' },
+      { category: 'tests', label: 'tests', required: false, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+    ],
+    missing_required: [],
+    missing_semantic: ['structure'],
+    available_relationships: 1,
+    selected_relationships: 1,
+  }
+}
+
 function lowConfidenceImplementation(): ImplementationPackGuidance {
   return {
     summary: 'Evidence is partial, so the starting file still needs targeted verification.',
@@ -280,5 +301,22 @@ describe('context-pack adapter gating', () => {
     } as never, buildDependencies(buildRetrieval(coverage), buildCompactPack(coverage)))
 
     expect(output).toContain('Do not start with a broad repo search.')
+  })
+
+  it('suppresses claude anti-search guidance when required semantic coverage is still missing', async () => {
+    const coverage = missingSemanticCoverage()
+    buildImplementationPackGuidanceMock.mockReturnValue(highConfidenceImplementation())
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement issue #312 by gating directive adapter wording on pack quality',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'claude',
+    } as never, buildDependencies(buildRetrieval(coverage), buildCompactPack(coverage)))
+
+    expect(output).not.toContain('Do not start with a broad repo search.')
+    expect(output).toContain('Use targeted verification to confirm the listed starting points before widening the search.')
   })
 })

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -1052,7 +1052,7 @@ describe('context-pack-command', () => {
     expect(output.match(/^Workflow centers$/gm)).toHaveLength(1)
   })
 
-  it('renders a claude adapter brief with direct execution guidance', async () => {
+  it('renders a claude adapter brief with confidence-aware execution guidance', async () => {
     const graph = buildImplementationPackGraph()
     const dependencies: ContextPackCommandDependencies = {
       loadGraph: vi.fn().mockReturnValue(graph),
@@ -1075,7 +1075,7 @@ describe('context-pack-command', () => {
 
     expect(output).toContain('# Claude Code execution brief')
     expect(output).toContain('## Start here')
-    expect(output).toContain('Do not start with a broad repo search.')
+    expect(output).toContain('Use targeted verification to confirm the listed starting points before widening the search.')
     expect(output).toContain('## Workflow centers')
     expect(output).toContain('## Likely edit files')
     expect(output).toContain('## Likely test files')
@@ -1087,7 +1087,7 @@ describe('context-pack-command', () => {
     expect(output).not.toContain(': undefined')
   })
 
-  it('renders a copilot adapter brief with an implementation-oriented plan', async () => {
+  it('renders a copilot adapter brief with a confidence-aware implementation plan', async () => {
     const graph = buildImplementationPackGraph()
     const dependencies: ContextPackCommandDependencies = {
       loadGraph: vi.fn().mockReturnValue(graph),
@@ -1110,6 +1110,7 @@ describe('context-pack-command', () => {
 
     expect(output).toContain('# GitHub Copilot implementation brief')
     expect(output).toContain('## Suggested plan')
+    expect(output).toContain('Verify the suggested starting file against the prompt and workflow centers before editing.')
     expect(output).toContain('## Workflow centers')
     expect(output).toContain('## Likely edit files')
     expect(output).toContain('## Likely test files')


### PR DESCRIPTION
## Summary
- gate claude/copilot directive wording on pack confidence and grounded first-read guidance
- switch weaker packs to targeted verification language while keeping strong packs directive
- add focused adapter gating regressions and update the existing adapter expectations

Closes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pack output now uses confidence-aware guidance that toggles messaging based on evidence and semantic coverage
  * Guidance text adapts per renderer (e.g., "do not start with a broad repo search" vs targeted verification / verify-before-editing)

* **Tests**
  * Added unit tests covering confidence-gated guidance across output formats
  * Updated existing tests to expect the new, confidence-aware guidance wording

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->