### PR TITLE
Build reproducible benchmark suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Changed
 
 - **Public claim surfaces now map directly to evidence**: README/package/docs language now separates demonstrated behavior from in-progress and not-yet-measured claims, benchmark docs point at the per-repo suite scaffold instead of a single cross-repo headline, and `docs/claims-and-evidence.md` records what each public claim is allowed to say.
+- **The benchmark suite is now runnable and seeded with a real measured row**: `madar bench:suite` expands fixed repo/task manifests, stages compare-backed trials safely, writes summaries and share-safe raw artifacts under `docs/benchmarks/suite/results/`, and ships the first 3-trial warm `nestjs-mid` / `explain-runtime` receipt.
 
 ## [0.27.0-next.1] - 2026-05-26
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ That means the same selected nodes can render differently for `explain`, `review
 
 ## In progress
 
-- **Reproducible benchmark suite with per-repo spread.** The public suite scaffold lives at [`docs/benchmarks/suite/`](docs/benchmarks/suite/); issue [#332](https://github.com/mohanagy/madar/issues/332) tracks the runner-backed matrix.
+- **Reproducible benchmark suite with per-repo spread.** The public suite now ships fixed manifests, methodology, and the `madar bench:suite` runner under [`docs/benchmarks/suite/`](docs/benchmarks/suite/).
 - **Exploration reduction as a product outcome.** Strict install guidance now pushes agents toward one graph/pack-first pass, but the public evidence is still mixed. The current counterexample note is in [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](docs/benchmarks/2026-05-25-founder-command-center-auth-flow/).
 - **Clearer compare evidence.** Native-agent compare traces now preserve more machine-readable metadata, but we still treat them as repo/task-specific receipts rather than a universal claim.
 
@@ -181,7 +181,7 @@ That means the same selected nodes can render differently for `explain`, `review
 
 - We publish dated artifact folders under [`docs/benchmarks/`](docs/benchmarks/) and map each public claim to evidence in [`docs/claims-and-evidence.md`](docs/claims-and-evidence.md).
 - We separate **cold-cache** and **warm-cache** observations, and we call out mixed evidence when a repo or prompt regresses.
-- The benchmark-suite direction is **per-repo spread**, fixed tasks, and reproducible artifacts under [`docs/benchmarks/suite/`](docs/benchmarks/suite/). There is **no single-number cross-repo headline** in the public docs.
+- The benchmark-suite direction is **per-repo spread**, fixed tasks, and reproducible artifacts under [`docs/benchmarks/suite/`](docs/benchmarks/suite/). Run `madar bench:suite --dry-run` to inspect the current matrix, then `madar bench:suite --repo nestjs-mid --task explain-runtime ...` to populate a wired cell. There is **no single-number cross-repo headline** in the public docs.
 - Any stronger public claim belongs behind a reproducible suite artifact, not a one-off anecdote.
 
 ---
@@ -288,7 +288,7 @@ Everything stays local by default. No telemetry, no cloud upload, no API key req
 
 - [Quick start guide](docs/proof-workflows.md) — three reproducible workflows: local proof, A/B compare, federated proof
 - [Claims and evidence map](docs/claims-and-evidence.md) — which public claims are demonstrated, in progress, or not yet measured
