### PR TITLE
fix: restore explain pack guidance compatibility

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -6,7 +6,7 @@ import type { ContextPackRoutingDebug } from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
-import { buildExplainPackPayload } from './context-pack-command.js'
+import { buildExplainPackPayloadCore } from './context-pack-command.js'
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
@@ -1623,7 +1623,7 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
 
 export function buildMadarPromptPack(input: BuildMadarPromptPackInput): ComparePromptPack {
   const explainPayload = JSON.stringify(
-    buildExplainPackPayload(compactRetrieveResult(input.retrieval), input.retrieval),
+    buildExplainPackPayloadCore(compactRetrieveResult(input.retrieval), input.retrieval),
     null,
     2,
   )

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -65,7 +65,7 @@ interface ContextPlaneMetadata {
 }
 
 export interface ExplainPackPayload extends ContextPlaneMetadata {
-  pack: ReturnType<typeof compactRetrieveResult>
+  pack: RetrievePackPayload & Partial<PackGuidanceCompatibilityFields>
   implementation?: ImplementationPackGuidance
   routing?: ContextPackRoutingDebug
 }
@@ -80,6 +80,36 @@ type PackResponseBase = ReturnType<typeof baseResponse>
 type PackSchemaEnvelope<TPack extends PackPayload = PackPayload> = ContextPackSchemaV1<TPack> & PackResponseBase & {
   implementation?: ImplementationPackGuidance
   target?: string
+}
+
+interface PackGuidanceCompatibilityFields {
+  workflow_centers: ContextPackWorkflowCenter[]
+  recommended_first_read: ContextPackRecommendedFirstRead[]
+  confidence_score: number
+}
+
+type PackPayloadWithCompatibility<TPack extends PackPayload> = TPack & PackGuidanceCompatibilityFields
+
+function packWithCompatibilityFields<TPack extends PackPayload>(
+  pack: TPack,
+  fields: PackGuidanceCompatibilityFields,
+): PackPayloadWithCompatibility<TPack> {
+  return {
+    ...pack,
+    ...fields,
+  }
+}
+
+function packForSchema<TPack extends PackPayload>(
+  task: TaskContextPlan['task_kind'],
+  pack: TPack,
+  fields: PackGuidanceCompatibilityFields,
+): TPack | PackPayloadWithCompatibility<TPack> {
+  if (task !== 'explain') {
+    return pack
+  }
+
+  return packWithCompatibilityFields(pack, fields)
 }
 
 function emptyCoverage(): ContextPackCoverage {
@@ -129,6 +159,39 @@ export function buildExplainPackPayload(
     pack,
     ...(implementation ? { implementation } : {}),
     ...contextMetadata(retrieval),
+  }
+}
+
+export function buildExplainPackPayloadCore(
+  pack: ReturnType<typeof compactRetrieveResult>,
+  retrieval: Partial<{
+    question: string
+    coverage: ContextPackCoverage
+    task_contract: { budget: number; task_intent?: string; evidence_recipe_id?: string }
+  }> & {
+    question: string
+  },
+  implementation?: ImplementationPackGuidance,
+): ExplainPackPayload {
+  const payload = buildExplainPackPayload(pack, retrieval, implementation)
+  const plan = buildTaskContextPlan({
+    task_kind: 'explain',
+    prompt: retrieval.question,
+    budget: Math.max(retrieval.task_contract?.budget ?? 3000, 3),
+    task_intent: (retrieval.task_contract?.task_intent ?? retrieval.task_contract?.evidence_recipe_id ?? 'explain') as TaskContextPlan['evidence']['recipe_id'],
+  })
+  const centers = workflowCenters('explain', pack, plan, implementation, retrieval as RetrieveResult)
+  const firstRead = recommendedFirstRead('explain', pack, implementation, retrieval as RetrieveResult)
+  const score = confidenceScore(payload.coverage, pack, implementation)
+
+  return {
+    ...payload,
+    pack: {
+      ...payload.pack,
+      workflow_centers: centers,
+      recommended_first_read: firstRead,
+      confidence_score: score,
+    },
   }
 }
 
@@ -648,17 +711,23 @@ function buildPackSchemaV1<TPack extends PackPayload>(
     target?: string
     retrieval?: RetrieveResult
   },
-): PackSchemaEnvelope<TPack> {
+): PackSchemaEnvelope<TPack | PackPayloadWithCompatibility<TPack>> {
   const { retrieval, ...serializableResponse } = response
   const centers = workflowCenters(response.task, response.pack, response.plan, response.implementation, retrieval)
   const firstRead = recommendedFirstRead(response.task, response.pack, response.implementation, retrieval)
   const contracts = publicContracts(response.implementation)
   const guidance = negativeGuidance(response.task, response.coverage, response.pack, response.implementation, retrieval)
   const score = confidenceScore(response.coverage, response.pack, response.implementation)
+  const compatibilityFields: PackGuidanceCompatibilityFields = {
+    workflow_centers: centers,
+    recommended_first_read: firstRead,
+    confidence_score: score,
+  }
 
   return {
     schema_version: 1,
     ...serializableResponse,
+    pack: packForSchema(response.task, response.pack, compatibilityFields),
     workflow_centers: centers,
     recommended_first_read: firstRead,
     likely_edit_files: response.implementation?.likely_edit_files ?? [],
@@ -1018,7 +1087,7 @@ export async function runContextPackCommand(
     : undefined
   return renderContextPackOutput(options.format, buildPackSchemaV1({
     ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
-    ...buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval, implementation),
+    ...buildExplainPackPayloadCore(dependencies.compactRetrieveResult(retrieval), retrieval, implementation),
     retrieval,
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
   }))

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -1087,7 +1087,11 @@ export async function runContextPackCommand(
     : undefined
   return renderContextPackOutput(options.format, buildPackSchemaV1({
     ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
-    ...buildExplainPackPayloadCore(dependencies.compactRetrieveResult(retrieval), retrieval, implementation),
+    ...(
+      resolvedTask.task_kind === 'explain'
+        ? buildExplainPackPayloadCore(dependencies.compactRetrieveResult(retrieval), retrieval, implementation)
+        : buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval, implementation)
+    ),
     retrieval,
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
   }))

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -997,6 +997,11 @@ describe('context-pack-command', () => {
       schema_version?: number
       task?: string
       task_intent?: string
+      pack?: {
+        workflow_centers?: unknown
+        recommended_first_read?: unknown
+        confidence_score?: unknown
+      }
       workflow_centers?: Array<{
         label?: string
         path?: string
@@ -1066,6 +1071,9 @@ describe('context-pack-command', () => {
     expect(payload.recommended_first_read?.[0]?.path).toBe(payload.workflow_centers?.[0]?.path)
     expect(payload.recommended_first_read?.[0]?.path).toBe('src/infrastructure/context-pack-command.ts')
     expect(payload.likely_edit_files?.some((entry) => entry.path === 'src/contracts/context-pack.ts')).toBe(false)
+    expect(payload.pack?.workflow_centers).toBeUndefined()
+    expect(payload.pack?.recommended_first_read).toBeUndefined()
+    expect(payload.pack?.confidence_score).toBeUndefined()
   })
 
   it('surfaces lexical helpers as negative guidance instead of edit targets for implementation packs', async () => {

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -100,6 +100,12 @@ describe('pack-quality fixtures (#298)', () => {
         'src/modules/pipeline/api/queue-registry.service.ts',
       ]),
     )
+    expect(payload.confidence_score).toEqual(expect.any(Number))
+    expect(payload.confidence_score).toBeGreaterThanOrEqual(0)
+    expect(payload.confidence_score).toBeLessThanOrEqual(1)
+    expect(payload.pack?.confidence_score).toEqual(expect.any(Number))
+    expect(payload.pack?.confidence_score).toBeGreaterThanOrEqual(0)
+    expect(payload.pack?.confidence_score).toBeLessThanOrEqual(1)
     expect(payload.pack?.confidence_score).toBe(payload.confidence_score)
     expect(payload.pack?.workflow_centers?.map((entry) => entry.path)).toEqual(payload.workflow_centers?.map((entry) => entry.path))
     expect(payload.pack?.recommended_first_read?.map((entry) => entry.path)).toEqual(

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -66,8 +66,13 @@ describe('pack-quality fixtures (#298)', () => {
   it('generates a deterministic explain pack for runtime-generation-explain-report-flow', async () => {
     const result = await runPackQualityFixture('runtime-generation-explain-report-flow')
     const payload = result.payload as typeof result.payload & {
+      confidence_score?: number
+      workflow_centers?: Array<{ path?: string }>
       recommended_first_read?: Array<{ path?: string }>
       pack?: {
+        confidence_score?: number
+        workflow_centers?: Array<{ path?: string }>
+        recommended_first_read?: Array<{ path?: string }>
         execution_slice?: {
           steps?: Array<{ label?: string }>
           phase_coverage?: {
@@ -94,6 +99,11 @@ describe('pack-quality fixtures (#298)', () => {
         'src/modules/pipeline/api/pipeline-trigger.service.ts',
         'src/modules/pipeline/api/queue-registry.service.ts',
       ]),
+    )
+    expect(payload.pack?.confidence_score).toBe(payload.confidence_score)
+    expect(payload.pack?.workflow_centers?.map((entry) => entry.path)).toEqual(payload.workflow_centers?.map((entry) => entry.path))
+    expect(payload.pack?.recommended_first_read?.map((entry) => entry.path)).toEqual(
+      payload.recommended_first_read?.map((entry) => entry.path),
     )
     expect(payload.recommended_first_read?.map((entry) => entry.path)).not.toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- restore nested explain-pack guidance fields inside `pack` for runtime consumers that still read that shape
- reuse the same explain payload core in `madar pack` and `madar compare` so they stay aligned
- add regression coverage for the runtime-generation explain fixture

Closes #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved explain-task payload generation to include guidance compatibility fields (workflow centers, recommended first read, confidence score) and adjusted internal packing to keep non-explain outputs unchanged.
* **Tests**
  * Updated unit fixtures and schema tests to validate the new guidance fields, their values, and their expected placement in emitted payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->