### PR TITLE
Fix managed hook install detection

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -7,6 +7,7 @@ import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
 import { buildExplainPackPayload } from './context-pack-command.js'
+import { isMadarProjectHook } from './install.js'
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
@@ -2323,8 +2324,6 @@ export interface ExecuteNativeAgentCompareDependencies {
 }
 
 const MADAR_SECTION_MARKER = '## madar'
-const OUT_PATH_SEGMENT_PATTERN = /(^|[^a-z0-9_])out(?:[\\/]|[^a-z0-9_]|$)/i
-
 function readJsonObject(filePath: string): Record<string, unknown> | null {
   if (!existsSync(filePath)) {
     return null
@@ -2336,19 +2335,6 @@ function readJsonObject(filePath: string): Record<string, unknown> | null {
   } catch {
     return null
   }
-}
-
-function containsOutPathReference(value: unknown): boolean {
-  if (typeof value === 'string') {
-    return OUT_PATH_SEGMENT_PATTERN.test(value)
-  }
-  if (Array.isArray(value)) {
-    return value.some(containsOutPathReference)
-  }
-  if (isRecord(value)) {
-    return Object.values(value).some(containsOutPathReference)
-  }
-  return false
 }
 
 function hasSectionMarker(filePath: string, marker = MADAR_SECTION_MARKER): boolean {
@@ -2373,7 +2359,13 @@ function findHookEntry(
   }
 
   const hookEntries = hooks[hookName]
-  return Array.isArray(hookEntries) && hookEntries.some(containsOutPathReference)
+  const matcher =
+    hookName === 'PreToolUse'
+      ? 'Glob|Grep|Bash|Agent|Read'
+      : hookName === 'BeforeTool'
+        ? 'read_file|list_directory|search_for_pattern'
+        : undefined
+  return Array.isArray(hookEntries) && hookEntries.some((hook) => isMadarProjectHook(hook, matcher))
 }
 
 function hasMadarMcpEntry(configPath: string): boolean {

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -32,6 +32,8 @@ export const MCP_TOOL_PROFILES = ['core', 'full'] as const
 export type McpToolProfile = (typeof MCP_TOOL_PROFILES)[number]
 export const INSTALL_PROFILES = [...MCP_TOOL_PROFILES, 'strict'] as const
 export type InstallProfile = (typeof INSTALL_PROFILES)[number]
+const MANAGED_HOOK_NAME = 'madar'
+const MANAGED_HOOK_SOURCE = 'madar'
 
 interface InstallPlatformConfig {
   skillFile: string
@@ -200,13 +202,31 @@ function isMadarProjectHookCommand(command: string): boolean {
   )
 }
 
-function isMadarProjectHook(hook: unknown, matcher?: string): boolean {
+function hasMadarHookSentinel(hook: Record<string, unknown>): boolean {
+  return hook.name === MANAGED_HOOK_NAME
+    || hook.source === MANAGED_HOOK_SOURCE
+    || (typeof hook.source === 'string' && hook.source.startsWith(`${MANAGED_HOOK_SOURCE}:`))
+}
+
+function withManagedHookIdentity<T extends Record<string, unknown>>(hook: T): T & { name: string; source: string } {
+  return {
+    ...hook,
+    name: MANAGED_HOOK_NAME,
+    source: MANAGED_HOOK_SOURCE,
+  }
+}
+
+export function isMadarProjectHook(hook: unknown, matcher?: string): boolean {
   if (!isRecord(hook) || !Array.isArray(hook.hooks)) {
     return false
   }
 
   if (matcher !== undefined && hook.matcher !== matcher) {
     return false
+  }
+
+  if (hasMadarHookSentinel(hook)) {
+    return true
   }
 
   return hook.hooks.some(
@@ -310,7 +330,7 @@ const CODEX_HOOK = {
   // SECURITY: Keep this command static. Do not interpolate user-controlled input here.
   hooks: {
     PreToolUse: [
-      {
+      withManagedHookIdentity({
         matcher: 'Bash',
         hooks: [
           {
@@ -326,7 +346,7 @@ const CODEX_HOOK = {
             ),
           },
         ],
-      },
+      }),
     ],
   },
 }
@@ -609,7 +629,7 @@ function cursorRule(profile?: InstallProfile): string {
 }
 
 function settingsHook(profile?: InstallProfile): Record<string, unknown> {
-  return {
+  return withManagedHookIdentity({
     hooks: [
       {
         type: 'command',
@@ -624,11 +644,11 @@ function settingsHook(profile?: InstallProfile): Record<string, unknown> {
         ),
       },
     ],
-  }
+  })
 }
 
 function geminiHook(profile?: InstallProfile): Record<string, unknown> {
-  return {
+  return withManagedHookIdentity({
     matcher: 'read_file|list_directory|search_for_pattern',
     hooks: [
       {
@@ -642,7 +662,7 @@ function geminiHook(profile?: InstallProfile): Record<string, unknown> {
         ),
       },
     ],
-  }
+  })
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1722,7 +1742,7 @@ function uninstallGeminiHook(projectDir: string): string | undefined {
   const settings = readJsonObject(settingsPath)
   const hooks = ensureRecord(settings, 'hooks')
   const beforeTool = ensureArray(hooks, 'BeforeTool')
-  const filtered = beforeTool.filter((hook) => !JSON.stringify(hook).includes('out'))
+  const filtered = beforeTool.filter((hook) => !isMadarProjectHook(hook, 'read_file|list_directory|search_for_pattern'))
 
   if (filtered.length === beforeTool.length) {
     return undefined

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest'
 import type { GenerateGraphResult } from '../../src/infrastructure/generate.js'
 import type { NativeAgentCompareResult, NativeAgentCompareReport } from '../../src/infrastructure/compare.js'
 import type { BenchmarkEnvironment, BenchmarkExpectedEnvironment } from '../../src/infrastructure/benchmark/environment.js'
+import { claudeInstall } from '../../src/infrastructure/install.js'
 import {
   loadBenchmarkSuiteRepos,
   loadBenchmarkSuiteTasks,
@@ -37,42 +38,7 @@ function createFixtureRepo(rootPath: string): string {
   writeFileSync(join(rootPath, 'src', 'auth-controller.ts'), 'export const controller = true\n', 'utf8')
   mkdirSync(join(rootPath, 'out'), { recursive: true })
   writeFileSync(join(rootPath, 'out', 'graph.json'), '{}\n', 'utf8')
-  writeFileSync(
-    join(rootPath, '.mcp.json'),
-    JSON.stringify(
-      {
-        mcpServers: {
-          madar: {
-            command: 'node',
-            args: ['dist/src/cli/bin.js', '--stdio', join(rootPath, 'out', 'graph.json')],
-          },
-        },
-      },
-      null,
-      2,
-    ),
-    'utf8',
-  )
-  writeFileSync(join(rootPath, 'CLAUDE.md'), '## madar\n', 'utf8')
-  mkdirSync(join(rootPath, '.claude'), { recursive: true })
-  writeFileSync(
-    join(rootPath, '.claude', 'settings.json'),
-    JSON.stringify(
-      {
-        hooks: {
-          UserPromptSubmit: [
-            {
-              type: 'command',
-              command: 'echo out/graph.json',
-            },
-          ],
-        },
-      },
-      null,
-      2,
-    ),
-    'utf8',
-  )
+  claudeInstall(rootPath)
   return rootPath
 }
 

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -6,56 +6,23 @@ import { describe, expect, it } from 'vitest'
 import {
   executeNativeAgentCompare,
   formatNativeAgentCompareSummary,
+  inspectClaudeNativeAgentInstall,
   parseAnthropicResultEvent,
   type CompareRunMode,
   type NativeAgentCompareResult,
   type NativeAgentCompareReport,
   type NativeAgentRunner,
 } from '../../src/infrastructure/compare.js'
+import { claudeInstall } from '../../src/infrastructure/install.js'
 
 const FIXTURE_PARENT = resolve('out', 'test-runtime', 'native-agent')
 const COMPARE_OUTPUT_PARENT = resolve('out', 'compare', 'test-runtime-native-agent')
 
-function writeClaudeInstallArtifacts(projectDir: string, graphPath: string): void {
-  writeFileSync(
-    join(projectDir, '.mcp.json'),
-    JSON.stringify(
-      {
-        mcpServers: {
-          madar: {
-            command: 'node',
-            args: ['dist/src/cli/bin.js', '--stdio', graphPath],
-          },
-        },
-      },
-      null,
-      2,
-    ),
-    'utf8',
-  )
-  writeFileSync(join(projectDir, 'CLAUDE.md'), '## madar\n', 'utf8')
-  mkdirSync(join(projectDir, '.claude'), { recursive: true })
-  writeFileSync(
-    join(projectDir, '.claude', 'settings.json'),
-    JSON.stringify(
-      {
-        hooks: {
-          UserPromptSubmit: [
-            {
-              type: 'command',
-              command: 'echo out/graph.json',
-            },
-          ],
-        },
-      },
-      null,
-      2,
-    ),
-    'utf8',
-  )
+function writeClaudeInstallArtifacts(projectDir: string): void {
+  claudeInstall(projectDir)
 }
 
-function makeFixtureProject(options: { installState?: 'valid' | 'missing' } = {}): { projectDir: string; graphPath: string; outputDir: string } {
+function makeFixtureProject(options: { installState?: 'managed' | 'valid' | 'missing' } = {}): { projectDir: string; graphPath: string; outputDir: string } {
   mkdirSync(FIXTURE_PARENT, { recursive: true })
   mkdirSync(COMPARE_OUTPUT_PARENT, { recursive: true })
   const projectDir = mkdtempSync(join(FIXTURE_PARENT, 'project-'))
@@ -75,8 +42,10 @@ function makeFixtureProject(options: { installState?: 'valid' | 'missing' } = {}
     'utf8',
   )
   const graphPath = join(projectDir, 'out', 'graph.json')
-  if (options.installState !== 'missing') {
-    writeClaudeInstallArtifacts(projectDir, graphPath)
+  if (options.installState === 'managed') {
+    claudeInstall(projectDir)
+  } else if (options.installState !== 'missing') {
+    writeClaudeInstallArtifacts(projectDir)
   }
   return { projectDir, graphPath, outputDir }
 }
@@ -612,6 +581,67 @@ describe('executeNativeAgentCompare', () => {
         },
         exploration_outcome: 'madar_invoked',
       }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('recognizes the real Claude installer hook as a verified Madar install', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject({ installState: 'managed' })
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({ baseline: VERBOSE_BASELINE_PAYLOAD, madar: VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.install_verified).toBe(true)
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.madar_mcp_call_count).toBe(1)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not treat a non-Claude managed hook matcher as a verified Claude install', () => {
+    const { projectDir } = makeFixtureProject({ installState: 'managed' })
+    try {
+      writeFileSync(
+        join(projectDir, '.claude', 'settings.json'),
+        JSON.stringify(
+          {
+            hooks: {
+              PreToolUse: [
+                {
+                  name: 'madar',
+                  source: 'madar',
+                  matcher: 'read_file|list_directory|search_for_pattern',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: 'echo ignored',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+        'utf8',
+      )
+
+      expect(inspectClaudeNativeAgentInstall(projectDir).verified).toBe(false)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -18,6 +18,7 @@ import {
   resolveCompareQuestions,
 } from '../../src/infrastructure/compare.js'
 import { runContextPackCommand } from '../../src/infrastructure/context-pack-command.js'
+import { claudeInstall } from '../../src/infrastructure/install.js'
 import { parsePromptRunnerOutput } from '../../src/infrastructure/prompt-runner.js'
 import { saveManifest } from '../../src/pipeline/manifest.js'
 import { toJson } from '../../src/pipeline/export.js'
@@ -236,42 +237,7 @@ function writeProjectFiles(projectRoot: string = PROJECT_FIXTURE_ROOT): void {
     writeFileSync(absolutePath, `${content}\n`, 'utf8')
   }
 
-  writeFileSync(
-    join(projectRoot, '.mcp.json'),
-    JSON.stringify(
-      {
-        mcpServers: {
-          madar: {
-            command: 'node',
-            args: ['dist/src/cli/bin.js', '--stdio', join(projectRoot, 'out', 'graph.json')],
-          },
-        },
-      },
-      null,
-      2,
-    ),
-    'utf8',
-  )
-  writeFileSync(join(projectRoot, 'CLAUDE.md'), '## madar\n', 'utf8')
-  mkdirSync(join(projectRoot, '.claude'), { recursive: true })
-  writeFileSync(
-    join(projectRoot, '.claude', 'settings.json'),
-    JSON.stringify(
-      {
-        hooks: {
-          UserPromptSubmit: [
-            {
-              type: 'command',
-              command: 'echo out/graph.json',
-            },
-          ],
-        },
-      },
-      null,
-      2,
-    ),
-    'utf8',
-  )
+  claudeInstall(projectRoot)
 }
 
 function writeGraphFixture(graph: KnowledgeGraph, graphFixtureRoot: string = GRAPH_FIXTURE_ROOT): string {

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -226,6 +226,22 @@ function extractHookCommand(settingsJson: string, eventName: string): string {
   return parsed.hooks?.[eventName]?.[0]?.hooks?.[0]?.command ?? ''
 }
 
+function extractHookEntry(settingsJson: string, eventName: string): Record<string, unknown> {
+  const parsed = JSON.parse(settingsJson) as {
+    hooks?: Record<string, Array<Record<string, unknown>>>
+  }
+  return parsed.hooks?.[eventName]?.[0] ?? {}
+}
+
+function extractCodexPreToolUseEntry(hooksJson: string): Record<string, unknown> {
+  const parsed = JSON.parse(hooksJson) as {
+    hooks?: {
+      PreToolUse?: Array<Record<string, unknown>>
+    }
+  }
+  return parsed.hooks?.PreToolUse?.[0] ?? {}
+}
+
 function shellCommandForPlatform(
   platform: NodeJS.Platform,
   command: string,
@@ -676,6 +692,22 @@ describe('install helpers', () => {
       expect(decodedPayloads).toContain('Use the graph result as the first bounded pass')
       expect(decodedPayloads).toContain(STRICT_NON_MADAR_MCP_RULE_PLAIN)
       expect(decodedPayloads).toContain(STRICT_SKILL_OVERRIDE_RULE_PLAIN)
+    })
+  })
+
+  it('writes a stable `name: madar` sentinel into installed Claude, Gemini, and Codex hook entries', () => {
+    withTempDir((projectDir) => {
+      claudeInstall(projectDir)
+      geminiInstall(projectDir)
+      agentsInstall(projectDir, 'codex')
+
+      const claudeSettings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
+      const geminiSettings = readFileSync(join(projectDir, '.gemini', 'settings.json'), 'utf8')
+      const codexHooks = readFileSync(join(projectDir, '.codex', 'hooks.json'), 'utf8')
+
+      expect(extractHookEntry(claudeSettings, 'UserPromptSubmit').name).toBe('madar')
+      expect(extractHookEntry(geminiSettings, 'BeforeTool').name).toBe('madar')
+      expect(extractCodexPreToolUseEntry(codexHooks).name).toBe('madar')
     })
   })
 


### PR DESCRIPTION
## Summary
- detect native-agent installs via the shared managed-hook recognizer instead of the old out-path heuristic
- write stable `name`/`source` madar sentinels into Claude, Gemini, and Codex hook entries
- cover real installer output, matcher precision, and compare/benchmark fixture setup with regression tests

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable native-agent install verification by standardizing how managed hooks are identified, improving reinstall/uninstall accuracy.

* **Tests**
  * Expanded test coverage and fixtures now use the real installer flow; added assertions to verify managed hook presence across integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->