### PR TITLE
[P1] compare reductions summary can present a misleading win when uncached / cache-creation tokens regressed

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1878,6 +1878,10 @@ export type NativeAgentRunStatus =
   | { kind: 'answer_only'; evidence: string | null; exit_code: number; stderr: string | null; result_path: string }
   | { kind: 'runner_error'; evidence: string | null; exit_code: number | null; stderr: string | null }
 
+export type NativeAgentTokenRegressionMetric =
+  | 'uncached_input_tokens'
+  | 'cache_creation_input_tokens'
+
 export interface NativeAgentCompareReport {
   baseline_mode: 'native_agent'
   question: string
@@ -1888,10 +1892,14 @@ export interface NativeAgentCompareReport {
   madar_trace?: CompareMadarTrace
   reductions: {
     input_tokens: number | null
+    uncached_input_tokens?: number | null
+    cache_creation_input_tokens?: number | null
     num_turns: number | null
     duration_ms: number | null
     cost_usd: number | null
   } | null
+  token_regression: boolean
+  token_regression_reasons: NativeAgentTokenRegressionMetric[]
   prompt_token_source: {
     baseline: 'anthropic_provider_reported' | 'unknown'
     madar: 'anthropic_provider_reported' | 'unknown'
@@ -2264,13 +2272,36 @@ function computeReduction(baseline: number, madar: number): number | null {
   return Number((baseline / madar).toFixed(2))
 }
 
+function relativeChangeFraction(baseline: number, madar: number): number | null {
+  if (baseline <= 0 || madar <= 0) {
+    return null
+  }
+  return Math.abs(madar - baseline) / baseline
+}
+
 function formatDirectionalDelta(
   baseline: number,
   madar: number,
   decreasedLabel: string,
   increasedLabel: string,
+  options: {
+    noMeaningfulChangeThreshold?: number
+    neutralLabel?: string
+  } = {},
 ): string {
-  if (baseline <= 0 || madar <= 0 || baseline === madar) {
+  if (baseline <= 0 || madar <= 0) {
+    return ''
+  }
+
+  if (
+    options.neutralLabel
+    && options.noMeaningfulChangeThreshold !== undefined
+    && (relativeChangeFraction(baseline, madar) ?? Number.POSITIVE_INFINITY) <= options.noMeaningfulChangeThreshold
+  ) {
+    return ` (${options.neutralLabel})`
+  }
+
+  if (baseline === madar) {
     return ''
   }
 
@@ -2279,6 +2310,44 @@ function formatDirectionalDelta(
   }
 
   return ` (${Number((madar / baseline).toFixed(2))}x ${increasedLabel})`
+}
+
+function collectTokenRegressionReasons(
+  baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+  madar: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+): NativeAgentTokenRegressionMetric[] {
+  const reasons: NativeAgentTokenRegressionMetric[] = []
+  if (madar.uncached_input_tokens_anthropic_exact > baseline.uncached_input_tokens_anthropic_exact) {
+    reasons.push('uncached_input_tokens')
+  }
+  if (madar.usage.cache_creation_input_tokens > baseline.usage.cache_creation_input_tokens) {
+    reasons.push('cache_creation_input_tokens')
+  }
+  return reasons
+}
+
+function formatTokenRegressionMetric(
+  metric: NativeAgentTokenRegressionMetric,
+  baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+  madar: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+): string {
+  if (metric === 'uncached_input_tokens') {
+    return `uncached_input_tokens baseline ${baseline.uncached_input_tokens_anthropic_exact} → madar ${madar.uncached_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.uncached_input_tokens_anthropic_exact, madar.uncached_input_tokens_anthropic_exact, 'less', 'more')}`
+  }
+
+  return `cache_creation_input_tokens baseline ${baseline.usage.cache_creation_input_tokens} → madar ${madar.usage.cache_creation_input_tokens}${formatDirectionalDelta(baseline.usage.cache_creation_input_tokens, madar.usage.cache_creation_input_tokens, 'less', 'more')}`
+}
+
+function formatTokenRegressionWarning(
+  baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+  madar: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+  reasons: readonly NativeAgentTokenRegressionMetric[],
+): string | null {
+  if (reasons.length === 0) {
+    return null
+  }
+
+  return `WARNING: fresh-token regression — ${reasons.map((metric) => formatTokenRegressionMetric(metric, baseline, madar)).join('; ')}`
 }
 
 type NativeAgentComparableReport = NativeAgentCompareReport & {
@@ -2456,6 +2525,8 @@ export async function executeNativeAgentCompare(
       baseline: { kind: 'runner_error', evidence: null, exit_code: null, stderr: null },
       madar: { kind: 'runner_error', evidence: null, exit_code: null, stderr: null },
       reductions: null,
+      token_regression: false,
+      token_regression_reasons: [],
       prompt_token_source: {
         baseline: 'unknown',
         madar: 'unknown',
@@ -2635,6 +2706,8 @@ export async function executeNativeAgentCompare(
     if (reportShell.baseline.kind === 'succeeded' && reportShell.madar.kind === 'succeeded') {
       reportShell.reductions = {
         input_tokens: computeReduction(reportShell.baseline.total_input_tokens_anthropic_exact, reportShell.madar.total_input_tokens_anthropic_exact),
+        uncached_input_tokens: computeReduction(reportShell.baseline.uncached_input_tokens_anthropic_exact, reportShell.madar.uncached_input_tokens_anthropic_exact),
+        cache_creation_input_tokens: computeReduction(reportShell.baseline.usage.cache_creation_input_tokens, reportShell.madar.usage.cache_creation_input_tokens),
         num_turns: computeReduction(reportShell.baseline.num_turns, reportShell.madar.num_turns),
         duration_ms: computeReduction(reportShell.baseline.duration_ms, reportShell.madar.duration_ms),
         cost_usd:
@@ -2642,6 +2715,8 @@ export async function executeNativeAgentCompare(
             ? computeReduction(reportShell.baseline.total_cost_usd, reportShell.madar.total_cost_usd)
             : null,
       }
+      reportShell.token_regression_reasons = collectTokenRegressionReasons(reportShell.baseline, reportShell.madar)
+      reportShell.token_regression = reportShell.token_regression_reasons.length > 0
     }
     if (reportShell.provider_proof) {
       reportShell.provider_proof.reduction_basis =
@@ -2784,7 +2859,7 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       `- "${report.question}"`,
       `    num_turns: baseline ${baseline.num_turns} → madar ${madar.num_turns}${formatDirectionalDelta(baseline.num_turns, madar.num_turns, 'fewer', 'more')}`,
       `    latency:   baseline ${baseline.duration_ms}ms → madar ${madar.duration_ms}ms${formatDirectionalDelta(baseline.duration_ms, madar.duration_ms, 'faster', 'slower')}`,
-      `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → madar ${madar.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, madar.total_input_tokens_anthropic_exact, 'less', 'more')}`,
+      `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → madar ${madar.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, madar.total_input_tokens_anthropic_exact, 'less', 'more', { noMeaningfulChangeThreshold: 0.1, neutralLabel: 'no meaningful change' })}`,
     )
     if (hasCacheActivity) {
       lines.push(
@@ -2792,6 +2867,15 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
         `    cache_creation_input_tokens (Anthropic-reported): baseline ${baseline.usage.cache_creation_input_tokens} → madar ${madar.usage.cache_creation_input_tokens}${formatDirectionalDelta(baseline.usage.cache_creation_input_tokens, madar.usage.cache_creation_input_tokens, 'less', 'more')}`,
         `    cache_read_input_tokens (Anthropic-reported): baseline ${baseline.usage.cache_read_input_tokens} → madar ${madar.usage.cache_read_input_tokens}${formatDirectionalDelta(baseline.usage.cache_read_input_tokens, madar.usage.cache_read_input_tokens, 'less', 'more')}`,
       )
+    }
+    const derivedTokenRegressionReasons = collectTokenRegressionReasons(baseline, madar)
+    const tokenRegressionReasons =
+      report.token_regression_reasons && report.token_regression_reasons.length > 0
+        ? report.token_regression_reasons
+        : derivedTokenRegressionReasons
+    const tokenRegressionWarning = formatTokenRegressionWarning(baseline, madar, tokenRegressionReasons)
+    if (tokenRegressionWarning) {
+      lines.push(`    ${tokenRegressionWarning}`)
     }
     if (report.answer_quality) {
       const baselineFindings = [

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -75,6 +75,38 @@ const MADAR_USAGE_PAYLOAD = {
   },
 }
 
+const BASELINE_TOKEN_REGRESSION_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 42000,
+  num_turns: 5,
+  result: 'baseline answer',
+  total_cost_usd: 0.62,
+  usage: {
+    input_tokens: 21144,
+    cache_creation_input_tokens: 43534,
+    cache_read_input_tokens: 324040,
+    output_tokens: 1200,
+  },
+}
+
+const MADAR_TOKEN_REGRESSION_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 39000,
+  num_turns: 4,
+  result: 'madar answer',
+  total_cost_usd: 0.71,
+  usage: {
+    input_tokens: 18023,
+    cache_creation_input_tokens: 72305,
+    cache_read_input_tokens: 277531,
+    output_tokens: 1000,
+  },
+}
+
 function scriptedRunner(payloads: { baseline: unknown; madar: unknown }): NativeAgentRunner {
   return async (input) => ({
     exitCode: 0,
@@ -139,6 +171,8 @@ function buildSummaryResult(overrides: {
           result_path: '/tmp/project/madar.txt',
         },
         reductions: overrides.reductions,
+        token_regression: false,
+        token_regression_reasons: [],
         prompt_token_source: {
           baseline: 'anthropic_provider_reported',
           madar: 'anthropic_provider_reported',
@@ -277,6 +311,47 @@ describe('executeNativeAgentCompare', () => {
       // a usage block was present in the runner output.
       expect(report.prompt_token_source.baseline).toBe('anthropic_provider_reported')
       expect(report.prompt_token_source.madar).toBe('anthropic_provider_reported')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('flags token regressions when fresh-token usage rises despite near-flat total input tokens', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How idea report is being generated',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: BASELINE_TOKEN_REGRESSION_PAYLOAD,
+            madar: MADAR_TOKEN_REGRESSION_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-26T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+      const reductions = savedReport.reductions as Record<string, unknown>
+      const shareSafeReductions = shareSafeReport.reductions as Record<string, unknown>
+
+      expect(reductions.input_tokens).toBeCloseTo(1.06, 2)
+      expect(reductions.uncached_input_tokens).toBeCloseTo(0.72, 2)
+      expect(reductions.cache_creation_input_tokens).toBeCloseTo(0.6, 2)
+      expect(savedReport.token_regression).toBe(true)
+      expect(savedReport.token_regression_reasons).toEqual(expect.arrayContaining([
+        'uncached_input_tokens',
+        'cache_creation_input_tokens',
+      ]))
+      expect(shareSafeReductions.uncached_input_tokens).toBeCloseTo(0.72, 2)
+      expect(shareSafeReport.token_regression).toBe(true)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -766,5 +841,42 @@ describe('formatNativeAgentCompareSummary', () => {
 
     expect(summary).toContain('madar_trace: reduced_exploration')
     expect(summary).toContain('1 context_pack call; 1 focused follow-up call; no broad exploration recorded')
+  })
+
+  it('warns when total input tokens show no meaningful change but fresh-token usage regresses', () => {
+    const result = buildSummaryResult({
+      question: 'regression honesty',
+      baselineTurns: 5,
+      madarTurns: 4,
+      baselineDurationMs: 42000,
+      madarDurationMs: 39000,
+      baselineInputTokens: 388718,
+      madarInputTokens: 367859,
+      reductions: {
+        num_turns: 1.25,
+        duration_ms: 1.08,
+        input_tokens: 1.06,
+        cost_usd: 0.87,
+      },
+    })
+    const report = result.reports[0]
+    if (!report || report.baseline.kind !== 'succeeded' || report.madar.kind !== 'succeeded') {
+      throw new Error('summary fixture should produce succeeded runs')
+    }
+    report.baseline.usage = BASELINE_TOKEN_REGRESSION_PAYLOAD.usage
+    report.baseline.total_input_tokens_anthropic_exact = 388718
+    report.baseline.uncached_input_tokens_anthropic_exact = 64678
+    report.baseline.cached_input_tokens_anthropic_exact = 324040
+    report.madar.usage = MADAR_TOKEN_REGRESSION_PAYLOAD.usage
+    report.madar.total_input_tokens_anthropic_exact = 367859
+    report.madar.uncached_input_tokens_anthropic_exact = 90328
+    report.madar.cached_input_tokens_anthropic_exact = 277531
+
+    const summary = formatNativeAgentCompareSummary(result)
+
+    expect(summary).toContain('input_tokens (Anthropic-reported): baseline 388718 → madar 367859 (no meaningful change)')
+    expect(summary).toContain('WARNING: fresh-token regression')
+    expect(summary).toContain('uncached_input_tokens')
+    expect(summary).toContain('cache_creation_input_tokens')
   })
 })


### PR DESCRIPTION
## Summary
- expose uncached and cache-creation token deltas alongside the existing native-agent compare reductions
- carry an explicit token regression flag and regression reasons into report.json and report.share-safe.json
- label near-flat total input as no meaningful change in the terminal summary and print a fresh-token regression warning when uncached or cache-creation tokens rise

## Testing
- npm run test:run -- tests/unit/compare.test.ts tests/unit/compare-native-agent.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token regression detection now identifies when fresh-token usage increases beyond baseline.
  * Warning messages alert users to fresh-token regressions in comparison summaries.
  * Enhanced metrics reporting with granular token component tracking for improved performance visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->