### PR TITLE
Fix runtime evidence wiring for issue 353

### DIFF
--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -10,6 +10,7 @@ import type { TaskIntentKind } from './task-intent.js'
 import type { ContextPackDiagnosticWarning } from './context-pack-diagnostics.js'
 import type { SourceDomain } from '../shared/source-discovery.js'
 import type { TaskContextPlan } from './task-context-plan.js'
+import type { MadarResponseEvidence } from '../runtime/mcp-response-evidence.js'
 
 export type ContextPackTaskKind = 'explain' | 'implement' | 'review' | 'impact'
 export type ContextPackFormat = 'json' | 'text' | 'markdown' | 'claude' | 'copilot'
@@ -439,6 +440,7 @@ export interface ContextPackSchemaV1<TPack = unknown> {
   confidence_score: number
   why_explanation: string[]
   pack: TPack
+  evidence: MadarResponseEvidence
   claims: ContextPackClaim[]
   expandable: ContextPackExpandableRef[]
   coverage: ContextPackCoverage

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -126,6 +126,7 @@ export interface CompareMadarTrace {
   tool_call_count: number
   tool_calls_by_name: Record<string, number>
   per_turn: CompareMadarTraceTurnSummary[]
+  agent_directive_seen?: string[]
   madar_mcp_call_count: number
   madar_mcp_calls_by_name: Record<string, number>
   context_pack_call_count: number
@@ -1238,6 +1239,7 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
 
   const sortedTurns = [...perTurnIndex.keys()].sort((leftTurn, rightTurn) => leftTurn - rightTurn)
   const perTurn = sortedTurns.map((turn) => perTurnIndex.get(turn)!)
+  const agentDirectivesSeen = [...new Set(perTurn.flatMap((turn) => turn.agent_directive_seen ?? []))]
   const exploration = analyzeMadarTraceExploration(perTurn)
 
   return {
@@ -1248,6 +1250,7 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
       Object.entries(toolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
     ),
     per_turn: perTurn,
+    ...(agentDirectivesSeen.length > 0 ? { agent_directive_seen: agentDirectivesSeen } : {}),
     ...exploration,
   }
 }

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -27,6 +27,12 @@ import { buildTaskContextPlan } from '../runtime/task-context-planner.js'
 import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
+import {
+  buildMadarResponseEvidence,
+  collectWorkflowOwners,
+  missingPhasesFromPayload,
+  type MadarResponseEvidence,
+} from '../runtime/mcp-response-evidence.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
 
@@ -78,6 +84,7 @@ type PackPayload = RetrievePackPayload | ReviewPackPayload | ImpactPackPayload
 type PackResponseBase = ReturnType<typeof baseResponse>
 
 type PackSchemaEnvelope<TPack extends PackPayload = PackPayload> = ContextPackSchemaV1<TPack> & PackResponseBase & {
+  evidence: MadarResponseEvidence
   implementation?: ImplementationPackGuidance
   target?: string
 }
@@ -718,6 +725,20 @@ function buildPackSchemaV1<TPack extends PackPayload>(
   const contracts = publicContracts(response.implementation)
   const guidance = negativeGuidance(response.task, response.coverage, response.pack, response.implementation, retrieval)
   const score = confidenceScore(response.coverage, response.pack, response.implementation)
+  const evidence = buildMadarResponseEvidence({
+    coverage: response.coverage,
+    missingPhases: missingPhasesFromPayload(response.pack as {
+      answer_contract?: { missing_phases?: readonly unknown[] }
+      execution_slice?: { phase_coverage?: { missing?: readonly unknown[] } }
+    }),
+    coveredWorkflowOwners: collectWorkflowOwners(
+      centers.map((entry) => entry.path),
+      firstRead.map((entry) => entry.path),
+      response.implementation?.likely_edit_files.map((entry) => entry.path) ?? [],
+      response.implementation?.likely_test_files.map((entry) => entry.path) ?? [],
+    ),
+    score,
+  })
   const compatibilityFields: PackGuidanceCompatibilityFields = {
     workflow_centers: centers,
     recommended_first_read: firstRead,
@@ -727,6 +748,7 @@ function buildPackSchemaV1<TPack extends PackPayload>(
   return {
     schema_version: 1,
     ...serializableResponse,
+    evidence,
     pack: packForSchema(response.task, response.pack, compatibilityFields),
     workflow_centers: centers,
     recommended_first_read: firstRead,

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -835,11 +835,13 @@ function hasGroundedFirstRead(schema: PackSchemaEnvelope): boolean {
 }
 
 function useDirectiveAdapterGuidance(schema: PackSchemaEnvelope): boolean {
-  return schema.confidence_score >= ADAPTER_DIRECTIVE_CONFIDENCE_THRESHOLD
-    && schema.missing_context.length === 0
-    && schema.missing_semantic.length === 0
-    && hasGraphBackedWorkflowCenter(schema)
-    && hasGroundedFirstRead(schema)
+  switch (schema.evidence.agent_directive) {
+    case 'answer_from_pack':
+      return true
+    case 'verify_one_targeted_file':
+    case 'explore_with_caution':
+      return false
+  }
 }
 
 function claudeSearchGuidanceLine(schema: PackSchemaEnvelope): string {

--- a/src/runtime/mcp-response-evidence.ts
+++ b/src/runtime/mcp-response-evidence.ts
@@ -97,3 +97,39 @@ export function buildMadarResponseEvidence(input: {
     agent_directive: agentDirectiveForEvidence(packConfidence, coverage),
   }
 }
+
+export function collectWorkflowOwners(...groups: Array<readonly (string | null | undefined)[]>): string[] {
+  const seen = new Set<string>()
+  const owners: string[] = []
+
+  for (const group of groups) {
+    for (const value of group) {
+      const normalized = typeof value === 'string' ? value.trim() : ''
+      if (normalized.length === 0 || seen.has(normalized)) {
+        continue
+      }
+      seen.add(normalized)
+      owners.push(normalized)
+      if (owners.length >= 5) {
+        return owners
+      }
+    }
+  }
+
+  return owners
+}
+
+export function missingPhasesFromPayload(
+  payload: Partial<{
+    answer_contract: { missing_phases?: readonly unknown[] }
+    execution_slice: { phase_coverage?: { missing?: readonly unknown[] } }
+  }>,
+): ContextPackExecutionPhase[] {
+  const fromAnswer = Array.isArray(payload.answer_contract?.missing_phases)
+    ? payload.answer_contract.missing_phases.filter((value): value is ContextPackExecutionPhase => typeof value === 'string')
+    : []
+  const fromSlice = Array.isArray(payload.execution_slice?.phase_coverage?.missing)
+    ? payload.execution_slice.phase_coverage.missing.filter((value): value is ContextPackExecutionPhase => typeof value === 'string')
+    : []
+  return [...new Set([...fromAnswer, ...fromSlice])]
+}

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -45,7 +45,11 @@ import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
 import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-delta.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
 import { buildImplementationPackGuidance } from '../implementation-pack.js'
-import { buildMadarResponseEvidence } from '../mcp-response-evidence.js'
+import {
+  buildMadarResponseEvidence,
+  collectWorkflowOwners,
+  missingPhasesFromPayload,
+} from '../mcp-response-evidence.js'
 import { resolveTaskSelection } from '../task-intent.js'
 import { riskMap } from '../risk-map.js'
 import { buildTaskContextPlan } from '../task-context-planner.js'
@@ -320,42 +324,6 @@ function contextMetadata(
     missing_semantic: coverage.missing_semantic,
     ...(payload.retrieval_gate ? { retrieval_gate: payload.retrieval_gate } : {}),
   }
-}
-
-function collectWorkflowOwners(...groups: Array<readonly (string | null | undefined)[]>): string[] {
-  const seen = new Set<string>()
-  const owners: string[] = []
-
-  for (const group of groups) {
-    for (const value of group) {
-      const normalized = typeof value === 'string' ? value.trim() : ''
-      if (normalized.length === 0 || seen.has(normalized)) {
-        continue
-      }
-      seen.add(normalized)
-      owners.push(normalized)
-      if (owners.length >= 5) {
-        return owners
-      }
-    }
-  }
-
-  return owners
-}
-
-function missingPhasesFromPayload(
-  payload: Partial<{
-    answer_contract: { missing_phases?: readonly unknown[] }
-    execution_slice: { phase_coverage?: { missing?: readonly unknown[] } }
-  }>,
-): ContextPackExecutionPhase[] {
-  const fromAnswer = Array.isArray(payload.answer_contract?.missing_phases)
-    ? payload.answer_contract.missing_phases.filter((value): value is ContextPackExecutionPhase => typeof value === 'string')
-    : []
-  const fromSlice = Array.isArray(payload.execution_slice?.phase_coverage?.missing)
-    ? payload.execution_slice.phase_coverage.missing.filter((value): value is ContextPackExecutionPhase => typeof value === 'string')
-    : []
-  return [...new Set([...fromAnswer, ...fromSlice])]
 }
 
 function evidenceForRetrievePayload(

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1948,10 +1948,12 @@ describe('compare runtime', () => {
     const report = result.reports[0]!
     const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as {
       madar_trace?: {
+        agent_directive_seen?: string[]
         per_turn?: Array<Record<string, unknown>>
       }
     }
 
+    expect(savedReport.madar_trace?.agent_directive_seen).toEqual(['answer_from_pack'])
     expect(savedReport.madar_trace?.per_turn).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/unit/context-pack-adapter-gating.test.ts
+++ b/tests/unit/context-pack-adapter-gating.test.ts
@@ -303,6 +303,38 @@ describe('context-pack adapter gating', () => {
     expect(output).toContain('Do not start with a broad repo search.')
   })
 
+  it('aligns claude anti-search guidance with answer_from_pack evidence', async () => {
+    const coverage = highConfidenceCoverage()
+    buildImplementationPackGuidanceMock.mockReturnValue(lowConfidenceImplementation())
+    const dependencies = buildDependencies(buildRetrieval(coverage), buildCompactPack(coverage))
+
+    const json = JSON.parse(await runContextPackCommand({
+      prompt: 'Implement issue #312 by gating directive adapter wording on pack quality',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'json',
+    } as never, dependencies)) as {
+      evidence?: {
+        agent_directive?: string
+      }
+    }
+
+    expect(json.evidence?.agent_directive).toBe('answer_from_pack')
+
+    const output = await runContextPackCommand({
+      prompt: 'Implement issue #312 by gating directive adapter wording on pack quality',
+      budget: 1800,
+      task: 'implement',
+      taskExplicit: true,
+      graphPath: 'out/graph.json',
+      format: 'claude',
+    } as never, dependencies)
+
+    expect(output).toContain('Do not start with a broad repo search.')
+  })
+
   it('suppresses claude anti-search guidance when required semantic coverage is still missing', async () => {
     const coverage = missingSemanticCoverage()
     buildImplementationPackGuidanceMock.mockReturnValue(highConfidenceImplementation())

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -411,11 +411,21 @@ describe('context-pack-command', () => {
     }, dependencies)
 
     const payload = JSON.parse(output) as {
+      evidence?: {
+        pack_confidence?: string
+        coverage?: string
+        agent_directive?: string
+      }
       workflow_centers?: Array<{ path?: string; label?: string }>
       recommended_first_read?: Array<{ path?: string; label?: string }>
       negative_guidance?: string[]
     }
 
+    expect(payload.evidence).toEqual(expect.objectContaining({
+      pack_confidence: 'high',
+      coverage: 'complete',
+      agent_directive: 'answer_from_pack',
+    }))
     expect(payload.workflow_centers?.slice(0, 4)).toEqual([
       expect.objectContaining({
         path: 'src/ideas/controller.ts',


### PR DESCRIPTION
## Summary
- expose top-level evidence on CLI context-pack JSON output using the shared Madar response evidence contract
- promote compare report agent_directive_seen to a top-level aggregate while keeping per-turn details
- add regression coverage for CLI pack evidence and compare trace directive visibility

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context pack output now includes an evidence section with coverage, confidence, missing phases, workflow owners, and an agent directive flag.
  * Agent-directive guidance is now driven by that evidence, affecting how adapter guidance is selected.

* **Refactor**
  * Evidence collection and processing utilities were centralized and reused across runtime components.

* **Tests**
  * Unit tests updated/added to validate evidence presence, agent-directive aggregation, and adapter gating.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->