### PR TITLE
Fix runtime-generation phase coverage honesty

### DIFF
--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -2273,7 +2273,13 @@ function executionFlowAdjacency(
   resolveNodeId: (nodeId: string | undefined, label: string) => string | undefined,
 ): Map<string, ExecutionFlowEdge[]> {
   const adjacency = new Map<string, ExecutionFlowEdge[]>()
+  const seenEdges = new Set<string>()
   const record = (edge: ExecutionFlowEdge): void => {
+    const edgeKey = `${edge.fromId}:${edge.relation}:${edge.toId}`
+    if (seenEdges.has(edgeKey)) {
+      return
+    }
+    seenEdges.add(edgeKey)
     const current = adjacency.get(edge.fromId) ?? []
     current.push(edge)
     adjacency.set(edge.fromId, current)
@@ -2316,10 +2322,6 @@ function executionFlowAdjacency(
       }
     }
     }
-  }
-
-  if (adjacency.size > 0) {
-    return adjacency
   }
 
   for (const fromId of idSet) {
@@ -2448,10 +2450,13 @@ function phaseCoverageForPath(
   boundaries: readonly ContextPackExecutionSliceBoundary[],
   question: string,
   scopeSteps: readonly ContextPackExecutionSliceStep[] = steps,
+  tracedSteps: readonly ContextPackExecutionSliceStep[] = steps,
 ): { expected: ExecutionPhase[]; observed: ExecutionPhase[]; missing: ExecutionPhase[] } {
   const phaseOrder = executionPhaseOrder(question)
-  const observedSourceSteps = promptUsesExpandedExecutionTaxonomy(question) ? scopeSteps : steps
-  const expected = expectedExecutionPhases(question, observedSourceSteps)
+  const expandedTaxonomy = promptUsesExpandedExecutionTaxonomy(question)
+  const expectedSourceSteps = expandedTaxonomy ? scopeSteps : steps
+  const observedSourceSteps = expandedTaxonomy ? tracedSteps : steps
+  const expected = expectedExecutionPhases(question, expectedSourceSteps)
   const observed = new Set<ExecutionPhase>()
   for (const step of observedSourceSteps) {
     for (const phase of executionPhasesForStep(step)) {
@@ -2510,6 +2515,7 @@ function collectExecutionBranches(
   sideEffects: ContextPackExecutionSliceBranch[]
   terminalBoundaries: ContextPackExecutionSliceBranch[]
   omittedBranches: ContextPackExecutionSliceOmittedBranch[]
+  omittedEvidenceSteps: ContextPackExecutionSliceStep[]
 } {
   const primaryEdgeKeys = new Set(primaryPath.edges.map((edge) => `${edge.fromId}:${edge.relation}:${edge.toId}`))
   const primaryNodeIds = new Set(primaryPath.nodeIds)
@@ -2517,6 +2523,7 @@ function collectExecutionBranches(
   const sideEffects: ContextPackExecutionSliceBranch[] = []
   const terminalBoundaries: ContextPackExecutionSliceBranch[] = []
   const omittedBranches: ContextPackExecutionSliceOmittedBranch[] = []
+  const omittedEvidenceSteps: ContextPackExecutionSliceStep[] = []
 
   for (const nodeId of primaryPath.nodeIds) {
     for (const edge of adjacency.get(nodeId) ?? []) {
@@ -2554,6 +2561,7 @@ function collectExecutionBranches(
       }
 
       if (omittedBranches.length < 6) {
+        omittedEvidenceSteps.push(...branchSteps)
         const from = nodeById.get(edge.fromId)?.label
         const to = nodeById.get(edge.toId)?.label
         omittedBranches.push({
@@ -2566,7 +2574,7 @@ function collectExecutionBranches(
     }
   }
 
-  return { sideEffects, terminalBoundaries, omittedBranches }
+  return { sideEffects, terminalBoundaries, omittedBranches, omittedEvidenceSteps }
 }
 
 function pickExecutionSliceStart(
@@ -2881,10 +2889,16 @@ function buildExecutionSlice(
   const scopeSteps = orderedIds
     .map((nodeId) => nodeById.get(nodeId))
     .filter((step): step is ContextPackExecutionSliceStep => step !== undefined)
-  const phaseCoverage = phaseCoverageForPath(steps, boundaries, question, scopeSteps)
+  const branches = collectExecutionBranches(adjacency, primaryPath, nodeById, question)
+  const tracedSteps = [
+    ...steps,
+    ...branches.sideEffects.flatMap((branch) => branch.steps),
+    ...branches.terminalBoundaries.flatMap((branch) => branch.steps),
+    ...branches.omittedEvidenceSteps,
+  ]
+  const phaseCoverage = phaseCoverageForPath(steps, boundaries, question, scopeSteps, tracedSteps)
   const missingPhase = phaseCoverage.missing[0]
   const boundaryReason = missingPhase ? missingExecutionPhaseBoundaryReason(missingPhase) : undefined
-  const branches = collectExecutionBranches(adjacency, primaryPath, nodeById, question)
   const executionSlice: ContextPackExecutionSlice = {
     status: missingPhase ? 'partial' : 'complete',
     ...(boundaryReason ? { boundary_reason: boundaryReason } : {}),

--- a/tests/unit/retrieve-production-correctness.test.ts
+++ b/tests/unit/retrieve-production-correctness.test.ts
@@ -454,7 +454,47 @@ describe('retrieveContext production retrieval regressions', () => {
     ]))
   })
 
-  it('surfaces richer report-generation phases when graph evidence covers planner, research, assembly, scoring, and rendering', () => {
+  it('keeps low-confidence report-generation slices honest when no runtime handoff was traced', () => {
+    const compact = compactRetrieveResult(retrieveContext(buildBroadReportGenerationGraph(), {
+      question: 'How idea report is being generated',
+      budget: 4000,
+      retrievalLevel: 4,
+      retrievalStrategy: 'slice-v1',
+    }))
+
+    expect(compact.execution_slice?.confidence).toBe('low')
+    expect(compact.execution_slice?.confidence_reasons).toEqual(expect.arrayContaining([
+      'no_runtime_handoff',
+    ]))
+    expect(compact.execution_slice?.status).toBe('partial')
+    expect(compact.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
+      observed: expect.not.arrayContaining([
+        'external_research_or_api',
+        'report_builder',
+        'scoring',
+        'quality_gate',
+        'renderer_or_synthesis',
+        'persistence',
+      ]),
+      missing: expect.arrayContaining([
+        'external_research_or_api',
+        'report_builder',
+        'scoring',
+        'quality_gate',
+        'renderer_or_synthesis',
+        'persistence',
+      ]),
+    }))
+    expect(compact.answer_contract).toEqual(expect.objectContaining({
+      observed_phases: compact.execution_slice?.phase_coverage?.observed,
+      missing_phases: compact.execution_slice?.phase_coverage?.missing,
+      do_not_claim: expect.arrayContaining([
+        'full_runtime_certainty_when_slice_is_partial',
+      ]),
+    }))
+  })
+
+  it('retains richer report-generation expectations without overclaiming untraced phases', () => {
     const compact = compactRetrieveResult(retrieveContext(buildBroadReportGenerationGraph(), {
       question: 'How idea report is being generated',
       budget: 4000,
@@ -473,6 +513,11 @@ describe('retrieveContext production retrieval regressions', () => {
         'persistence',
       ],
       observed: expect.arrayContaining([
+        'controller',
+        'service',
+        'queue',
+      ]),
+      missing: expect.arrayContaining([
         'planner',
         'external_research_or_api',
         'report_builder',
@@ -481,7 +526,6 @@ describe('retrieveContext production retrieval regressions', () => {
         'renderer_or_synthesis',
         'persistence',
       ]),
-      missing: [],
     }))
   })
 })


### PR DESCRIPTION
## Summary
- derive observed runtime-generation phases from traced execution evidence instead of the whole slice scope
- keep real forward runtime edges available even when slice-v1 also selects backward structural paths
- add a regression for low-confidence no-runtime-handoff report-generation packs and update the realistic fixture expectation

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #315
