### PR TITLE
Relax pipeline fixture timeout on Windows

### DIFF
--- a/tests/unit/pipeline.test.ts
+++ b/tests/unit/pipeline.test.ts
@@ -111,12 +111,14 @@ function runPipeline(tempDir: string) {
 }
 
 describe('pipeline', () => {
+  const referenceFixturesTimeoutMs = 30_000
+
   it('runs end to end on the reference fixtures', () => {
     withTempDir((tempDir) => {
       const result = runPipeline(tempDir)
       expect(result.graph.numberOfNodes()).toBeGreaterThan(0)
     })
-  }, 15_000)
+  }, referenceFixturesTimeoutMs)
 
   it('keeps node and edge counts stable across repeated runs', () => {
     withTempDir((tempDir) => {


### PR DESCRIPTION
## Summary
- raise the timeout for the end-to-end reference-fixture pipeline test from 15s to 30s
- keep the change scoped to the single flaky test that timed out on windows-latest / Node 22 in PR #359
- follow up on the merged failure without changing product code

## Root cause
The failing run was PR #359 job `validate (windows-latest, Node 22)` in the `Run tests` step. The only failing case was `tests/unit/pipeline.test.ts > pipeline > runs end to end on the reference fixtures`, which hit Vitest's 15s per-test timeout. PR #359 only changed docs and committed benchmark artifacts, not the pipeline code or this test, so the failure was a latent timing issue exposed by the slowest CI leg rather than a product regression.

## Verification
- npm run test:run -- tests/unit/pipeline.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to improve reliability of end-to-end reference fixture tests.

---

**Note:** This release contains no changes visible to end-users. These updates are internal testing infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->