### PR TITLE
Add compare install validity gate

### DIFF
--- a/docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.json
+++ b/docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.json
@@ -1,0 +1,13 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How idea report is being generated",
+  "graph_path": "out/graph.json",
+  "install_verified": false,
+  "measurement_validity": "invalid",
+  "madar_mcp_call_count": 0,
+  "paths": {
+    "output_dir": "docs/benchmarks/regression/install-ab-govalidate-explain/no-install",
+    "report": "docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.json",
+    "share_safe_report": "docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.share-safe.json"
+  }
+}

--- a/docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.share-safe.json
+++ b/docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.share-safe.json
@@ -1,0 +1,13 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How idea report is being generated",
+  "graph_path": "out/graph.json",
+  "install_verified": false,
+  "measurement_validity": "invalid",
+  "madar_mcp_call_count": 0,
+  "paths": {
+    "output_dir": "docs/benchmarks/regression/install-ab-govalidate-explain/no-install",
+    "report": "docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.json",
+    "share_safe_report": "docs/benchmarks/regression/install-ab-govalidate-explain/no-install/report.share-safe.json"
+  }
+}

--- a/docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.json
+++ b/docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.json
@@ -1,0 +1,44 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How idea report is being generated",
+  "graph_path": "out/graph.json",
+  "install_verified": true,
+  "measurement_validity": "valid",
+  "madar_mcp_call_count": 2,
+  "madar_trace": {
+    "source": "claude_messages_tool_use",
+    "summary": "2 tool calls across 2 turns",
+    "tool_call_count": 2,
+    "tool_calls_by_name": {
+      "mcp__madar__retrieve": 2
+    },
+    "per_turn": [
+      {
+        "turn": 1,
+        "tool_call_count": 1,
+        "tools": [
+          "mcp__madar__retrieve"
+        ]
+      },
+      {
+        "turn": 2,
+        "tool_call_count": 1,
+        "tools": [
+          "mcp__madar__retrieve"
+        ]
+      }
+    ],
+    "madar_mcp_call_count": 2,
+    "context_pack_call_count": 0,
+    "focused_follow_up_tool_call_count": 2,
+    "broad_exploration_tool_call_count": 0,
+    "broad_exploration_tool_calls_by_name": {},
+    "exploration_outcome": "no_context_pack",
+    "exploration_summary": "no context_pack call recorded"
+  },
+  "paths": {
+    "output_dir": "docs/benchmarks/regression/install-ab-govalidate-explain/with-install",
+    "report": "docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.json",
+    "share_safe_report": "docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.share-safe.json"
+  }
+}

