### PR TITLE
Add bounded snippets to retrieve responses

### DIFF
--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { basename } from 'node:path'
 
+import { decode as decodeTokens, encode as encodeTokens } from 'gpt-tokenizer/encoding/cl100k_base'
+
 import type {
   ContextPackExecutionPhase,
   ContextPackExecutionSlice,
@@ -59,6 +61,8 @@ import { communitiesFromGraph, estimateQueryTokens } from './serve.js'
 const SNIPPET_HALF_WINDOW = 7
 const DERIVED_SNIPPET_HALF_WINDOW = 1
 const MAX_SNIPPET_LINE_LENGTH = 200
+export const DEFAULT_RETRIEVE_SNIPPET_BUDGET = 3000
+export const DEFAULT_RETRIEVE_TOP_N_WITH_SNIPPET = 8
 const BM25_K1 = 1.2
 const BM25_B = 0.6
 const SEED_FUSION_SCORE_SCALE = 10
@@ -96,6 +100,13 @@ export interface RetrieveOptions {
   /** Internal additive override for benchmarks/tests. */
   selectionStrategy?: ContextPackSelectionStrategy
   retrievalStrategy?: ContextPackRetrievalStrategy
+  snippetBudget?: number
+  topNWithSnippet?: number
+}
+
+export interface RetrieveSnippetOptions {
+  snippetBudget?: number
+  topNWithSnippet?: number
 }
 
 function effectiveRetrieveTaskKind(options: RetrieveOptions): ContextPackTaskKind {
@@ -128,6 +139,7 @@ export interface RetrieveMatchedNode {
   source_domain?: SourceDomain
   file_type: string
   snippet: string | null
+  snippet_truncated?: boolean
   match_score: number
   relevance_band: 'direct' | 'related' | 'peripheral'
   community: number | null
@@ -168,18 +180,23 @@ export interface RetrieveResult {
   selection_diagnostics?: ContextPackSelectionDiagnostics
   retrieval_gate?: RetrievalGateDecision
   retrieval_strategy?: ContextPackRetrievalStrategy
+  snippet_budget_tokens_used?: number
+  snippet_budget_tokens_remaining?: number
   slice?: ContextPackSliceMetadata
   execution_slice?: ContextPackExecutionSlice
   answer_contract?: ContextPackRuntimeGenerationAnswerContract
 }
 
-export interface CompactRetrieveMatchedNode extends Omit<RetrieveMatchedNode, 'community_label' | 'file_type' | 'framework_boost'> {
+export interface CompactRetrieveMatchedNode extends Omit<RetrieveMatchedNode, 'community_label' | 'file_type' | 'framework_boost' | 'snippet_truncated'> {
   file_type?: string
+  snippet_truncated: boolean
 }
 
-export interface CompactRetrieveResult extends Omit<RetrieveResult, 'matched_nodes'> {
+export interface CompactRetrieveResult extends Omit<RetrieveResult, 'matched_nodes' | 'snippet_budget_tokens_used' | 'snippet_budget_tokens_remaining'> {
   matched_nodes: CompactRetrieveMatchedNode[]
   shared_file_type?: string
+  snippet_budget_tokens_used: number
+  snippet_budget_tokens_remaining: number
 }
 
 interface RetrieveGraphSignals {
@@ -362,6 +379,12 @@ function estimateTokens(text: string): number {
   return estimateQueryTokens(text)
 }
 
+function snippetTokenCount(snippet: string | null | undefined): number {
+  return typeof snippet === 'string' && snippet.trim().length > 0
+    ? estimateTokens(snippet)
+    : 0
+}
+
 export function estimateRetrieveEntryTokens(label: string, sourceFile: string, lineNumber: number, snippet: string | null): number {
   return estimateContextPackEntryTokens(label, sourceFile, lineNumber, snippet)
 }
@@ -373,6 +396,193 @@ function tokenCountForMatchedNodes(
     (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet),
     0,
   )
+}
+
+function normalizedRetrieveSnippetOptions(options: RetrieveSnippetOptions = {}): { snippetBudget: number; topNWithSnippet: number } {
+  const resolvedSnippetBudget =
+    typeof options.snippetBudget === 'number' && Number.isFinite(options.snippetBudget)
+      ? Math.max(0, Math.floor(options.snippetBudget))
+      : DEFAULT_RETRIEVE_SNIPPET_BUDGET
+  const resolvedTopNWithSnippet =
+    typeof options.topNWithSnippet === 'number' && Number.isFinite(options.topNWithSnippet)
+      ? Math.max(0, Math.floor(options.topNWithSnippet))
+      : DEFAULT_RETRIEVE_TOP_N_WITH_SNIPPET
+  return {
+    snippetBudget: resolvedSnippetBudget,
+    topNWithSnippet: resolvedTopNWithSnippet,
+  }
+}
+
+function truncateTextToTokenBudget(text: string, remainingTokens: number): string | null {
+  const trimmedText = text.trim()
+  if (trimmedText.length === 0 || remainingTokens <= 0) {
+    return null
+  }
+
+  const tokens = encodeTokens(trimmedText)
+  if (tokens.length <= remainingTokens) {
+    return trimmedText
+  }
+
+  for (let tokenLimit = Math.min(remainingTokens, tokens.length); tokenLimit > 0; tokenLimit -= 1) {
+    const decoded = decodeTokens(tokens.slice(0, tokenLimit)).trim()
+    if (decoded.length === 0) {
+      continue
+    }
+    if (estimateTokens(decoded) <= remainingTokens) {
+      return decoded
+    }
+  }
+
+  return null
+}
+
+function truncateSnippetToTokenBudget(
+  snippet: string,
+  remainingTokens: number,
+): { snippet: string | null; tokensUsed: number; truncated: boolean } {
+  const trimmedSnippet = snippet.trim()
+  if (trimmedSnippet.length === 0) {
+    return { snippet: null, tokensUsed: 0, truncated: false }
+  }
+  if (remainingTokens <= 0) {
+    return { snippet: null, tokensUsed: 0, truncated: true }
+  }
+
+  const fullTokens = estimateTokens(trimmedSnippet)
+  if (fullTokens <= remainingTokens) {
+    return { snippet: trimmedSnippet, tokensUsed: fullTokens, truncated: false }
+  }
+
+  const lines = trimmedSnippet.split('\n')
+  const nonEmptyLineIndexes = lines
+    .map((line, index) => (line.trim().length > 0 ? index : -1))
+    .filter((index) => index >= 0)
+  const focusIndex = nonEmptyLineIndexes.length > 0
+    ? nonEmptyLineIndexes[Math.floor(nonEmptyLineIndexes.length / 2)]!
+    : 0
+  const focusLine = lines[focusIndex]?.trim() ?? ''
+
+  if (focusLine.length > 0 && estimateTokens(focusLine) <= remainingTokens) {
+    let start = focusIndex
+    let end = focusIndex
+    let bestSnippet = focusLine
+
+    while (true) {
+      let expanded = false
+
+      if (start > 0) {
+        const candidate = lines.slice(start - 1, end + 1).join('\n').trim()
+        if (candidate.length > 0 && estimateTokens(candidate) <= remainingTokens) {
+          start -= 1
+          bestSnippet = candidate
+          expanded = true
+        }
+      }
+
+      if (end < lines.length - 1) {
+        const candidate = lines.slice(start, end + 2).join('\n').trim()
+        if (candidate.length > 0 && estimateTokens(candidate) <= remainingTokens) {
+          end += 1
+          bestSnippet = candidate
+          expanded = true
+        }
+      }
+
+      if (!expanded) {
+        break
+      }
+    }
+
+    return {
+      snippet: bestSnippet,
+      tokensUsed: estimateTokens(bestSnippet),
+      truncated: true,
+    }
+  }
+
+  const tokenBoundSnippet = truncateTextToTokenBudget(focusLine.length > 0 ? focusLine : trimmedSnippet, remainingTokens)
+  if (tokenBoundSnippet === null) {
+    return { snippet: null, tokensUsed: 0, truncated: true }
+  }
+
+  return {
+    snippet: tokenBoundSnippet,
+    tokensUsed: estimateTokens(tokenBoundSnippet),
+    truncated: true,
+  }
+}
+
+function applyRetrieveSnippetBudgetToNodes<TNode extends { snippet?: string | null }>(
+  nodes: readonly TNode[],
+  options: RetrieveSnippetOptions = {},
+): {
+  nodes: Array<TNode & { snippet: string | null; snippet_truncated: boolean }>
+  usedTokens: number
+  remainingTokens: number
+} {
+  const { snippetBudget, topNWithSnippet } = normalizedRetrieveSnippetOptions(options)
+  let usedTokens = 0
+
+  const shapedNodes = nodes.map((node, index) => {
+    const originalSnippet = typeof node.snippet === 'string' && node.snippet.trim().length > 0
+      ? node.snippet
+      : null
+
+    if (originalSnippet === null) {
+      return {
+        ...node,
+        snippet: null,
+        snippet_truncated: false,
+      }
+    }
+
+    if (index >= topNWithSnippet) {
+      return {
+        ...node,
+        snippet: null,
+        snippet_truncated: false,
+      }
+    }
+
+    const remainingSnippetBudget = Math.max(0, snippetBudget - usedTokens)
+    const shapedSnippet = truncateSnippetToTokenBudget(originalSnippet, remainingSnippetBudget)
+    const serializedSnippetTokens = snippetTokenCount(shapedSnippet.snippet)
+    const boundedSnippet = serializedSnippetTokens <= remainingSnippetBudget
+      ? shapedSnippet
+      : truncateSnippetToTokenBudget(shapedSnippet.snippet ?? '', remainingSnippetBudget)
+    usedTokens += snippetTokenCount(boundedSnippet.snippet)
+    return {
+      ...node,
+      snippet: boundedSnippet.snippet,
+      snippet_truncated: shapedSnippet.truncated || boundedSnippet.truncated,
+    }
+  })
+
+  const serializedSnippetTokensUsed = shapedNodes.reduce(
+    (total, node) => total + snippetTokenCount(node.snippet),
+    0,
+  )
+
+  return {
+    nodes: shapedNodes,
+    usedTokens: serializedSnippetTokensUsed,
+    remainingTokens: Math.max(0, snippetBudget - serializedSnippetTokensUsed),
+  }
+}
+
+export function withRetrieveSnippetBudget(
+  result: RetrieveResult,
+  options: RetrieveSnippetOptions = {},
+): RetrieveResult {
+  const shapedNodes = applyRetrieveSnippetBudgetToNodes(result.matched_nodes, options)
+  return {
+    ...result,
+    token_count: tokenCountForMatchedNodes(shapedNodes.nodes),
+    matched_nodes: shapedNodes.nodes as RetrieveMatchedNode[],
+    snippet_budget_tokens_used: shapedNodes.usedTokens,
+    snippet_budget_tokens_remaining: shapedNodes.remainingTokens,
+  }
 }
 
 function fileLinesForSnippet(sourceFile: string, fileCache?: Map<string, string[] | null>): string[] | null {
@@ -4363,7 +4573,7 @@ export async function retrieveContextAsync(graph: KnowledgeGraph, options: Retri
   )
 }
 
-export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveResult {
+export function compactRetrieveResult(result: RetrieveResult, options: RetrieveSnippetOptions = {}): CompactRetrieveResult {
   const frameworkProfile = buildFrameworkQuestionProfile(result.question, tokenizeQuestion(result.question))
   const compactFrameworkLimit =
     frameworkProfile.frameworkShaped && result.matched_nodes.some((node) => (node.framework_boost ?? 0) > 0) ? 5 : Number.POSITIVE_INFINITY
@@ -4382,19 +4592,22 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
         kind: 'retrieve',
         ...(Number.isFinite(compactFrameworkLimit) ? { max_nodes: compactFrameworkLimit } : {}),
       })
+  const shapedNodes = applyRetrieveSnippetBudgetToNodes(compactPack.nodes, options)
 
   return {
     question: result.question,
-    token_count: compactPack.nodes.reduce(
+    token_count: shapedNodes.nodes.reduce(
       (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet ?? null),
       0,
     ),
-    matched_nodes: compactPack.nodes.map(({ evidence_class: _evidenceClass, ...node }) => node as CompactRetrieveMatchedNode),
+    matched_nodes: shapedNodes.nodes.map(({ evidence_class: _evidenceClass, ...node }) => node as CompactRetrieveMatchedNode),
     relationships: compactPack.relationships,
     community_context: compactPack.community_context,
     graph_signals: compactPack.graph_signals ?? { god_nodes: [], bridge_nodes: [] },
     ...(compactPack.shared_file_type ? { shared_file_type: compactPack.shared_file_type } : {}),
     retrieval_strategy: result.retrieval_strategy ?? 'default',
+    snippet_budget_tokens_used: shapedNodes.usedTokens,
+    snippet_budget_tokens_remaining: shapedNodes.remainingTokens,
     ...(result.slice ? { slice: result.slice } : {}),
     ...(executionSlice ? { execution_slice: executionSlice } : {}),
     ...(result.answer_contract ? { answer_contract: result.answer_contract } : {}),
@@ -4402,8 +4615,8 @@ export function compactRetrieveResult(result: RetrieveResult): CompactRetrieveRe
   }
 }
 
-export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveResult {
-  const compactResult = compactRetrieveResult(result)
+export function compactRetrieveResultForStdio(result: RetrieveResult, options: RetrieveSnippetOptions = {}): RetrieveResult {
+  const compactResult = compactRetrieveResult(result, options)
   const originalNodesById = new Map(
     result.matched_nodes
       .map((node) => [matchedNodeId(node), node] as const)
@@ -4413,7 +4626,11 @@ export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveR
   const matchedNodes: RetrieveResult['matched_nodes'] = compactResult.matched_nodes.map((node): RetrieveMatchedNode => {
     const original = matchedNodeId(node) !== null ? originalNodesById.get(matchedNodeId(node)!) : undefined
     if (original) {
-      return stripRetrieveMatchedNodeIdentity(original)
+      return {
+        ...stripRetrieveMatchedNodeIdentity(original),
+        snippet: node.snippet,
+        snippet_truncated: node.snippet_truncated,
+      }
     }
 
     return {
@@ -4423,6 +4640,7 @@ export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveR
       framework_boost: 0,
       file_type: node.file_type ?? compactResult.shared_file_type ?? '',
       snippet: node.snippet,
+      snippet_truncated: node.snippet_truncated,
       match_score: node.match_score,
       relevance_band: node.relevance_band,
       community: node.community,
@@ -4444,6 +4662,8 @@ export function compactRetrieveResultForStdio(result: RetrieveResult): RetrieveR
     ...(result.coverage ? { coverage: result.coverage } : {}),
     ...(result.selection_diagnostics ? { selection_diagnostics: result.selection_diagnostics } : {}),
     retrieval_strategy: result.retrieval_strategy ?? 'default',
+    snippet_budget_tokens_used: compactResult.snippet_budget_tokens_used,
+    snippet_budget_tokens_remaining: compactResult.snippet_budget_tokens_remaining,
     ...(result.slice ? { slice: result.slice } : {}),
     ...(compactResult.execution_slice ? { execution_slice: compactResult.execution_slice } : {}),
     ...(result.answer_contract ? { answer_contract: result.answer_contract } : {}),

--- a/src/runtime/stdio/definitions.ts
+++ b/src/runtime/stdio/definitions.ts
@@ -229,6 +229,8 @@ export const MCP_TOOLS: McpToolDefinition[] = [
         semantic_model: { type: 'string', description: 'Override semantic model or local path' },
         rerank: { type: 'boolean', description: 'Enable cross-encoder reranking' },
         rerank_model: { type: 'string', description: 'Override reranker model or local path' },
+        snippet_budget: { type: 'number', description: 'Snippet-token budget (default 3000)' },
+        top_n_with_snippet: { type: 'number', description: 'Top matched nodes with snippets (default 8)' },
         verbose: { type: 'boolean', description: 'Return verbose payload (default: compact)' },
         retrieval_level: { type: 'number', description: 'Override retrieval-gate level 0-5 (#75)' },
         retrieval_strategy: { type: 'string', enum: ['default', 'slice-v1'], description: 'Experimental retrieval strategy.' },

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -29,7 +29,17 @@ import { pickImpactTarget } from '../context-pack-target.js'
 import { analyzeImpact, callChains, compactImpactResult, type ImpactResult } from '../impact.js'
 import { analyzePrImpact, compactPrImpactResult } from '../pr-impact.js'
 import { relevantFiles } from '../relevant-files.js'
-import { collectRelationships, compactRetrieveResult, contextPackFromRetrieveResult, readSnippet, retrieveContext, retrieveContextAsync, type RetrieveResult } from '../retrieve.js'
+import {
+  collectRelationships,
+  compactRetrieveResult,
+  contextPackFromRetrieveResult,
+  readSnippet,
+  retrieveContext,
+  retrieveContextAsync,
+  withRetrieveSnippetBudget,
+  type RetrieveResult,
+  type RetrieveSnippetOptions,
+} from '../retrieve.js'
 import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
 import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-delta.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
@@ -908,6 +918,14 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const retrieveRerank = toolArguments.rerank === true
       const retrieveSemanticModel = helpers.stringParamAlias(toolArguments, ['semantic_model', 'semanticModel'])
       const retrieveRerankModel = helpers.stringParamAlias(toolArguments, ['rerank_model', 'rerankModel'])
+      const retrieveSnippetBudget = helpers.numberParamAlias(toolArguments, ['snippet_budget', 'snippetBudget'], { min: 0, max: helpers.maxStdioTokenBudget })
+      if ((Object.hasOwn(toolArguments, 'snippet_budget') || Object.hasOwn(toolArguments, 'snippetBudget')) && retrieveSnippetBudget === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, `snippet_budget must be a number between 0 and ${helpers.maxStdioTokenBudget}`)
+      }
+      const retrieveTopNWithSnippet = helpers.numberParamAlias(toolArguments, ['top_n_with_snippet', 'topNWithSnippet'], { min: 0 })
+      if ((Object.hasOwn(toolArguments, 'top_n_with_snippet') || Object.hasOwn(toolArguments, 'topNWithSnippet')) && retrieveTopNWithSnippet === null) {
+        return helpers.failure(id, helpers.jsonrpcInvalidParams, 'top_n_with_snippet must be a non-negative number')
+      }
       // #75 manual override: numeric retrieval_level argument (0-5) bypasses
       // the gate's heuristics and forces the supplied level. numberParamAlias
       // already enforces the range and returns null for absent/out-of-range
@@ -919,6 +937,10 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const retrieveStrategy = parseRetrievalStrategyParam(helpers, toolArguments)
       if (retrieveStrategy === 'invalid') {
         return helpers.failure(id, helpers.jsonrpcInvalidParams, 'retrieval_strategy must be one of default, slice-v1')
+      }
+      const retrieveSnippetOptions: RetrieveSnippetOptions = {
+        ...(retrieveSnippetBudget !== null ? { snippetBudget: retrieveSnippetBudget } : {}),
+        ...(retrieveTopNWithSnippet !== null ? { topNWithSnippet: retrieveTopNWithSnippet } : {}),
       }
       const retrieveLevelTyped = retrieveLevelOverride === null ? null : (retrieveLevelOverride as 0 | 1 | 2 | 3 | 4 | 5)
       const retrieval = retrieveSemantic || retrieveRerank ? retrieveContextAsync(graph, {
@@ -943,9 +965,9 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const useVerboseRetrieve = toolArguments.verbose === true || toolArguments.compact === false
       return retrieval.then((result) => helpers.ok(id, helpers.textToolResult(JSON.stringify(
         useVerboseRetrieve
-          ? result
+          ? withRetrieveSnippetBudget(result, retrieveSnippetOptions)
           : {
-              ...compactRetrieveResult(result),
+              ...compactRetrieveResult(result, retrieveSnippetOptions),
               ...contextMetadata(result),
             },
       ))))

--- a/tests/unit/benchmark-artifact.test.ts
+++ b/tests/unit/benchmark-artifact.test.ts
@@ -30,6 +30,10 @@ interface PackQualityGateDefinition {
   manual_review_notes: string[]
 }
 
+function estimateSnippetTokens(snippet: string | null): number {
+  return snippet?.trim().split(/\s+/).filter(Boolean).length ?? 0
+}
+
 const DOCS_ARTIFACT_GATE: PackQualityGateDefinition = {
   prompt: 'Explain how idea report is getting generated',
   required_labels: ['IdeaReportController', 'GenerateIdeaReportService'],
@@ -51,6 +55,7 @@ function buildMatchedNodes(totalCount: number, labels: readonly string[]): Compa
       source_file: `src/runtime/report-${index + 1}.ts`,
       line_number: index + 1,
       snippet: `// ${label}`,
+      snippet_truncated: false,
       match_score: totalCount - index,
       relevance_band: index === 0 ? 'direct' : 'related',
       community: 1,
@@ -65,6 +70,7 @@ function buildMatchedNodes(totalCount: number, labels: readonly string[]): Compa
       source_file: `src/runtime/supporting-${index}.ts`,
       line_number: index,
       snippet: `// SupportingReportNode${index}`,
+      snippet_truncated: false,
       match_score: totalCount - index,
       relevance_band: 'peripheral',
       community: 1,
@@ -91,10 +97,16 @@ function buildRelationships(
   }))
 }
 
-function buildPackFixture(overrides: Partial<Pick<CompareReportPack, 'token_count' | 'matched_nodes' | 'relationships'>> = {}): CompareReportPack {
+function buildPackFixture(
+  overrides: Partial<Pick<CompareReportPack, 'token_count' | 'matched_nodes' | 'relationships' | 'snippet_budget_tokens_used' | 'snippet_budget_tokens_remaining'>> = {},
+): CompareReportPack {
   const matched_nodes = overrides.matched_nodes
     ?? buildMatchedNodes(DOCS_ARTIFACT_GATE.max_matched_nodes, DOCS_ARTIFACT_GATE.required_labels)
   const relationships = overrides.relationships ?? buildRelationships(DOCS_ARTIFACT_GATE.max_relationships, matched_nodes)
+  const snippetBudgetTokensUsed = overrides.snippet_budget_tokens_used
+    ?? matched_nodes.reduce((total, node) => total + estimateSnippetTokens(node.snippet), 0)
+  const snippetBudgetTokensRemaining = overrides.snippet_budget_tokens_remaining
+    ?? Math.max(0, 3_000 - snippetBudgetTokensUsed)
 
   return {
     question: 'Explain how idea report is getting generated',
@@ -104,6 +116,8 @@ function buildPackFixture(overrides: Partial<Pick<CompareReportPack, 'token_coun
     community_context: [{ id: 1, label: 'Report Generation', node_count: 38 }],
     graph_signals: { god_nodes: [], bridge_nodes: [] },
     retrieval_strategy: 'default',
+    snippet_budget_tokens_used: snippetBudgetTokensUsed,
+    snippet_budget_tokens_remaining: snippetBudgetTokensRemaining,
     ...overrides,
   }
 }

--- a/tests/unit/mcp-schema-budget.test.ts
+++ b/tests/unit/mcp-schema-budget.test.ts
@@ -8,16 +8,16 @@ import { activeMcpTools, MCP_TOOLS } from '../../src/runtime/stdio/definitions.j
 // new tool genuinely needs more bytes, raise the ceiling here in the same PR
 // with a note in the commit message and the README.
 //
-// Post-#188 measurements (taken from `node -e "JSON.stringify({tools: ...})"`):
-//   * Core profile (7 tools, the default):  ≈ 3,203 bytes  ≈ ~801 tokens
-//   * Full profile (26 tools, opt-in):      ≈ 12,395 bytes ≈ ~3,099 tokens
+// Post-#338 measurements (taken from `node -e "JSON.stringify({tools: ...})"`):
+//   * Core profile (7 tools, the default):  ≈ 3,389 bytes
+//   * Full profile (26 tools, opt-in):      ≈ 12,620 bytes
 //
 // Pre-#82 core was 4,271 bytes / ~1,068 tokens — i.e. #82 cut the core profile
 // by 30%. The ceilings below sit just above today's measurements to leave a
 // small growth buffer without permitting a silent regression.
 
-const CORE_PROFILE_BYTE_CEILING = 3_250
-const FULL_PROFILE_BYTE_CEILING = 12_450  // v0.23: raised for the default-core graph_summary tool
+const CORE_PROFILE_BYTE_CEILING = 3_400
+const FULL_PROFILE_BYTE_CEILING = 12_650  // v0.27: raised for additive retrieve snippet-budget arguments
 
 function payloadBytes(tools: ReadonlyArray<unknown>): number {
   return JSON.stringify({ tools }).length

--- a/tests/unit/retrieve.test.ts
+++ b/tests/unit/retrieve.test.ts
@@ -19,6 +19,7 @@ import {
   tokenWeightsForQuestion,
   tokenizeLabel,
   tokenizeQuestion,
+  withRetrieveSnippetBudget,
 } from '../../src/runtime/retrieve.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 import { afterEach, vi } from 'vitest'
@@ -2783,6 +2784,139 @@ describe('retrieve', () => {
       expect(compactResult.matched_nodes.length).toBeLessThan(rawResult.matched_nodes.length)
       expect(compactResult.token_count).toBe(compactTokenCount)
       expect(compactResult.token_count).toBeLessThan(rawResult.token_count)
+    })
+
+    it('adds snippet budget metadata and bounds compact retrieve snippets independently of node selection', () => {
+      const compactResult = compactRetrieveResult({
+        question: 'how does auth work',
+        token_count: 999,
+        matched_nodes: Array.from({ length: 4 }, (_, index) => ({
+          node_id: `auth_node_${index + 1}`,
+          label: `AuthNode${index + 1}`,
+          source_file: `/src/auth-${index + 1}.ts`,
+          line_number: index + 1,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: `export function authNode${index + 1}() {\n  return "${'token '.repeat(12).trim()}"\n}`,
+          match_score: 10 - index,
+          relevance_band: index === 0 ? 'direct' : 'related',
+          community: 0,
+          community_label: 'Auth',
+        })),
+        relationships: [],
+        community_context: [{ id: 0, label: 'Auth', node_count: 4 }],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }, {
+        snippetBudget: 20,
+        topNWithSnippet: 2,
+      })
+
+      const snippetTokenCount = compactResult.matched_nodes.reduce(
+        (total, node) => total + (typeof node.snippet === 'string' && node.snippet.length > 0 ? estimateQueryTokens(node.snippet) : 0),
+        0,
+      )
+      const compactTokenCount = compactResult.matched_nodes.reduce((total, node) => {
+        const nodeText = `${node.label} ${node.source_file}:${node.line_number} ${node.snippet ?? ''}`
+        return total + estimateQueryTokens(nodeText)
+      }, 0)
+
+      expect(compactResult.snippet_budget_tokens_used).toBe(snippetTokenCount)
+      expect(compactResult.snippet_budget_tokens_used).toBeLessThanOrEqual(20)
+      expect(compactResult.snippet_budget_tokens_remaining).toBe(20 - snippetTokenCount)
+      expect(compactResult.matched_nodes[0]).toHaveProperty('snippet_truncated')
+      expect(compactResult.matched_nodes[1]).toHaveProperty('snippet_truncated')
+      expect(
+        compactResult.matched_nodes.slice(0, 2).some((node) => typeof node.snippet === 'string' && node.snippet.length > 0),
+      ).toBe(true)
+      expect(compactResult.matched_nodes[2]).toEqual(expect.objectContaining({
+        snippet: null,
+        snippet_truncated: false,
+      }))
+      expect(compactResult.matched_nodes.some((node) => node.snippet_truncated === true)).toBe(true)
+      expect(compactResult.token_count).toBe(compactTokenCount)
+    })
+
+    it('keeps the focused middle line when compact snippet budgets are tiny', () => {
+      const compactResult = compactRetrieveResult({
+        question: 'where is the target handler',
+        token_count: 999,
+        matched_nodes: [
+          {
+            node_id: 'target_handler',
+            label: 'targetHandler',
+            source_file: '/src/target.ts',
+            line_number: 10,
+            node_kind: 'function',
+            file_type: 'code',
+            snippet: [
+              'beforeOne()',
+              'beforeTwo()',
+              'TARGET()',
+              'afterOne()',
+              'afterTwo()',
+            ].join('\n'),
+            match_score: 10,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Target',
+          },
+        ],
+        relationships: [],
+        community_context: [{ id: 0, label: 'Target', node_count: 1 }],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }, {
+        snippetBudget: 1,
+        topNWithSnippet: 1,
+      })
+
+      expect(compactResult.matched_nodes[0]?.snippet).toContain('TARGET')
+      expect(compactResult.matched_nodes[0]?.snippet_truncated).toBe(true)
+    })
+
+    it('recomputes token_count for verbose retrieve payloads after snippet shaping', () => {
+      const verboseResult = withRetrieveSnippetBudget({
+        question: 'how does auth work',
+        token_count: 999,
+        matched_nodes: [
+          {
+            label: 'AuthController',
+            source_file: '/src/auth/controller.ts',
+            line_number: 12,
+            file_type: 'code',
+            snippet: 'export async function authController() {\n  return token token token token token\n}',
+            match_score: 10,
+            relevance_band: 'direct',
+            community: 0,
+            community_label: 'Auth',
+          },
+          {
+            label: 'AuthService',
+            source_file: '/src/auth/service.ts',
+            line_number: 24,
+            file_type: 'code',
+            snippet: 'export async function authService() {\n  return token token token token token\n}',
+            match_score: 9,
+            relevance_band: 'related',
+            community: 0,
+            community_label: 'Auth',
+          },
+        ],
+        relationships: [],
+        community_context: [{ id: 0, label: 'Auth', node_count: 2 }],
+        graph_signals: { god_nodes: [], bridge_nodes: [] },
+      }, {
+        snippetBudget: 4,
+        topNWithSnippet: 1,
+      })
+
+      const verboseTokenCount = verboseResult.matched_nodes.reduce((total, node) => {
+        const nodeText = `${node.label} ${node.source_file}:${node.line_number} ${node.snippet ?? ''}`
+        return total + estimateQueryTokens(nodeText)
+      }, 0)
+
+      expect(verboseResult.token_count).toBe(verboseTokenCount)
+      expect(verboseResult.token_count).toBeLessThan(999)
+      expect(verboseResult.snippet_budget_tokens_used).toBeLessThanOrEqual(4)
     })
 
     it('drops relationships for truncated same-label nodes during compact serialization', () => {

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -64,6 +64,92 @@ afterEach(() => {
 })
 
 describe('stdio slice-v1 surface', () => {
+  it('adds bounded snippet fields to retrieve responses and keeps top-node snippets aligned with context_pack', async () => {
+    const graphPath = createGraphPath()
+
+    const retrieveResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 6,
+      method: 'tools/call',
+      params: {
+        name: 'retrieve',
+        arguments: {
+          question: 'Explain `AuthService.login`',
+          budget: 1000,
+          snippet_budget: 12,
+          top_n_with_snippet: 1,
+        },
+      },
+    }))
+
+    const contextPackResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 7,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Explain `AuthService.login`',
+          budget: 1000,
+          task: 'explain',
+          verbose: true,
+        },
+      },
+    }))
+
+    const retrievePayload = JSON.parse(((retrieveResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? '') as {
+      matched_nodes: Array<{
+        label: string
+        source_file: string
+        line_number: number
+        snippet: string | null
+        snippet_truncated: boolean
+      }>
+      snippet_budget_tokens_used: number
+      snippet_budget_tokens_remaining: number
+    }
+    const contextPackPayload = JSON.parse(((contextPackResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? '') as {
+      pack: {
+        matched_nodes: Array<{
+          label: string
+          source_file: string
+          line_number: number
+          snippet: string | null
+        }>
+      }
+    }
+
+    expect(retrievePayload.snippet_budget_tokens_used).toBeLessThanOrEqual(12)
+    expect(retrievePayload.snippet_budget_tokens_remaining).toBeGreaterThanOrEqual(0)
+    expect(retrievePayload.matched_nodes[0]).toHaveProperty('snippet_truncated')
+    expect(retrievePayload.matched_nodes[0]?.snippet).toEqual(expect.any(String))
+    expect(retrievePayload.matched_nodes[1]).toEqual(expect.objectContaining({
+      snippet: null,
+      snippet_truncated: false,
+    }))
+
+    const retrieveNode = retrievePayload.matched_nodes.find((node) => typeof node.snippet === 'string')
+    const contextPackNode = contextPackPayload.pack.matched_nodes.find((node) => node.label === retrieveNode?.label)
+
+    expect(retrieveNode).toBeDefined()
+    expect(contextPackNode).toBeDefined()
+    expect(retrieveNode?.source_file).toBe(contextPackNode?.source_file)
+    expect(retrieveNode?.line_number).toBe(contextPackNode?.line_number)
+
+    const retrieveSnippetLines = new Set(
+      (retrieveNode?.snippet ?? '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+    )
+    const contextPackSnippetLines = new Set(
+      (contextPackNode?.snippet ?? '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+    )
+
+    expect([...retrieveSnippetLines].some((line) => contextPackSnippetLines.has(line))).toBe(true)
+  })
+
   it('accepts retrieval_strategy=slice-v1 for retrieve and context_pack', async () => {
     const graphPath = createGraphPath()
 


### PR DESCRIPTION
## Summary
- add bounded snippet shaping to retrieve compact and verbose responses
- expose snippet_budget and top_n_with_snippet on the retrieve MCP tool
- cover review-driven token-count and focus-line regressions in unit tests

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added snippet token budgeting to retrieval operations with configurable limits.
  * New retrieval parameters: `snippet_budget` (default 3000 tokens) and `top_n_with_snippet` (default 8 nodes) to control snippet text size and coverage.

* **Updates**
  * Retrieval results now include snippet truncation tracking and token usage accounting fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->