-- [Benchmark suite scaffold](docs/benchmarks/suite/README.md) — per-repo spread methodology and the reproducible-suite direction tracked in #332
+- [Benchmark suite](docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results
 - [GoValidate shared benchmark suite](docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates
 - [Public roadmap](docs/roadmap.md) — contributor-facing priority tracks and issue links
 - [Language and capability matrix](docs/language-capability-matrix.md) — exactly what each file type and language gets

--- a/docs/benchmarks/suite/README.md
+++ b/docs/benchmarks/suite/README.md
@@ -18,4 +18,39 @@ This directory is the public landing zone for the reproducible benchmark suite t
 
 ## Current status
 
-The full runner-backed matrix does not ship yet. Until it does, public claims stay conservative and point back to dated artifact folders plus [`docs/claims-and-evidence.md`](../../claims-and-evidence.md).
+The runner-backed suite now ships in this directory:
+
+- [`repos.json`](./repos.json) — fixed repo ids and current readiness
+- [`tasks.json`](./tasks.json) — fixed task ids and current prompt wiring
+- [`methodology.md`](./methodology.md) — trial protocol, caveats, and reporting rules
+- `madar bench:suite` — the CLI entrypoint that expands runnable cells and writes results under `docs/benchmarks/suite/results/<timestamp>/`
+
+Current wiring is intentionally conservative:
+
+- `nestjs-mid` is the first runnable fixture-style mid-size service proxy
+- `explain-runtime` is the first runnable task kind
+- the rest of the fixed matrix is present in the manifests as planned rows so the public surface shows the intended spread without pretending those cells are already measured
+
+First measured row:
+
+- [`results/2026-05-26T18-31-04/summary.md`](./results/2026-05-26T18-31-04/summary.md) — warm-cache `nestjs-mid` / `explain-runtime`, 3 trials, baseline vs Madar vs SPI Madar
+
+Run a dry-run first:
+
+```bash
+madar bench:suite --dry-run
+```
+
+Run the first wired cell:
+
+```bash
+madar bench:suite \
+  --repo nestjs-mid \
+  --task explain-runtime \
+  --mode warm \
+  --trials 3 \
+  --exec 'cat {prompt_file} | claude -p --output-format json' \
+  --yes
+```
+
+Measured results remain repo/task specific receipts. Public claims stay conservative and point back to dated artifact folders plus [`docs/claims-and-evidence.md`](../../claims-and-evidence.md) until the broader matrix is populated.

--- a/docs/benchmarks/suite/methodology.md
+++ b/docs/benchmarks/suite/methodology.md
@@ -1,0 +1,68 @@
+# Benchmark suite methodology
+
+This suite exists to make Madar's benchmark claims reproducible without collapsing everything into one blended marketing number.
+
+## Repo selection
+
+The fixed repo set is tracked in [`repos.json`](./repos.json).
+
+- Keep the shape mix explicit: small TypeScript, mid-size service, larger TypeScript monorepo, Python service, Go service.
+- The suite may use public repos or fixture-style proxies. It must not require the private GoValidate codebase.
+- Only rows marked `status: "ready"` are runnable today. Planned rows stay visible in the manifest so the public surface shows the intended spread honestly.
+
+## Task selection
+
+The fixed task set is tracked in [`tasks.json`](./tasks.json).
+
+- Task ids are suite dispatch keys such as `explain-runtime`, `implement`, and `review`.
+- A task becomes runnable only when it has `status: "ready"` and a repo-specific prompt in `prompts`.
+- Missing prompts are treated as planned cells, not silently skipped evidence.
+
+## Trial protocol
+
+- Default trials per runnable cell: **3**
+- Run modes:
+  - **cold** — measured directly with no suite-managed priming run
+  - **warm** — one priming compare run is executed and discarded before the measured run
+- Each measured cell currently records:
+  - baseline
+  - Madar
+  - SPI Madar when the repo entry supports SPI
+
+## What is measured
+
+Primary metric:
+
+- Anthropic-reported input tokens per task from the native-agent compare `result` event
+
+Secondary metrics:
+
+- total tool-call count
+- `Read` count
+- `Glob` + `Grep` count
+- wall-clock duration
+- total cost
+
+Per-cell artifacts keep `report.share-safe.json` as the canonical persisted report so summaries can be inspected without leaking private local paths.
+
+## Reporting rules
+
+- Results are written under `docs/benchmarks/suite/results/<timestamp>/`
+- `summary.json` is the machine-readable rollup
+- `summary.md` is the human-readable rollup
+- Keep **repos as rows**
+- Report **median + min/max + n**
+- Keep **cold** and **warm** separate
+- Do **not** add a blended cross-repo rollup row
+
+## What is not controlled
+
+The suite is reproducible, but it is not a lab instrument. The following still vary:
+
+- model version drift
+- provider-side routing changes
+- rate limits and queueing
+- time-of-day cache state
+- agent runtime behavior outside the prompt itself
+
+Those caveats are part of the evidence, not a reason to hide variance.

--- a/docs/benchmarks/suite/repos.json
+++ b/docs/benchmarks/suite/repos.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ts-small",
+    "name": "TypeScript small workspace",
+    "path": "examples/sample-workspace",
+    "description": "Small TypeScript demo workspace kept in-tree for future suite expansion.",
+    "size": "small",
+    "language": "typescript",
+    "shape": "library",
+    "status": "planned",
+    "supportsSpi": true
+  },
+  {
+    "id": "nestjs-mid",
+    "name": "NestJS-like service fixture",
+    "path": "tests/fixtures/pack-quality/controller-service-test-flow/workspace",
+    "description": "Fixture-style controller/service/persistence workspace used as the first runnable mid-size service proxy.",
+    "size": "mid",
+    "language": "typescript",
+    "shape": "nestjs-service-proxy",
+    "status": "ready",
+    "supportsSpi": true
+  },
+  {
+    "id": "ts-monorepo-large",
+    "name": "TypeScript monorepo proxy",
+    "path": "tests/fixtures/pack-quality/monorepo-package-boundary/workspace",
+    "description": "Fixture-style monorepo proxy reserved for future large-workspace suite cells.",
+    "size": "large",
+    "language": "typescript",
+    "shape": "monorepo",
+    "status": "planned",
+    "supportsSpi": true
+  },
+  {
+    "id": "python-service",
+    "name": "Python service proxy",
+    "path": "docs/benchmarks/suite/fixtures/python-service",
+    "description": "Reserved slot for a public or fixture-style Python service benchmark target.",
+    "size": "mid",
+    "language": "python",
+    "shape": "fastapi-or-django",
+    "status": "planned",
+    "supportsSpi": false
+  },
+  {
+    "id": "go-service",
+    "name": "Go HTTP service proxy",
+    "path": "docs/benchmarks/suite/fixtures/go-service",
+    "description": "Reserved slot for a public or fixture-style Go HTTP benchmark target.",
+    "size": "mid",
+    "language": "go",
+    "shape": "http-service",
+    "status": "planned",
+    "supportsSpi": false
+  }
+]

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/baseline-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/baseline-answer.txt
@@ -1,0 +1,43 @@
+Here's the login session creation flow, traced end-to-end:
+
+**1. Controller — `src/controllers/auth-controller.ts:6`**
+```ts
+async login(input: { email: string }) {
+  return this.authService.login(input)
+}
+```
+`AuthController.login` accepts `{ email }` and delegates to an injected `AuthService` (default-constructed via the constructor parameter default at `auth-controller.ts:4`).
+
+**2. Service — `src/services/auth-service.ts:4`**
+```ts
+async login(input: { email: string }) {
+  return createSession(input.email)
+}
+```
+`AuthService.login` is a thin pass-through that unwraps `input.email` and calls the persistence function `createSession`.
+
+**3. Persistence — `src/persistence/session-store.ts:1`**
+```ts
+export function createSession(email: string) {
+  return { sessionId: `session:${email}` }
+}
+```
+`createSession` synthesizes a session object `{ sessionId: "session:<email>" }` and returns it. There is no actual storage — it's a pure function returning a derived ID.
+
+**Flow summary**
+
+```
+AuthController.login({ email })
+  → AuthService.login({ email })
+    → createSession(email)
+      → { sessionId: `session:${email}` }
+```
+
+**Observations worth flagging:**
+- No real persistence: `createSession` doesn't write to a store, DB, or cache despite the file/module name.
+- No validation: email isn't validated (no Zod/format check) — the value is interpolated directly into the session ID.
+- No password/credential check: the "login" only takes an email; there's no authentication step.
+- Deterministic, guessable IDs: `session:<email>` is trivially forgeable since any caller who knows an email can construct the same ID.
+- `async` is unnecessary in `AuthService.login` — `createSession` is synchronous.
+
+Likely this is a scaffold/legacy stub awaiting a real implementation.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/madar-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/madar-answer.txt
@@ -1,0 +1,12 @@
+The login session creation flow is a three-layer pass-through:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6-8`
+`AuthController.login({ email })` delegates to `this.authService.login(input)`. The service is instantiated via a default constructor parameter (`new AuthService()`), so there's no DI wiring.
+
+**2. Service** — `src/services/auth-service.ts:4-6`
+`AuthService.login({ email })` calls the module-level `createSession(input.email)` from the persistence layer. The service adds no logic — no validation, no password check, no user lookup.
+
+**3. Persistence** — `src/persistence/session-store.ts:1-3`
+`createSession(email)` returns `{ sessionId: \`session:${email}\` }` synchronously. There is no actual store: no DB, no in-memory map, no expiry, no token signing — the "session ID" is just the email interpolated into a string.
+
+**Flow summary:** `controller → service → createSession` → returns `{ sessionId: "session:<email>" }`. Nothing is persisted; the function name is misleading. Notable gaps if this is meant to be real auth: no email validation, no credential verification, no session storage, no expiration, and the deterministic `session:<email>` ID is trivially guessable.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/native_agent-prompt.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/native_agent-prompt.txt
@@ -1,0 +1,1 @@
+How does login session creation flow work from controller to persistence?

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/legacy/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31471,
+      "cache_read_input_tokens": 352547,
+      "output_tokens": 1357,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31471,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 641,
+          "cache_read_input_tokens": 65690,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 384029,
+    "uncached_input_tokens_anthropic_exact": 31482,
+    "cached_input_tokens_anthropic_exact": 352547,
+    "total_cost_usd": 0.40694725,
+    "num_turns": 6,
+    "duration_ms": 35436,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32344,
+      "cache_read_input_tokens": 415419,
+      "output_tokens": 1502,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32344,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 427,
+          "cache_read_input_tokens": 66563,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 447775,
+    "uncached_input_tokens_anthropic_exact": 32356,
+    "cached_input_tokens_anthropic_exact": 415419,
+    "total_cost_usd": 0.4474695,
+    "num_turns": 7,
+    "duration_ms": 40180,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.86,
+    "uncached_input_tokens": 0.97,
+    "cache_creation_input_tokens": 0.97,
+    "num_turns": 0.86,
+    "duration_ms": 0.88,
+    "cost_usd": 0.91
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:32:17.709Z",
+  "completed_at": "2026-05-26T18:33:39.908Z",
+  "paths": {
+    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17",
+    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.json",
+    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.share-safe.json",
+    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/baseline-answer.txt",
+    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/madar-answer.txt",
+    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.json
@@ -1,7 +1,7 @@
 {
   "baseline_mode": "native_agent",
   "question": "How does login session creation flow work from controller to persistence?",
-  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/legacy/out/graph.json",
+  "graph_path": "<project-root>/out/graph.json",
   "exec_command": {
     "command": null,
     "placeholders": [
@@ -48,7 +48,7 @@
     "total_cost_usd": 0.40694725,
     "num_turns": 6,
     "duration_ms": 35436,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/baseline-answer.txt"
+    "result_path": "<artifact-root>/baseline-answer.txt"
   },
   "madar": {
     "kind": "succeeded",
@@ -89,7 +89,7 @@
     "total_cost_usd": 0.4474695,
     "num_turns": 7,
     "duration_ms": 40180,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/madar-answer.txt"
+    "result_path": "<artifact-root>/madar-answer.txt"
   },
   "reductions": {
     "input_tokens": 0.86,
@@ -126,11 +126,11 @@
   "started_at": "2026-05-26T18:32:17.709Z",
   "completed_at": "2026-05-26T18:33:39.908Z",
   "paths": {
-    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17",
-    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.json",
-    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.share-safe.json",
-    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/baseline-answer.txt",
-    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/madar-answer.txt",
-    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/native_agent-prompt.txt"
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
   }
 }

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.share-safe.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.share-safe.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31471,
+      "cache_read_input_tokens": 352547,
+      "output_tokens": 1357,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31471,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 641,
+          "cache_read_input_tokens": 65690,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 384029,
+    "uncached_input_tokens_anthropic_exact": 31482,
+    "cached_input_tokens_anthropic_exact": 352547,
+    "total_cost_usd": 0.40694725,
+    "num_turns": 6,
+    "duration_ms": 35436,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32344,
+      "cache_read_input_tokens": 415419,
+      "output_tokens": 1502,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32344,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 427,
+          "cache_read_input_tokens": 66563,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 447775,
+    "uncached_input_tokens_anthropic_exact": 32356,
+    "cached_input_tokens_anthropic_exact": 415419,
+    "total_cost_usd": 0.4474695,
+    "num_turns": 7,
+    "duration_ms": 40180,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.86,
+    "uncached_input_tokens": 0.97,
+    "cache_creation_input_tokens": 0.97,
+    "num_turns": 0.86,
+    "duration_ms": 0.88,
+    "cost_usd": 0.91
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:32:17.709Z",
+  "completed_at": "2026-05-26T18:33:39.908Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/baseline-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/baseline-answer.txt
@@ -1,0 +1,30 @@
+The login session creation flow is a straightforward three-layer pass-through:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6`
+```ts
+async login(input: { email: string }) {
+  return this.authService.login(input)
+}
+```
+`AuthController.login` receives `{ email }`, delegates directly to `AuthService`. No validation, no auth checks. The service is instantiated via a default-parameter `new AuthService()` in the constructor (not real DI).
+
+**2. Service** — `src/services/auth-service.ts:4`
+```ts
+async login(input: { email: string }) {
+  return createSession(input.email)
+}
+```
+`AuthService.login` unwraps the email and calls the persistence function. No password check, no rate limiting, no user lookup — there's no actual authentication happening.
+
+**3. Persistence** — `src/persistence/session-store.ts:1`
+```ts
+export function createSession(email: string) {
+  return { sessionId: `session:${email}` }
+}
+```
+`createSession` returns a synthetic object with a deterministic `sessionId` derived from the email. Nothing is actually stored — there's no DB, no in-memory map, no expiry. The session "ID" is just `"session:" + email`.
+
+**Summary of the flow:**
+`AuthController.login({ email })` → `AuthService.login({ email })` → `createSession(email)` → `{ sessionId: "session:<email>" }`
+
+**Notable gaps** (consistent with this being a `legacy` scaffold): no credential verification, no token/secret in the session ID (it's email-derived and predictable), no persistence layer despite the directory name, no Zod validation at the boundary, and no NestJS decorators despite the project being described as NestJS — these are plain classes wired manually.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/madar-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/madar-answer.txt
@@ -1,0 +1,23 @@
+Login session creation traces through three layers:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6-8`
+`AuthController.login({ email })` delegates straight to `AuthService.login`. No validation, no auth-token extraction, no response shaping; the controller is a pass-through.
+
+**2. Service** — `src/services/auth-service.ts:4-6`
+`AuthService.login({ email })` calls the persistence helper `createSession(input.email)`. No business logic (no password check, no user lookup, no rate limiting, no session expiry, no audit log).
+
+**3. Persistence** — `src/persistence/session-store.ts:1-3`
+`createSession(email)` returns a synthetic object `{ sessionId: \`session:${email}\` }`. Nothing is actually persisted — no store, no DB, no in-memory map. The "sessionId" is a deterministic string derived from the email.
+
+**Flow summary:**
+```
+login({email}) → AuthController.login → AuthService.login → createSession(email) → { sessionId: `session:${email}` }
+```
+
+**Caveats worth noting** (despite the "session creation" framing):
+- Not NestJS despite the project label — plain TS classes, no `@Controller`/`@Injectable` decorators, no DI container (`AuthController` instantiates `AuthService` via default-arg `new`).
+- No persistence — `createSession` is pure; sessions don't survive the call.
+- No auth — any email yields a valid sessionId; the sessionId leaks the email and is trivially guessable.
+- No expiry, revocation, or session lookup paths exist.
+
+This reads like a stub/skeleton rather than a working session subsystem.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/native_agent-prompt.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/native_agent-prompt.txt
@@ -1,0 +1,1 @@
+How does login session creation flow work from controller to persistence?

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.json
@@ -1,0 +1,133 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/legacy/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32355,
+      "cache_read_input_tokens": 415466,
+      "output_tokens": 1673,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32355,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 583,
+          "cache_read_input_tokens": 66574,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 447833,
+    "uncached_input_tokens_anthropic_exact": 32367,
+    "cached_input_tokens_anthropic_exact": 415466,
+    "total_cost_usd": 0.45183675,
+    "num_turns": 7,
+    "duration_ms": 43757,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31749,
+      "cache_read_input_tokens": 351989,
+      "output_tokens": 1266,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31749,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 558,
+          "cache_read_input_tokens": 65968,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383749,
+    "uncached_input_tokens_anthropic_exact": 31760,
+    "cached_input_tokens_anthropic_exact": 351989,
+    "total_cost_usd": 0.40613075000000004,
+    "num_turns": 6,
+    "duration_ms": 31102,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.17,
+    "uncached_input_tokens": 1.02,
+    "cache_creation_input_tokens": 1.02,
+    "num_turns": 1.17,
+    "duration_ms": 1.41,
+    "cost_usd": 1.11
+  },
+  "token_regression": false,
+  "token_regression_reasons": [],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:37:29.371Z",
+  "completed_at": "2026-05-26T18:38:50.734Z",
+  "paths": {
+    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29",
+    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.json",
+    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.share-safe.json",
+    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/baseline-answer.txt",
+    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/madar-answer.txt",
+    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.json
@@ -1,7 +1,7 @@
 {
   "baseline_mode": "native_agent",
   "question": "How does login session creation flow work from controller to persistence?",
-  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/legacy/out/graph.json",
+  "graph_path": "<project-root>/out/graph.json",
   "exec_command": {
     "command": null,
     "placeholders": [
@@ -48,7 +48,7 @@
     "total_cost_usd": 0.45183675,
     "num_turns": 7,
     "duration_ms": 43757,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/baseline-answer.txt"
+    "result_path": "<artifact-root>/baseline-answer.txt"
   },
   "madar": {
     "kind": "succeeded",
@@ -89,7 +89,7 @@
     "total_cost_usd": 0.40613075000000004,
     "num_turns": 6,
     "duration_ms": 31102,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/madar-answer.txt"
+    "result_path": "<artifact-root>/madar-answer.txt"
   },
   "reductions": {
     "input_tokens": 1.17,
@@ -123,11 +123,11 @@
   "started_at": "2026-05-26T18:37:29.371Z",
   "completed_at": "2026-05-26T18:38:50.734Z",
   "paths": {
-    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29",
-    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.json",
-    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.share-safe.json",
-    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/baseline-answer.txt",
-    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/madar-answer.txt",
-    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/native_agent-prompt.txt"
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
   }
 }

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.share-safe.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.share-safe.json
@@ -1,0 +1,133 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32355,
+      "cache_read_input_tokens": 415466,
+      "output_tokens": 1673,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32355,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 583,
+          "cache_read_input_tokens": 66574,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 447833,
+    "uncached_input_tokens_anthropic_exact": 32367,
+    "cached_input_tokens_anthropic_exact": 415466,
+    "total_cost_usd": 0.45183675,
+    "num_turns": 7,
+    "duration_ms": 43757,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31749,
+      "cache_read_input_tokens": 351989,
+      "output_tokens": 1266,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31749,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 558,
+          "cache_read_input_tokens": 65968,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383749,
+    "uncached_input_tokens_anthropic_exact": 31760,
+    "cached_input_tokens_anthropic_exact": 351989,
+    "total_cost_usd": 0.40613075000000004,
+    "num_turns": 6,
+    "duration_ms": 31102,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.17,
+    "uncached_input_tokens": 1.02,
+    "cache_creation_input_tokens": 1.02,
+    "num_turns": 1.17,
+    "duration_ms": 1.41,
+    "cost_usd": 1.11
+  },
+  "token_regression": false,
+  "token_regression_reasons": [],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:37:29.371Z",
+  "completed_at": "2026-05-26T18:38:50.734Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/baseline-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/baseline-answer.txt
@@ -1,0 +1,34 @@
+The login session creation flows through three layers:
+
+**1. Controller** (`src/controllers/auth-controller.ts:6`)
+`AuthController.login({ email })` is the entry point. It instantiates `AuthService` by default and delegates immediately:
+```ts
+async login(input: { email: string }) {
+  return this.authService.login(input)
+}
+```
+
+**2. Service** (`src/services/auth-service.ts:4`)
+`AuthService.login` is a thin pass-through — no validation, hashing, or credential check. It calls the persistence helper directly:
+```ts
+async login(input: { email: string }) {
+  return createSession(input.email)
+}
+```
+
+**3. Persistence** (`src/persistence/session-store.ts:1`)
+`createSession(email)` is a pure function that synthesizes a deterministic session object — no storage, no I/O, no expiry:
+```ts
+return { sessionId: `session:${email}` }
+```
+
+**Flow summary:** `AuthController.login` → `AuthService.login` → `createSession` → returns `{ sessionId: "session:<email>" }`.
+
+**Observations worth flagging:**
+- No password/credential verification — login succeeds for any email
+- No input validation (no Zod schema, no email format check)
+- Session ID is fully derivable from the email — not random, not signed, trivially forgeable
+- "Persistence" doesn't actually persist; it returns an object and nothing is stored
+- `AuthController` instantiates `AuthService` in its default param rather than receiving it via DI, which couples the layers and complicates testing
+
+This looks like a skeleton/legacy stub rather than a real auth flow.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/madar-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/madar-answer.txt
@@ -1,0 +1,14 @@
+The login session creation flow has three layers, each delegating straight through:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6-8`
+`AuthController.login({ email })` is the entry point. It instantiates `AuthService` via a default constructor argument and forwards the input untouched.
+
+**2. Service** — `src/services/auth-service.ts:4-6`
+`AuthService.login({ email })` extracts `email` and calls the persistence helper `createSession(email)`. No validation, hashing, or auth checks happen here — it's a pure pass-through.
+
+**3. Persistence** — `src/persistence/session-store.ts:1-3`
+`createSession(email)` synchronously returns `{ sessionId: \`session:${email}\` }`. There's no database, no store, no expiry — just a string-templated session id derived from the email.
+
+**Flow:** `AuthController.login` → `AuthService.login` → `createSession` → returns `{ sessionId }` back up the chain.
+
+**Notable gaps** (likely intentional for a "legacy/mid" benchmark fixture): no password/credential check, no input validation, no real persistence, no async I/O despite `async` signatures, and `sessionId` is trivially guessable from the email.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/native_agent-prompt.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/native_agent-prompt.txt
@@ -1,0 +1,1 @@
+How does login session creation flow work from controller to persistence?

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/legacy/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31459,
+      "cache_read_input_tokens": 352499,
+      "output_tokens": 1243,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31459,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 539,
+          "cache_read_input_tokens": 65678,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383969,
+    "uncached_input_tokens_anthropic_exact": 31470,
+    "cached_input_tokens_anthropic_exact": 352499,
+    "total_cost_usd": 0.40399825,
+    "num_turns": 6,
+    "duration_ms": 30246,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31685,
+      "cache_read_input_tokens": 352179,
+      "output_tokens": 1099,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31685,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 411,
+          "cache_read_input_tokens": 65904,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383875,
+    "uncached_input_tokens_anthropic_exact": 31696,
+    "cached_input_tokens_anthropic_exact": 352179,
+    "total_cost_usd": 0.40165075000000006,
+    "num_turns": 6,
+    "duration_ms": 29183,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1,
+    "uncached_input_tokens": 0.99,
+    "cache_creation_input_tokens": 0.99,
+    "num_turns": 1,
+    "duration_ms": 1.04,
+    "cost_usd": 1.01
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:42:36.921Z",
+  "completed_at": "2026-05-26T18:43:42.854Z",
+  "paths": {
+    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36",
+    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.json",
+    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.share-safe.json",
+    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/baseline-answer.txt",
+    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/madar-answer.txt",
+    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.json
@@ -1,7 +1,7 @@
 {
   "baseline_mode": "native_agent",
   "question": "How does login session creation flow work from controller to persistence?",
-  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/legacy/out/graph.json",
+  "graph_path": "<project-root>/out/graph.json",
   "exec_command": {
     "command": null,
     "placeholders": [
@@ -48,7 +48,7 @@
     "total_cost_usd": 0.40399825,
     "num_turns": 6,
     "duration_ms": 30246,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/baseline-answer.txt"
+    "result_path": "<artifact-root>/baseline-answer.txt"
   },
   "madar": {
     "kind": "succeeded",
@@ -89,7 +89,7 @@
     "total_cost_usd": 0.40165075000000006,
     "num_turns": 6,
     "duration_ms": 29183,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/madar-answer.txt"
+    "result_path": "<artifact-root>/madar-answer.txt"
   },
   "reductions": {
     "input_tokens": 1,
@@ -126,11 +126,11 @@
   "started_at": "2026-05-26T18:42:36.921Z",
   "completed_at": "2026-05-26T18:43:42.854Z",
   "paths": {
-    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36",
-    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.json",
-    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.share-safe.json",
-    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/baseline-answer.txt",
-    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/madar-answer.txt",
-    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/native_agent-prompt.txt"
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
   }
 }

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.share-safe.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.share-safe.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31459,
+      "cache_read_input_tokens": 352499,
+      "output_tokens": 1243,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31459,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 539,
+          "cache_read_input_tokens": 65678,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383969,
+    "uncached_input_tokens_anthropic_exact": 31470,
+    "cached_input_tokens_anthropic_exact": 352499,
+    "total_cost_usd": 0.40399825,
+    "num_turns": 6,
+    "duration_ms": 30246,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31685,
+      "cache_read_input_tokens": 352179,
+      "output_tokens": 1099,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31685,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 411,
+          "cache_read_input_tokens": 65904,
+          "cache_creation_input_tokens": 192,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 192
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383875,
+    "uncached_input_tokens_anthropic_exact": 31696,
+    "cached_input_tokens_anthropic_exact": 352179,
+    "total_cost_usd": 0.40165075000000006,
+    "num_turns": 6,
+    "duration_ms": 29183,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1,
+    "uncached_input_tokens": 0.99,
+    "cache_creation_input_tokens": 0.99,
+    "num_turns": 1,
+    "duration_ms": 1.04,
+    "cost_usd": 1.01
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:42:36.921Z",
+  "completed_at": "2026-05-26T18:43:42.854Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/baseline-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/baseline-answer.txt
@@ -1,0 +1,17 @@
+## Login session creation flow
+
+The flow is a three-layer chain — controller → service → persistence — with no validation, hashing, or real storage:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6`
+- `AuthController.login({ email })` is the entry point.
+- It instantiates `AuthService` in its constructor default (`new AuthService()`) and delegates straight through: `this.authService.login(input)`.
+
+**2. Service** — `src/services/auth-service.ts:4`
+- `AuthService.login({ email })` does no business logic — no credential check, no user lookup, no token issuance.
+- It calls the persistence helper directly: `createSession(input.email)`.
+
+**3. Persistence** — `src/persistence/session-store.ts:1`
+- `createSession(email)` is a pure function that returns `{ sessionId: \`session:${email}\` }`.
+- Nothing is persisted — no DB, no in-memory map, no expiry. The "session" is a synthesized string returned to the caller.
+
+This is a skeleton/stub layered architecture (likely a benchmark fixture). The session ID is deterministic and trivially forgeable, and there's no authentication step before "logging in."

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/madar-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/madar-answer.txt
@@ -1,0 +1,21 @@
+The login session creation flow is a thin 3-layer pipeline:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6`
+`AuthController.login({ email })` receives the input and delegates straight to the service. No validation or transformation happens here; it lazily instantiates `AuthService` via a default constructor parameter.
+
+**2. Service** — `src/services/auth-service.ts:4`
+`AuthService.login({ email })` forwards `input.email` to the persistence layer's `createSession`. It's a pass-through with no business logic (no password check, no rate limiting, no token issuance).
+
+**3. Persistence** — `src/persistence/session-store.ts:1`
+`createSession(email)` returns a synchronous object `{ sessionId: 'session:${email}' }`. Despite the "store" name, nothing is actually persisted — there's no DB, no in-memory map, no expiry. The session ID is just the email prefixed with `session:`.
+
+**Flow summary:**
+```
+login({ email })
+  → AuthController.login          (controllers/auth-controller.ts:6)
+  → AuthService.login              (services/auth-service.ts:4)
+  → createSession(email)           (persistence/session-store.ts:1)
+  → { sessionId: `session:${email}` }
+```
+
+**Notable gaps** (likely intentional for a benchmark skeleton): no credential verification, no session storage, no expiry/TTL, no input validation (Zod), no error handling, and the deterministic `session:${email}` ID is trivially guessable — not production-safe.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/native_agent-prompt.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/native_agent-prompt.txt
@@ -1,0 +1,1 @@
+How does login session creation flow work from controller to persistence?

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.json
@@ -1,0 +1,133 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/spi/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32352,
+      "cache_read_input_tokens": 416548,
+      "output_tokens": 1484,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32352,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 398,
+          "cache_read_input_tokens": 66572,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448912,
+    "uncached_input_tokens_anthropic_exact": 32364,
+    "cached_input_tokens_anthropic_exact": 416548,
+    "total_cost_usd": 0.44763400000000003,
+    "num_turns": 7,
+    "duration_ms": 36971,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31435,
+      "cache_read_input_tokens": 352405,
+      "output_tokens": 1207,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31435,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 517,
+          "cache_read_input_tokens": 65655,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383851,
+    "uncached_input_tokens_anthropic_exact": 31446,
+    "cached_input_tokens_anthropic_exact": 352405,
+    "total_cost_usd": 0.40290125,
+    "num_turns": 6,
+    "duration_ms": 30181,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.17,
+    "uncached_input_tokens": 1.03,
+    "cache_creation_input_tokens": 1.03,
+    "num_turns": 1.17,
+    "duration_ms": 1.22,
+    "cost_usd": 1.11
+  },
+  "token_regression": false,
+  "token_regression_reasons": [],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:34:53.929Z",
+  "completed_at": "2026-05-26T18:36:07.772Z",
+  "paths": {
+    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53",
+    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.json",
+    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.share-safe.json",
+    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/baseline-answer.txt",
+    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/madar-answer.txt",
+    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.json
@@ -1,7 +1,7 @@
 {
   "baseline_mode": "native_agent",
   "question": "How does login session creation flow work from controller to persistence?",
-  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/spi/out/graph.json",
+  "graph_path": "<project-root>/out/graph.json",
   "exec_command": {
     "command": null,
     "placeholders": [
@@ -48,7 +48,7 @@
     "total_cost_usd": 0.44763400000000003,
     "num_turns": 7,
     "duration_ms": 36971,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/baseline-answer.txt"
+    "result_path": "<artifact-root>/baseline-answer.txt"
   },
   "madar": {
     "kind": "succeeded",
@@ -89,7 +89,7 @@
     "total_cost_usd": 0.40290125,
     "num_turns": 6,
     "duration_ms": 30181,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/madar-answer.txt"
+    "result_path": "<artifact-root>/madar-answer.txt"
   },
   "reductions": {
     "input_tokens": 1.17,
@@ -123,11 +123,11 @@
   "started_at": "2026-05-26T18:34:53.929Z",
   "completed_at": "2026-05-26T18:36:07.772Z",
   "paths": {
-    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53",
-    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.json",
-    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.share-safe.json",
-    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/baseline-answer.txt",
-    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/madar-answer.txt",
-    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/native_agent-prompt.txt"
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
   }
 }

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.share-safe.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.share-safe.json
@@ -1,0 +1,133 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32352,
+      "cache_read_input_tokens": 416548,
+      "output_tokens": 1484,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32352,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 398,
+          "cache_read_input_tokens": 66572,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448912,
+    "uncached_input_tokens_anthropic_exact": 32364,
+    "cached_input_tokens_anthropic_exact": 416548,
+    "total_cost_usd": 0.44763400000000003,
+    "num_turns": 7,
+    "duration_ms": 36971,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31435,
+      "cache_read_input_tokens": 352405,
+      "output_tokens": 1207,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31435,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 517,
+          "cache_read_input_tokens": 65655,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 383851,
+    "uncached_input_tokens_anthropic_exact": 31446,
+    "cached_input_tokens_anthropic_exact": 352405,
+    "total_cost_usd": 0.40290125,
+    "num_turns": 6,
+    "duration_ms": 30181,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1.17,
+    "uncached_input_tokens": 1.03,
+    "cache_creation_input_tokens": 1.03,
+    "num_turns": 1.17,
+    "duration_ms": 1.22,
+    "cost_usd": 1.11
+  },
+  "token_regression": false,
+  "token_regression_reasons": [],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:34:53.929Z",
+  "completed_at": "2026-05-26T18:36:07.772Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/baseline-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/baseline-answer.txt
@@ -1,0 +1,27 @@
+The login flow goes through three thin layers — each just delegates to the next.
+
+**1. Controller** — `src/controllers/auth-controller.ts:6`
+```ts
+async login(input: { email: string }) {
+  return this.authService.login(input)
+}
+```
+Receives `{ email }` and forwards it to `AuthService`. The service is injected via a default-instantiated constructor param (`authService = new AuthService()`), so it can be swapped for tests.
+
+**2. Service** — `src/services/auth-service.ts:4`
+```ts
+async login(input: { email: string }) {
+  return createSession(input.email)
+}
+```
+Unwraps the email from the input object and calls the persistence function. No business logic (no password check, no validation, no token generation).
+
+**3. Persistence** — `src/persistence/session-store.ts:1`
+```ts
+export function createSession(email: string) {
+  return { sessionId: `session:${email}` }
+}
+```
+Synchronously returns a `{ sessionId }` object where the ID is just `"session:" + email`. There's no actual store — no database, no in-memory map, no expiration. Each call constructs a fresh object.
+
+**Flow summary:** `AuthController.login({email}) → AuthService.login({email}) → createSession(email) → {sessionId: "session:<email>"}`. It's a skeleton/stub — three files, ~15 lines total, with no auth, no persistence, and no immutability concerns since nothing is stored.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/madar-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/madar-answer.txt
@@ -1,0 +1,29 @@
+The login session creation flow is a thin three-layer pass-through:
+
+**1. Controller — `src/controllers/auth-controller.ts:6`**
+```ts
+async login(input: { email: string }) {
+  return this.authService.login(input)
+}
+```
+`AuthController.login` accepts `{ email }` and delegates straight to the service. The service is injected via constructor default (`new AuthService()`).
+
+**2. Service — `src/services/auth-service.ts:4`**
+```ts
+async login(input: { email: string }) {
+  return createSession(input.email)
+}
+```
+`AuthService.login` unwraps `input.email` and calls the persistence helper. No validation, hashing, lookup, or auth check happens here.
+
+**3. Persistence — `src/persistence/session-store.ts:1`**
+```ts
+export function createSession(email: string) {
+  return { sessionId: `session:${email}` }
+}
+```
+`createSession` is a pure function — it just returns `{ sessionId: "session:<email>" }`. There's no actual store (no DB, no in-memory map, no TTL), so "persistence" is a misnomer here; nothing is persisted.
+
+**Flow:** `AuthController.login({email})` → `AuthService.login({email})` → `createSession(email)` → `{ sessionId: "session:<email>" }`.
+
+Notable gaps if this is meant to be production-shaped: no password/credential check, no input validation (Zod or otherwise), no unique session id (deterministic from email — same email always yields same id), and no actual storage.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/native_agent-prompt.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/native_agent-prompt.txt
@@ -1,0 +1,1 @@
+How does login session creation flow work from controller to persistence?

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/spi/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 31917,
+      "cache_read_input_tokens": 416797,
+      "output_tokens": 1385,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31917,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 478,
+          "cache_read_input_tokens": 66137,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448726,
+    "uncached_input_tokens_anthropic_exact": 31929,
+    "cached_input_tokens_anthropic_exact": 416797,
+    "total_cost_usd": 0.44256474999999995,
+    "num_turns": 7,
+    "duration_ms": 34896,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32349,
+      "cache_read_input_tokens": 416541,
+      "output_tokens": 1583,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32349,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 504,
+          "cache_read_input_tokens": 66569,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448902,
+    "uncached_input_tokens_anthropic_exact": 32361,
+    "cached_input_tokens_anthropic_exact": 416541,
+    "total_cost_usd": 0.45008675000000004,
+    "num_turns": 7,
+    "duration_ms": 34241,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1,
+    "uncached_input_tokens": 0.99,
+    "cache_creation_input_tokens": 0.99,
+    "num_turns": 1,
+    "duration_ms": 1.02,
+    "cost_usd": 0.98
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:40:05.011Z",
+  "completed_at": "2026-05-26T18:41:20.662Z",
+  "paths": {
+    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05",
+    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.json",
+    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.share-safe.json",
+    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/baseline-answer.txt",
+    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/madar-answer.txt",
+    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.json
@@ -1,7 +1,7 @@
 {
   "baseline_mode": "native_agent",
   "question": "How does login session creation flow work from controller to persistence?",
-  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/spi/out/graph.json",
+  "graph_path": "<project-root>/out/graph.json",
   "exec_command": {
     "command": null,
     "placeholders": [
@@ -48,7 +48,7 @@
     "total_cost_usd": 0.44256474999999995,
     "num_turns": 7,
     "duration_ms": 34896,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/baseline-answer.txt"
+    "result_path": "<artifact-root>/baseline-answer.txt"
   },
   "madar": {
     "kind": "succeeded",
@@ -89,7 +89,7 @@
     "total_cost_usd": 0.45008675000000004,
     "num_turns": 7,
     "duration_ms": 34241,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/madar-answer.txt"
+    "result_path": "<artifact-root>/madar-answer.txt"
   },
   "reductions": {
     "input_tokens": 1,
@@ -126,11 +126,11 @@
   "started_at": "2026-05-26T18:40:05.011Z",
   "completed_at": "2026-05-26T18:41:20.662Z",
   "paths": {
-    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05",
-    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.json",
-    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.share-safe.json",
-    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/baseline-answer.txt",
-    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/madar-answer.txt",
-    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/native_agent-prompt.txt"
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
   }
 }

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.share-safe.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.share-safe.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 31917,
+      "cache_read_input_tokens": 416797,
+      "output_tokens": 1385,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31917,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 478,
+          "cache_read_input_tokens": 66137,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448726,
+    "uncached_input_tokens_anthropic_exact": 31929,
+    "cached_input_tokens_anthropic_exact": 416797,
+    "total_cost_usd": 0.44256474999999995,
+    "num_turns": 7,
+    "duration_ms": 34896,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32349,
+      "cache_read_input_tokens": 416541,
+      "output_tokens": 1583,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32349,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 504,
+          "cache_read_input_tokens": 66569,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448902,
+    "uncached_input_tokens_anthropic_exact": 32361,
+    "cached_input_tokens_anthropic_exact": 416541,
+    "total_cost_usd": 0.45008675000000004,
+    "num_turns": 7,
+    "duration_ms": 34241,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 1,
+    "uncached_input_tokens": 0.99,
+    "cache_creation_input_tokens": 0.99,
+    "num_turns": 1,
+    "duration_ms": 1.02,
+    "cost_usd": 0.98
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:40:05.011Z",
+  "completed_at": "2026-05-26T18:41:20.662Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/baseline-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/baseline-answer.txt
@@ -1,0 +1,12 @@
+The login session creation flow is a straight three-layer pass-through:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6-8`
+`AuthController.login({ email })` instantiates `AuthService` (defaulted in the constructor) and forwards the input.
+
+**2. Service** — `src/services/auth-service.ts:4-6`
+`AuthService.login` delegates straight to the persistence layer's `createSession`, passing `input.email`.
+
+**3. Persistence** — `src/persistence/session-store.ts:1-3`
+`createSession(email)` synchronously returns `{ sessionId: \`session:${email}\` }`. There is no DB, no async I/O, no validation, no error handling — the "session" is a derived string.
+
+Flow: `AuthController.login` → `AuthService.login` → `createSession` → returns `{ sessionId }` back up the chain. The whole thing is a thin skeleton; everything past the controller is one-line forwarding with no real persistence behind it.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/madar-answer.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/madar-answer.txt
@@ -1,0 +1,12 @@
+The flow is three thin layers, each delegating straight down:
+
+**1. Controller** — `src/controllers/auth-controller.ts:6`
+`AuthController.login({ email })` takes the input DTO and forwards it to the service. The controller instantiates `AuthService` via a constructor default (`new AuthService()`), so there's no DI container.
+
+**2. Service** — `src/services/auth-service.ts:4`
+`AuthService.login({ email })` unwraps the DTO and calls the persistence-layer function `createSession(input.email)`. No business logic, validation, hashing, or token signing happens here — it's a pure pass-through.
+
+**3. Persistence** — `src/persistence/session-store.ts:1`
+`createSession(email)` returns a synchronous in-memory object `{ sessionId: \`session:${email}\` }`. Nothing is stored — the "session" is just a deterministic string derived from the email, returned to the caller.
+
+**End-to-end:** `Controller.login` → `AuthService.login` → `createSession` → `{ sessionId: "session:<email>" }` bubbles back up unchanged. No DB, no async work despite the `async` keywords, no auth check, no expiry, no cookie/JWT — it's a skeleton scaffold suitable for a benchmark or fixture, not a real auth flow.

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/native_agent-prompt.txt
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/native_agent-prompt.txt
@@ -1,0 +1,1 @@
+How does login session creation flow work from controller to persistence?

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/spi/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31739,
+      "cache_read_input_tokens": 350702,
+      "output_tokens": 1023,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31739,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 333,
+          "cache_read_input_tokens": 65959,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 382452,
+    "uncached_input_tokens_anthropic_exact": 31750,
+    "cached_input_tokens_anthropic_exact": 350702,
+    "total_cost_usd": 0.39934975,
+    "num_turns": 6,
+    "duration_ms": 28006,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32258,
+      "cache_read_input_tokens": 416690,
+      "output_tokens": 1504,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32258,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 440,
+          "cache_read_input_tokens": 66478,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448960,
+    "uncached_input_tokens_anthropic_exact": 32270,
+    "cached_input_tokens_anthropic_exact": 416690,
+    "total_cost_usd": 0.4476175,
+    "num_turns": 7,
+    "duration_ms": 34803,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.85,
+    "uncached_input_tokens": 0.98,
+    "cache_creation_input_tokens": 0.98,
+    "num_turns": 0.86,
+    "duration_ms": 0.8,
+    "cost_usd": 0.89
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:45:15.518Z",
+  "completed_at": "2026-05-26T18:46:24.823Z",
+  "paths": {
+    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15",
+    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.json",
+    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.share-safe.json",
+    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/baseline-answer.txt",
+    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/madar-answer.txt",
+    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.json
@@ -1,7 +1,7 @@
 {
   "baseline_mode": "native_agent",
   "question": "How does login session creation flow work from controller to persistence?",
-  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-bench-suite-nestjs-mid-3rfNit/spi/out/graph.json",
+  "graph_path": "<project-root>/out/graph.json",
   "exec_command": {
     "command": null,
     "placeholders": [
@@ -48,7 +48,7 @@
     "total_cost_usd": 0.39934975,
     "num_turns": 6,
     "duration_ms": 28006,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/baseline-answer.txt"
+    "result_path": "<artifact-root>/baseline-answer.txt"
   },
   "madar": {
     "kind": "succeeded",
@@ -89,7 +89,7 @@
     "total_cost_usd": 0.4476175,
     "num_turns": 7,
     "duration_ms": 34803,
-    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-332-benchmark-suite/out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/madar-answer.txt"
+    "result_path": "<artifact-root>/madar-answer.txt"
   },
   "reductions": {
     "input_tokens": 0.85,
@@ -126,11 +126,11 @@
   "started_at": "2026-05-26T18:45:15.518Z",
   "completed_at": "2026-05-26T18:46:24.823Z",
   "paths": {
-    "output_dir": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15",
-    "report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.json",
-    "share_safe_report": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.share-safe.json",
-    "baseline_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/baseline-answer.txt",
-    "madar_answer": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/madar-answer.txt",
-    "prompt_file": "out/benchmark-suite-staging/2026-05-26T18-31-04/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/native_agent-prompt.txt"
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
   }
 }

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.share-safe.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.share-safe.json
@@ -1,0 +1,136 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How does login session creation flow work from controller to persistence?",
+  "graph_path": "<project-root>/out/graph.json",
+  "exec_command": {
+    "command": null,
+    "placeholders": [
+      "{prompt_file}"
+    ],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 11,
+      "cache_creation_input_tokens": 31739,
+      "cache_read_input_tokens": 350702,
+      "output_tokens": 1023,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 31739,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 333,
+          "cache_read_input_tokens": 65959,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 382452,
+    "uncached_input_tokens_anthropic_exact": 31750,
+    "cached_input_tokens_anthropic_exact": 350702,
+    "total_cost_usd": 0.39934975,
+    "num_turns": 6,
+    "duration_ms": 28006,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 12,
+      "cache_creation_input_tokens": 32258,
+      "cache_read_input_tokens": 416690,
+      "output_tokens": 1504,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 32258,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 440,
+          "cache_read_input_tokens": 66478,
+          "cache_creation_input_tokens": 191,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 191
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "total_input_tokens_anthropic_exact": 448960,
+    "uncached_input_tokens_anthropic_exact": 32270,
+    "cached_input_tokens_anthropic_exact": 416690,
+    "total_cost_usd": 0.4476175,
+    "num_turns": 7,
+    "duration_ms": 34803,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "reductions": {
+    "input_tokens": 0.85,
+    "uncached_input_tokens": 0.98,
+    "cache_creation_input_tokens": 0.98,
+    "num_turns": 0.86,
+    "duration_ms": 0.8,
+    "cost_usd": 0.89
+  },
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-26T18:45:15.518Z",
+  "completed_at": "2026-05-26T18:46:24.823Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  }
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/summary.json
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/summary.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "started_at": "2026-05-26T18:31:04.097Z",
+  "completed_at": "2026-05-26T18:46:24.848Z",
+  "output_root": "docs/benchmarks/suite/results/2026-05-26T18-31-04",
+  "filters": {
+    "repo": "nestjs-mid",
+    "task": "explain-runtime",
+    "mode": "warm",
+    "trials": 3
+  },
+  "cells": [
+    {
+      "repoId": "nestjs-mid",
+      "repoName": "NestJS-like service fixture",
+      "taskId": "explain-runtime",
+      "taskName": "Explain runtime flow",
+      "mode": "warm",
+      "prompt": "How does login session creation flow work from controller to persistence?",
+      "status": "completed",
+      "reason": null,
+      "baseline": {
+        "input_tokens": {
+          "median": 384029,
+          "min": 383969,
+          "max": 447833,
+          "n": 3
+        },
+        "total_tool_calls": null,
+        "read_calls": null,
+        "glob_grep_calls": null,
+        "wall_clock_ms": {
+          "median": 35436,
+          "min": 30246,
+          "max": 43757,
+          "n": 3
+        },
+        "cost_usd": {
+          "median": 0.40694725,
+          "min": 0.40399825,
+          "max": 0.45183675,
+          "n": 3
+        }
+      },
+      "madar": {
+        "input_tokens": {
+          "median": 383875,
+          "min": 383749,
+          "max": 447775,
+          "n": 3
+        },
+        "total_tool_calls": null,
+        "read_calls": null,
+        "glob_grep_calls": null,
+        "wall_clock_ms": {
+          "median": 31102,
+          "min": 29183,
+          "max": 40180,
+          "n": 3
+        },
+        "cost_usd": {
+          "median": 0.40613075000000004,
+          "min": 0.40165075000000006,
+          "max": 0.4474695,
+          "n": 3
+        }
+      },
+      "spi_madar": {
+        "input_tokens": {
+          "median": 448902,
+          "min": 383851,
+          "max": 448960,
+          "n": 3
+        },
+        "total_tool_calls": null,
+        "read_calls": null,
+        "glob_grep_calls": null,
+        "wall_clock_ms": {
+          "median": 34241,
+          "min": 30181,
+          "max": 34803,
+          "n": 3
+        },
+        "cost_usd": {
+          "median": 0.4476175,
+          "min": 0.40290125,
+          "max": 0.45008675000000004,
+          "n": 3
+        }
+      },
+      "artifacts": {
+        "legacy_share_safe_reports": [
+          "docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-001/2026-05-26T18-32-17/report.share-safe.json",
+          "docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-002/2026-05-26T18-37-29/report.share-safe.json",
+          "docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/legacy/trial-003/2026-05-26T18-42-36/report.share-safe.json"
+        ],
+        "spi_share_safe_reports": [
+          "docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-001/2026-05-26T18-34-53/report.share-safe.json",
+          "docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-002/2026-05-26T18-40-05/report.share-safe.json",
+          "docs/benchmarks/suite/results/2026-05-26T18-31-04/raw/nestjs-mid/explain-runtime/warm-cache/spi/trial-003/2026-05-26T18-45-15/report.share-safe.json"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/benchmarks/suite/results/2026-05-26T18-31-04/summary.md
+++ b/docs/benchmarks/suite/results/2026-05-26T18-31-04/summary.md
@@ -1,0 +1,13 @@
+# Benchmark suite summary
+
+- Generated: 2026-05-26T18:46:24.848Z
+- Filters: repo=nestjs-mid, task=explain-runtime, mode=warm, trials=3
+- Per-repo rows only.
+
+## explain-runtime
+
+### Warm cache
+
+| Repo | Baseline input tokens | Madar input tokens | SPI Madar input tokens | Baseline tool calls | Madar tool calls | SPI Madar tool calls | Baseline Read | Madar Read | SPI Madar Read | Baseline Glob/Grep | Madar Glob/Grep | SPI Madar Glob/Grep | Baseline wall-clock (ms) | Madar wall-clock (ms) | SPI Madar wall-clock (ms) | Baseline cost (USD) | Madar cost (USD) | SPI Madar cost (USD) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| nestjs-mid | 384029 (383969-447833, n=3) | 383875 (383749-447775, n=3) | 448902 (383851-448960, n=3) | — | — | — | — | — | — | — | — | — | 35436 (30246-43757, n=3) | 31102 (29183-40180, n=3) | 34241 (30181-34803, n=3) | 0.41 (0.40-0.45, n=3) | 0.41 (0.40-0.45, n=3) | 0.45 (0.40-0.45, n=3) |

--- a/docs/benchmarks/suite/tasks.json
+++ b/docs/benchmarks/suite/tasks.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "explain-runtime",
+    "name": "Explain runtime flow",
+    "description": "Trace how a runtime path executes end to end for a concrete repo-specific prompt.",
+    "status": "ready",
+    "prompts": {
+      "nestjs-mid": "How does login session creation flow work from controller to persistence?"
+    }
+  },
+  {
+    "id": "explain-auth",
+    "name": "Explain auth and middleware behavior",
+    "description": "Trace auth, middleware, or request-guard behavior.",
+    "status": "planned",
+    "prompts": {}
+  },
+  {
+    "id": "implement",
+    "name": "Implement task",
+    "description": "A real edit prompt suitable for measuring likely edit-file and validation guidance quality later.",
+    "status": "planned",
+    "prompts": {}
+  },
+  {
+    "id": "review",
+    "name": "Review task",
+    "description": "A PR-style review prompt measured against a fixed diff later.",
+    "status": "planned",
+    "prompts": {}
+  },
+  {
+    "id": "impact",
+    "name": "Impact analysis task",
+    "description": "A what-breaks-if-I-change-X prompt reserved for future suite cells.",
+    "status": "planned",
+    "prompts": {}
+  },
+  {
+    "id": "applicability-skip",
+    "name": "Applicability skip task",
+    "description": "A non-code prompt that should bypass Madar entirely once the gate-specific suite cell is wired.",
+    "status": "planned",
+    "prompts": {}
+  }
+]

--- a/docs/claims-and-evidence.md
+++ b/docs/claims-and-evidence.md
@@ -15,8 +15,8 @@ This file is the public map between what Madar says and what the repo can actual
 
 | Claim | Current status | Next evidence |
 | --- | --- | --- |
-| Strict install guidance reduces exploration in practice. | Mixed evidence today; the FounderCommandCenter contrast note shows a regression case where the pack was treated as extra context instead of a stop condition. | Track per-repo/task tool-call spread in [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md) and linked work in [#332](https://github.com/mohanagy/madar/issues/332). |
-| Public benchmark claims should be reproducible across repos. | The repo has dated receipts and the GoValidate shared prompt set, but not the full fixed-repo matrix yet. | Suite scaffold and methodology in [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md). |
+| Strict install guidance reduces exploration in practice. | Mixed evidence today; the FounderCommandCenter contrast note shows a regression case where the pack was treated as extra context instead of a stop condition. | Track per-repo/task tool-call spread and future measured rows under [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md). |
+| Public benchmark claims should be reproducible across repos. | The repo now ships the fixed manifests, methodology, `madar bench:suite` runner, and the first measured warm-cache `nestjs-mid` / `explain-runtime` row. The broader matrix is still incomplete. | Add more measured rows under `docs/benchmarks/suite/results/` and keep the manifests/methodology current. |
 
 ## Not yet measured
 
@@ -36,4 +36,5 @@ This file is the public map between what Madar says and what the repo can actual
 
 - [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](docs/benchmarks/2026-05-25-founder-command-center-auth-flow/README.md) — mixed exploration evidence, including the FounderCommandCenter contrast note.
 - [`docs/benchmarks/govalidate-suite/`](docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates.
-- [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md) — per-repo spread methodology and the suite direction tracked in [#332](https://github.com/mohanagy/madar/issues/332).
+- [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results.
+- [`docs/benchmarks/suite/results/2026-05-26T18-31-04/summary.md`](docs/benchmarks/suite/results/2026-05-26T18-31-04/summary.md) — first measured warm-cache `nestjs-mid` / `explain-runtime` suite row.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs'
 import { createInterface } from 'node:readline/promises'
 
 import { loadBenchmarkQuestions, type BenchmarkResult, printBenchmark, runBenchmark } from '../infrastructure/benchmark.js'
+import { runBenchmarkSuite } from '../infrastructure/benchmark/suite.js'
 import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure/benchmark/quality.js'
 import { runCompareCommand } from '../infrastructure/compare.js'
 import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
@@ -42,7 +43,9 @@ import { findPackageRoot, readPackageName, readPackageVersion } from '../shared/
 import { getUpdateNotification } from '../shared/update-notifier.js'
 import {
   parseBenchmarkArgs,
+  parseBenchSuiteArgs,
   parseAddArgs,
+  type BenchSuiteCliOptions,
   type BenchmarkCliOptions,
   parseCompareArgs,
   parseDoctorArgs,
@@ -92,6 +95,11 @@ export interface BenchmarkCommandContext {
   io: CliIO
 }
 
+export interface BenchSuiteCommandContext {
+  options: BenchSuiteCliOptions
+  io: CliIO
+}
+
 export interface EvalCommandContext {
   options: BenchmarkCliOptions
   io: CliIO
@@ -118,6 +126,7 @@ export interface CliDependencies {
   saveQueryResult: typeof saveQueryResult
   ingest: typeof ingest
   runBenchmark: (context: BenchmarkCommandContext) => Promise<BenchmarkResult> | BenchmarkResult
+  runBenchSuite: (context: BenchSuiteCommandContext) => Promise<string | void> | string | void
   runEval: (context: EvalCommandContext) => Promise<string | void> | string | void
   runCompare: (context: CompareCommandContext) => Promise<string | void> | string | void
   runReviewCompare: (context: ReviewCompareCommandContext) => Promise<string | void> | string | void
@@ -156,6 +165,7 @@ export interface CliDependencies {
 const COMPARE_WARNING_MESSAGE = 'compare will execute a baseline prompt and a madar prompt for each question. This may consume paid model tokens.'
 const REVIEW_COMPARE_WARNING_MESSAGE = 'review-compare will execute verbose and compact pr_impact prompts for the current git diff. This may consume paid model tokens.'
 const BENCHMARK_WARNING_MESSAGE = 'benchmark will execute the benchmark/eval runner. This may consume paid model tokens.'
+const BENCH_SUITE_WARNING_MESSAGE = 'bench:suite will execute baseline, madar, and SPI suite prompts. This may consume paid model tokens.'
 const EVAL_WARNING_MESSAGE = 'eval will execute the benchmark/eval runner. This may consume paid model tokens.'
 
 const DEFAULT_DEPENDENCIES: CliDependencies = {
@@ -166,6 +176,10 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   runBenchmark: ({ options }) => {
     const questions = options.questionsPath ? loadBenchmarkQuestions(options.questionsPath) : undefined
     return runBenchmark(options.graphPath, undefined, questions, { execTemplate: options.execTemplate })
+  },
+  runBenchSuite: async ({ options }) => {
+    const result = await runBenchmarkSuite(options)
+    return result.text
   },
   runEval: async ({ options }) => {
     const graph = loadGraph(options.graphPath)
@@ -370,6 +384,15 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}',
     '    --questions PATH      load benchmark/eval questions from a JSON file',
     '    --yes                 skip confirmation before running the paid benchmark/eval prompts',
+    '  bench:suite           run the reproducible benchmark matrix and write results under docs/benchmarks/suite/results/',
+    '    --exec TEMPLATE       required unless --dry-run; supports {prompt_file}, {question}, {mode}, and {output_file}',
+    '    --repo ID             limit the suite to one repo id from docs/benchmarks/suite/repos.json',
+    '    --task ID             limit the suite to one task id from docs/benchmarks/suite/tasks.json',
+    '    --mode MODE           cold | warm | all (default all)',
+    '    --trials N            measured trials per runnable cell (default 3)',
+    '    --output-dir DIR      suite results directory (default docs/benchmarks/suite/results)',
+    '    --dry-run             list planned and runnable suite cells without executing prompts',
+    '    --yes                 skip confirmation before running the paid suite prompts',
     '  eval [graph.json]      measure retrieval quality: recall, MRR, and snippet coverage through the benchmark/eval runner. This may consume paid model tokens.',
     '    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}',
     '    --questions PATH      load benchmark/eval questions from a JSON file',
@@ -848,6 +871,20 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       }
       const result = await dependencies.runBenchmark({ options, io })
       dependencies.printBenchmark(result)
+      return 0
+    }
+
+    if (command === 'bench:suite') {
+      const options = parseBenchSuiteArgs(args)
+      if (!options.dryRun) {
+        if (!(await confirmPaidCommand('bench:suite', BENCH_SUITE_WARNING_MESSAGE, 'Benchmark suite cancelled.', options.yes, io, dependencies))) {
+          return 1
+        }
+      }
+      const output = await dependencies.runBenchSuite({ options, io })
+      if (output) {
+        io.log(output)
+      }
       return 0
     }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -87,6 +87,17 @@ export interface BenchmarkCliOptions {
   yes: boolean
 }
 
+export interface BenchSuiteCliOptions {
+  repo: string | null
+  task: string | null
+  mode: 'cold' | 'warm' | 'all'
+  trials: number
+  outputDir: string
+  execTemplate: string
+  dryRun: boolean
+  yes: boolean
+}
+
 export interface CompareCliOptions {
   question: string | null
   graphPath: string
@@ -940,6 +951,121 @@ export function parseBenchmarkArgs(args: string[], commandName = 'benchmark'): B
   }
 
   return { graphPath, questionsPath, execTemplate, yes }
+}
+
+export function parseBenchSuiteArgs(args: string[]): BenchSuiteCliOptions {
+  let repo: string | null = null
+  let task: string | null = null
+  let mode: BenchSuiteCliOptions['mode'] = 'all'
+  let trials = 3
+  let outputDir = resolve('docs/benchmarks/suite/results')
+  let execTemplate = ''
+  let dryRun = false
+  let yes = false
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (argument === '--repo') {
+      repo = requireOptionValue('--repo', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--repo=')) {
+      const [, value] = argument.split('=', 2)
+      repo = requireOptionValue('--repo', value)
+      continue
+    }
+
+    if (argument === '--task') {
+      task = requireOptionValue('--task', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--task=')) {
+      const [, value] = argument.split('=', 2)
+      task = requireOptionValue('--task', value)
+      continue
+    }
+
+    if (argument === '--mode') {
+      const value = requireOptionValue('--mode', args[index + 1])
+      if (value !== 'cold' && value !== 'warm' && value !== 'all') {
+        throw new UsageError('error: --mode must be one of cold, warm, all')
+      }
+      mode = value
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--mode=')) {
+      const [, value] = argument.split('=', 2)
+      if (value !== 'cold' && value !== 'warm' && value !== 'all') {
+        throw new UsageError('error: --mode must be one of cold, warm, all')
+      }
+      mode = value
+      continue
+    }
+
+    if (argument === '--trials') {
+      trials = parsePositiveDecimalInteger('--trials', requireOptionValue('--trials', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--trials=')) {
+      const [, value] = argument.split('=', 2)
+      trials = parsePositiveDecimalInteger('--trials', requireOptionValue('--trials', value))
+      continue
+    }
+
+    if (argument === '--output-dir') {
+      outputDir = resolve(requireOptionValue('--output-dir', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--output-dir=')) {
+      const [, value] = argument.split('=', 2)
+      outputDir = resolve(requireOptionValue('--output-dir', value))
+      continue
+    }
+
+    if (argument === '--exec') {
+      execTemplate = requireOptionValue('--exec', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--exec=')) {
+      const [, value] = argument.split('=', 2)
+      execTemplate = requireOptionValue('--exec', value)
+      continue
+    }
+
+    if (argument === '--dry-run') {
+      dryRun = true
+      continue
+    }
+
+    if (argument === '--yes') {
+      yes = true
+      continue
+    }
+
+    throw new UsageError(`error: unknown option for bench:suite: ${argument}`)
+  }
+
+  if (!dryRun && execTemplate.length === 0) {
+    throw new UsageError('error: --exec is required unless --dry-run is set')
+  }
+
+  return { repo, task, mode, trials, outputDir, execTemplate, dryRun, yes }
 }
 
 export function parseCompareArgs(args: string[]): CompareCliOptions {

--- a/src/infrastructure/benchmark/suite.ts
+++ b/src/infrastructure/benchmark/suite.ts
@@ -1,0 +1,682 @@
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join, relative, resolve, sep } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { executeNativeAgentCompare, type NativeAgentCompareReport, type NativeAgentCompareResult } from '../compare.js'
+import { generateGraph, type GenerateGraphOptions, type GenerateGraphResult } from '../generate.js'
+
+export type BenchmarkSuiteMode = 'cold' | 'warm' | 'all'
+export type BenchmarkSuiteEntryStatus = 'ready' | 'planned'
+
+export interface BenchmarkSuiteRepo {
+  id: string
+  name: string
+  path: string
+  description: string
+  size: 'small' | 'mid' | 'large'
+  language: string
+  shape: string
+  status: BenchmarkSuiteEntryStatus
+  supportsSpi: boolean
+}
+
+export interface BenchmarkSuiteTask {
+  id: string
+  name: string
+  description: string
+  status: BenchmarkSuiteEntryStatus
+  prompts: Record<string, string>
+}
+
+export interface BenchmarkSuiteRunOptions {
+  repo: string | null
+  task: string | null
+  mode: BenchmarkSuiteMode
+  trials: number
+  outputDir: string
+  execTemplate: string
+  dryRun: boolean
+  yes: boolean
+}
+
+interface BenchmarkSuiteMetricStats {
+  median: number
+  min: number
+  max: number
+  n: number
+}
+
+interface BenchmarkSuiteArmMetricsSummary {
+  input_tokens: BenchmarkSuiteMetricStats | null
+  total_tool_calls: BenchmarkSuiteMetricStats | null
+  read_calls: BenchmarkSuiteMetricStats | null
+  glob_grep_calls: BenchmarkSuiteMetricStats | null
+  wall_clock_ms: BenchmarkSuiteMetricStats | null
+  cost_usd: BenchmarkSuiteMetricStats | null
+}
+
+interface BenchmarkSuiteCellPlan {
+  repo: BenchmarkSuiteRepo
+  task: BenchmarkSuiteTask
+  mode: 'cold' | 'warm'
+  prompt: string | null
+  status: 'ready' | 'planned'
+  reason: string | null
+}
+
+export interface BenchmarkSuiteSummaryCell {
+  repoId: string
+  repoName: string
+  taskId: string
+  taskName: string
+  mode: 'cold' | 'warm'
+  prompt: string | null
+  status: 'completed' | 'partial' | 'planned'
+  reason: string | null
+  baseline: BenchmarkSuiteArmMetricsSummary
+  madar: BenchmarkSuiteArmMetricsSummary
+  spi_madar: BenchmarkSuiteArmMetricsSummary | null
+  artifacts: {
+    legacy_share_safe_reports: string[]
+    spi_share_safe_reports: string[]
+  }
+}
+
+export interface BenchmarkSuiteSummary {
+  schema_version: 1
+  started_at: string
+  completed_at: string
+  output_root: string
+  filters: {
+    repo: string | null
+    task: string | null
+    mode: BenchmarkSuiteMode
+    trials: number
+  }
+  cells: BenchmarkSuiteSummaryCell[]
+}
+
+export interface BenchmarkSuiteRunResult {
+  text: string
+  outputRoot?: string
+  summaryPath?: string
+  summaryJsonPath?: string
+  summary?: BenchmarkSuiteSummary
+}
+
+export interface BenchmarkSuiteDependencies {
+  repos?: BenchmarkSuiteRepo[]
+  tasks?: BenchmarkSuiteTask[]
+  now?: () => Date
+  generateGraph?: (rootPath?: string, options?: GenerateGraphOptions) => GenerateGraphResult
+  executeNativeAgentCompare?: (
+    input: Parameters<typeof executeNativeAgentCompare>[0],
+  ) => Promise<NativeAgentCompareResult>
+}
+
+const DEFAULT_REPOS_PATH = resolve('docs/benchmarks/suite/repos.json')
+const DEFAULT_TASKS_PATH = resolve('docs/benchmarks/suite/tasks.json')
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown
+}
+
+export function loadBenchmarkSuiteRepos(path = DEFAULT_REPOS_PATH): BenchmarkSuiteRepo[] {
+  const parsed = readJsonFile(path)
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Benchmark suite repo manifest must be an array: ${path}`)
+  }
+
+  return parsed.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Benchmark suite repo manifest entry ${index + 1} must be an object`)
+    }
+    const repo = entry as Record<string, unknown>
+    if (typeof repo.id !== 'string' || repo.id.trim().length === 0) {
+      throw new Error(`Benchmark suite repo manifest entry ${index + 1} is missing id`)
+    }
+    validateSuiteId(repo.id, 'repo')
+    if (typeof repo.name !== 'string' || repo.name.trim().length === 0) {
+      throw new Error(`Benchmark suite repo ${repo.id} is missing name`)
+    }
+    if (typeof repo.path !== 'string' || repo.path.trim().length === 0) {
+      throw new Error(`Benchmark suite repo ${repo.id} is missing path`)
+    }
+    if (repo.status !== 'ready' && repo.status !== 'planned') {
+      throw new Error(`Benchmark suite repo ${repo.id} status must be "ready" or "planned"`)
+    }
+    if (typeof repo.supportsSpi !== 'boolean') {
+      throw new Error(`Benchmark suite repo ${repo.id} is missing supportsSpi`)
+    }
+
+    return {
+      id: repo.id,
+      name: repo.name,
+      path: resolve(String(repo.path)),
+      description: typeof repo.description === 'string' ? repo.description : '',
+      size: repo.size === 'small' || repo.size === 'mid' || repo.size === 'large' ? repo.size : 'mid',
+      language: typeof repo.language === 'string' ? repo.language : 'unknown',
+      shape: typeof repo.shape === 'string' ? repo.shape : 'unknown',
+      status: repo.status,
+      supportsSpi: repo.supportsSpi,
+    }
+  })
+}
+
+export function loadBenchmarkSuiteTasks(path = DEFAULT_TASKS_PATH): BenchmarkSuiteTask[] {
+  const parsed = readJsonFile(path)
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Benchmark suite task manifest must be an array: ${path}`)
+  }
+
+  return parsed.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Benchmark suite task manifest entry ${index + 1} must be an object`)
+    }
+    const task = entry as Record<string, unknown>
+    if (typeof task.id !== 'string' || task.id.trim().length === 0) {
+      throw new Error(`Benchmark suite task manifest entry ${index + 1} is missing id`)
+    }
+    validateSuiteId(task.id, 'task')
+    if (typeof task.name !== 'string' || task.name.trim().length === 0) {
+      throw new Error(`Benchmark suite task ${task.id} is missing name`)
+    }
+    if (task.status !== 'ready' && task.status !== 'planned') {
+      throw new Error(`Benchmark suite task ${task.id} status must be "ready" or "planned"`)
+    }
+    const prompts = task.prompts
+    if (!prompts || typeof prompts !== 'object' || Array.isArray(prompts)) {
+      throw new Error(`Benchmark suite task ${task.id} prompts must be an object`)
+    }
+    return {
+      id: task.id,
+      name: task.name,
+      description: typeof task.description === 'string' ? task.description : '',
+      status: task.status,
+      prompts: Object.fromEntries(
+        Object.entries(prompts as Record<string, unknown>)
+          .filter(([, value]) => typeof value === 'string' && value.trim().length > 0)
+          .map(([repoId, value]) => [repoId, String(value)]),
+      ),
+    }
+  })
+}
+
+function timestampDirectoryName(date: Date): string {
+  return date.toISOString().slice(0, 19).replace(/:/g, '-')
+}
+
+function validateSuiteId(id: string, kind: string): void {
+  if (id.includes('/') || id.includes('\\') || id.includes('..')) {
+    throw new Error(`Benchmark suite ${kind} id contains unsafe path characters: ${id}`)
+  }
+}
+
+function createSuiteOutputRoot(outputDir: string, now: Date): string {
+  mkdirSync(outputDir, { recursive: true })
+  const timestamp = timestampDirectoryName(now)
+  for (let suffix = 0; suffix < 10_000; suffix += 1) {
+    const candidate = join(outputDir, suffix === 0 ? timestamp : `${timestamp}-${String(suffix).padStart(3, '0')}`)
+    try {
+      mkdirSync(candidate)
+      return candidate
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        continue
+      }
+      throw error
+    }
+  }
+  throw new Error(`Unable to create a unique benchmark suite directory inside ${outputDir}`)
+}
+
+function suiteModes(mode: BenchmarkSuiteMode): Array<'cold' | 'warm'> {
+  return mode === 'all' ? ['cold', 'warm'] : [mode]
+}
+
+function selectById<T extends { id: string }>(entries: readonly T[], kind: string, id: string | null): T[] {
+  if (id === null) {
+    return [...entries]
+  }
+  const match = entries.find((entry) => entry.id === id)
+  if (!match) {
+    throw new Error(`Unknown ${kind} id: ${id}`)
+  }
+  return [match]
+}
+
+function planCell(repo: BenchmarkSuiteRepo, task: BenchmarkSuiteTask, mode: 'cold' | 'warm'): BenchmarkSuiteCellPlan {
+  const prompt = task.prompts[repo.id] ?? null
+  if (repo.status !== 'ready') {
+    return { repo, task, mode, prompt, status: 'planned', reason: 'repo not wired yet' }
+  }
+  if (task.status !== 'ready') {
+    return { repo, task, mode, prompt, status: 'planned', reason: 'task not wired yet' }
+  }
+  if (prompt === null) {
+    return { repo, task, mode, prompt: null, status: 'planned', reason: 'prompt not defined for repo' }
+  }
+  return { repo, task, mode, prompt, status: 'ready', reason: null }
+}
+
+function portablePath(path: string): string {
+  return relative(process.cwd(), path) || '.'
+}
+
+function filterWorkspaceCopy(sourceRoot: string, sourcePath: string): boolean {
+  const relativePath = relative(sourceRoot, sourcePath)
+  return (
+    relativePath !== 'out'
+    && !relativePath.startsWith(`out${sep}`)
+    && relativePath !== '.git'
+    && !relativePath.startsWith(`.git${sep}`)
+  )
+}
+
+function copyWorkspace(sourceRoot: string, targetRoot: string): void {
+  mkdirSync(dirname(targetRoot), { recursive: true })
+  cpSync(sourceRoot, targetRoot, {
+    recursive: true,
+    filter: (sourcePath) => filterWorkspaceCopy(sourceRoot, sourcePath),
+  })
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\"'\"'`)}'`
+}
+
+function execTemplateForWorkspace(execTemplate: string, workspaceRoot: string): string {
+  if (process.platform === 'win32') {
+    return `Set-Location -LiteralPath ${shellQuote(workspaceRoot)}; ${execTemplate}`
+  }
+  return `cd ${shellQuote(workspaceRoot)} && ${execTemplate}`
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null
+  }
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? null
+  }
+  const left = sorted[middle - 1]
+  const right = sorted[middle]
+  if (left === undefined || right === undefined) {
+    return null
+  }
+  return (left + right) / 2
+}
+
+function summarizeValues(values: number[]): BenchmarkSuiteMetricStats | null {
+  if (values.length === 0) {
+    return null
+  }
+  const sorted = [...values].sort((left, right) => left - right)
+  const min = sorted[0]
+  const max = sorted[sorted.length - 1]
+  const medianValue = median(sorted)
+  if (min === undefined || max === undefined || medianValue === null) {
+    return null
+  }
+  return {
+    median: medianValue,
+    min,
+    max,
+    n: values.length,
+  }
+}
+
+function baselineMetric(report: NativeAgentCompareReport, selector: (report: NativeAgentCompareReport) => number | null): number | null {
+  if (report.baseline.kind !== 'succeeded') {
+    return null
+  }
+  return selector(report)
+}
+
+function madarMetric(report: NativeAgentCompareReport, selector: (report: NativeAgentCompareReport) => number | null): number | null {
+  if (report.madar.kind !== 'succeeded') {
+    return null
+  }
+  return selector(report)
+}
+
+function collectNumbers<T>(reports: readonly T[], selector: (report: T) => number | null): number[] {
+  return reports.flatMap((report) => {
+    const value = selector(report)
+    return typeof value === 'number' && Number.isFinite(value) ? [value] : []
+  })
+}
+
+function summarizeArmMetrics(
+  reports: readonly NativeAgentCompareReport[],
+  arm: 'baseline' | 'madar',
+): BenchmarkSuiteArmMetricsSummary {
+  const select = arm === 'baseline' ? baselineMetric : madarMetric
+  return {
+    input_tokens: summarizeValues(collectNumbers(reports, (report) => select(report, (candidate) => candidate[arm].kind === 'succeeded' ? candidate[arm].total_input_tokens_anthropic_exact : null))),
+    total_tool_calls: summarizeValues(collectNumbers(reports, (report) => report.tool_call_counts ? report.tool_call_counts[arm].total : null)),
+    read_calls: summarizeValues(collectNumbers(reports, (report) => report.tool_call_counts ? report.tool_call_counts[arm].Read : null)),
+    glob_grep_calls: summarizeValues(collectNumbers(reports, (report) => report.tool_call_counts ? report.tool_call_counts[arm].Glob + report.tool_call_counts[arm].Grep : null)),
+    wall_clock_ms: summarizeValues(collectNumbers(reports, (report) => select(report, (candidate) => candidate[arm].kind === 'succeeded' ? candidate[arm].duration_ms : null))),
+    cost_usd: summarizeValues(collectNumbers(reports, (report) => select(report, (candidate) => candidate[arm].kind === 'succeeded' ? candidate[arm].total_cost_usd : null))),
+  }
+}
+
+function isCompletedArm(summary: BenchmarkSuiteArmMetricsSummary): boolean {
+  return summary.input_tokens !== null
+}
+
+function summarizeCellStatus(
+  baseline: BenchmarkSuiteArmMetricsSummary,
+  madar: BenchmarkSuiteArmMetricsSummary,
+  spiMadar: BenchmarkSuiteArmMetricsSummary | null,
+  planned: boolean,
+): BenchmarkSuiteSummaryCell['status'] {
+  if (planned) {
+    return 'planned'
+  }
+  const baselineDone = isCompletedArm(baseline)
+  const madarDone = isCompletedArm(madar)
+  const spiDone = spiMadar === null || isCompletedArm(spiMadar)
+  if (baselineDone && madarDone && spiDone) {
+    return 'completed'
+  }
+  return 'partial'
+}
+
+function formatMetric(stats: BenchmarkSuiteMetricStats | null, digits = 0): string {
+  if (stats === null) {
+    return '—'
+  }
+  const formatter = (value: number) => digits === 0 ? Math.round(value).toString() : value.toFixed(digits)
+  return `${formatter(stats.median)} (${formatter(stats.min)}-${formatter(stats.max)}, n=${stats.n})`
+}
+
+function formatCellRow(cell: BenchmarkSuiteSummaryCell): string {
+  return [
+    cell.repoId,
+    formatMetric(cell.baseline.input_tokens),
+    formatMetric(cell.madar.input_tokens),
+    formatMetric(cell.spi_madar?.input_tokens ?? null),
+    formatMetric(cell.baseline.total_tool_calls),
+    formatMetric(cell.madar.total_tool_calls),
+    formatMetric(cell.spi_madar?.total_tool_calls ?? null),
+    formatMetric(cell.baseline.read_calls),
+    formatMetric(cell.madar.read_calls),
+    formatMetric(cell.spi_madar?.read_calls ?? null),
+    formatMetric(cell.baseline.glob_grep_calls),
+    formatMetric(cell.madar.glob_grep_calls),
+    formatMetric(cell.spi_madar?.glob_grep_calls ?? null),
+    formatMetric(cell.baseline.wall_clock_ms),
+    formatMetric(cell.madar.wall_clock_ms),
+    formatMetric(cell.spi_madar?.wall_clock_ms ?? null),
+    formatMetric(cell.baseline.cost_usd, 2),
+    formatMetric(cell.madar.cost_usd, 2),
+    formatMetric(cell.spi_madar?.cost_usd ?? null, 2),
+  ].join(' | ')
+}
+
+function formatBenchmarkSuiteSummaryMarkdown(summary: BenchmarkSuiteSummary): string {
+  const lines = [
+    '# Benchmark suite summary',
+    '',
+    `- Generated: ${summary.completed_at}`,
+    `- Filters: repo=${summary.filters.repo ?? 'all'}, task=${summary.filters.task ?? 'all'}, mode=${summary.filters.mode}, trials=${summary.filters.trials}`,
+    '- Per-repo rows only.',
+    '',
+  ]
+
+  const taskIds = [...new Set(summary.cells.map((cell) => cell.taskId))]
+  for (const taskId of taskIds) {
+    const taskCells = summary.cells.filter((cell) => cell.taskId === taskId)
+    if (taskCells.length === 0) {
+      continue
+    }
+    lines.push(`## ${taskId}`)
+    lines.push('')
+    for (const mode of ['cold', 'warm'] as const) {
+      const modeCells = taskCells.filter((cell) => cell.mode === mode)
+      if (modeCells.length === 0) {
+        continue
+      }
+      lines.push(`### ${mode === 'cold' ? 'Cold cache' : 'Warm cache'}`)
+      lines.push('')
+      lines.push('| Repo | Baseline input tokens | Madar input tokens | SPI Madar input tokens | Baseline tool calls | Madar tool calls | SPI Madar tool calls | Baseline Read | Madar Read | SPI Madar Read | Baseline Glob/Grep | Madar Glob/Grep | SPI Madar Glob/Grep | Baseline wall-clock (ms) | Madar wall-clock (ms) | SPI Madar wall-clock (ms) | Baseline cost (USD) | Madar cost (USD) | SPI Madar cost (USD) |')
+      lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+      for (const cell of modeCells) {
+        lines.push(`| ${formatCellRow(cell)} |`)
+      }
+      lines.push('')
+    }
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
+function writeSummary(outputRoot: string, summary: BenchmarkSuiteSummary): { summaryPath: string; summaryJsonPath: string } {
+  const summaryJsonPath = join(outputRoot, 'summary.json')
+  const summaryPath = join(outputRoot, 'summary.md')
+  writeFileSync(summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(summaryPath, formatBenchmarkSuiteSummaryMarkdown(summary), 'utf8')
+  return { summaryPath, summaryJsonPath }
+}
+
+function dryRunText(plans: readonly BenchmarkSuiteCellPlan[]): string {
+  if (plans.length === 0) {
+    return 'No suite cells matched the selected filters.'
+  }
+  return plans.map((plan) => `[${plan.status}] ${plan.repo.id} / ${plan.task.id} / ${plan.mode}-cache`).join('\n')
+}
+
+async function maybePrimeWarmCache(
+  mode: 'cold' | 'warm',
+  compare: NonNullable<BenchmarkSuiteDependencies['executeNativeAgentCompare']>,
+  input: Parameters<NonNullable<BenchmarkSuiteDependencies['executeNativeAgentCompare']>>[0],
+): Promise<void> {
+  if (mode !== 'warm') {
+    return
+  }
+  await compare({
+    ...input,
+    outputDir: join(input.outputDir, '..', '_warmup'),
+  })
+}
+
+function stringifyArtifacts(paths: string[]): string[] {
+  return paths.map((path) => portablePath(path))
+}
+
+function copyReportArtifacts(
+  report: NativeAgentCompareReport,
+  destinationParent: string,
+): string {
+  const copiedRoot = join(destinationParent, basename(report.paths.output_dir))
+  mkdirSync(dirname(copiedRoot), { recursive: true })
+  cpSync(report.paths.output_dir, copiedRoot, { recursive: true })
+  return join(copiedRoot, 'report.share-safe.json')
+}
+
+export async function runBenchmarkSuite(
+  options: BenchmarkSuiteRunOptions,
+  dependencies: BenchmarkSuiteDependencies = {},
+): Promise<BenchmarkSuiteRunResult> {
+  const repos = dependencies.repos ?? loadBenchmarkSuiteRepos()
+  const tasks = dependencies.tasks ?? loadBenchmarkSuiteTasks()
+  const now = dependencies.now ?? (() => new Date())
+  const runGenerateGraph = dependencies.generateGraph ?? generateGraph
+  const runCompare = dependencies.executeNativeAgentCompare ?? executeNativeAgentCompare
+
+  const selectedRepos = selectById(repos, 'repo', options.repo)
+  const selectedTasks = selectById(tasks, 'task', options.task)
+  const plans = selectedRepos.flatMap((repo) => selectedTasks.flatMap((task) => suiteModes(options.mode).map((mode) => planCell(repo, task, mode))))
+
+  if (options.dryRun) {
+    return { text: dryRunText(plans) }
+  }
+
+  const startedAt = now()
+  const outputRoot = createSuiteOutputRoot(resolve(options.outputDir), startedAt)
+  const readyPlans = plans.filter((plan) => plan.status === 'ready')
+  const preparedRepos = new Map<string, { legacyGraphPath: string; spiGraphPath: string | null }>()
+  const scratchRoots: string[] = []
+  const stagingRoot = resolve('out/benchmark-suite-staging', timestampDirectoryName(startedAt))
+  const summaryCells: BenchmarkSuiteSummaryCell[] = []
+
+  try {
+    mkdirSync(stagingRoot, { recursive: true })
+
+    for (const repo of [...new Set(readyPlans.map((plan) => plan.repo))]) {
+      const scratchRoot = mkdtempSync(join(tmpdir(), `madar-bench-suite-${repo.id}-`))
+      scratchRoots.push(scratchRoot)
+
+      const legacyWorkspace = join(scratchRoot, 'legacy')
+      copyWorkspace(repo.path, legacyWorkspace)
+      const legacyResult = runGenerateGraph(legacyWorkspace, { noHtml: true })
+
+      let spiGraphPath: string | null = null
+      if (repo.supportsSpi) {
+        const spiWorkspace = join(scratchRoot, 'spi')
+        copyWorkspace(repo.path, spiWorkspace)
+        spiGraphPath = runGenerateGraph(spiWorkspace, { noHtml: true, useSpi: true }).graphPath
+      }
+
+      preparedRepos.set(repo.id, {
+        legacyGraphPath: legacyResult.graphPath,
+        spiGraphPath,
+      })
+    }
+
+    for (const plan of plans) {
+      if (plan.status !== 'ready' || plan.prompt === null) {
+        summaryCells.push({
+          repoId: plan.repo.id,
+          repoName: plan.repo.name,
+          taskId: plan.task.id,
+          taskName: plan.task.name,
+          mode: plan.mode,
+          prompt: plan.prompt,
+          status: 'planned',
+          reason: plan.reason,
+          baseline: summarizeArmMetrics([], 'baseline'),
+          madar: summarizeArmMetrics([], 'madar'),
+          spi_madar: plan.repo.supportsSpi ? summarizeArmMetrics([], 'madar') : null,
+          artifacts: {
+            legacy_share_safe_reports: [],
+            spi_share_safe_reports: [],
+          },
+        })
+        continue
+      }
+
+      const prepared = preparedRepos.get(plan.repo.id)
+      if (!prepared) {
+        throw new Error(`Missing prepared repo for ${plan.repo.id}`)
+      }
+
+      const legacyReports: NativeAgentCompareReport[] = []
+      const spiReports: NativeAgentCompareReport[] = []
+      const copiedLegacyArtifacts: string[] = []
+      const copiedSpiArtifacts: string[] = []
+
+      for (let trial = 1; trial <= options.trials; trial += 1) {
+        const trialLabel = `trial-${String(trial).padStart(3, '0')}`
+        const legacyInput = {
+          graphPath: prepared.legacyGraphPath,
+          question: plan.prompt,
+          outputDir: join(stagingRoot, plan.repo.id, plan.task.id, `${plan.mode}-cache`, 'legacy', trialLabel),
+          execTemplate: execTemplateForWorkspace(options.execTemplate, dirname(dirname(prepared.legacyGraphPath))),
+          baselineMode: 'native_agent' as const,
+        }
+        await maybePrimeWarmCache(plan.mode, runCompare, legacyInput)
+        const legacyResult = await runCompare(legacyInput)
+        const legacyReport = legacyResult.reports[0]
+        if (legacyReport) {
+          legacyReports.push(legacyReport)
+          copiedLegacyArtifacts.push(copyReportArtifacts(
+            legacyReport,
+            join(outputRoot, 'raw', plan.repo.id, plan.task.id, `${plan.mode}-cache`, 'legacy', trialLabel),
+          ))
+        }
+
+        if (prepared.spiGraphPath) {
+          const spiInput = {
+            graphPath: prepared.spiGraphPath,
+            question: plan.prompt,
+            outputDir: join(stagingRoot, plan.repo.id, plan.task.id, `${plan.mode}-cache`, 'spi', trialLabel),
+            execTemplate: execTemplateForWorkspace(options.execTemplate, dirname(dirname(prepared.spiGraphPath))),
+            baselineMode: 'native_agent' as const,
+          }
+          await maybePrimeWarmCache(plan.mode, runCompare, spiInput)
+          const spiResult = await runCompare(spiInput)
+          const spiReport = spiResult.reports[0]
+          if (spiReport) {
+            spiReports.push(spiReport)
+            copiedSpiArtifacts.push(copyReportArtifacts(
+              spiReport,
+              join(outputRoot, 'raw', plan.repo.id, plan.task.id, `${plan.mode}-cache`, 'spi', trialLabel),
+            ))
+          }
+        }
+      }
+
+      const baseline = summarizeArmMetrics(legacyReports, 'baseline')
+      const madar = summarizeArmMetrics(legacyReports, 'madar')
+      const spiMadar = prepared.spiGraphPath ? summarizeArmMetrics(spiReports, 'madar') : null
+      summaryCells.push({
+        repoId: plan.repo.id,
+        repoName: plan.repo.name,
+        taskId: plan.task.id,
+        taskName: plan.task.name,
+        mode: plan.mode,
+        prompt: plan.prompt,
+        status: summarizeCellStatus(baseline, madar, spiMadar, false),
+        reason: null,
+        baseline,
+        madar,
+        spi_madar: spiMadar,
+        artifacts: {
+          legacy_share_safe_reports: stringifyArtifacts(copiedLegacyArtifacts),
+          spi_share_safe_reports: stringifyArtifacts(copiedSpiArtifacts),
+        },
+      })
+    }
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true })
+    for (const scratchRoot of scratchRoots) {
+      rmSync(scratchRoot, { recursive: true, force: true })
+    }
+  }
+
+  const completedAt = now()
+  const summary: BenchmarkSuiteSummary = {
+    schema_version: 1,
+    started_at: startedAt.toISOString(),
+    completed_at: completedAt.toISOString(),
+    output_root: portablePath(outputRoot),
+    filters: {
+      repo: options.repo,
+      task: options.task,
+      mode: options.mode,
+      trials: options.trials,
+    },
+    cells: summaryCells,
+  }
+  const { summaryPath, summaryJsonPath } = writeSummary(outputRoot, summary)
+  const runnableCount = summaryCells.filter((cell) => cell.status !== 'planned').length
+  const plannedCount = summaryCells.filter((cell) => cell.status === 'planned').length
+
+  return {
+    text: [
+      `Wrote benchmark suite results to ${portablePath(outputRoot)}`,
+      `Summary: ${portablePath(summaryPath)}`,
+      `JSON: ${portablePath(summaryJsonPath)}`,
+      `Cells: ${runnableCount} measured · ${plannedCount} planned`,
+    ].join('\n'),
+    outputRoot,
+    summaryPath,
+    summaryJsonPath,
+    summary,
+  }
+}

--- a/src/infrastructure/benchmark/suite.ts
+++ b/src/infrastructure/benchmark/suite.ts
@@ -1,4 +1,4 @@
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -495,7 +495,12 @@ function copyReportArtifacts(
   const copiedRoot = join(destinationParent, basename(report.paths.output_dir))
   mkdirSync(dirname(copiedRoot), { recursive: true })
   cpSync(report.paths.output_dir, copiedRoot, { recursive: true })
-  return join(copiedRoot, 'report.share-safe.json')
+  const copiedShareSafeReport = join(copiedRoot, 'report.share-safe.json')
+  if (!existsSync(copiedShareSafeReport)) {
+    throw new Error(`Missing share-safe report in copied benchmark artifacts: ${copiedShareSafeReport}`)
+  }
+  writeFileSync(join(copiedRoot, 'report.json'), readFileSync(copiedShareSafeReport, 'utf8'), 'utf8')
+  return copiedShareSafeReport
 }
 
 export async function runBenchmarkSuite(

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -1,0 +1,496 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+import type { GenerateGraphResult } from '../../src/infrastructure/generate.js'
+import type { NativeAgentCompareResult, NativeAgentCompareReport } from '../../src/infrastructure/compare.js'
+import {
+  loadBenchmarkSuiteRepos,
+  loadBenchmarkSuiteTasks,
+  runBenchmarkSuite,
+  type BenchmarkSuiteRepo,
+  type BenchmarkSuiteTask,
+} from '../../src/infrastructure/benchmark/suite.js'
+
+function withTempDir(callback: (tempDir: string) => void | Promise<void>): void | Promise<void> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'madar-bench-suite-'))
+  const finalize = () => rmSync(tempDir, { recursive: true, force: true })
+  try {
+    const result = callback(tempDir)
+    if (result && typeof (result as Promise<void>).then === 'function') {
+      return (result as Promise<void>).finally(finalize)
+    }
+    finalize()
+  } catch (error) {
+    finalize()
+    throw error
+  }
+}
+
+function createFixtureRepo(rootPath: string): string {
+  mkdirSync(rootPath, { recursive: true })
+  writeFileSync(join(rootPath, 'package.json'), JSON.stringify({ name: 'fixture-repo', private: true }, null, 2), 'utf8')
+  mkdirSync(join(rootPath, 'src'), { recursive: true })
+  writeFileSync(join(rootPath, 'src', 'auth-controller.ts'), 'export const controller = true\n', 'utf8')
+  return rootPath
+}
+
+function makeSucceededRun(
+  resultPath: string,
+  inputTokens: number,
+  turns: number,
+  durationMs: number,
+  costUsd: number,
+): NativeAgentCompareReport['baseline'] {
+  return {
+    kind: 'succeeded',
+    model: 'claude-sonnet',
+    usage: {
+      input_tokens: inputTokens,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      output_tokens: 100,
+    },
+    total_input_tokens_anthropic_exact: inputTokens,
+    uncached_input_tokens_anthropic_exact: inputTokens,
+    cached_input_tokens_anthropic_exact: 0,
+    total_cost_usd: costUsd,
+    num_turns: turns,
+    duration_ms: durationMs,
+    result_path: resultPath,
+  }
+}
+
+function makeCompareResult(input: {
+  question: string
+  graphPath: string
+  outputDir: string
+  baselineInputTokens: number
+  madarInputTokens: number
+  baselineTurns: number
+  madarTurns: number
+  baselineDurationMs: number
+  madarDurationMs: number
+  baselineCostUsd: number
+  madarCostUsd: number
+  baselineToolTotal: number
+  madarToolTotal: number
+  baselineRead: number
+  madarRead: number
+  baselineGlob: number
+  madarGlob: number
+  baselineGrep: number
+  madarGrep: number
+}): NativeAgentCompareResult {
+  mkdirSync(input.outputDir, { recursive: true })
+  writeFileSync(join(input.outputDir, 'report.json'), '{}\n', 'utf8')
+  writeFileSync(join(input.outputDir, 'report.share-safe.json'), '{}\n', 'utf8')
+  writeFileSync(join(input.outputDir, 'baseline-answer.txt'), 'baseline\n', 'utf8')
+  writeFileSync(join(input.outputDir, 'madar-answer.txt'), 'madar\n', 'utf8')
+  writeFileSync(join(input.outputDir, 'native_agent-prompt.txt'), `${input.question}\n`, 'utf8')
+
+  const report: NativeAgentCompareReport = {
+    baseline_mode: 'native_agent',
+    question: input.question,
+    graph_path: input.graphPath,
+    exec_command: {
+      command: null,
+      placeholders: ['{prompt_file}'],
+      redacted: true,
+    },
+    baseline: makeSucceededRun(join(input.outputDir, 'baseline-answer.txt'), input.baselineInputTokens, input.baselineTurns, input.baselineDurationMs, input.baselineCostUsd),
+    madar: makeSucceededRun(join(input.outputDir, 'madar-answer.txt'), input.madarInputTokens, input.madarTurns, input.madarDurationMs, input.madarCostUsd),
+    tool_call_counts: {
+      baseline: {
+        total: input.baselineToolTotal,
+        Read: input.baselineRead,
+        Bash: 0,
+        Glob: input.baselineGlob,
+        Grep: input.baselineGrep,
+        ToolSearch: 0,
+        other: {},
+      },
+      madar: {
+        total: input.madarToolTotal,
+        Read: input.madarRead,
+        Bash: 0,
+        Glob: input.madarGlob,
+        Grep: input.madarGrep,
+        ToolSearch: 0,
+        other: {},
+      },
+    },
+    reductions: {
+      input_tokens: input.baselineInputTokens / input.madarInputTokens,
+      uncached_input_tokens: input.baselineInputTokens / input.madarInputTokens,
+      cache_creation_input_tokens: null,
+      num_turns: input.baselineTurns / input.madarTurns,
+      duration_ms: input.baselineDurationMs / input.madarDurationMs,
+      cost_usd: input.baselineCostUsd / input.madarCostUsd,
+    },
+    token_regression: false,
+    token_regression_reasons: [],
+    prompt_token_source: {
+      baseline: 'anthropic_provider_reported',
+      madar: 'anthropic_provider_reported',
+    },
+    provider_proof: {
+      baseline: {
+        provider: 'anthropic',
+        input_tokens_source: 'anthropic_provider_reported',
+        effective_tokens_source: 'anthropic_provider_reported',
+        total_tokens_source: 'anthropic_provider_reported',
+      },
+      madar: {
+        provider: 'anthropic',
+        input_tokens_source: 'anthropic_provider_reported',
+        effective_tokens_source: 'anthropic_provider_reported',
+        total_tokens_source: 'anthropic_provider_reported',
+      },
+      reduction_basis: 'provider_reported',
+    },
+    started_at: '2026-05-27T00:00:00.000Z',
+    completed_at: '2026-05-27T00:00:01.000Z',
+    paths: {
+      output_dir: input.outputDir,
+      report: join(input.outputDir, 'report.json'),
+      share_safe_report: join(input.outputDir, 'report.share-safe.json'),
+      baseline_answer: join(input.outputDir, 'baseline-answer.txt'),
+      madar_answer: join(input.outputDir, 'madar-answer.txt'),
+      prompt_file: join(input.outputDir, 'native_agent-prompt.txt'),
+    },
+  }
+
+  return {
+    graph_path: input.graphPath,
+    output_root: input.outputDir,
+    reports: [report],
+  }
+}
+
+describe('benchmark suite manifests', () => {
+  it('loads the fixed repo and task manifests from docs/benchmarks/suite', () => {
+    const repos = loadBenchmarkSuiteRepos()
+    const tasks = loadBenchmarkSuiteTasks()
+
+    expect(repos).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'nestjs-mid',
+        status: 'ready',
+      }),
+      expect.objectContaining({
+        id: 'python-service',
+        status: 'planned',
+      }),
+    ]))
+    expect(tasks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'explain-runtime',
+        status: 'ready',
+      }),
+      expect.objectContaining({
+        id: 'review',
+        status: 'planned',
+      }),
+    ]))
+  })
+
+  it('rejects repo ids with unsafe path characters', async () => {
+    await withTempDir(async (tempDir) => {
+      const manifestPath = join(tempDir, 'repos.json')
+      writeFileSync(manifestPath, JSON.stringify([
+        {
+          id: '../escape',
+          name: 'Bad repo',
+          path: '.',
+          status: 'ready',
+          supportsSpi: false,
+        },
+      ], null, 2), 'utf8')
+
+      expect(() => loadBenchmarkSuiteRepos(manifestPath)).toThrow('repo id contains unsafe path characters')
+    })
+  })
+
+  it('rejects task ids with unsafe path characters', async () => {
+    await withTempDir(async (tempDir) => {
+      const manifestPath = join(tempDir, 'tasks.json')
+      writeFileSync(manifestPath, JSON.stringify([
+        {
+          id: '../escape',
+          name: 'Bad task',
+          status: 'ready',
+          prompts: {},
+        },
+      ], null, 2), 'utf8')
+
+      expect(() => loadBenchmarkSuiteTasks(manifestPath)).toThrow('task id contains unsafe path characters')
+    })
+  })
+})
+
+describe('runBenchmarkSuite', () => {
+  it('lists runnable and planned cells during dry-run without executing anything', async () => {
+    await withTempDir(async (tempDir) => {
+      const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+      const repos: BenchmarkSuiteRepo[] = [
+        {
+          id: 'nestjs-mid',
+          name: 'Fixture NestJS-like service',
+          path: runnableRepoPath,
+          description: 'Ready fixture',
+          size: 'mid',
+          language: 'typescript',
+          shape: 'service',
+          status: 'ready',
+          supportsSpi: true,
+        },
+        {
+          id: 'python-service',
+          name: 'Planned Python service',
+          path: join(tempDir, 'repos', 'python-service'),
+          description: 'Planned fixture',
+          size: 'mid',
+          language: 'python',
+          shape: 'fastapi',
+          status: 'planned',
+          supportsSpi: false,
+        },
+      ]
+      const tasks: BenchmarkSuiteTask[] = [
+        {
+          id: 'explain-runtime',
+          name: 'Explain runtime flow',
+          description: 'Trace a runtime path end to end.',
+          status: 'ready',
+          prompts: {
+            'nestjs-mid': 'How does login session creation flow work?',
+          },
+        },
+        {
+          id: 'review',
+          name: 'Review prompt',
+          description: 'Review a diff.',
+          status: 'planned',
+          prompts: {},
+        },
+      ]
+      let generateCalls = 0
+      let compareCalls = 0
+
+      const result = await runBenchmarkSuite(
+        {
+          repo: null,
+          task: null,
+          mode: 'all',
+          trials: 3,
+          outputDir: join(tempDir, 'results'),
+          execTemplate: '',
+          dryRun: true,
+          yes: false,
+        },
+        {
+          repos,
+          tasks,
+          generateGraph: () => {
+            generateCalls += 1
+            throw new Error('dry-run should not generate graphs')
+          },
+          executeNativeAgentCompare: async () => {
+            compareCalls += 1
+            throw new Error('dry-run should not execute compares')
+          },
+        },
+      )
+
+      expect(generateCalls).toBe(0)
+      expect(compareCalls).toBe(0)
+      expect(result.text).toContain('[ready] nestjs-mid / explain-runtime / cold-cache')
+      expect(result.text).toContain('[ready] nestjs-mid / explain-runtime / warm-cache')
+      expect(result.text).toContain('[planned] python-service / explain-runtime / cold-cache')
+      expect(result.text).toContain('[planned] nestjs-mid / review / warm-cache')
+    })
+  })
+
+  it('writes summary.json and summary.md with per-repo rows and no aggregate headline', async () => {
+    await withTempDir(async (tempDir) => {
+      const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+      const repos: BenchmarkSuiteRepo[] = [
+        {
+          id: 'nestjs-mid',
+          name: 'Fixture NestJS-like service',
+          path: runnableRepoPath,
+          description: 'Ready fixture',
+          size: 'mid',
+          language: 'typescript',
+          shape: 'service',
+          status: 'ready',
+          supportsSpi: true,
+        },
+        {
+          id: 'python-service',
+          name: 'Planned Python service',
+          path: join(tempDir, 'repos', 'python-service'),
+          description: 'Planned fixture',
+          size: 'mid',
+          language: 'python',
+          shape: 'fastapi',
+          status: 'planned',
+          supportsSpi: false,
+        },
+      ]
+      const tasks: BenchmarkSuiteTask[] = [
+        {
+          id: 'explain-runtime',
+          name: 'Explain runtime flow',
+          description: 'Trace a runtime path end to end.',
+          status: 'ready',
+          prompts: {
+            'nestjs-mid': 'How does login session creation flow work?',
+          },
+        },
+      ]
+      const result = await runBenchmarkSuite(
+        {
+          repo: null,
+          task: 'explain-runtime',
+          mode: 'all',
+          trials: 3,
+          outputDir: join(tempDir, 'results'),
+          execTemplate: 'mock-runner',
+          dryRun: false,
+          yes: true,
+        },
+        {
+          repos,
+          tasks,
+          now: () => new Date('2026-05-27T12:34:56Z'),
+          generateGraph: (rootPath = '.', options = {}) => {
+            const outputDir = join(rootPath, 'out')
+            mkdirSync(outputDir, { recursive: true })
+            const graphPath = join(outputDir, 'graph.json')
+            writeFileSync(graphPath, '{}\n', 'utf8')
+            return {
+              mode: options.useSpi ? 'generate' : 'generate',
+              rootPath,
+              outputDir,
+              graphPath,
+              reportPath: join(outputDir, 'GRAPH_REPORT.md'),
+              htmlPath: null,
+              wikiPath: null,
+              obsidianPath: null,
+              svgPath: null,
+              graphmlPath: null,
+              cypherPath: null,
+              docsPath: null,
+              totalFiles: 1,
+              codeFiles: 1,
+              nonCodeFiles: 0,
+              extractableFiles: 1,
+              extractedFiles: 1,
+              totalWords: 10,
+              nodeCount: 1,
+              edgeCount: 0,
+              communityCount: 1,
+              changedFiles: 0,
+              deletedFiles: 0,
+              cache: null,
+              warning: null,
+              notes: [],
+            } satisfies GenerateGraphResult
+          },
+          executeNativeAgentCompare: async (input) => {
+            const isSpi = input.graphPath.includes('/spi/')
+            const trialMatch = input.outputDir.match(/trial-(\d+)/)
+            const trialNumber = trialMatch ? Number.parseInt(trialMatch[1] ?? '1', 10) : 1
+            return makeCompareResult({
+              question: input.question ?? 'unknown',
+              graphPath: input.graphPath,
+              outputDir: input.outputDir,
+              baselineInputTokens: 300 + trialNumber,
+              madarInputTokens: isSpi ? 180 + trialNumber : 200 + trialNumber,
+              baselineTurns: 6,
+              madarTurns: isSpi ? 3 : 4,
+              baselineDurationMs: 9000 + trialNumber,
+              madarDurationMs: isSpi ? 5000 + trialNumber : 6000 + trialNumber,
+              baselineCostUsd: 1.2,
+              madarCostUsd: isSpi ? 0.7 : 0.8,
+              baselineToolTotal: 9,
+              madarToolTotal: isSpi ? 4 : 5,
+              baselineRead: 4,
+              madarRead: isSpi ? 2 : 3,
+              baselineGlob: 2,
+              madarGlob: isSpi ? 0 : 1,
+              baselineGrep: 1,
+              madarGrep: isSpi ? 0 : 1,
+            })
+          },
+        },
+      )
+
+      expect(result.summaryPath).toBeTruthy()
+      expect(result.summaryJsonPath).toBeTruthy()
+
+      const summaryJson = JSON.parse(readFileSync(result.summaryJsonPath!, 'utf8')) as {
+        cells: Array<{
+          repoId: string
+          taskId: string
+          mode: string
+          status: string
+          baseline: { input_tokens: { median: number; min: number; max: number; n: number } }
+          madar: { input_tokens: { median: number; min: number; max: number; n: number } }
+          spi_madar: { input_tokens: { median: number; min: number; max: number; n: number } | null }
+        }>
+      }
+      const summaryMarkdown = readFileSync(result.summaryPath!, 'utf8')
+
+      expect(summaryJson.cells).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          repoId: 'nestjs-mid',
+          taskId: 'explain-runtime',
+          mode: 'cold',
+          status: 'completed',
+          baseline: expect.objectContaining({
+            input_tokens: expect.objectContaining({
+              median: 302,
+              min: 301,
+              max: 303,
+              n: 3,
+            }),
+          }),
+          madar: expect.objectContaining({
+            input_tokens: expect.objectContaining({
+              median: 202,
+              min: 201,
+              max: 203,
+              n: 3,
+            }),
+          }),
+          spi_madar: expect.objectContaining({
+            input_tokens: expect.objectContaining({
+              median: 182,
+              min: 181,
+              max: 183,
+              n: 3,
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          repoId: 'python-service',
+          taskId: 'explain-runtime',
+          mode: 'warm',
+          status: 'planned',
+        }),
+      ]))
+      expect(summaryMarkdown).toContain('## explain-runtime')
+      expect(summaryMarkdown).toContain('### Cold cache')
+      expect(summaryMarkdown).toContain('### Warm cache')
+      expect(summaryMarkdown).toContain('| nestjs-mid |')
+      expect(summaryMarkdown).toContain('| python-service |')
+      expect(summaryMarkdown).not.toContain('average across repos')
+      expect(summaryMarkdown).not.toContain('headline')
+    })
+  })
+})

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -37,6 +37,10 @@ function createFixtureRepo(rootPath: string): string {
   return rootPath
 }
 
+function isSpiGraphPath(graphPath: string): boolean {
+  return /(?:^|[\\/])spi(?:[\\/])/.test(graphPath)
+}
+
 function makeSucceededRun(
   resultPath: string,
   inputTokens: number,
@@ -85,11 +89,36 @@ function makeCompareResult(input: {
   madarGrep: number
 }): NativeAgentCompareResult {
   mkdirSync(input.outputDir, { recursive: true })
-  writeFileSync(join(input.outputDir, 'report.json'), '{}\n', 'utf8')
-  writeFileSync(join(input.outputDir, 'report.share-safe.json'), '{}\n', 'utf8')
-  writeFileSync(join(input.outputDir, 'baseline-answer.txt'), 'baseline\n', 'utf8')
-  writeFileSync(join(input.outputDir, 'madar-answer.txt'), 'madar\n', 'utf8')
-  writeFileSync(join(input.outputDir, 'native_agent-prompt.txt'), `${input.question}\n`, 'utf8')
+  const baselineAnswerPath = join(input.outputDir, 'baseline-answer.txt')
+  const madarAnswerPath = join(input.outputDir, 'madar-answer.txt')
+  const promptPath = join(input.outputDir, 'native_agent-prompt.txt')
+  const reportPath = join(input.outputDir, 'report.json')
+  const shareSafeReportPath = join(input.outputDir, 'report.share-safe.json')
+
+  writeFileSync(baselineAnswerPath, 'baseline\n', 'utf8')
+  writeFileSync(madarAnswerPath, 'madar\n', 'utf8')
+  writeFileSync(promptPath, `${input.question}\n`, 'utf8')
+
+  const publishedReport = {
+    graph_path: input.graphPath,
+    baseline: {
+      result_path: baselineAnswerPath,
+    },
+    madar: {
+      result_path: madarAnswerPath,
+    },
+  }
+  const shareSafeReport = {
+    graph_path: '<project-root>/out/graph.json',
+    baseline: {
+      result_path: '<artifact-root>/baseline-answer.txt',
+    },
+    madar: {
+      result_path: '<artifact-root>/madar-answer.txt',
+    },
+  }
+  writeFileSync(reportPath, `${JSON.stringify(publishedReport, null, 2)}\n`, 'utf8')
+  writeFileSync(shareSafeReportPath, `${JSON.stringify(shareSafeReport, null, 2)}\n`, 'utf8')
 
   const report: NativeAgentCompareReport = {
     baseline_mode: 'native_agent',
@@ -100,8 +129,8 @@ function makeCompareResult(input: {
       placeholders: ['{prompt_file}'],
       redacted: true,
     },
-    baseline: makeSucceededRun(join(input.outputDir, 'baseline-answer.txt'), input.baselineInputTokens, input.baselineTurns, input.baselineDurationMs, input.baselineCostUsd),
-    madar: makeSucceededRun(join(input.outputDir, 'madar-answer.txt'), input.madarInputTokens, input.madarTurns, input.madarDurationMs, input.madarCostUsd),
+    baseline: makeSucceededRun(baselineAnswerPath, input.baselineInputTokens, input.baselineTurns, input.baselineDurationMs, input.baselineCostUsd),
+    madar: makeSucceededRun(madarAnswerPath, input.madarInputTokens, input.madarTurns, input.madarDurationMs, input.madarCostUsd),
     tool_call_counts: {
       baseline: {
         total: input.baselineToolTotal,
@@ -155,11 +184,11 @@ function makeCompareResult(input: {
     completed_at: '2026-05-27T00:00:01.000Z',
     paths: {
       output_dir: input.outputDir,
-      report: join(input.outputDir, 'report.json'),
-      share_safe_report: join(input.outputDir, 'report.share-safe.json'),
-      baseline_answer: join(input.outputDir, 'baseline-answer.txt'),
-      madar_answer: join(input.outputDir, 'madar-answer.txt'),
-      prompt_file: join(input.outputDir, 'native_agent-prompt.txt'),
+      report: reportPath,
+      share_safe_report: shareSafeReportPath,
+      baseline_answer: baselineAnswerPath,
+      madar_answer: madarAnswerPath,
+      prompt_file: promptPath,
     },
   }
 
@@ -402,7 +431,7 @@ describe('runBenchmarkSuite', () => {
             } satisfies GenerateGraphResult
           },
           executeNativeAgentCompare: async (input) => {
-            const isSpi = input.graphPath.includes('/spi/')
+            const isSpi = isSpiGraphPath(input.graphPath)
             const trialMatch = input.outputDir.match(/trial-(\d+)/)
             const trialNumber = trialMatch ? Number.parseInt(trialMatch[1] ?? '1', 10) : 1
             return makeCompareResult({
@@ -491,6 +520,227 @@ describe('runBenchmarkSuite', () => {
       expect(summaryMarkdown).toContain('| python-service |')
       expect(summaryMarkdown).not.toContain('average across repos')
       expect(summaryMarkdown).not.toContain('headline')
+    })
+  })
+
+  it('treats SPI graph paths with Windows separators as SPI runs', async () => {
+    await withTempDir(async (tempDir) => {
+      const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+      const repos: BenchmarkSuiteRepo[] = [
+        {
+          id: 'nestjs-mid',
+          name: 'Fixture NestJS-like service',
+          path: runnableRepoPath,
+          description: 'Ready fixture',
+          size: 'mid',
+          language: 'typescript',
+          shape: 'service',
+          status: 'ready',
+          supportsSpi: true,
+        },
+      ]
+      const tasks: BenchmarkSuiteTask[] = [
+        {
+          id: 'explain-runtime',
+          name: 'Explain runtime flow',
+          description: 'Trace a runtime path end to end.',
+          status: 'ready',
+          prompts: {
+            'nestjs-mid': 'How does login session creation flow work?',
+          },
+        },
+      ]
+
+      const result = await runBenchmarkSuite(
+        {
+          repo: null,
+          task: 'explain-runtime',
+          mode: 'cold',
+          trials: 1,
+          outputDir: join(tempDir, 'results'),
+          execTemplate: 'mock-runner',
+          dryRun: false,
+          yes: true,
+        },
+        {
+          repos,
+          tasks,
+          generateGraph: (rootPath = '.', options = {}) => ({
+            mode: options.useSpi ? 'generate' : 'generate',
+            rootPath,
+            outputDir: options.useSpi ? 'C:\\tmp\\spi\\out' : 'C:\\tmp\\legacy\\out',
+            graphPath: options.useSpi ? 'C:\\tmp\\spi\\out\\graph.json' : 'C:\\tmp\\legacy\\out\\graph.json',
+            reportPath: options.useSpi ? 'C:\\tmp\\spi\\out\\GRAPH_REPORT.md' : 'C:\\tmp\\legacy\\out\\GRAPH_REPORT.md',
+            htmlPath: null,
+            wikiPath: null,
+            obsidianPath: null,
+            svgPath: null,
+            graphmlPath: null,
+            cypherPath: null,
+            docsPath: null,
+            totalFiles: 1,
+            codeFiles: 1,
+            nonCodeFiles: 0,
+            extractableFiles: 1,
+            extractedFiles: 1,
+            totalWords: 10,
+            nodeCount: 1,
+            edgeCount: 0,
+            communityCount: 1,
+            changedFiles: 0,
+            deletedFiles: 0,
+            cache: null,
+            warning: null,
+            notes: [],
+          } satisfies GenerateGraphResult),
+          executeNativeAgentCompare: async (input) => {
+            const isSpi = isSpiGraphPath(input.graphPath)
+            return makeCompareResult({
+              question: input.question ?? 'unknown',
+              graphPath: input.graphPath,
+              outputDir: input.outputDir,
+              baselineInputTokens: 300,
+              madarInputTokens: isSpi ? 180 : 200,
+              baselineTurns: 6,
+              madarTurns: isSpi ? 3 : 4,
+              baselineDurationMs: 9000,
+              madarDurationMs: isSpi ? 5000 : 6000,
+              baselineCostUsd: 1.2,
+              madarCostUsd: isSpi ? 0.7 : 0.8,
+              baselineToolTotal: 9,
+              madarToolTotal: isSpi ? 4 : 5,
+              baselineRead: 4,
+              madarRead: isSpi ? 2 : 3,
+              baselineGlob: 2,
+              madarGlob: isSpi ? 0 : 1,
+              baselineGrep: 1,
+              madarGrep: isSpi ? 0 : 1,
+            })
+          },
+        },
+      )
+
+      const coldCell = result.summary?.cells.find((cell) => cell.repoId === 'nestjs-mid' && cell.mode === 'cold')
+      expect(coldCell?.spi_madar?.input_tokens?.median).toBe(180)
+    })
+  })
+
+  it('publishes share-safe report.json copies in docs artifacts', async () => {
+    await withTempDir(async (tempDir) => {
+      const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+      const repos: BenchmarkSuiteRepo[] = [
+        {
+          id: 'nestjs-mid',
+          name: 'Fixture NestJS-like service',
+          path: runnableRepoPath,
+          description: 'Ready fixture',
+          size: 'mid',
+          language: 'typescript',
+          shape: 'service',
+          status: 'ready',
+          supportsSpi: false,
+        },
+      ]
+      const tasks: BenchmarkSuiteTask[] = [
+        {
+          id: 'explain-runtime',
+          name: 'Explain runtime flow',
+          description: 'Trace a runtime path end to end.',
+          status: 'ready',
+          prompts: {
+            'nestjs-mid': 'How does login session creation flow work?',
+          },
+        },
+      ]
+
+      const result = await runBenchmarkSuite(
+        {
+          repo: null,
+          task: 'explain-runtime',
+          mode: 'cold',
+          trials: 1,
+          outputDir: join(tempDir, 'results'),
+          execTemplate: 'mock-runner',
+          dryRun: false,
+          yes: true,
+        },
+        {
+          repos,
+          tasks,
+          generateGraph: (rootPath = '.', options = {}) => {
+            const outputDir = join(rootPath, 'out')
+            mkdirSync(outputDir, { recursive: true })
+            const graphPath = join(outputDir, 'graph.json')
+            writeFileSync(graphPath, '{}\n', 'utf8')
+            return {
+              mode: options.useSpi ? 'generate' : 'generate',
+              rootPath,
+              outputDir,
+              graphPath,
+              reportPath: join(outputDir, 'GRAPH_REPORT.md'),
+              htmlPath: null,
+              wikiPath: null,
+              obsidianPath: null,
+              svgPath: null,
+              graphmlPath: null,
+              cypherPath: null,
+              docsPath: null,
+              totalFiles: 1,
+              codeFiles: 1,
+              nonCodeFiles: 0,
+              extractableFiles: 1,
+              extractedFiles: 1,
+              totalWords: 10,
+              nodeCount: 1,
+              edgeCount: 0,
+              communityCount: 1,
+              changedFiles: 0,
+              deletedFiles: 0,
+              cache: null,
+              warning: null,
+              notes: [],
+            } satisfies GenerateGraphResult
+          },
+          executeNativeAgentCompare: async (input) => makeCompareResult({
+            question: input.question ?? 'unknown',
+            graphPath: input.graphPath,
+            outputDir: input.outputDir,
+            baselineInputTokens: 300,
+            madarInputTokens: 200,
+            baselineTurns: 6,
+            madarTurns: 4,
+            baselineDurationMs: 9000,
+            madarDurationMs: 6000,
+            baselineCostUsd: 1.2,
+            madarCostUsd: 0.8,
+            baselineToolTotal: 9,
+            madarToolTotal: 5,
+            baselineRead: 4,
+            madarRead: 3,
+            baselineGlob: 2,
+            madarGlob: 1,
+            baselineGrep: 1,
+            madarGrep: 1,
+          }),
+        },
+      )
+
+      const shareSafePath = result.summary?.cells[0]?.artifacts.legacy_share_safe_reports[0]
+      expect(shareSafePath).toBeTruthy()
+
+      const publishedReportPath = resolve(
+        process.cwd(),
+        shareSafePath!.replace(/report\.share-safe\.json$/, 'report.json'),
+      )
+      const publishedReport = JSON.parse(readFileSync(publishedReportPath, 'utf8')) as {
+        graph_path: string
+        baseline: { result_path: string }
+        madar: { result_path: string }
+      }
+
+      expect(publishedReport.graph_path).toBe('<project-root>/out/graph.json')
+      expect(publishedReport.baseline.result_path).toBe('<artifact-root>/baseline-answer.txt')
+      expect(publishedReport.madar.result_path).toBe('<artifact-root>/madar-answer.txt')
     })
   })
 })

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import { type CliDependencies, executeCli, formatHelp } from '../../src/cli/main.js'
 import {
   parseAddArgs,
+  parseBenchSuiteArgs,
   parseBenchmarkArgs,
   parseCompareArgs,
   parseDoctorArgs,
@@ -130,6 +131,7 @@ function createDependencies(): CliTestDependencies {
       }
     },
     runEval: () => 'madar retrieval quality benchmark\nRecall: 100.0%\ncreate session login',
+    runBenchSuite: async () => 'bench suite command is not implemented yet',
     runCompare: async () => 'compare command is not implemented yet',
     runReviewCompare: async () => 'review compare command is not implemented yet',
     runTimeTravel: async () => 'time-travel command is not implemented yet',
@@ -496,6 +498,47 @@ describe('cli parser', () => {
     expect(() => parseBenchmarkArgs(['--questions', '--wat'])).toThrow('error: --questions requires a value')
     expect(() => parseBenchmarkArgs(['--exec', '--wat'])).toThrow('error: --exec requires a value')
     expect(() => parseBenchmarkArgs(['custom.json', '--wat'])).toThrow('error: unknown option for benchmark: --wat')
+  })
+
+  it('parses bench:suite args', () => {
+    expect(parseBenchSuiteArgs(['--dry-run'])).toEqual({
+      repo: null,
+      task: null,
+      mode: 'all',
+      trials: 3,
+      outputDir: resolve('docs/benchmarks/suite/results'),
+      execTemplate: '',
+      dryRun: true,
+      yes: false,
+    })
+    expect(parseBenchSuiteArgs([
+      '--exec',
+      'claude -p "$(cat {prompt_file})"',
+      '--repo',
+      'nestjs-mid',
+      '--task',
+      'explain-runtime',
+      '--mode',
+      'warm',
+      '--trials',
+      '5',
+      '--output-dir',
+      'docs/benchmarks/suite/results/custom',
+      '--yes',
+    ])).toEqual({
+      repo: 'nestjs-mid',
+      task: 'explain-runtime',
+      mode: 'warm',
+      trials: 5,
+      outputDir: resolve('docs/benchmarks/suite/results/custom'),
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      dryRun: false,
+      yes: true,
+    })
+    expect(() => parseBenchSuiteArgs([])).toThrow('error: --exec is required unless --dry-run is set')
+    expect(() => parseBenchSuiteArgs(['--mode', 'weird', '--dry-run'])).toThrow('error: --mode must be one of cold, warm, all')
+    expect(() => parseBenchSuiteArgs(['--trials', '0', '--dry-run'])).toThrow('error: --trials must be a positive integer')
+    expect(() => parseBenchSuiteArgs(['--wat', '--dry-run'])).toThrow('error: unknown option for bench:suite: --wat')
   })
 
   it('parses compare args with a question or question file', () => {
@@ -994,6 +1037,9 @@ describe('cli main', () => {
     expect(help).toContain('    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}')
     expect(help).toContain('--questions PATH')
     expect(help).toContain('    --yes                 skip confirmation before running the paid benchmark/eval prompts')
+    expect(help).toContain('bench:suite')
+    expect(help).toContain('docs/benchmarks/suite/results/')
+    expect(help).toContain('    --dry-run             list planned and runnable suite cells without executing prompts')
     expect(help).toContain('eval [graph.json]')
     expect(help).toContain('compare [question]    run a real baseline vs madar prompt comparison')
     expect(help).toContain('    --format MODE       json|text|markdown|claude|copilot (default json)')
@@ -1089,6 +1135,81 @@ describe('cli main', () => {
     expect(compareRequest.io).toBe(io)
     await expect(compareRequest.confirm('Proceed?')).resolves.toBe(true)
     expect(confirmCalls).toBe(1)
+  })
+
+  it('routes bench:suite through the injected dependency after parsing args', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies()
+    let capturedRequest: unknown
+
+    dependencies.runBenchSuite = async (request) => {
+      capturedRequest = request
+      return 'bench suite result'
+    }
+
+    const exitCode = await executeCli(
+      [
+        'bench:suite',
+        '--exec',
+        'claude -p "$(cat {prompt_file})"',
+        '--repo',
+        'nestjs-mid',
+        '--task',
+        'explain-runtime',
+        '--mode',
+        'warm',
+        '--trials',
+        '5',
+        '--output-dir',
+        'docs/benchmarks/suite/results/custom',
+        '--yes',
+      ],
+      io,
+      dependencies,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(logs).toEqual(['bench suite result'])
+    expect(errors).toEqual([])
+    const benchSuiteRequest = capturedRequest as {
+      options: ReturnType<typeof parseBenchSuiteArgs>
+      io: typeof io
+    }
+    expect(benchSuiteRequest.options).toEqual({
+      repo: 'nestjs-mid',
+      task: 'explain-runtime',
+      mode: 'warm',
+      trials: 5,
+      outputDir: resolve('docs/benchmarks/suite/results/custom'),
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      dryRun: false,
+      yes: true,
+    })
+    expect(benchSuiteRequest.io).toBe(io)
+  })
+
+  it('runs bench:suite dry-run without confirmation', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies()
+    let confirmCalls = 0
+    let benchSuiteCalls = 0
+
+    dependencies.confirm = async () => {
+      confirmCalls += 1
+      return true
+    }
+    dependencies.runBenchSuite = async () => {
+      benchSuiteCalls += 1
+      return 'bench suite dry run'
+    }
+
+    const exitCode = await executeCli(['bench:suite', '--dry-run'], io, dependencies)
+
+    expect(exitCode).toBe(0)
+    expect(benchSuiteCalls).toBe(1)
+    expect(confirmCalls).toBe(0)
+    expect(logs).toEqual(['bench suite dry run'])
+    expect(errors).toEqual([])
   })
 
   it('routes review-compare through the injected dependency after parsing args', async () => {
@@ -1255,6 +1376,26 @@ describe('cli main', () => {
       expect(exitCode).toBe(2)
       expect(logs).toEqual(['Warning: eval will execute the benchmark/eval runner. This may consume paid model tokens.'])
       expect(errors).toEqual(['error: eval requires --yes in non-interactive mode.'])
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: stdinTty })
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutTty })
+    }
+  })
+
+  it('fails fast when bench:suite is run without --yes in non-interactive mode', async () => {
+    const { io, logs, errors } = createIo()
+    const stdinTty = process.stdin.isTTY
+    const stdoutTty = process.stdout.isTTY
+
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false })
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: false })
+
+    try {
+      const exitCode = await executeCli(['bench:suite', '--exec', 'claude -p "$(cat {prompt_file})"'], io)
+
+      expect(exitCode).toBe(2)
+      expect(logs).toEqual(['Warning: bench:suite will execute baseline, madar, and SPI suite prompts. This may consume paid model tokens.'])
+      expect(errors).toEqual(['error: bench:suite requires --yes in non-interactive mode.'])
     } finally {
       Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: stdinTty })
       Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutTty })


### PR DESCRIPTION
## Summary
- add a new `madar bench:suite` command with fixed repo/task manifests, methodology, and compare-backed suite orchestration
- stage compare runs safely under `out/` then copy raw artifacts plus summary outputs into `docs/benchmarks/suite/results/`
- ship the first real measured suite row for warm-cache `nestjs-mid` / `explain-runtime` with 3 trials and update README/claims/changelog links

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- node dist/src/cli/bin.js bench:suite --dry-run
- node dist/src/cli/bin.js bench:suite --repo nestjs-mid --task explain-runtime --mode warm --trials 3 --exec 'cat {prompt_file} | claude -p --output-format json' --yes\n\nCloses #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run the benchmark suite with madar bench:suite (repo/task/mode/trials/exec/output-dir/dry-run options) and publish per-repo results; first warm-cache row measured and available.

* **Documentation**
  * Added suite README, methodology, tasks/repos manifests, usage examples (dry-run and per-repo runs), and guidance; results and share-safe receipts placed under docs/benchmarks/suite/results/.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->