### PR TITLE
fix: classify any Madar MCP call as invoked

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -112,7 +112,11 @@ export interface CompareMadarTraceTurnSummary {
   tools: string[]
 }
 
-type CompareMadarTraceOutcome = 'reduced_exploration' | 'added_context_only' | 'no_context_pack'
+type CompareMadarTraceOutcome =
+  | 'no_install'
+  | 'madar_available_but_unused'
+  | 'madar_invoked'
+  | 'madar_invoked_with_followup_exploration'
 
 export interface CompareMadarTrace {
   source: 'claude_messages_tool_use'
@@ -121,6 +125,7 @@ export interface CompareMadarTrace {
   tool_calls_by_name: Record<string, number>
   per_turn: CompareMadarTraceTurnSummary[]
   madar_mcp_call_count: number
+  madar_mcp_calls_by_name: Record<string, number>
   context_pack_call_count: number
   focused_follow_up_tool_call_count: number
   broad_exploration_tool_call_count: number
@@ -848,8 +853,26 @@ const MADAR_FOCUSED_FOLLOW_UP_TOOL_NAMES = new Set([
   'pr_impact',
 ])
 
+const TRACE_FOCUSED_FOLLOW_UP_TOOL_NAMES = new Set(['read'])
+const TRACE_BROAD_EXPLORATION_TOOL_NAMES = new Set(['bash', 'glob', 'grep', 'toolsearch'])
+
 function canonicalTraceToolName(toolName: string): string {
   return toolName.startsWith('mcp__madar__') ? toolName.slice('mcp__madar__'.length) : toolName
+}
+
+function isMadarTraceToolName(toolName: string): boolean {
+  const canonicalName = canonicalTraceToolName(toolName)
+  return toolName.startsWith('mcp__madar__')
+    || MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)
+    || MADAR_FOCUSED_FOLLOW_UP_TOOL_NAMES.has(canonicalName)
+}
+
+function isFocusedFollowUpTraceToolName(toolName: string): boolean {
+  return TRACE_FOCUSED_FOLLOW_UP_TOOL_NAMES.has(toolName.toLowerCase())
+}
+
+function isBroadExplorationTraceToolName(toolName: string): boolean {
+  return TRACE_BROAD_EXPLORATION_TOOL_NAMES.has(toolName.toLowerCase())
 }
 
 function traceToolCountSummary(toolCallsByName: Record<string, number>): string {
@@ -859,8 +882,9 @@ function traceToolCountSummary(toolCallsByName: Record<string, number>): string 
     .join(', ')
 }
 
-function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): {
+function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): {
   madar_mcp_call_count: number
+  madar_mcp_calls_by_name: Record<string, number>
   context_pack_call_count: number
   focused_follow_up_tool_call_count: number
   broad_exploration_tool_call_count: number
@@ -872,84 +896,120 @@ function analyzeMadarTraceExploration(toolCallsByName: Record<string, number>): 
   let contextPackCallCount = 0
   let focusedFollowUpToolCallCount = 0
   let broadExplorationToolCallCount = 0
+  const madarMcpCallsByName: Record<string, number> = {}
+  const focusedFollowUpToolCallsByName: Record<string, number> = {}
   const broadExplorationToolCallsByName: Record<string, number> = {}
+  let sawFirstMadarCall = false
 
-  for (const [toolName, count] of Object.entries(toolCallsByName)) {
-    const canonicalName = canonicalTraceToolName(toolName)
-    if (
-      toolName.startsWith('mcp__madar__')
-      || MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)
-      || MADAR_FOCUSED_FOLLOW_UP_TOOL_NAMES.has(canonicalName)
-    ) {
-      madarMcpCallCount += count
-    }
-    if (MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)) {
-      contextPackCallCount += count
-      continue
-    }
+  for (const turn of perTurn) {
+    for (const toolName of turn.tools) {
+      const canonicalName = canonicalTraceToolName(toolName)
+      const hadSeenMadarCall = sawFirstMadarCall
+      if (isMadarTraceToolName(toolName)) {
+        madarMcpCallCount += 1
+        madarMcpCallsByName[toolName] = (madarMcpCallsByName[toolName] ?? 0) + 1
+        if (MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)) {
+          contextPackCallCount += 1
+        } else if (hadSeenMadarCall) {
+          focusedFollowUpToolCallCount += 1
+          focusedFollowUpToolCallsByName[toolName] = (focusedFollowUpToolCallsByName[toolName] ?? 0) + 1
+        }
+        sawFirstMadarCall = true
+        continue
+      }
 
-    if (MADAR_FOCUSED_FOLLOW_UP_TOOL_NAMES.has(canonicalName)) {
-      focusedFollowUpToolCallCount += count
-      continue
-    }
+      if (!hadSeenMadarCall) {
+        continue
+      }
 
-    broadExplorationToolCallCount += count
-    broadExplorationToolCallsByName[toolName] = count
+      if (isFocusedFollowUpTraceToolName(toolName)) {
+        focusedFollowUpToolCallCount += 1
+        focusedFollowUpToolCallsByName[toolName] = (focusedFollowUpToolCallsByName[toolName] ?? 0) + 1
+        continue
+      }
+
+      if (!isBroadExplorationTraceToolName(toolName)) {
+        continue
+      }
+
+      broadExplorationToolCallCount += 1
+      broadExplorationToolCallsByName[toolName] = (broadExplorationToolCallsByName[toolName] ?? 0) + 1
+    }
   }
 
