### PR TITLE
Route explain prompts to context_pack

### DIFF
--- a/src/infrastructure/install-routing-guidance.ts
+++ b/src/infrastructure/install-routing-guidance.ts
@@ -1,0 +1,134 @@
+interface RoutingRow {
+  promptType: string
+  markdownTarget: string
+  plainPromptType?: string
+  plainTarget: string
+}
+
+const MCP_ROUTING_ROWS: RoutingRow[] = [
+  {
+    promptType: '"how does X work" / explain runtime / flow',
+    markdownTarget: '`context_pack`',
+    plainPromptType: '"how does X work?" / explain runtime / flow',
+    plainTarget: 'context_pack',
+  },
+  {
+    promptType: '"what breaks if I change X" / impact analysis',
+    markdownTarget: '`impact`',
+    plainPromptType: '"what breaks if I change X?" / impact analysis',
+    plainTarget: 'impact',
+  },
+  {
+    promptType: '"which files should I open first"',
+    markdownTarget: '`relevant_files`',
+    plainPromptType: '"which files should I open first?"',
+    plainTarget: 'relevant_files',
+  },
+  {
+    promptType: '"give me a repo overview"',
+    markdownTarget: '`graph_summary`',
+    plainPromptType: '"give me a repo overview?"',
+    plainTarget: 'graph_summary',
+  },
+  {
+    promptType: '"what parts are involved in feature X"',
+    markdownTarget: '`feature_map`',
+    plainTarget: 'feature_map',
+  },
+  {
+    promptType: '"what\'s risky to edit in X"',
+    markdownTarget: '`risk_map`',
+    plainTarget: 'risk_map',
+  },
+  {
+    promptType: '"give me a build/edit checklist"',
+    markdownTarget: '`implementation_checklist`',
+    plainTarget: 'implementation_checklist',
+  },
+  {
+    promptType: 'general retrieval / list of nodes',
+    markdownTarget: '`retrieve`',
+    plainTarget: 'retrieve',
+  },
+]
+
+const CODEX_ROUTING_ROWS: RoutingRow[] = [
+  {
+    promptType: '"how does X work" / explain runtime / flow',
+    markdownTarget: '`madar pack "<task or question>" --task explain`',
+    plainPromptType: '"how does X work?" / explain runtime / flow',
+    plainTarget: 'madar pack "<task or question>" --task explain',
+  },
+  {
+    promptType: '"what breaks if I change X" / impact analysis',
+    markdownTarget: '`madar pack "<task or question>" --task impact`',
+    plainPromptType: '"what breaks if I change X?" / impact analysis',
+    plainTarget: 'madar pack "<task or question>" --task impact',
+  },
+  {
+    promptType: '"which files should I open first"',
+    markdownTarget: '`relevant_files` when MCP graph tools are available; otherwise `madar pack "<task or question>" --task explain`',
+    plainPromptType: '"which files should I open first?"',
+    plainTarget: 'relevant_files when MCP graph tools are available',
+  },
+  {
+    promptType: '"give me a repo overview"',
+    markdownTarget: '`graph_summary` when MCP graph tools are available; otherwise `madar pack "<task or question>" --task explain`',
+    plainPromptType: '"give me a repo overview?"',
+    plainTarget: 'graph_summary when MCP graph tools are available',
+  },
+]
+
+function renderMarkdownTable(lead: string, rows: RoutingRow[], toolSearchSentence: string): string {
+  const lines = [
+    lead,
+    '',
+    '| Prompt type | First tool |',
+    '| --- | --- |',
+    ...rows.map((row) => `| ${row.promptType} | ${row.markdownTarget} |`),
+    '',
+    toolSearchSentence,
+  ]
+  return lines.join('\n')
+}
+
+function renderPlainGuide(
+  lead: string,
+  rows: RoutingRow[],
+  toolSearchSentence: string,
+): string {
+  const rules = rows.map((row) => `${row.plainTarget} for ${row.plainPromptType ?? row.promptType}`).join('; ')
+  return `${lead}: ${rules}. ${toolSearchSentence}`
+}
+
+export function renderMarkdownMcpRoutingTable(): string {
+  return renderMarkdownTable(
+    'For each codebase question, use the specific Madar MCP tool below first:',
+    MCP_ROUTING_ROWS,
+    'Do not run ToolSearch before calling a Madar tool — the tool names above are stable. Pick the one that matches and call it directly.',
+  )
+}
+
+export function renderPlainMcpRoutingGuide(): string {
+  return renderPlainGuide(
+    'For each codebase question, call the matching Madar MCP tool directly first',
+    MCP_ROUTING_ROWS,
+    'Do not run ToolSearch before calling a Madar tool — the tool names above are stable. Pick the one that matches and call it directly.',
+  )
+}
+
+export function renderMarkdownCodexRoutingTable(): string {
+  return renderMarkdownTable(
+    'For each codebase question, start with the specific Madar command below first:',
+    CODEX_ROUTING_ROWS,
+    'Do not run ToolSearch before calling a Madar command or graph tool — pick the matching command first, then refine with MCP graph tools only when they are available and still needed.',
+  )
+}
+
+export function renderPlainCodexRoutingGuide(): string {
+  return renderPlainGuide(
+    'For each codebase question, start with the specific Madar command below first',
+    CODEX_ROUTING_ROWS,
+    'Do not run ToolSearch before calling a Madar command or graph tool — pick the matching command first, then refine with MCP graph tools only when they are available and still needed.',
+  )
+}