--- a/docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.share-safe.json
+++ b/docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.share-safe.json
@@ -1,0 +1,44 @@
+{
+  "baseline_mode": "native_agent",
+  "question": "How idea report is being generated",
+  "graph_path": "out/graph.json",
+  "install_verified": true,
+  "measurement_validity": "valid",
+  "madar_mcp_call_count": 2,
+  "madar_trace": {
+    "source": "claude_messages_tool_use",
+    "summary": "2 tool calls across 2 turns",
+    "tool_call_count": 2,
+    "tool_calls_by_name": {
+      "mcp__madar__retrieve": 2
+    },
+    "per_turn": [
+      {
+        "turn": 1,
+        "tool_call_count": 1,
+        "tools": [
+          "mcp__madar__retrieve"
+        ]
+      },
+      {
+        "turn": 2,
+        "tool_call_count": 1,
+        "tools": [
+          "mcp__madar__retrieve"
+        ]
+      }
+    ],
+    "madar_mcp_call_count": 2,
+    "context_pack_call_count": 0,
+    "focused_follow_up_tool_call_count": 2,
+    "broad_exploration_tool_call_count": 0,
+    "broad_exploration_tool_calls_by_name": {},
+    "exploration_outcome": "no_context_pack",
+    "exploration_summary": "no context_pack call recorded"
+  },
+  "paths": {
+    "output_dir": "docs/benchmarks/regression/install-ab-govalidate-explain/with-install",
+    "report": "docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.json",
+    "share_safe_report": "docs/benchmarks/regression/install-ab-govalidate-explain/with-install/report.share-safe.json"
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -411,6 +411,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --questions PATH      load questions from a JSON file instead of a positional question',
     '    --output-dir DIR      compare output directory (default out/compare)',
     '    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
+    '    --allow-no-install    allow native_agent compare without a verified Madar install and mark the run invalid',
     '    --yes                 skip confirmation before running the paid prompt comparison',
     '    --limit N             cap processed prompts/questions for the comparison run',
     '    --why                 include retrieval-routing debug metadata in the compare summary and reports',

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,7 +4,7 @@ import { createInterface } from 'node:readline/promises'
 import { loadBenchmarkQuestions, type BenchmarkResult, printBenchmark, runBenchmark } from '../infrastructure/benchmark.js'
 import { runBenchmarkSuite } from '../infrastructure/benchmark/suite.js'
 import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure/benchmark/quality.js'
-import { runCompareCommand } from '../infrastructure/compare.js'
+import { NativeAgentInstallRequiredError, runCompareCommand } from '../infrastructure/compare.js'
 import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
 import { runContextPromptCommand } from '../infrastructure/context-prompt-command.js'
 import { runDoctorCommand, runStatusCommand } from '../infrastructure/doctor.js'
@@ -191,16 +191,24 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
     return formatQualityReport(report)
   },
   runCompare: async ({ options }) => {
-    return await runCompareCommand({
-      graphPath: options.graphPath,
-      question: options.question,
-      questionsPath: options.questionsPath,
-      outputDir: options.outputDir,
-      execTemplate: options.execTemplate,
-      baselineMode: options.baselineMode,
-      limit: options.limit,
-      ...(options.why ? { why: true } : {}),
-    })
+    try {
+      return await runCompareCommand({
+        graphPath: options.graphPath,
+        question: options.question,
+        questionsPath: options.questionsPath,
+        outputDir: options.outputDir,
+        execTemplate: options.execTemplate,
+        baselineMode: options.baselineMode,
+        allowNoInstall: options.allowNoInstall,
+        limit: options.limit,
+        ...(options.why ? { why: true } : {}),
+      })
+    } catch (error) {
+      if (error instanceof NativeAgentInstallRequiredError) {
+        throw new UsageError(error.message)
+      }
+      throw error
+    }
   },
   runReviewCompare: async ({ options }) => {
     return await runReviewCompareCommand({

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -187,6 +187,8 @@ export interface InstallCliOptions {
   platform: InstallPlatform
 }
 
+const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--allow-no-install] [--yes] [--limit N]'
+
 export interface PlatformActionCliOptions {
   action: 'install' | 'uninstall'
   profile?: InstallProfile
@@ -1089,15 +1091,11 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
 
     if (!argument.startsWith('--')) {
       if (question !== null) {
-        throw new UsageError(
-          'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--yes] [--limit N]',
-        )
+        throw new UsageError(COMPARE_USAGE)
       }
       const normalizedQuestion = argument.trim()
       if (normalizedQuestion.length === 0) {
-        throw new UsageError(
-          'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--yes] [--limit N]',
-        )
+        throw new UsageError(COMPARE_USAGE)
       }
       question = normalizedQuestion
       continue
@@ -1198,9 +1196,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   }
 
   if (question === null && questionsPath === null) {
-    throw new UsageError(
-      'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--yes] [--limit N]',
-    )
+    throw new UsageError(COMPARE_USAGE)
   }
 
   if (execTemplate.length === 0) {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -105,6 +105,7 @@ export interface CompareCliOptions {
   questionsPath: string | null
   outputDir: string
   baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent'
+  allowNoInstall: boolean
   yes: boolean
   limit: number | null
   why?: boolean
@@ -1075,6 +1076,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   let questionsPath: string | null = null
   let outputDir = 'out/compare'
   let baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent' = 'full'
+  let allowNoInstall = false
   let yes = false
   let limit: number | null = null
   let why = false
@@ -1166,6 +1168,11 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
       continue
     }
 
+    if (argument === '--allow-no-install') {
+      allowNoInstall = true
+      continue
+    }
+
     if (argument === '--limit') {
       limit = parsePositiveDecimalInteger('--limit', requireOptionValue('--limit', args[index + 1]))
       index += 1
@@ -1202,7 +1209,18 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
 
   outputDir = validateGraphOutputPath(outputDir)
 
-  return { question, graphPath, execTemplate, questionsPath, outputDir, baselineMode, yes, limit, ...(why ? { why: true } : {}) }
+  return {
+    question,
+    graphPath,
+    execTemplate,
+    questionsPath,
+    outputDir,
+    baselineMode,
+    allowNoInstall,
+    yes,
+    limit,
+    ...(why ? { why: true } : {}),
+  }
 }
 
 export function parseReviewCompareArgs(args: string[]): ReviewCompareCliOptions {

--- a/src/infrastructure/benchmark/suite.ts
+++ b/src/infrastructure/benchmark/suite.ts
@@ -405,8 +405,12 @@ function formatMetric(stats: BenchmarkSuiteMetricStats | null, digits = 0): stri
 }
 
 function formatCellRow(cell: BenchmarkSuiteSummaryCell): string {
+  const statusLabel = cell.status === 'skipped' ? 'skipped (no install)' : cell.status
+  const reason = cell.reason ?? '—'
   return [
     cell.repoId,
+    statusLabel,
+    reason,
     formatMetric(cell.baseline.input_tokens),
     formatMetric(cell.madar.input_tokens),
     formatMetric(cell.spi_madar?.input_tokens ?? null),
@@ -454,8 +458,8 @@ function formatBenchmarkSuiteSummaryMarkdown(summary: BenchmarkSuiteSummary): st
       }
       lines.push(`### ${mode === 'cold' ? 'Cold cache' : 'Warm cache'}`)
       lines.push('')
-      lines.push('| Repo | Baseline input tokens | Madar input tokens | SPI Madar input tokens | Baseline tool calls | Madar tool calls | SPI Madar tool calls | Baseline Read | Madar Read | SPI Madar Read | Baseline Glob/Grep | Madar Glob/Grep | SPI Madar Glob/Grep | Baseline wall-clock (ms) | Madar wall-clock (ms) | SPI Madar wall-clock (ms) | Baseline cost (USD) | Madar cost (USD) | SPI Madar cost (USD) |')
-      lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+      lines.push('| Repo | Status | Reason | Baseline input tokens | Madar input tokens | SPI Madar input tokens | Baseline tool calls | Madar tool calls | SPI Madar tool calls | Baseline Read | Madar Read | SPI Madar Read | Baseline Glob/Grep | Madar Glob/Grep | SPI Madar Glob/Grep | Baseline wall-clock (ms) | Madar wall-clock (ms) | SPI Madar wall-clock (ms) | Baseline cost (USD) | Madar cost (USD) | SPI Madar cost (USD) |')
+      lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
       for (const cell of modeCells) {
         lines.push(`| ${formatCellRow(cell)} |`)
       }

--- a/src/infrastructure/benchmark/suite.ts
+++ b/src/infrastructure/benchmark/suite.ts
@@ -2,7 +2,12 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, write
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 
-import { executeNativeAgentCompare, type NativeAgentCompareReport, type NativeAgentCompareResult } from '../compare.js'
+import {
+  executeNativeAgentCompare,
+  inspectClaudeNativeAgentInstall,
+  type NativeAgentCompareReport,
+  type NativeAgentCompareResult,
+} from '../compare.js'
 import { generateGraph, type GenerateGraphOptions, type GenerateGraphResult } from '../generate.js'
 
 export type BenchmarkSuiteMode = 'cold' | 'warm' | 'all'
@@ -71,7 +76,7 @@ export interface BenchmarkSuiteSummaryCell {
   taskName: string
   mode: 'cold' | 'warm'
   prompt: string | null
-  status: 'completed' | 'partial' | 'planned'
+  status: 'completed' | 'partial' | 'planned' | 'skipped'
   reason: string | null
   baseline: BenchmarkSuiteArmMetricsSummary
   madar: BenchmarkSuiteArmMetricsSummary
@@ -93,6 +98,7 @@ export interface BenchmarkSuiteSummary {
     mode: BenchmarkSuiteMode
     trials: number
   }
+  cells_skipped_for_install: number
   cells: BenchmarkSuiteSummaryCell[]
 }
 
@@ -373,9 +379,13 @@ function summarizeCellStatus(
   madar: BenchmarkSuiteArmMetricsSummary,
   spiMadar: BenchmarkSuiteArmMetricsSummary | null,
   planned: boolean,
+  skipped: boolean,
 ): BenchmarkSuiteSummaryCell['status'] {
   if (planned) {
     return 'planned'
+  }
+  if (skipped) {
+    return 'skipped'
   }
   const baselineDone = isCompletedArm(baseline)
   const madarDone = isCompletedArm(madar)
@@ -424,6 +434,7 @@ function formatBenchmarkSuiteSummaryMarkdown(summary: BenchmarkSuiteSummary): st
     '',
     `- Generated: ${summary.completed_at}`,
     `- Filters: repo=${summary.filters.repo ?? 'all'}, task=${summary.filters.task ?? 'all'}, mode=${summary.filters.mode}, trials=${summary.filters.trials}`,
+    `- cells_skipped_for_install: ${summary.cells_skipped_for_install}`,
     '- Per-repo rows only.',
     '',
   ]
@@ -525,6 +536,7 @@ export async function runBenchmarkSuite(
   const outputRoot = createSuiteOutputRoot(resolve(options.outputDir), startedAt)
   const readyPlans = plans.filter((plan) => plan.status === 'ready')
   const preparedRepos = new Map<string, { legacyGraphPath: string; spiGraphPath: string | null }>()
+  const skippedRepos = new Map<string, string>()
   const scratchRoots: string[] = []
   const stagingRoot = resolve('out/benchmark-suite-staging', timestampDirectoryName(startedAt))
   const summaryCells: BenchmarkSuiteSummaryCell[] = []
@@ -533,6 +545,20 @@ export async function runBenchmarkSuite(
     mkdirSync(stagingRoot, { recursive: true })
 
     for (const repo of [...new Set(readyPlans.map((plan) => plan.repo))]) {
+      const installCheck = inspectClaudeNativeAgentInstall(repo.path)
+      if (!installCheck.verified) {
+        skippedRepos.set(
+          repo.id,
+          [
+            'No Madar install detected in repo; skipped benchmark cell.',
+            ...installCheck.artifacts
+              .filter((artifact) => !artifact.ok)
+              .map((artifact) => artifact.detail),
+          ].join(' '),
+        )
+        continue
+      }
+
       const scratchRoot = mkdtempSync(join(tmpdir(), `madar-bench-suite-${repo.id}-`))
       scratchRoots.push(scratchRoot)
 
@@ -564,6 +590,28 @@ export async function runBenchmarkSuite(
           prompt: plan.prompt,
           status: 'planned',
           reason: plan.reason,
+          baseline: summarizeArmMetrics([], 'baseline'),
+          madar: summarizeArmMetrics([], 'madar'),
+          spi_madar: plan.repo.supportsSpi ? summarizeArmMetrics([], 'madar') : null,
+          artifacts: {
+            legacy_share_safe_reports: [],
+            spi_share_safe_reports: [],
+          },
+        })
+        continue
+      }
+
+      const skippedReason = skippedRepos.get(plan.repo.id)
+      if (skippedReason) {
+        summaryCells.push({
+          repoId: plan.repo.id,
+          repoName: plan.repo.name,
+          taskId: plan.task.id,
+          taskName: plan.task.name,
+          mode: plan.mode,
+          prompt: plan.prompt,
+          status: 'skipped',
+          reason: skippedReason,
           baseline: summarizeArmMetrics([], 'baseline'),
           madar: summarizeArmMetrics([], 'madar'),
           spi_madar: plan.repo.supportsSpi ? summarizeArmMetrics([], 'madar') : null,
@@ -636,7 +684,7 @@ export async function runBenchmarkSuite(
         taskName: plan.task.name,
         mode: plan.mode,
         prompt: plan.prompt,
-        status: summarizeCellStatus(baseline, madar, spiMadar, false),
+        status: summarizeCellStatus(baseline, madar, spiMadar, false, false),
         reason: null,
         baseline,
         madar,
@@ -666,18 +714,20 @@ export async function runBenchmarkSuite(
       mode: options.mode,
       trials: options.trials,
     },
+    cells_skipped_for_install: summaryCells.filter((cell) => cell.status === 'skipped').length,
     cells: summaryCells,
   }
   const { summaryPath, summaryJsonPath } = writeSummary(outputRoot, summary)
-  const runnableCount = summaryCells.filter((cell) => cell.status !== 'planned').length
+  const runnableCount = summaryCells.filter((cell) => cell.status !== 'planned' && cell.status !== 'skipped').length
   const plannedCount = summaryCells.filter((cell) => cell.status === 'planned').length
+  const skippedCount = summary.cells_skipped_for_install
 
   return {
     text: [
       `Wrote benchmark suite results to ${portablePath(outputRoot)}`,
       `Summary: ${portablePath(summaryPath)}`,
       `JSON: ${portablePath(summaryJsonPath)}`,
-      `Cells: ${runnableCount} measured · ${plannedCount} planned`,
+      `Cells: ${runnableCount} measured · ${plannedCount} planned · ${skippedCount} skipped for install`,
     ].join('\n'),
     outputRoot,
     summaryPath,

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -112,12 +112,27 @@ export interface CompareMadarTrace {
   tool_call_count: number
   tool_calls_by_name: Record<string, number>
   per_turn: CompareMadarTraceTurnSummary[]
+  madar_mcp_call_count: number
   context_pack_call_count: number
   focused_follow_up_tool_call_count: number
   broad_exploration_tool_call_count: number
   broad_exploration_tool_calls_by_name: Record<string, number>
   exploration_outcome: CompareMadarTraceOutcome
   exploration_summary: string
+}
+
+export type NativeAgentMeasurementValidity = 'valid' | 'degraded' | 'invalid'
+
+interface NativeAgentInstallArtifactCheck {
+  label: string
+  ok: boolean
+  detail: string
+  path: string
+}
+
+export interface NativeAgentInstallCheck {
+  verified: boolean
+  artifacts: NativeAgentInstallArtifactCheck[]
 }
 
 export interface ComparePromptReport {
@@ -189,6 +204,7 @@ export interface GenerateCompareArtifactsInput {
   outputDir: string
   execTemplate: string
   baselineMode: CompareBaselineMode
+  allowNoInstall?: boolean
   why?: boolean
   corpusText?: string
   limit?: number | null
@@ -836,6 +852,7 @@ function traceToolCountSummary(toolCallsByName: Record<string, number>): string 
 }
 
 function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): {
+  madar_mcp_call_count: number
   context_pack_call_count: number
   focused_follow_up_tool_call_count: number
   broad_exploration_tool_call_count: number
@@ -843,6 +860,7 @@ function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): 
   exploration_outcome: CompareMadarTraceOutcome
   exploration_summary: string
 } {
+  let madarMcpCallCount = 0
   let contextPackCallCount = 0
   let focusedFollowUpToolCallCount = 0
   let broadExplorationToolCallCount = 0
@@ -850,6 +868,13 @@ function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): 
 
   for (const [toolName, count] of Object.entries(toolCallsByName)) {
     const canonicalName = canonicalTraceToolName(toolName)
+    if (
+      toolName.startsWith('mcp__madar__')
+      || MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)
+      || MADAR_FOCUSED_FOLLOW_UP_TOOL_NAMES.has(canonicalName)
+    ) {
+      madarMcpCallCount += count
+    }
     if (MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)) {
       contextPackCallCount += count
       continue
@@ -870,6 +895,7 @@ function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): 
 
   if (contextPackCallCount === 0) {
     return {
+      madar_mcp_call_count: madarMcpCallCount,
       context_pack_call_count: 0,
       focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
       broad_exploration_tool_call_count: broadExplorationToolCallCount,
@@ -887,6 +913,7 @@ function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): 
 
   if (contextPackCallCount === 1 && broadExplorationToolCallCount === 0) {
     return {
+      madar_mcp_call_count: madarMcpCallCount,
       context_pack_call_count: contextPackCallCount,
       focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
       broad_exploration_tool_call_count: 0,
@@ -905,6 +932,7 @@ function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): 
       : `${broadExplorationToolCallCount} broad exploration ${broadExplorationToolCallCount === 1 ? 'call' : 'calls'}${Object.keys(sortedBroadExplorationToolCallsByName).length > 0 ? ` (${traceToolCountSummary(sortedBroadExplorationToolCallsByName)})` : ''}`
 
   return {
+    madar_mcp_call_count: madarMcpCallCount,
     context_pack_call_count: contextPackCallCount,
     focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
     broad_exploration_tool_call_count: broadExplorationToolCallCount,
@@ -2022,6 +2050,9 @@ export interface NativeAgentCompareReport {
   exec_command: CompareExecCommandSummary
   baseline: NativeAgentRunStatus
   madar: NativeAgentRunStatus
+  install_verified: boolean
+  measurement_validity: NativeAgentMeasurementValidity
+  madar_mcp_call_count: number
   tool_call_counts?: NativeAgentToolCallCounts
   madar_trace?: CompareMadarTrace
   reductions: {
@@ -2116,6 +2147,125 @@ export type NativeAgentRunner = (input: NativeAgentRunnerInput) => Promise<Nativ
 export interface ExecuteNativeAgentCompareDependencies {
   runner?: NativeAgentRunner
   now?: () => Date
+}
+
+const MADAR_SECTION_MARKER = '## madar'
+const OUT_PATH_SEGMENT_PATTERN = /(^|[^a-z0-9_])out(?:[\\/]|[^a-z0-9_]|$)/i
+
+function readJsonObject(filePath: string): Record<string, unknown> | null {
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function containsOutPathReference(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return OUT_PATH_SEGMENT_PATTERN.test(value)
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsOutPathReference)
+  }
+  if (isRecord(value)) {
+    return Object.values(value).some(containsOutPathReference)
+  }
+  return false
+}
+
+function hasSectionMarker(filePath: string, marker = MADAR_SECTION_MARKER): boolean {
+  if (!existsSync(filePath)) {
+    return false
+  }
+  return readFileSync(filePath, 'utf8').includes(marker)
+}
+
+function findHookEntry(
+  settingsPath: string,
+  hookName: 'UserPromptSubmit' | 'PreToolUse' | 'BeforeTool',
+): boolean {
+  const settings = readJsonObject(settingsPath)
+  if (!settings) {
+    return false
+  }
+
+  const hooks = settings.hooks
+  if (!isRecord(hooks)) {
+    return false
+  }
+
+  const hookEntries = hooks[hookName]
+  return Array.isArray(hookEntries) && hookEntries.some(containsOutPathReference)
+}
+
+function hasMadarMcpEntry(configPath: string): boolean {
+  const config = readJsonObject(configPath)
+  if (!config) {
+    return false
+  }
+
+  return [config.mcpServers, config.servers].some((servers) => isRecord(servers) && isRecord(servers.madar))
+}
+
+export function inspectClaudeNativeAgentInstall(projectRoot: string): NativeAgentInstallCheck {
+  const mcpPath = join(projectRoot, '.mcp.json')
+  const claudeRulesPath = join(projectRoot, 'CLAUDE.md')
+  const settingsPath = join(projectRoot, '.claude', 'settings.json')
+  const artifacts: NativeAgentInstallArtifactCheck[] = [
+    {
+      label: '.mcp.json',
+      ok: hasMadarMcpEntry(mcpPath),
+      detail: '.mcp.json missing or has no `madar` entry',
+      path: mcpPath,
+    },
+    {
+      label: 'CLAUDE.md',
+      ok: hasSectionMarker(claudeRulesPath),
+      detail: 'CLAUDE.md missing `## madar` section',
+      path: claudeRulesPath,
+    },
+    {
+      label: '.claude/settings.json',
+      ok:
+        findHookEntry(settingsPath, 'UserPromptSubmit')
+        || findHookEntry(settingsPath, 'PreToolUse')
+        || findHookEntry(settingsPath, 'BeforeTool'),
+      detail: '.claude/settings.json missing Madar hook',
+      path: settingsPath,
+    },
+  ]
+
+  return {
+    verified: artifacts.every((artifact) => artifact.ok),
+    artifacts,
+  }
+}
+
+function formatNativeAgentInstallRequiredMessage(check: NativeAgentInstallCheck): string {
+  return [
+    'No Madar install detected in this directory:',
+    ...check.artifacts
+      .filter((artifact) => !artifact.ok)
+      .map((artifact) => `  x ${artifact.detail}`),
+    '',
+    'Run `madar claude install` in the target repo, then rerun compare.',
+    'To proceed without a verified install and mark the metrics INVALID, add `--allow-no-install`.',
+  ].join('\n')
+}
+
+export class NativeAgentInstallRequiredError extends Error {
+  readonly check: NativeAgentInstallCheck
+
+  constructor(check: NativeAgentInstallCheck) {
+    super(formatNativeAgentInstallRequiredMessage(check))
+    this.name = 'NativeAgentInstallRequiredError'
+    this.check = check
+  }
 }
 
 interface NativeAgentAnswerQualityGate {
@@ -2609,6 +2759,10 @@ export async function executeNativeAgentCompare(
   const runner = dependencies.runner ?? defaultNativeAgentRunner
   const reports: NativeAgentCompareReport[] = []
   const answerQualityGates = loadNativeAgentAnswerQualityGates(input.questionsPath)
+  const installCheck = inspectClaudeNativeAgentInstall(projectRoot)
+  if (!installCheck.verified && !input.allowNoInstall) {
+    throw new NativeAgentInstallRequiredError(installCheck)
+  }
 
   for (const [index, question] of questions.entries()) {
     const questionDir = questions.length === 1 ? outputRoot : join(outputRoot, `question-${String(index + 1).padStart(3, '0')}`)
@@ -2628,6 +2782,9 @@ export async function executeNativeAgentCompare(
       exec_command: summarizeExecTemplate(input.execTemplate),
       baseline: { kind: 'runner_error', evidence: null, exit_code: null, stderr: null },
       madar: { kind: 'runner_error', evidence: null, exit_code: null, stderr: null },
+      install_verified: installCheck.verified,
+      measurement_validity: installCheck.verified ? 'degraded' : 'invalid',
+      madar_mcp_call_count: 0,
       reductions: null,
       token_regression: false,
       token_regression_reasons: [],
@@ -2763,8 +2920,10 @@ export async function executeNativeAgentCompare(
       const madarTrace = extractMadarTrace(madarRun.stdout)
       if (madarTrace) {
         reportShell.madar_trace = madarTrace
+        reportShell.madar_mcp_call_count = madarTrace.madar_mcp_call_count
       } else {
         delete reportShell.madar_trace
+        reportShell.madar_mcp_call_count = 0
       }
       const event = parseAnthropicResultEvent(madarRun.stdout)
       if (event !== null) {
@@ -2845,6 +3004,12 @@ export async function executeNativeAgentCompare(
             ? 'mixed'
             : 'unknown'
     }
+    reportShell.measurement_validity =
+      reportShell.install_verified
+        ? reportShell.madar_mcp_call_count > 0
+          ? 'valid'
+          : 'degraded'
+        : 'invalid'
     const answerQuality = evaluateNativeAgentAnswerQualityReport(
       answerQualityGates,
       question,
@@ -2900,6 +3065,41 @@ function writeNativeAgentReport(report: NativeAgentCompareReport): void {
   )
 }
 
+function formatMeasurementValidityLine(report: NativeAgentCompareReport): string {
+  switch (report.measurement_validity) {
+    case 'valid':
+      return 'measurement_validity: valid'
+    case 'degraded':
+      return 'measurement_validity: degraded (install detected, but no Madar MCP call was recorded)'
+    case 'invalid':
+      return 'measurement_validity: INVALID — no Madar install was detected; do not cite these numbers'
+  }
+}
+
+function formatMadarMcpCallCountLine(report: NativeAgentCompareReport): string {
+  if (!report.madar_trace) {
+    return `madar_mcp_call_count: ${report.madar_mcp_call_count}`
+  }
+
+  const madarToolSummary = Object.entries(report.madar_trace.tool_calls_by_name)
+    .filter(([toolName]) => toolName.startsWith('mcp__madar__'))
+    .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))
+    .map(([toolName]) => toolName)
+    .join(', ')
+
+  return madarToolSummary.length > 0
+    ? `madar_mcp_call_count: ${report.madar_mcp_call_count} (${madarToolSummary})`
+    : `madar_mcp_call_count: ${report.madar_mcp_call_count}`
+}
+
+function appendNativeAgentValidityLines(lines: string[], report: NativeAgentCompareReport): void {
+  lines.push(
+    `    ${formatMeasurementValidityLine(report)}`,
+    `    install_verified: ${report.install_verified}`,
+    `    ${formatMadarMcpCallCountLine(report)}`,
+  )
+}
+
 export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult): string {
   const lines: string[] = [
     `[madar compare] completed ${result.reports.length} native_agent question(s)`,
@@ -2951,11 +3151,15 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
   }
   for (const report of result.reports) {
     if (isNativeAgentRunFailure(report.baseline) || isNativeAgentRunFailure(report.madar)) {
-      lines.push(`- "${report.question}" → runner error (see ${portablePath(report.paths.report)})`)
+      lines.push(`- "${report.question}"`)
+      appendNativeAgentValidityLines(lines, report)
+      lines.push(`    runner error (see ${portablePath(report.paths.report)})`)
       continue
     }
     if (report.baseline.kind === 'answer_only' || report.madar.kind === 'answer_only') {
-      lines.push(`- "${report.question}" → answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed (see ${portablePath(report.paths.report)})`)
+      lines.push(`- "${report.question}"`)
+      appendNativeAgentValidityLines(lines, report)
+      lines.push(`    answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed (see ${portablePath(report.paths.report)})`)
       continue
     }
 
@@ -2974,6 +3178,11 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
 
     lines.push(
       `- "${report.question}"`,
+      ...(() => {
+        const validityLines: string[] = []
+        appendNativeAgentValidityLines(validityLines, report)
+        return validityLines
+      })(),
       `    num_turns: baseline ${baseline.num_turns} → madar ${madar.num_turns}${formatDirectionalDelta(baseline.num_turns, madar.num_turns, 'fewer', 'more')}`,
       `    latency:   baseline ${baseline.duration_ms}ms → madar ${madar.duration_ms}ms${formatDirectionalDelta(baseline.duration_ms, madar.duration_ms, 'faster', 'slower')}`,
       `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → madar ${madar.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, madar.total_input_tokens_anthropic_exact, 'less', 'more', { noMeaningfulChangeThreshold: 0.1, neutralLabel: 'no meaningful change' })}`,

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -496,104 +496,6 @@ describe('runBenchmarkSuite', () => {
               baselineGrep: 1,
               madarGrep: isSpi ? 0 : 1,
             })
-
-            it('skips runnable cells when the repo has no verified Madar install', async () => {
-              await withTempDir(async (tempDir) => {
-                const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
-                rmSync(join(runnableRepoPath, '.mcp.json'), { force: true })
-                rmSync(join(runnableRepoPath, 'CLAUDE.md'), { force: true })
-                rmSync(join(runnableRepoPath, '.claude'), { recursive: true, force: true })
-
-                const repos: BenchmarkSuiteRepo[] = [
-                  {
-                    id: 'nestjs-mid',
-                    name: 'Fixture NestJS-like service',
-                    path: runnableRepoPath,
-                    description: 'Ready fixture',
-                    size: 'mid',
-                    language: 'typescript',
-                    shape: 'service',
-                    status: 'ready',
-                    supportsSpi: false,
-                  },
-                ]
-                const tasks: BenchmarkSuiteTask[] = [
-                  {
-                    id: 'explain-runtime',
-                    name: 'Explain runtime flow',
-                    description: 'Trace a runtime path end to end.',
-                    status: 'ready',
-                    prompts: {
-                      'nestjs-mid': 'How does login session creation flow work?',
-                    },
-                  },
-                ]
-                let generateCalls = 0
-                let compareCalls = 0
-
-                const result = await runBenchmarkSuite(
-                  {
-                    repo: null,
-                    task: 'explain-runtime',
-                    mode: 'cold',
-                    trials: 1,
-                    outputDir: join(tempDir, 'results'),
-                    execTemplate: 'mock-runner',
-                    dryRun: false,
-                    yes: true,
-                  },
-                  {
-                    repos,
-                    tasks,
-                    generateGraph: (rootPath = '.', options = {}) => {
-                      generateCalls += 1
-                      return {
-                        mode: options.useSpi ? 'generate' : 'generate',
-                        rootPath,
-                        outputDir: join(rootPath, 'out'),
-                        graphPath: join(rootPath, 'out', 'graph.json'),
-                        reportPath: join(rootPath, 'out', 'GRAPH_REPORT.md'),
-                        htmlPath: null,
-                        wikiPath: null,
-                        obsidianPath: null,
-                        svgPath: null,
-                        graphmlPath: null,
-                        cypherPath: null,
-                        docsPath: null,
-                        totalFiles: 1,
-                        codeFiles: 1,
-                        nonCodeFiles: 0,
-                        extractableFiles: 1,
-                        extractedFiles: 1,
-                        totalWords: 10,
-                        nodeCount: 1,
-                        edgeCount: 0,
-                        communityCount: 1,
-                        changedFiles: 0,
-                        deletedFiles: 0,
-                        cache: null,
-                        warning: null,
-                        notes: [],
-                      } satisfies GenerateGraphResult
-                    },
-                    executeNativeAgentCompare: async () => {
-                      compareCalls += 1
-                      throw new Error('install-skipped cells should not execute compare')
-                    },
-                  },
-                )
-
-                expect(generateCalls).toBe(0)
-                expect(compareCalls).toBe(0)
-                expect(result.summary?.cells[0]).toEqual(expect.objectContaining({
-                  repoId: 'nestjs-mid',
-                  status: 'skipped',
-                  reason: expect.stringContaining('No Madar install detected'),
-                }))
-                expect(result.summary?.cells_skipped_for_install).toBe(1)
-                expect(readFileSync(result.summaryPath!, 'utf8')).toContain('cells_skipped_for_install: 1')
-              })
-            })
           },
         },
       )
@@ -659,6 +561,108 @@ describe('runBenchmarkSuite', () => {
       expect(summaryMarkdown).toContain('| python-service |')
       expect(summaryMarkdown).not.toContain('average across repos')
       expect(summaryMarkdown).not.toContain('headline')
+    })
+  })
+
+  it('skips runnable cells when the repo has no verified Madar install', async () => {
+    await withTempDir(async (tempDir) => {
+      const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+      rmSync(join(runnableRepoPath, '.mcp.json'), { force: true })
+      rmSync(join(runnableRepoPath, 'CLAUDE.md'), { force: true })
+      rmSync(join(runnableRepoPath, '.claude'), { recursive: true, force: true })
+
+      const repos: BenchmarkSuiteRepo[] = [
+        {
+          id: 'nestjs-mid',
+          name: 'Fixture NestJS-like service',
+          path: runnableRepoPath,
+          description: 'Ready fixture',
+          size: 'mid',
+          language: 'typescript',
+          shape: 'service',
+          status: 'ready',
+          supportsSpi: false,
+        },
+      ]
+      const tasks: BenchmarkSuiteTask[] = [
+        {
+          id: 'explain-runtime',
+          name: 'Explain runtime flow',
+          description: 'Trace a runtime path end to end.',
+          status: 'ready',
+          prompts: {
+            'nestjs-mid': 'How does login session creation flow work?',
+          },
+        },
+      ]
+      let generateCalls = 0
+      let compareCalls = 0
+
+      const result = await runBenchmarkSuite(
+        {
+          repo: null,
+          task: 'explain-runtime',
+          mode: 'cold',
+          trials: 1,
+          outputDir: join(tempDir, 'results'),
+          execTemplate: 'mock-runner',
+          dryRun: false,
+          yes: true,
+        },
+        {
+          repos,
+          tasks,
+          generateGraph: (rootPath = '.', options = {}) => {
+            generateCalls += 1
+            return {
+              mode: options.useSpi ? 'generate' : 'generate',
+              rootPath,
+              outputDir: join(rootPath, 'out'),
+              graphPath: join(rootPath, 'out', 'graph.json'),
+              reportPath: join(rootPath, 'out', 'GRAPH_REPORT.md'),
+              htmlPath: null,
+              wikiPath: null,
+              obsidianPath: null,
+              svgPath: null,
+              graphmlPath: null,
+              cypherPath: null,
+              docsPath: null,
+              totalFiles: 1,
+              codeFiles: 1,
+              nonCodeFiles: 0,
+              extractableFiles: 1,
+              extractedFiles: 1,
+              totalWords: 10,
+              nodeCount: 1,
+              edgeCount: 0,
+              communityCount: 1,
+              changedFiles: 0,
+              deletedFiles: 0,
+              cache: null,
+              warning: null,
+              notes: [],
+            } satisfies GenerateGraphResult
+          },
+          executeNativeAgentCompare: async () => {
+            compareCalls += 1
+            throw new Error('install-skipped cells should not execute compare')
+          },
+        },
+      )
+
+      const summaryMarkdown = readFileSync(result.summaryPath!, 'utf8')
+
+      expect(generateCalls).toBe(0)
+      expect(compareCalls).toBe(0)
+      expect(result.summary?.cells[0]).toEqual(expect.objectContaining({
+        repoId: 'nestjs-mid',
+        status: 'skipped',
+        reason: expect.stringContaining('No Madar install detected'),
+      }))
+      expect(result.summary?.cells_skipped_for_install).toBe(1)
+      expect(summaryMarkdown).toContain('cells_skipped_for_install: 1')
+      expect(summaryMarkdown).toContain('skipped (no install)')
+      expect(summaryMarkdown).toContain('No Madar install detected in repo; skipped benchmark cell.')
     })
   })
 

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -34,6 +34,44 @@ function createFixtureRepo(rootPath: string): string {
   writeFileSync(join(rootPath, 'package.json'), JSON.stringify({ name: 'fixture-repo', private: true }, null, 2), 'utf8')
   mkdirSync(join(rootPath, 'src'), { recursive: true })
   writeFileSync(join(rootPath, 'src', 'auth-controller.ts'), 'export const controller = true\n', 'utf8')
+  mkdirSync(join(rootPath, 'out'), { recursive: true })
+  writeFileSync(join(rootPath, 'out', 'graph.json'), '{}\n', 'utf8')
+  writeFileSync(
+    join(rootPath, '.mcp.json'),
+    JSON.stringify(
+      {
+        mcpServers: {
+          madar: {
+            command: 'node',
+            args: ['dist/src/cli/bin.js', '--stdio', join(rootPath, 'out', 'graph.json')],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+  writeFileSync(join(rootPath, 'CLAUDE.md'), '## madar\n', 'utf8')
+  mkdirSync(join(rootPath, '.claude'), { recursive: true })
+  writeFileSync(
+    join(rootPath, '.claude', 'settings.json'),
+    JSON.stringify(
+      {
+        hooks: {
+          UserPromptSubmit: [
+            {
+              type: 'command',
+              command: 'echo out/graph.json',
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
   return rootPath
 }
 
@@ -151,6 +189,9 @@ function makeCompareResult(input: {
         other: {},
       },
     },
+    install_verified: true,
+    measurement_validity: 'valid',
+    madar_mcp_call_count: 1,
     reductions: {
       input_tokens: input.baselineInputTokens / input.madarInputTokens,
       uncached_input_tokens: input.baselineInputTokens / input.madarInputTokens,
@@ -454,6 +495,104 @@ describe('runBenchmarkSuite', () => {
               madarGlob: isSpi ? 0 : 1,
               baselineGrep: 1,
               madarGrep: isSpi ? 0 : 1,
+            })
+
+            it('skips runnable cells when the repo has no verified Madar install', async () => {
+              await withTempDir(async (tempDir) => {
+                const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+                rmSync(join(runnableRepoPath, '.mcp.json'), { force: true })
+                rmSync(join(runnableRepoPath, 'CLAUDE.md'), { force: true })
+                rmSync(join(runnableRepoPath, '.claude'), { recursive: true, force: true })
+
+                const repos: BenchmarkSuiteRepo[] = [
+                  {
+                    id: 'nestjs-mid',
+                    name: 'Fixture NestJS-like service',
+                    path: runnableRepoPath,
+                    description: 'Ready fixture',
+                    size: 'mid',
+                    language: 'typescript',
+                    shape: 'service',
+                    status: 'ready',
+                    supportsSpi: false,
+                  },
+                ]
+                const tasks: BenchmarkSuiteTask[] = [
+                  {
+                    id: 'explain-runtime',
+                    name: 'Explain runtime flow',
+                    description: 'Trace a runtime path end to end.',
+                    status: 'ready',
+                    prompts: {
+                      'nestjs-mid': 'How does login session creation flow work?',
+                    },
+                  },
+                ]
+                let generateCalls = 0
+                let compareCalls = 0
+
+                const result = await runBenchmarkSuite(
+                  {
+                    repo: null,
+                    task: 'explain-runtime',
+                    mode: 'cold',
+                    trials: 1,
+                    outputDir: join(tempDir, 'results'),
+                    execTemplate: 'mock-runner',
+                    dryRun: false,
+                    yes: true,
+                  },
+                  {
+                    repos,
+                    tasks,
+                    generateGraph: (rootPath = '.', options = {}) => {
+                      generateCalls += 1
+                      return {
+                        mode: options.useSpi ? 'generate' : 'generate',
+                        rootPath,
+                        outputDir: join(rootPath, 'out'),
+                        graphPath: join(rootPath, 'out', 'graph.json'),
+                        reportPath: join(rootPath, 'out', 'GRAPH_REPORT.md'),
+                        htmlPath: null,
+                        wikiPath: null,
+                        obsidianPath: null,
+                        svgPath: null,
+                        graphmlPath: null,
+                        cypherPath: null,
+                        docsPath: null,
+                        totalFiles: 1,
+                        codeFiles: 1,
+                        nonCodeFiles: 0,
+                        extractableFiles: 1,
+                        extractedFiles: 1,
+                        totalWords: 10,
+                        nodeCount: 1,
+                        edgeCount: 0,
+                        communityCount: 1,
+                        changedFiles: 0,
+                        deletedFiles: 0,
+                        cache: null,
+                        warning: null,
+                        notes: [],
+                      } satisfies GenerateGraphResult
+                    },
+                    executeNativeAgentCompare: async () => {
+                      compareCalls += 1
+                      throw new Error('install-skipped cells should not execute compare')
+                    },
+                  },
+                )
+
+                expect(generateCalls).toBe(0)
+                expect(compareCalls).toBe(0)
+                expect(result.summary?.cells[0]).toEqual(expect.objectContaining({
+                  repoId: 'nestjs-mid',
+                  status: 'skipped',
+                  reason: expect.stringContaining('No Madar install detected'),
+                }))
+                expect(result.summary?.cells_skipped_for_install).toBe(1)
+                expect(readFileSync(result.summaryPath!, 'utf8')).toContain('cells_skipped_for_install: 1')
+              })
             })
           },
         },

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -661,8 +661,8 @@ describe('cli parser', () => {
     expect(() => parseCompareArgs(['how does login work', '--exec', 'claude -p "$(cat {prompt_file})"', '--output-dir', '../outside'])).toThrow(
       'Only paths inside out/ are permitted',
     )
-    expect(() => parseCompareArgs(['   ', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Usage: madar compare')
-    expect(() => parseCompareArgs(['--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('Usage: madar compare')
+    expect(() => parseCompareArgs(['   ', '--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('--allow-no-install')
+    expect(() => parseCompareArgs(['--exec', 'claude -p "$(cat {prompt_file})"'])).toThrow('--allow-no-install')
   })
 
   it('parses review-compare args with optional overrides', () => {
@@ -1023,6 +1023,7 @@ describe('cli main', () => {
     expect(help).toContain('--obsidian')
     expect(help).toContain('--svg')
     expect(help).toContain('--graphml')
+    expect(help).toContain('--allow-no-install')
     expect(help).toContain('--neo4j')
     expect(help).toContain('--neo4j-push')
     expect(help).toContain('--transport')
@@ -1416,7 +1417,7 @@ describe('cli main', () => {
 
     expect(exitCode).toBe(2)
     expect(logs).toEqual([])
-    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--yes] [--limit N]'])
+    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--allow-no-install] [--yes] [--limit N]'])
   })
 
   it('prefers the explicit compare command over an implicit generate path match', async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -549,6 +549,7 @@ describe('cli parser', () => {
       questionsPath: null,
       outputDir: resolve('out/compare'),
       baselineMode: 'full',
+      allowNoInstall: false,
       yes: false,
       limit: null,
     })
@@ -560,6 +561,7 @@ describe('cli parser', () => {
       questionsPath: 'benchmark-questions.json',
       outputDir: resolve('out/compare'),
       baselineMode: 'full',
+      allowNoInstall: false,
       yes: false,
       limit: null,
     })
@@ -577,6 +579,7 @@ describe('cli parser', () => {
         'out/compare/custom',
         '--baseline-mode',
         'bounded',
+        '--allow-no-install',
         '--yes',
         '--limit',
         '5',
@@ -588,6 +591,7 @@ describe('cli parser', () => {
       questionsPath: null,
       outputDir: resolve('out/compare/custom'),
       baselineMode: 'bounded',
+      allowNoInstall: true,
       yes: true,
       limit: 5,
     })
@@ -609,6 +613,7 @@ describe('cli parser', () => {
       questionsPath: null,
       outputDir: resolve('out/compare'),
       baselineMode: 'pack_only',
+      allowNoInstall: false,
       yes: false,
       limit: null,
     })
@@ -629,6 +634,7 @@ describe('cli parser', () => {
     questionsPath: null,
     outputDir: resolve('out/compare'),
     baselineMode: 'full',
+    allowNoInstall: false,
     yes: false,
     limit: null,
     why: true,
@@ -1128,6 +1134,7 @@ describe('cli main', () => {
       questionsPath: 'benchmark-questions.json',
       outputDir: resolve('out/compare/custom'),
       baselineMode: 'bounded',
+      allowNoInstall: false,
       yes: true,
       limit: 5,
       why: true,

--- a/tests/unit/compare-install-regression-fixture.test.ts
+++ b/tests/unit/compare-install-regression-fixture.test.ts
@@ -20,12 +20,16 @@ describe('compare install regression fixture', () => {
 
     expect(noInstallReport.install_verified).toBe(false)
     expect(noInstallReport.measurement_validity).toBe('invalid')
+    expect(noInstallReport.madar_mcp_call_count).toBe(0)
     expect(withInstallReport.install_verified).toBe(true)
     expect(withInstallReport.measurement_validity).toBe('valid')
+    expect(withInstallReport.madar_mcp_call_count).toBe(2)
 
     expect(noInstallShareSafeReport.install_verified).toBe(false)
     expect(noInstallShareSafeReport.measurement_validity).toBe('invalid')
+    expect(noInstallShareSafeReport.madar_mcp_call_count).toBe(0)
     expect(withInstallShareSafeReport.install_verified).toBe(true)
     expect(withInstallShareSafeReport.measurement_validity).toBe('valid')
+    expect(withInstallShareSafeReport.madar_mcp_call_count).toBe(2)
   })
 })

--- a/tests/unit/compare-install-regression-fixture.test.ts
+++ b/tests/unit/compare-install-regression-fixture.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+function readFixtureReport(
+  arm: 'no-install' | 'with-install',
+  fileName: 'report.json' | 'report.share-safe.json',
+): Record<string, unknown> {
+  const reportPath = resolve('docs/benchmarks/regression/install-ab-govalidate-explain', arm, fileName)
+  return JSON.parse(readFileSync(reportPath, 'utf8')) as Record<string, unknown>
+}
+
+describe('compare install regression fixture', () => {
+  it('stores invalid vs valid measurement validity across the no-install and with-install arms', () => {
+    const noInstallReport = readFixtureReport('no-install', 'report.json')
+    const withInstallReport = readFixtureReport('with-install', 'report.json')
+    const noInstallShareSafeReport = readFixtureReport('no-install', 'report.share-safe.json')
+    const withInstallShareSafeReport = readFixtureReport('with-install', 'report.share-safe.json')
+
+    expect(noInstallReport.install_verified).toBe(false)
+    expect(noInstallReport.measurement_validity).toBe('invalid')
+    expect(withInstallReport.install_verified).toBe(true)
+    expect(withInstallReport.measurement_validity).toBe('valid')
+
+    expect(noInstallShareSafeReport.install_verified).toBe(false)
+    expect(noInstallShareSafeReport.measurement_validity).toBe('invalid')
+    expect(withInstallShareSafeReport.install_verified).toBe(true)
+    expect(withInstallShareSafeReport.measurement_validity).toBe('valid')
+  })
+})

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -16,7 +16,46 @@ import {
 const FIXTURE_PARENT = resolve('out', 'test-runtime', 'native-agent')
 const COMPARE_OUTPUT_PARENT = resolve('out', 'compare', 'test-runtime-native-agent')
 
-function makeFixtureProject(): { projectDir: string; graphPath: string; outputDir: string } {
+function writeClaudeInstallArtifacts(projectDir: string, graphPath: string): void {
+  writeFileSync(
+    join(projectDir, '.mcp.json'),
+    JSON.stringify(
+      {
+        mcpServers: {
+          madar: {
+            command: 'node',
+            args: ['dist/src/cli/bin.js', '--stdio', graphPath],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+  writeFileSync(join(projectDir, 'CLAUDE.md'), '## madar\n', 'utf8')
+  mkdirSync(join(projectDir, '.claude'), { recursive: true })
+  writeFileSync(
+    join(projectDir, '.claude', 'settings.json'),
+    JSON.stringify(
+      {
+        hooks: {
+          UserPromptSubmit: [
+            {
+              type: 'command',
+              command: 'echo out/graph.json',
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+}
+
+function makeFixtureProject(options: { installState?: 'valid' | 'missing' } = {}): { projectDir: string; graphPath: string; outputDir: string } {
   mkdirSync(FIXTURE_PARENT, { recursive: true })
   mkdirSync(COMPARE_OUTPUT_PARENT, { recursive: true })
   const projectDir = mkdtempSync(join(FIXTURE_PARENT, 'project-'))
@@ -35,12 +74,11 @@ function makeFixtureProject(): { projectDir: string; graphPath: string; outputDi
     }),
     'utf8',
   )
-  // Plant the other snapshot targets so we can verify they round-trip.
-  writeFileSync(join(projectDir, '.mcp.json'), JSON.stringify({ mcpServers: { 'madar': {} } }, null, 2), 'utf8')
-  writeFileSync(join(projectDir, 'CLAUDE.md'), '# Project Claude rules\n', 'utf8')
-  mkdirSync(join(projectDir, '.claude'), { recursive: true })
-  writeFileSync(join(projectDir, '.claude', 'settings.json'), '{}\n', 'utf8')
-  return { projectDir, graphPath: join(projectDir, 'out', 'graph.json'), outputDir }
+  const graphPath = join(projectDir, 'out', 'graph.json')
+  if (options.installState !== 'missing') {
+    writeClaudeInstallArtifacts(projectDir, graphPath)
+  }
+  return { projectDir, graphPath, outputDir }
 }
 
 const BASELINE_USAGE_PAYLOAD = {
@@ -156,6 +194,35 @@ const VERBOSE_MADAR_PAYLOAD = [
   MADAR_USAGE_PAYLOAD,
 ] as const
 
+const VERBOSE_MADAR_NO_INSTALL_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'Read' },
+        { type: 'tool_use', name: 'Grep' },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
 function scriptedRunner(payloads: { baseline: unknown; madar: unknown }): NativeAgentRunner {
   return async (input) => ({
     exitCode: 0,
@@ -176,7 +243,13 @@ function buildSummaryResult(overrides: {
   reductions: NonNullable<NativeAgentCompareReport['reductions']>
   madarTrace?: NativeAgentCompareReport['madar_trace']
   toolCallCounts?: NativeAgentCompareReport['tool_call_counts']
+  installVerified?: boolean
+  measurementValidity?: 'valid' | 'degraded' | 'invalid'
+  madarMcpCallCount?: number
 }): NativeAgentCompareResult {
+  const installVerified = overrides.installVerified ?? true
+  const madarMcpCallCount = overrides.madarMcpCallCount ?? overrides.madarTrace?.madar_mcp_call_count ?? 0
+  const measurementValidity = overrides.measurementValidity ?? (installVerified ? (madarMcpCallCount > 0 ? 'valid' : 'degraded') : 'invalid')
   return {
     graph_path: '/tmp/project/out/graph.json',
     output_root: '/tmp/project/out/compare/2026-05-12T00-00-00Z',
@@ -242,6 +315,9 @@ function buildSummaryResult(overrides: {
           },
           reduction_basis: 'provider_reported',
         },
+        install_verified: installVerified,
+        measurement_validity: measurementValidity,
+        madar_mcp_call_count: madarMcpCallCount,
         ...(overrides.toolCallCounts ? { tool_call_counts: overrides.toolCallCounts } : {}),
         ...(overrides.madarTrace ? { madar_trace: overrides.madarTrace } : {}),
         started_at: '2026-05-12T00:00:00.000Z',
@@ -304,6 +380,115 @@ describe('parseAnthropicResultEvent', () => {
 })
 
 describe('executeNativeAgentCompare', () => {
+  it('aborts when no Madar install is detected and --allow-no-install is not set', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject({ installState: 'missing' })
+    try {
+      await expect(
+        executeNativeAgentCompare(
+          {
+            graphPath,
+            question: 'What is the cluster module?',
+            outputDir,
+            execTemplate: 'mock-runner',
+            baselineMode: 'native_agent',
+          },
+          {
+            runner: scriptedRunner({ baseline: BASELINE_USAGE_PAYLOAD, madar: MADAR_USAGE_PAYLOAD }),
+            now: () => new Date('2026-05-01T00:00:00Z'),
+          },
+        ),
+      ).rejects.toThrow(/No Madar install detected/)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks runs invalid when install is missing but --allow-no-install is set', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject({ installState: 'missing' })
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+          allowNoInstall: true,
+        },
+        {
+          runner: scriptedRunner({ baseline: BASELINE_USAGE_PAYLOAD, madar: MADAR_USAGE_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+
+      expect(report.install_verified).toBe(false)
+      expect(report.measurement_validity).toBe('invalid')
+      expect(report.madar_mcp_call_count).toBe(0)
+      expect(savedReport.install_verified).toBe(false)
+      expect(savedReport.measurement_validity).toBe('invalid')
+      expect(shareSafeReport.install_verified).toBe(false)
+      expect(shareSafeReport.measurement_validity).toBe('invalid')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks runs degraded when install is verified but the agent never invokes Madar', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({ baseline: VERBOSE_BASELINE_PAYLOAD, madar: VERBOSE_MADAR_NO_INSTALL_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.install_verified).toBe(true)
+      expect(report.measurement_validity).toBe('degraded')
+      expect(report.madar_mcp_call_count).toBe(0)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks runs valid when install is verified and Madar MCP is invoked', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({ baseline: VERBOSE_BASELINE_PAYLOAD, madar: VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.install_verified).toBe(true)
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.madar_mcp_call_count).toBe(1)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('produces a report with both Anthropic-reported usage blocks and computed reductions', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     try {
@@ -491,6 +676,7 @@ describe('executeNativeAgentCompare', () => {
           outputDir,
           execTemplate: 'mock-runner',
           baselineMode: 'native_agent',
+          allowNoInstall: true,
         },
         {
           runner: scriptedRunner({ baseline: BASELINE_USAGE_PAYLOAD, madar: MADAR_USAGE_PAYLOAD }),
@@ -908,7 +1094,8 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).toContain('Suite input_tokens (Anthropic-reported): 2 wins · 0 losses · 2/3 comparable · mean reduction 70.8% · median reduction 70.8% · best win: "win b" (75% less) · worst regression: none')
     expect(summary).toContain('Suite num_turns: 2 wins · 0 losses · 2/3 comparable · best win: "win b" (75% fewer) · worst regression: none')
     expect(summary).toContain('Suite latency: 2 wins · 0 losses · 2/3 comparable · best win: "win b" (75% faster) · worst regression: none')
-    expect(summary).toContain('"answer only" → answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed')
+    expect(summary).toContain('- "answer only"')
+    expect(summary).toContain('answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed')
   })
 
   it('surfaces whether Madar reduced exploration or only added context when trace data is present', () => {
@@ -946,6 +1133,7 @@ describe('formatNativeAgentCompareSummary', () => {
             tools: ['impact'],
           },
         ],
+        madar_mcp_call_count: 2,
         context_pack_call_count: 1,
         focused_follow_up_tool_call_count: 1,
         broad_exploration_tool_call_count: 0,
@@ -957,6 +1145,103 @@ describe('formatNativeAgentCompareSummary', () => {
 
     expect(summary).toContain('madar_trace: reduced_exploration')
     expect(summary).toContain('1 context_pack call; 1 focused follow-up call; no broad exploration recorded')
+    expect(summary).toContain('measurement_validity: valid')
+    expect(summary).toContain('install_verified: true')
+    expect(summary).toContain('madar_mcp_call_count: 2')
+  })
+
+  it('prints invalid measurement warnings when install is missing', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'invalid case',
+      baselineTurns: 6,
+      madarTurns: 6,
+      baselineDurationMs: 6000,
+      madarDurationMs: 6000,
+      baselineInputTokens: 600,
+      madarInputTokens: 600,
+      reductions: {
+        num_turns: 1,
+        duration_ms: 1,
+        input_tokens: 1,
+        cost_usd: 1,
+      },
+      installVerified: false,
+      measurementValidity: 'invalid',
+      madarMcpCallCount: 0,
+    }))
+
+    expect(summary).toContain('measurement_validity: INVALID')
+    expect(summary).toContain('install_verified: false')
+    expect(summary).toContain('madar_mcp_call_count: 0')
+  })
+
+  it('prints install validity lines for answer-only runs', () => {
+    const result = buildSummaryResult({
+      question: 'answer-only case',
+      baselineTurns: 6,
+      madarTurns: 6,
+      baselineDurationMs: 6000,
+      madarDurationMs: 6000,
+      baselineInputTokens: 600,
+      madarInputTokens: 600,
+      reductions: {
+        num_turns: 1,
+        duration_ms: 1,
+        input_tokens: 1,
+        cost_usd: 1,
+      },
+      installVerified: false,
+      measurementValidity: 'invalid',
+      madarMcpCallCount: 0,
+    })
+    result.reports[0]!.madar = {
+      kind: 'answer_only',
+      evidence: 'madar answer',
+      exit_code: 0,
+      stderr: null,
+      result_path: '/tmp/project/madar.txt',
+    }
+
+    const summary = formatNativeAgentCompareSummary(result)
+
+    expect(summary).toContain('measurement_validity: INVALID')
+    expect(summary).toContain('install_verified: false')
+    expect(summary).toContain('madar_mcp_call_count: 0')
+    expect(summary).toContain('answer-only run saved')
+  })
+
+  it('prints install validity lines for runner-error runs', () => {
+    const result = buildSummaryResult({
+      question: 'runner-error case',
+      baselineTurns: 6,
+      madarTurns: 6,
+      baselineDurationMs: 6000,
+      madarDurationMs: 6000,
+      baselineInputTokens: 600,
+      madarInputTokens: 600,
+      reductions: {
+        num_turns: 1,
+        duration_ms: 1,
+        input_tokens: 1,
+        cost_usd: 1,
+      },
+      installVerified: true,
+      measurementValidity: 'degraded',
+      madarMcpCallCount: 0,
+    })
+    result.reports[0]!.madar = {
+      kind: 'runner_error',
+      evidence: 'runner failed',
+      exit_code: 1,
+      stderr: 'boom',
+    }
+
+    const summary = formatNativeAgentCompareSummary(result)
+
+    expect(summary).toContain('measurement_validity: degraded')
+    expect(summary).toContain('install_verified: true')
+    expect(summary).toContain('madar_mcp_call_count: 0')
+    expect(summary).toContain('runner error')
   })
 
   it('prints the tool-call delta when per-side tool counts are available', () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -235,6 +235,43 @@ function writeProjectFiles(projectRoot: string = PROJECT_FIXTURE_ROOT): void {
     mkdirSync(dirname(absolutePath), { recursive: true })
     writeFileSync(absolutePath, `${content}\n`, 'utf8')
   }
+
+  writeFileSync(
+    join(projectRoot, '.mcp.json'),
+    JSON.stringify(
+      {
+        mcpServers: {
+          madar: {
+            command: 'node',
+            args: ['dist/src/cli/bin.js', '--stdio', join(projectRoot, 'out', 'graph.json')],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+  writeFileSync(join(projectRoot, 'CLAUDE.md'), '## madar\n', 'utf8')
+  mkdirSync(join(projectRoot, '.claude'), { recursive: true })
+  writeFileSync(
+    join(projectRoot, '.claude', 'settings.json'),
+    JSON.stringify(
+      {
+        hooks: {
+          UserPromptSubmit: [
+            {
+              type: 'command',
+              command: 'echo out/graph.json',
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
 }
 
 function writeGraphFixture(graph: KnowledgeGraph, graphFixtureRoot: string = GRAPH_FIXTURE_ROOT): string {


### PR DESCRIPTION
Closes #341

## Summary
- add native-agent compare install detection, --allow-no-install, and persisted validity/install reporting
- skip bench:suite cells when the target repo is missing a verified Madar install and count them in suite summaries
- add unit coverage plus a stored regression fixture for no-install vs with-install validity states

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI flag: --allow-no-install to permit compares when native install isn't present.
  * Reports now include install verification, measurement validity (valid/degraded/invalid), and Madar MCP call counts.

* **Improvements**
  * Benchmark suite skips cells when installs are missing and reports skipped counts.
  * Summaries and console output include install/validity details.

* **Tests**
  * Added unit tests and fixtures covering install detection and report variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->