+  const sortedMadarMcpCallsByName = Object.fromEntries(
+    Object.entries(madarMcpCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
+  )
+  const sortedFocusedFollowUpToolCallsByName = Object.fromEntries(
+    Object.entries(focusedFollowUpToolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
+  )
   const sortedBroadExplorationToolCallsByName = Object.fromEntries(
     Object.entries(broadExplorationToolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
   )
 
-  if (contextPackCallCount === 0) {
+  if (madarMcpCallCount === 0) {
     return {
       madar_mcp_call_count: madarMcpCallCount,
+      madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
       context_pack_call_count: 0,
-      focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
-      broad_exploration_tool_call_count: broadExplorationToolCallCount,
-      broad_exploration_tool_calls_by_name: sortedBroadExplorationToolCallsByName,
-      exploration_outcome: 'no_context_pack',
-      exploration_summary: 'no context_pack call recorded',
+      focused_follow_up_tool_call_count: 0,
+      broad_exploration_tool_call_count: 0,
+      broad_exploration_tool_calls_by_name: {},
+      exploration_outcome: 'madar_available_but_unused',
+      exploration_summary: 'No Madar MCP call was recorded.',
     }
   }
 
-  const contextPackSummary = `${contextPackCallCount} context_pack ${contextPackCallCount === 1 ? 'call' : 'calls'}`
+  const madarToolNames = Object.keys(sortedMadarMcpCallsByName)
+  const madarInvocationSummary = `Madar MCP invoked ${madarMcpCallCount} ${madarMcpCallCount === 1 ? 'time' : 'times'}${madarToolNames.length > 0 ? ` (${madarToolNames.join(', ')})` : ''}`
+  const contextPackSummary =
+    contextPackCallCount > 0
+      ? `${contextPackCallCount} context_pack ${contextPackCallCount === 1 ? 'call' : 'calls'}`
+      : null
   const focusedSummary =
     focusedFollowUpToolCallCount > 0
       ? `${focusedFollowUpToolCallCount} focused follow-up ${focusedFollowUpToolCallCount === 1 ? 'call' : 'calls'}`
       : null
-
-  if (contextPackCallCount === 1 && broadExplorationToolCallCount === 0) {
+  if (broadExplorationToolCallCount === 0) {
+    const summaryParts = [madarInvocationSummary]
+    if (contextPackSummary !== null) {
+      summaryParts.push(contextPackSummary)
+    }
+    if (focusedSummary !== null) {
+      summaryParts.push(focusedSummary)
+    }
+    summaryParts.push('no broad exploration after the first Madar call.')
     return {
       madar_mcp_call_count: madarMcpCallCount,
+      madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
       context_pack_call_count: contextPackCallCount,
       focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
       broad_exploration_tool_call_count: 0,
       broad_exploration_tool_calls_by_name: {},
-      exploration_outcome: 'reduced_exploration',
-      exploration_summary:
-        focusedSummary === null
-          ? `${contextPackSummary}; no broad exploration recorded`
-          : `${contextPackSummary}; ${focusedSummary}; no broad exploration recorded`,
+      exploration_outcome: 'madar_invoked',
+      exploration_summary: summaryParts.join('; '),
     }
   }
 
-  const broadSummary =
-    broadExplorationToolCallCount === 0
-      ? 'no broad exploration recorded'
-      : `${broadExplorationToolCallCount} broad exploration ${broadExplorationToolCallCount === 1 ? 'call' : 'calls'}${Object.keys(sortedBroadExplorationToolCallsByName).length > 0 ? ` (${traceToolCountSummary(sortedBroadExplorationToolCallsByName)})` : ''}`
+  const broadSummary = `${broadExplorationToolCallCount} broad exploration ${broadExplorationToolCallCount === 1 ? 'call' : 'calls'} after the first Madar call${Object.keys(sortedBroadExplorationToolCallsByName).length > 0 ? ` (${traceToolCountSummary(sortedBroadExplorationToolCallsByName)})` : ''}`
+  const summaryParts = [madarInvocationSummary]
+  if (contextPackSummary !== null) {
+    summaryParts.push(contextPackSummary)
+  }
+  if (focusedSummary !== null) {
+    summaryParts.push(focusedSummary)
+  }
+  summaryParts.push(broadSummary)
 
   return {
     madar_mcp_call_count: madarMcpCallCount,
+    madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
     context_pack_call_count: contextPackCallCount,
     focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
     broad_exploration_tool_call_count: broadExplorationToolCallCount,
     broad_exploration_tool_calls_by_name: sortedBroadExplorationToolCallsByName,
-    exploration_outcome: 'added_context_only',
-    exploration_summary:
-      focusedSummary === null
-        ? `${contextPackSummary}; ${broadSummary}`
-        : `${contextPackSummary}; ${focusedSummary}; ${broadSummary}`,
+    exploration_outcome: 'madar_invoked_with_followup_exploration',
+    exploration_summary: summaryParts.join('; '),
   }
 }
 
@@ -1098,7 +1158,8 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
   }
 
   const sortedTurns = [...perTurnIndex.keys()].sort((leftTurn, rightTurn) => leftTurn - rightTurn)
-  const exploration = analyzeMadarTraceExploration(toolCallsByName)
+  const perTurn = sortedTurns.map((turn) => perTurnIndex.get(turn)!)
+  const exploration = analyzeMadarTraceExploration(perTurn)
 
   return {
     source: 'claude_messages_tool_use',
@@ -1107,8 +1168,26 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
     tool_calls_by_name: Object.fromEntries(
       Object.entries(toolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
     ),
-    per_turn: sortedTurns.map((turn) => perTurnIndex.get(turn)!),
+    per_turn: perTurn,
     ...exploration,
+  }
+}
+
+function applyNativeAgentMadarTraceOutcome(
+  madarTrace: CompareMadarTrace,
+  installVerified: boolean,
+): CompareMadarTrace {
+  if (madarTrace.madar_mcp_call_count > 0) {
+    return madarTrace
+  }
+
+  return {
+    ...madarTrace,
+    exploration_outcome: installVerified ? 'madar_available_but_unused' : 'no_install',
+    exploration_summary:
+      installVerified
+        ? 'Madar install was verified, but no Madar MCP call was recorded.'
+        : 'No Madar install was detected, so no Madar MCP call could be recorded.',
   }
 }
 
@@ -1865,9 +1944,11 @@ function formatCompareMadarTraceSummary(result: GenerateCompareArtifactsResult):
     return total + trace.tool_call_count
   }, 0)
   const totalTurns = traces.reduce((total, trace) => total + trace.per_turn.length, 0)
-  const reducedExplorationRuns = traces.filter((trace) => trace.exploration_outcome === 'reduced_exploration').length
-  const addedContextOnlyRuns = traces.filter((trace) => trace.exploration_outcome === 'added_context_only').length
-  const noContextPackRuns = traces.filter((trace) => trace.exploration_outcome === 'no_context_pack').length
+  const noInstallRuns = traces.filter((trace) => trace.exploration_outcome === 'no_install').length
+  const madarAvailableButUnusedRuns = traces.filter((trace) => trace.exploration_outcome === 'madar_available_but_unused').length
+  const madarInvokedRuns = traces.filter((trace) => trace.exploration_outcome === 'madar_invoked').length
+  const madarInvokedWithFollowUpExplorationRuns =
+    traces.filter((trace) => trace.exploration_outcome === 'madar_invoked_with_followup_exploration').length
   const topTools = [...toolCallsByName.entries()]
     .sort((leftEntry, rightEntry) => rightEntry[1] - leftEntry[1] || leftEntry[0].localeCompare(rightEntry[0]))
     .slice(0, 3)
@@ -1875,14 +1956,17 @@ function formatCompareMadarTraceSummary(result: GenerateCompareArtifactsResult):
   const traceCoverage = traces.length === result.reports.length ? '' : ` · traces for ${traces.length}/${result.reports.length} madar runs`
   const topToolsSummary = topTools.length > 0 ? ` · top tools: ${topTools.join(', ')}` : ''
   const outcomeParts: string[] = []
-  if (reducedExplorationRuns > 0) {
-    outcomeParts.push(`${reducedExplorationRuns} reduced exploration`)
+  if (noInstallRuns > 0) {
+    outcomeParts.push(`${noInstallRuns} no install`)
   }
-  if (addedContextOnlyRuns > 0) {
-    outcomeParts.push(`${addedContextOnlyRuns} added context only`)
+  if (madarAvailableButUnusedRuns > 0) {
+    outcomeParts.push(`${madarAvailableButUnusedRuns} available but unused`)
   }
-  if (noContextPackRuns > 0) {
-    outcomeParts.push(`${noContextPackRuns} without context_pack`)
+  if (madarInvokedRuns > 0) {
+    outcomeParts.push(`${madarInvokedRuns} madar invoked`)
+  }
+  if (madarInvokedWithFollowUpExplorationRuns > 0) {
+    outcomeParts.push(`${madarInvokedWithFollowUpExplorationRuns} madar invoked with follow-up exploration`)
   }
   const outcomeSummary = outcomeParts.length > 0 ? ` · outcomes: ${outcomeParts.join(', ')}` : ''
 
@@ -2934,7 +3018,11 @@ export async function executeNativeAgentCompare(
     if (madarRun !== null) {
       madarToolCallCounts = extractNativeAgentToolCallCounts(madarRun.stdout)
       reportShell.environment_contamination = extractEnvironmentContamination(madarRun.stdout)
-      const madarTrace = extractMadarTrace(madarRun.stdout)
+      const rawMadarTrace = extractMadarTrace(madarRun.stdout)
+      const madarTrace =
+        rawMadarTrace === undefined
+          ? undefined
+          : applyNativeAgentMadarTraceOutcome(rawMadarTrace, installCheck.verified)
       if (madarTrace) {
         reportShell.madar_trace = madarTrace
         reportShell.madar_mcp_call_count = madarTrace.madar_mcp_call_count
@@ -3098,8 +3186,7 @@ function formatMadarMcpCallCountLine(report: NativeAgentCompareReport): string {
     return `madar_mcp_call_count: ${report.madar_mcp_call_count}`
   }
 
-  const madarToolSummary = Object.entries(report.madar_trace.tool_calls_by_name)
-    .filter(([toolName]) => toolName.startsWith('mcp__madar__'))
+  const madarToolSummary = Object.entries(report.madar_trace.madar_mcp_calls_by_name)
     .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))
     .map(([toolName]) => toolName)
     .join(', ')

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -251,6 +251,39 @@ const VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD = [
   MADAR_USAGE_PAYLOAD,
 ] as const
 
+const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'ToolSearch' },
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 2,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 3,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'Glob' },
+        { type: 'tool_use', name: 'Read' },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
 function scriptedRunner(payloads: { baseline: unknown; madar: unknown }): NativeAgentRunner {
   return async (input) => ({
     exitCode: 0,
@@ -512,6 +545,40 @@ describe('executeNativeAgentCompare', () => {
       expect(report.install_verified).toBe(true)
       expect(report.measurement_validity).toBe('degraded')
       expect(report.madar_mcp_call_count).toBe(0)
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        madar_mcp_call_count: 0,
+        exploration_outcome: 'madar_available_but_unused',
+      }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks verbose missing-install runs as no_install when trace data is present', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject({ installState: 'missing' })
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+          allowNoInstall: true,
+        },
+        {
+          runner: scriptedRunner({ baseline: VERBOSE_BASELINE_PAYLOAD, madar: VERBOSE_MADAR_NO_INSTALL_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.install_verified).toBe(false)
+      expect(report.measurement_validity).toBe('invalid')
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        madar_mcp_call_count: 0,
+        exploration_outcome: 'no_install',
+      }))
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -538,6 +605,43 @@ describe('executeNativeAgentCompare', () => {
       expect(report.install_verified).toBe(true)
       expect(report.measurement_validity).toBe('valid')
       expect(report.madar_mcp_call_count).toBe(1)
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        madar_mcp_call_count: 1,
+        madar_mcp_calls_by_name: {
+          'mcp__madar__retrieve': 1,
+        },
+        exploration_outcome: 'madar_invoked',
+      }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('classifies broad exploration after a Madar MCP call as madar_invoked_with_followup_exploration', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_PAYLOAD,
+            madar: VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        madar_mcp_call_count: 1,
+        exploration_outcome: 'madar_invoked_with_followup_exploration',
+      }))
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -1268,7 +1372,7 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).toContain('answer-only run saved; no Anthropic usage block was available, so provider-proof reductions were not computed')
   })
 
-  it('surfaces whether Madar reduced exploration or only added context when trace data is present', () => {
+  it('surfaces whether Madar was invoked cleanly when trace data is present', () => {
     const summary = formatNativeAgentCompareSummary(buildSummaryResult({
       question: 'trace case',
       baselineTurns: 6,
@@ -1288,36 +1392,38 @@ describe('formatNativeAgentCompareSummary', () => {
         summary: '2 tool calls across 2 turns',
         tool_call_count: 2,
         tool_calls_by_name: {
-          context_pack: 1,
-          impact: 1,
+          'mcp__madar__retrieve': 2,
         },
         per_turn: [
           {
             turn: 1,
             tool_call_count: 1,
-            tools: ['context_pack'],
+            tools: ['mcp__madar__retrieve'],
           },
           {
             turn: 2,
             tool_call_count: 1,
-            tools: ['impact'],
+            tools: ['mcp__madar__retrieve'],
           },
         ],
         madar_mcp_call_count: 2,
-        context_pack_call_count: 1,
+        madar_mcp_calls_by_name: {
+          'mcp__madar__retrieve': 2,
+        },
+        context_pack_call_count: 0,
         focused_follow_up_tool_call_count: 1,
         broad_exploration_tool_call_count: 0,
         broad_exploration_tool_calls_by_name: {},
-        exploration_outcome: 'reduced_exploration',
-        exploration_summary: '1 context_pack call; 1 focused follow-up call; no broad exploration recorded',
+        exploration_outcome: 'madar_invoked',
+        exploration_summary: 'Madar MCP invoked 2 times (mcp__madar__retrieve); 1 focused follow-up call; no broad exploration after the first Madar call.',
       },
     }))
 
-    expect(summary).toContain('madar_trace: reduced_exploration')
-    expect(summary).toContain('1 context_pack call; 1 focused follow-up call; no broad exploration recorded')
+    expect(summary).toContain('madar_trace: madar_invoked')
+    expect(summary).toContain('Madar MCP invoked 2 times (mcp__madar__retrieve); 1 focused follow-up call; no broad exploration after the first Madar call.')
     expect(summary).toContain('measurement_validity: valid')
     expect(summary).toContain('install_verified: true')
-    expect(summary).toContain('madar_mcp_call_count: 2')
+    expect(summary).toContain('madar_mcp_call_count: 2 (mcp__madar__retrieve)')
   })
 
   it('prints invalid measurement warnings when install is missing', () => {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1817,13 +1817,19 @@ describe('compare runtime', () => {
 
     expect(madarTrace).toEqual(
       expect.objectContaining({
+        madar_mcp_call_count: 2,
+        madar_mcp_calls_by_name: {
+          'mcp__madar__context_pack': 1,
+          'mcp__madar__impact': 1,
+        },
         context_pack_call_count: 1,
         focused_follow_up_tool_call_count: 1,
         broad_exploration_tool_call_count: 0,
         broad_exploration_tool_calls_by_name: {},
-        exploration_outcome: 'reduced_exploration',
+        exploration_outcome: 'madar_invoked',
       }),
     )
+    expect(formatCompareSummary(result)).toContain('outcomes: 1 madar invoked')
   })
 
   it('records when a context pack only added context before broad raw exploration continued', async () => {
@@ -1888,16 +1894,20 @@ describe('compare runtime', () => {
 
     expect(madarTrace).toEqual(
       expect.objectContaining({
+        madar_mcp_call_count: 1,
+        madar_mcp_calls_by_name: {
+          context_pack: 1,
+        },
         context_pack_call_count: 1,
-        focused_follow_up_tool_call_count: 0,
-        broad_exploration_tool_call_count: 2,
+        focused_follow_up_tool_call_count: 1,
+        broad_exploration_tool_call_count: 1,
         broad_exploration_tool_calls_by_name: {
           Grep: 1,
-          Read: 1,
         },
-        exploration_outcome: 'added_context_only',
+        exploration_outcome: 'madar_invoked_with_followup_exploration',
       }),
     )
+    expect(formatCompareSummary(result)).toContain('outcomes: 1 madar invoked with follow-up exploration')
   })
 
   it('keeps madar_trace absent when compare stdout does not expose trace data', async () => {


### PR DESCRIPTION
## Summary
- classify any `mcp__madar__*` call as an invoked Madar run in compare traces
- split zero-call native-agent traces into `no_install` vs `madar_available_but_unused`
- update compare/native-agent summaries and regression tests for the new taxonomy

Closes #340


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Madar tool usage classification with four refined outcome categories for clearer visibility into exploration patterns
  * Added detailed tool-by-tool MCP call tracking in trace reports for more granular analysis

* **Tests**
  * Updated test coverage to validate new trace classification outcomes and reporting formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->