--- a/src/infrastructure/install-skill-templates.ts
+++ b/src/infrastructure/install-skill-templates.ts
@@ -1,4 +1,8 @@
 import type { SkillInstallPlatform } from './install.js'
+import {
+  renderMarkdownCodexRoutingTable,
+  renderMarkdownMcpRoutingTable,
+} from './install-routing-guidance.js'
 
 /**
  * Built-in skill template generation for madar.
@@ -305,6 +309,19 @@ madar pack "<task or question>" --task explain
 # Use --task review, --task debug, or --task impact when that better matches the work.
 ${CODE_BLOCK_END}
 
+For each codebase question, start with the specific Madar command below first:
+
+${renderMarkdownCodexRoutingTable()}
+
+If MCP graph tools are available after the pack, use the focused tool that matches the next question:
+- ${CODE_SPAN_START}retrieve${CODE_SPAN_END} for direct codebase questions
+- ${CODE_SPAN_START}relevant_files${CODE_SPAN_END} for where to open first
+- ${CODE_SPAN_START}feature_map${CODE_SPAN_END} for involved areas and entry points
+- ${CODE_SPAN_START}risk_map${CODE_SPAN_END} before editing
+- ${CODE_SPAN_START}implementation_checklist${CODE_SPAN_END} for edit order and validation checkpoints
+- ${CODE_SPAN_START}impact${CODE_SPAN_END} for blast radius
+- ${CODE_SPAN_START}graph_summary${CODE_SPAN_END} for repo overview
+
 If the first pack is a high- or medium-confidence pack (diagnostics.quality_score >= 0.5, missing_context is empty, and diagnostics contain no error-severity gaps), answer from it before broader exploration.
 Do not run broad \`Glob\` patterns, repo-wide \`grep\` / \`find\` searches, or raw file sweeps after a high- or medium-confidence pack.
 Only expand when missing_context or missing_semantic is non-empty, diagnostics show warn/error gaps, or the user asks for deeper verification.
@@ -327,6 +344,19 @@ Codex limitations:
 - Automated tests do not require the Codex binary; they verify generated text and hook config.
 - The Codex hook can remind before Bash when ${CODE_SPAN_START}out/graph.json${CODE_SPAN_END} exists, but AGENTS.md remains the durable always-on instruction.
 - Context packs narrow first-pass discovery. They do not replace targeted reads, tests, or review for code changes.
+`
+}
+
+function mcpRoutingProfileSection(kind: PlatformKind): string {
+  if (kind !== 'default') {
+    return ''
+  }
+
+  return `## Installed MCP routing
+
+When the project also installs madar MCP integration (for example via Claude Code or GitHub Copilot workspace config), use the specific Madar MCP tool below first for codebase questions:
+
+${renderMarkdownMcpRoutingTable()}
 `
 }
 
@@ -438,6 +468,7 @@ function buildSkillDocument(kind: PlatformKind): string {
     FRONTMATTER[kind],
     commonOverview(),
     codexProfileSection(kind),
+    mcpRoutingProfileSection(kind),
     kind === 'windows' ? windowsInstallStep() : posixInstallStep(),
     detectStep(kind === 'windows' ? 'powershell' : 'bash'),
     extractionRules(),

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -2,6 +2,12 @@ import { existsSync, mkdirSync, readFileSync, rmdirSync, rmSync, statSync, unlin
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { getBuiltInSkillContent } from './install-skill-templates.js'
+import {
+  renderMarkdownCodexRoutingTable,
+  renderMarkdownMcpRoutingTable,
+  renderPlainCodexRoutingGuide,
+  renderPlainMcpRoutingGuide,
+} from './install-routing-guidance.js'
 import { buildPromptApplicabilityHookCommand } from '../runtime/task-applicability.js'
 import {
   findPackageRoot as resolvePackageRoot,
@@ -226,9 +232,6 @@ function isMadarCodexHook(hook: unknown): boolean {
   )
 }
 
-const MCP_ROUTING_GUIDANCE =
-  'Use the graph tool that matches the question: retrieve for direct codebase questions, relevant_files for where to open first, feature_map for the main areas and entry points, risk_map before editing, implementation_checklist for edit order and validation, and impact for blast radius.'
-
 function strictContextPackStopRule(markdown: boolean): string {
   if (markdown) {
     return 'Answer after one high- or medium-confidence pack when `diagnostics.quality_score >= 0.5`, `missing_context` is empty, and diagnostics show no error-severity gaps.'
@@ -262,13 +265,13 @@ function strictContextPackNoBroadExplorationRule(markdown: boolean): string {
 }
 
 const RETRIEVE_FIRST_MESSAGE =
-  `STOP. This project has a madar knowledge graph. ${MCP_ROUTING_GUIDANCE} Use the graph result as the first bounded pass for codebase questions, then validate with focused reads or tests when the graph is insufficient. Do not use Glob, Grep, Bash, Read, or Agent tools first. Only fall back to raw file tools if the graph tools cannot answer the question or the MCP server is unavailable.`
+  `STOP. This project has a madar knowledge graph. ${renderPlainMcpRoutingGuide()} Use the graph result as the first bounded pass for codebase questions, then validate with focused reads or tests when the graph is insufficient. Do not use Glob, Grep, Bash, Read, or Agent tools first. Only fall back to raw file tools if the graph tools cannot answer the question or the MCP server is unavailable.`
 
 const STRICT_CONTEXT_PACK_MESSAGE =
   `STOP. This project has a madar knowledge graph. Use strict compact MCP mode: call context_pack once for the task before broader exploration, ${strictContextPackStopRule(false)}, ${strictContextPackNoBroadExplorationRule(false)}, ${strictContextPackExpandRule(false)}, and ${strictGraphReportFallbackRule(false)}.`
 
 const CODEX_CONTEXT_PACK_FIRST_MESSAGE =
-  `STOP. This project has a madar knowledge graph. Follow the Codex context-pack-first workflow: run madar pack "<task or question>" --task explain before broad Bash search, raw file reads, or spawning workers. Use --task review, --task debug, or --task impact when that better matches the work. ${strictContextPackNoBroadExplorationRule(false)}. If MCP graph tools are available, use retrieve, relevant_files, feature_map, risk_map, implementation_checklist, or impact to refine the pack. ${strictGraphReportFallbackRule(false)}.`
+  `STOP. This project has a madar knowledge graph. Follow the Codex context-pack-first workflow: run madar pack "<task or question>" --task explain before broad Bash search, raw file reads, or spawning workers. Use --task review, --task debug, or --task impact when that better matches the work. ${renderPlainCodexRoutingGuide()} ${strictContextPackNoBroadExplorationRule(false)}. If MCP graph tools are available, use retrieve, relevant_files, feature_map, risk_map, implementation_checklist, impact, or graph_summary to refine the pack. ${strictGraphReportFallbackRule(false)}.`
 
 const SETTINGS_HOOK = {
   // SECURITY: Keep this command static. Do not interpolate user-controlled input here.
@@ -340,13 +343,9 @@ const CLAUDE_MD_SECTION = `${SECTION_MARKER}
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these rules:
 
 1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
-2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
-   - \`retrieve\` for "how does X work?" and other direct codebase questions
-   - \`relevant_files\` for "which files should I open first?"
-   - \`feature_map\` for "what parts of the codebase are involved?"
-   - \`risk_map\` before editing to see likely hotspots
-   - \`implementation_checklist\` for edit order and validation checkpoints
-   - \`impact\` for "what breaks if I change X?"
+2. **BEFORE answering a codebase question that needs local code context**, use the specific Madar MCP tool below first.
+
+${renderMarkdownMcpRoutingTable()}
 3. **Do NOT use Glob, Grep, Bash, Read, or dispatch Agent/Explore subagents first** for codebase questions.
 4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. ${strictGraphReportFallbackRule(true)}
 5. **Do NOT dispatch Explore or research agents** for codebase questions — the knowledge graph already has the structural context they would spend tokens discovering.
@@ -369,13 +368,9 @@ const AGENTS_MD_SECTION = `${SECTION_MARKER}
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these rules:
 
 1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
-2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
-   - \`retrieve\` for "how does X work?" and other direct codebase questions
-   - \`relevant_files\` for "which files should I open first?"
-   - \`feature_map\` for "what parts of the codebase are involved?"
-   - \`risk_map\` before editing to see likely hotspots
-   - \`implementation_checklist\` for edit order and validation checkpoints
-   - \`impact\` for "what breaks if I change X?"
+2. **BEFORE answering a codebase question that needs local code context**, use the specific Madar MCP tool below first.
+
+${renderMarkdownMcpRoutingTable()}
 3. **Do NOT search the codebase with other tools first** for codebase questions.
 4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. ${strictGraphReportFallbackRule(true)}
 `
@@ -418,17 +413,21 @@ IMPORTANT: This project has a madar knowledge graph. Use a strict context-pack-f
 2. **Before broad code search, file reads, or worker dispatch**, compile a task-specific context pack:
    - \`madar pack "<task or question>" --task explain\`
    - use \`--task review\`, \`--task debug\`, or \`--task impact\` when that better matches the work
-3. **${strictContextPackNoBroadExplorationRule(true)}**
-4. If MCP graph tools are available, use the focused tool that matches the question after the pack:
+3. **For each codebase question, start with the specific Madar command below first.**
+
+${renderMarkdownCodexRoutingTable()}
+4. If MCP graph tools are available after the pack, use the focused tool that matches the next question:
    - \`retrieve\` for direct codebase questions
    - \`relevant_files\` for where to open first
    - \`feature_map\` for involved areas and entry points
    - \`risk_map\` before editing
    - \`implementation_checklist\` for edit order and validation checkpoints
    - \`impact\` for blast radius
-5. **${strictGraphReportFallbackRule(true)}**
-6. **Do not dispatch \`spawn_agent\` workers first** for codebase discovery. Let the context pack define likely entry files, risks, and missing context before parallel work.
-7. **Uninstall behavior:** run \`madar codex uninstall\` to remove this AGENTS.md section and the madar Codex hook from \`.codex/hooks.json\` while preserving unrelated content.
+   - \`graph_summary\` for repo overview
+5. **${strictContextPackNoBroadExplorationRule(true)}**
+6. **${strictGraphReportFallbackRule(true)}**
+7. **Do not dispatch \`spawn_agent\` workers first** for codebase discovery. Let the context pack define likely entry files, risks, and missing context before parallel work.
+8. **Uninstall behavior:** run \`madar codex uninstall\` to remove this AGENTS.md section and the madar Codex hook from \`.codex/hooks.json\` while preserving unrelated content.
 
 Manual verification:
 
@@ -478,13 +477,9 @@ const GEMINI_MD_SECTION = `${SECTION_MARKER}
 IMPORTANT: This project has a madar knowledge graph. You MUST follow these rules:
 
 1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
-2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
-   - \`retrieve\` for "how does X work?" and other direct codebase questions
-   - \`relevant_files\` for "which files should I open first?"
-   - \`feature_map\` for "what parts of the codebase are involved?"
-   - \`risk_map\` before editing to see likely hotspots
-   - \`implementation_checklist\` for edit order and validation checkpoints
-   - \`impact\` for "what breaks if I change X?"
+2. **BEFORE answering a codebase question that needs local code context**, use the specific Madar MCP tool below first.
+
+${renderMarkdownMcpRoutingTable()}
 3. **Do NOT search the codebase with other tools first** for codebase questions.
 4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. ${strictGraphReportFallbackRule(true)}
 `
@@ -510,6 +505,8 @@ const OPENCODE_JSON_CONFIG_PATH = 'opencode.json'
 const OPENCODE_JSONC_CONFIG_PATH = 'opencode.jsonc'
 const OPENCODE_MCP_SERVER_NAME = 'madar'
 const CURSOR_RULE_RELATIVE_PATH = '.cursor/rules/madar.mdc'
+const OPENCODE_PLUGIN_REMINDER_COMMAND =
+  `echo "[madar] Knowledge graph available. ${renderPlainMcpRoutingGuide()} ${strictGraphReportFallbackRule(false)}" && `
 const OPENCODE_PLUGIN_JS = `// madar OpenCode plugin
 // Injects a knowledge graph reminder before bash tool calls when the graph exists.
 import { existsSync } from "fs";
@@ -525,7 +522,7 @@ export const MadarPlugin = async ({ directory }) => {
 
       if (input.tool === "bash") {
           output.args.command =
-            'echo "[madar] Knowledge graph available. Use the graph tool that matches the question: retrieve, relevant_files, feature_map, risk_map, implementation_checklist, or impact. Do not open out/GRAPH_REPORT.md unless the context pack or graph tools are unavailable, stale, or insufficient; treat it as a fallback before broader raw file exploration, not a default first read." && ' +
+            ${JSON.stringify(OPENCODE_PLUGIN_REMINDER_COMMAND)} +
             output.args.command;
         reminded = true;
       }
@@ -542,13 +539,9 @@ alwaysApply: true
 IMPORTANT: This project has a madar knowledge graph.
 
 1. **First decide whether the task needs local repository source-code context.** Only use madar when the task needs local repository source-code context. Skip madar for GitHub Projects board reviews, external URL/WebFetch-only tasks, \`gh auth\` / \`gh project\` setup, package-registry/security pages, and Product Hunt or marketing copy work.
-2. **BEFORE answering a codebase question that needs local code context**, start with the graph tool that matches the question:
-   - \`retrieve\` for "how does X work?" and other direct codebase questions
-   - \`relevant_files\` for "which files should I open first?"
-   - \`feature_map\` for "what parts of the codebase are involved?"
-   - \`risk_map\` before editing to see likely hotspots
-   - \`implementation_checklist\` for edit order and validation checkpoints
-   - \`impact\` for "what breaks if I change X?"
+2. **BEFORE answering a codebase question that needs local code context**, use the specific Madar MCP tool below first.
+
+${renderMarkdownMcpRoutingTable()}
 3. **Do NOT search the codebase with other tools first** for codebase questions.
 4. **Only fall back to raw file tools** if the graph tools cannot answer the question or the MCP server is unavailable. ${strictGraphReportFallbackRule(true)}
 `

--- a/tests/unit/install-templates.test.ts
+++ b/tests/unit/install-templates.test.ts
@@ -57,6 +57,60 @@ function decodeHookPayload(settingsJson: string): string {
   return decodedPayloads.join('\n')
 }
 
+function expectMarkdownRoutingTable(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, use the specific Madar MCP tool below first:')
+  expect(normalized).toContain('| Prompt type')
+  expect(normalized).toContain('| "how does X work" / explain runtime / flow')
+  expect(normalized).toContain('| "what breaks if I change X" / impact analysis')
+  expect(normalized).toContain('| "which files should I open first"')
+  expect(normalized).toContain('| "give me a repo overview"')
+  expect(normalized).toContain('`context_pack`')
+  expect(normalized).toContain('`impact`')
+  expect(normalized).toContain('`relevant_files`')
+  expect(normalized).toContain('`graph_summary`')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar tool')
+}
+
+function expectPlainRoutingGuide(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, call the matching Madar MCP tool directly first')
+  expect(normalized).toContain('context_pack for "how does X work?" / explain runtime / flow')
+  expect(normalized).toContain('impact for "what breaks if I change X?" / impact analysis')
+  expect(normalized).toContain('relevant_files for "which files should I open first?"')
+  expect(normalized).toContain('graph_summary for "give me a repo overview?"')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar tool')
+}
+
+function expectMarkdownPackRoutingTable(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, start with the specific Madar command below first:')
+  expect(normalized).toContain('| Prompt type')
+  expect(normalized).toContain('| "how does X work" / explain runtime / flow')
+  expect(normalized).toContain('| "what breaks if I change X" / impact analysis')
+  expect(normalized).toContain('| "which files should I open first"')
+  expect(normalized).toContain('| "give me a repo overview"')
+  expect(normalized).toContain('`madar pack "<task or question>" --task explain`')
+  expect(normalized).toContain('`madar pack "<task or question>" --task impact`')
+  expect(normalized).toContain('`relevant_files` when MCP graph tools are available')
+  expect(normalized).toContain('`graph_summary` when MCP graph tools are available')
+  expect(normalized).toContain('`retrieve` for direct codebase questions')
+  expect(normalized).toContain('`feature_map` for involved areas and entry points')
+  expect(normalized).toContain('`risk_map` before editing')
+  expect(normalized).toContain('`implementation_checklist` for edit order and validation checkpoints')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar command or graph tool')
+}
+
+function expectPlainPackRoutingGuide(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, start with the specific Madar command below first')
+  expect(normalized).toContain('madar pack "<task or question>" --task explain for "how does X work?" / explain runtime / flow')
+  expect(normalized).toContain('madar pack "<task or question>" --task impact for "what breaks if I change X?" / impact analysis')
+  expect(normalized).toContain('relevant_files when MCP graph tools are available for "which files should I open first?"')
+  expect(normalized).toContain('graph_summary when MCP graph tools are available for "give me a repo overview?"')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar command or graph tool')
+}
+
 describe('install hook payload', () => {
   it('decoded hook payload keeps the graph-first guidance without benchmark marketing copy', () => {
     withTempDir((projectDir) => {
@@ -94,11 +148,10 @@ describe('install hook payload', () => {
       claudeInstall(projectDir)
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
       const decoded = decodeHookPayload(settings)
-      expect(decoded).toContain('relevant_files')
+      expectPlainRoutingGuide(decoded)
       expect(decoded).toContain('feature_map')
       expect(decoded).toContain('risk_map')
       expect(decoded).toContain('implementation_checklist')
-      expect(decoded).toContain('impact')
     })
   })
 
@@ -109,6 +162,7 @@ describe('install hook payload', () => {
       const decoded = decodeHookPayload(settings)
       expect(decoded).toContain('context-pack-first')
       expect(decoded).toContain('madar pack')
+      expectPlainPackRoutingGuide(decoded)
     })
   })
 })
@@ -133,5 +187,13 @@ describe('built-in install templates', () => {
     expect(content).toContain('spawn_agent')
     expect(content).toContain('npx --yes madar --help')
     expect(content).toContain('Only use madar when the task needs local repository source-code context.')
+    expectMarkdownPackRoutingTable(content)
+  })
+
+  it('documents the Copilot routing decision table in the built-in skill', () => {
+    const content = getBuiltInSkillContent('copilot')
+
+    expect(content).toContain('# /madar')
+    expectMarkdownRoutingTable(content)
   })
 })

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -43,6 +43,50 @@ const STRICT_GRAPH_REPORT_RULE_PLAIN_SENTENCE =
 const STRICT_NO_BROAD_EXPLORATION_RULE_PLAIN =
   'do not run broad glob patterns, repo-wide grep / find searches, or raw file sweeps after a high- or medium-confidence pack'
 
+function expectMarkdownRoutingTable(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, use the specific Madar MCP tool below first:')
+  expect(normalized).toContain('| Prompt type')
+  expect(normalized).toContain('| "how does X work" / explain runtime / flow')
+  expect(normalized).toContain('| "what breaks if I change X" / impact analysis')
+  expect(normalized).toContain('| "which files should I open first"')
+  expect(normalized).toContain('| "give me a repo overview"')
+  expect(normalized).toContain('`context_pack`')
+  expect(normalized).toContain('`impact`')
+  expect(normalized).toContain('`relevant_files`')
+  expect(normalized).toContain('`graph_summary`')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar tool')
+}
+
+function expectPlainRoutingGuide(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, call the matching Madar MCP tool directly first')
+  expect(normalized).toContain('context_pack for "how does X work?" / explain runtime / flow')
+  expect(normalized).toContain('impact for "what breaks if I change X?" / impact analysis')
+  expect(normalized).toContain('relevant_files for "which files should I open first?"')
+  expect(normalized).toContain('graph_summary for "give me a repo overview?"')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar tool')
+}
+
+function expectCodexMarkdownRoutingTable(content: string): void {
+  const normalized = content.replaceAll('\\"', '"')
+  expect(normalized).toContain('For each codebase question, start with the specific Madar command below first:')
+  expect(normalized).toContain('| Prompt type')
+  expect(normalized).toContain('| "how does X work" / explain runtime / flow')
+  expect(normalized).toContain('| "what breaks if I change X" / impact analysis')
+  expect(normalized).toContain('| "which files should I open first"')
+  expect(normalized).toContain('| "give me a repo overview"')
+  expect(normalized).toContain('`madar pack "<task or question>" --task explain`')
+  expect(normalized).toContain('`madar pack "<task or question>" --task impact`')
+  expect(normalized).toContain('`relevant_files` when MCP graph tools are available')
+  expect(normalized).toContain('`graph_summary` when MCP graph tools are available')
+  expect(normalized).toContain('`retrieve` for direct codebase questions')
+  expect(normalized).toContain('`feature_map` for involved areas and entry points')
+  expect(normalized).toContain('`risk_map` before editing')
+  expect(normalized).toContain('`implementation_checklist` for edit order and validation checkpoints')
+  expect(normalized).toContain('Do not run ToolSearch before calling a Madar command or graph tool')
+}
+
 const BUNDLED_ASSET_CONTENT = {
   'skill.md': '# madar\n\nLocal bundled Claude skill\n',
   'skill-aider.md': '# madar\n\nAider bundled skill.\n',
@@ -432,6 +476,7 @@ describe('install helpers', () => {
           expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain('impact')
           expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain('Only use madar when the task needs local repository source-code context.')
           expect(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8')).toContain(STRICT_GRAPH_REPORT_RULE_MD)
+          expectMarkdownRoutingTable(readFileSync(join(projectDir, 'GEMINI.md'), 'utf8'))
           expect(readFileSync(join(projectDir, '.gemini', 'settings.json'), 'utf8')).toContain('out')
 
           const uninstallMessage = geminiUninstall(projectDir, { homeDir })
@@ -514,7 +559,9 @@ describe('install helpers', () => {
       const installMessage = cursorInstall(projectDir)
       expect(normalizeAssertionPath(installMessage)).toContain('.cursor/rules/madar.mdc')
       expect(existsSync(join(projectDir, '.cursor', 'rules', 'madar.mdc'))).toBe(true)
-      expect(readFileSync(join(projectDir, '.cursor', 'rules', 'madar.mdc'), 'utf8')).toContain('alwaysApply: true')
+      const rule = readFileSync(join(projectDir, '.cursor', 'rules', 'madar.mdc'), 'utf8')
+      expect(rule).toContain('alwaysApply: true')
+      expectMarkdownRoutingTable(rule)
 
       const uninstallMessage = cursorUninstall(projectDir)
       expect(uninstallMessage).toContain('removed')
@@ -536,6 +583,7 @@ describe('install helpers', () => {
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('implementation_checklist')
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('impact')
       expect(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8')).toContain('Only use madar when the task needs local repository source-code context.')
+      expectMarkdownRoutingTable(readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8'))
 
       const uninstallMessage = claudeUninstall(projectDir)
       expect(uninstallMessage).toMatch(/madar section removed|CLAUDE\.md was empty after removal/)
@@ -998,6 +1046,7 @@ describe('install helpers', () => {
       expect(agentsMd).toContain('madar codex uninstall')
       expect(agentsMd).toContain('Manual verification')
       expect(agentsMd).toContain(STRICT_GRAPH_REPORT_RULE_MD)
+      expectCodexMarkdownRoutingTable(agentsMd)
       expect(agentsMd).not.toContain('Only fall back to raw file tools** when the context pack or graph tools are missing, stale, or insufficient. In that case, read `out/GRAPH_REPORT.md` first.')
       expect(decodedHookPayload).toContain('context-pack-first')
       expect(decodedHookPayload).toContain('madar pack')
@@ -1042,7 +1091,8 @@ describe('install helpers', () => {
         expect(agentsMd).not.toContain('In that case, read `out/GRAPH_REPORT.md` first.')
 
         const plugin = readFileSync(join(projectDir, '.opencode', 'plugins', 'madar.js'), 'utf8')
-        expect(plugin).toContain(STRICT_GRAPH_REPORT_RULE_PLAIN_SENTENCE)
+        expectPlainRoutingGuide(plugin)
+        expect(plugin).toContain(STRICT_GRAPH_REPORT_RULE_PLAIN)
         expect(plugin).not.toContain('Read out/GRAPH_REPORT.md before raw file search if needed.')
       })
     })


### PR DESCRIPTION
## Summary
- add shared install routing guidance for MCP-first and Codex pack-first surfaces
- update Claude, Gemini, Cursor, Codex, OpenCode, and built-in skill guidance to name the right first tool for explain/runtime questions
- extend install regressions for hook payloads, project rules, and built-in templates

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intelligent routing guidance to help users select the right tools and commands for different question types across all supported platforms (Claude, Codex, Gemini, Cursor, and OpenCode).
  * Routing guidance is now automatically included in generated documentation and setup instructions for seamless user onboarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->