### PR TITLE
Prepare 0.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.0] - 2026-05-27
+
+### Added
+
+- **Pack Schema v1 and implementation-ready pack guidance**: `madar pack` now emits a stable schema for implementation tasks, including workflow centers, likely edit/test files, public contracts, risk boundaries, validation commands, negative guidance, and agent-ready brief renderers from one source of truth.
+- **A reproducible benchmark-suite scaffold**: `madar bench:suite` now ships fixed repo/task manifests, isolation assets, share-safe result publication, and the first measured public suite row under `docs/benchmarks/suite/`.
+
+### Changed
+
+- **Installed-agent and compare flows are more reliable**: installed guidance now stays stricter about bounded exploration, explain-mode MCP responses expose top-level `evidence` metadata, and managed install detection now keys off the real generated hook structure with stable Claude/Gemini/Codex identity markers.
+- **Runtime and implementation packs are more trustworthy**: implementation-mode packs now promote workflow owners more accurately, runtime-generation answers keep more honest `execution_slice` / `phase_coverage` reporting, and weak-evidence fallbacks are more explicit about uncertainty instead of overclaiming full runtime certainty.
+- **Public proof surfaces are more honest and reproducible**: README/package/docs language now maps public claims back to dated evidence, benchmark isolation metadata is checked in, and compare artifacts keep the share-safe/reporting posture introduced across the `0.27.0-next.*` line.
+
 ## [0.27.0-next.4] - 2026-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Want a broader local-first walkthrough that also covers install, `prompt`, and a
 
 ---
 
-## What's new in 0.27.0-next.4
+## What's new in 0.27.0
 
-- Managed install detection now matches the real generated hook shape: `madar compare` and `madar bench:suite` no longer mistake a fresh Claude install for a missing hook just because the managed command is base64-wrapped.
-- Installed Claude, Gemini, and Codex hooks now carry stable Madar identity markers, so compare/install/uninstall logic stays aligned on the same managed-hook contract across supported agent surfaces.
-- Native-agent install validation is more precise: compare now keeps hook matcher families distinct, which avoids treating the wrong managed hook type as a valid Claude install.
+- Pack Schema v1 is now the stable implementation-pack surface: workflow centers, likely edit/test files, validation commands, negative guidance, and agent-ready brief renderers all ship from one release line instead of a prerelease-only path.
+- The benchmark suite is now part of the public product surface: `madar bench:suite` ships with fixed manifests, isolation assets, share-safe artifacts, and the first measured suite row under `docs/benchmarks/suite/`.
+- Installed-agent and compare flows are more reliable: strict guidance keys off top-level response evidence, managed hook detection now matches the real generated structure, and Claude/Gemini/Codex installs share stable Madar identity markers.
 
-See the [`0.27.0-next.4` changelog entry](CHANGELOG.md#0270-next4---2026-05-27) for the full release notes.
+See the [`0.27.0` changelog entry](CHANGELOG.md#0270---2026-05-27) for the full release notes.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -89,7 +89,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.0-next.4. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.0. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.0-next.4",
+    "version": "0.27.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.0-next.4",
+            "version": "0.27.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.0-next.4",
+    "version": "0.27.0",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump the package from 0.27.0-next.4 to 0.27.0
- add the stable 0.27.0 changelog entry
- update the README release notes to point at the stable line

## Verification
- npm install --prefer-offline --no-audit
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- node dist/src/cli/bin.js --version
- node dist/src/cli/bin.js generate <temp sample workspace>
- node dist/src/cli/bin.js claude install/uninstall in temp sample workspace
- node dist/src/cli/bin.js codex install/uninstall in temp sample workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pack Schema v1 now stable for production use
  * Public benchmark-suite surface available for reproducible benchmarking

* **Bug Fixes & Improvements**
  * Enhanced reliability of installed-agent and compare workflows
  * Improved consistency of identity markers across different installations
  * Increased trustworthiness of public proof surfaces and comparison artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->