### PR TITLE
Fix detect sensitive path false positives

### DIFF
--- a/src/pipeline/detect.ts
+++ b/src/pipeline/detect.ts
@@ -142,9 +142,15 @@ function isNoiseDir(part: string): boolean {
   return SKIP_DIRS.has(part) || part.endsWith('_venv') || part.endsWith('_env') || part.endsWith('.egg-info')
 }
 
-function isSensitive(path: string): boolean {
-  const name = basename(path)
-  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(name) || pattern.test(path))
+function isSensitive(path: string, root?: string): boolean {
+  const candidates = [basename(path)]
+  if (root) {
+    const relativePath = toPosixPath(relative(root, path))
+    if (relativePath && !relativePath.startsWith('..')) {
+      candidates.push(relativePath)
+    }
+  }
+  return candidates.some((candidate) => SENSITIVE_PATTERNS.some((pattern) => pattern.test(candidate)))
 }
 
 export function _looksLikePaper(path: string): boolean {
@@ -359,7 +365,7 @@ export function detect(root: string, options: DetectOptions = {}): DetectResult 
   const skippedSensitive: string[] = []
 
   for (const filePath of collectFiles(root, followSymlinks, ignorePatterns)) {
-    if (isSensitive(filePath)) {
+    if (isSensitive(filePath, root)) {
       skippedSensitive.push(filePath)
       continue
     }

--- a/tests/unit/detect.test.ts
+++ b/tests/unit/detect.test.ts
@@ -112,6 +112,20 @@ describe('detect', () => {
     }
   })
 
+  it('does not treat ordinary files as sensitive just because an ancestor directory contains token-like words', () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-token-root-'))
+    try {
+      writeFileSync(join(root, 'app.ts'), 'export const value = 1\n', 'utf8')
+
+      const result = detect(root)
+
+      expect(result.files.code.some((filePath) => filePath.endsWith('app.ts'))).toBe(true)
+      expect(result.skipped_sensitive).toEqual([])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('ignores comments in madarignore files', () => {
     const root = createTempRoot()
     try {


### PR DESCRIPTION
## Summary
- stop detect from treating ordinary files as sensitive just because an ancestor checkout directory contains token-like words
- evaluate sensitivity using the file name and workspace-relative path instead of the absolute filesystem path
- add a regression test covering token-named checkout roots

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

This unblocks clean baseline verification from worktrees created for issue-specific branches like #316.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced sensitive file detection to evaluate repository-relative paths more accurately alongside basenames, significantly reducing false positives caused by ancestor directory names.

* **Tests**
  * Added test coverage to verify sensitive file detection works correctly and doesn't incorrectly flag files based on directory names alone.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->