### PR TITLE
Fix degraded compare attribution

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2783,15 +2783,9 @@ interface NativeAgentSuiteChange {
 }
 
 function nativeAgentReductionsAttributable(
-  report: Pick<NativeAgentCompareReport, 'measurement_validity' | 'madar_mcp_call_count' | 'madar_trace'>,
+  report: Pick<NativeAgentCompareReport, 'measurement_validity'>,
 ): boolean {
-  if (report.measurement_validity === 'invalid') {
-    return false
-  }
-  if (report.madar_trace) {
-    return report.madar_mcp_call_count > 0
-  }
-  return true
+  return report.measurement_validity === 'valid'
 }
 
 function isComparableNativeAgentReport(report: NativeAgentCompareReport): report is NativeAgentComparableReport {

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2782,8 +2782,22 @@ interface NativeAgentSuiteChange {
   percentReduction: number
 }
 
+function nativeAgentReductionsAttributable(
+  report: Pick<NativeAgentCompareReport, 'measurement_validity' | 'madar_mcp_call_count' | 'madar_trace'>,
+): boolean {
+  if (report.measurement_validity === 'invalid') {
+    return false
+  }
+  if (report.madar_trace) {
+    return report.madar_mcp_call_count > 0
+  }
+  return true
+}
+
 function isComparableNativeAgentReport(report: NativeAgentCompareReport): report is NativeAgentComparableReport {
-  return report.baseline.kind === 'succeeded' && report.madar.kind === 'succeeded'
+  return report.baseline.kind === 'succeeded'
+    && report.madar.kind === 'succeeded'
+    && nativeAgentReductionsAttributable(report)
 }
 
 function computeReductionPercent(baseline: number, madar: number): number | null {
@@ -3188,6 +3202,9 @@ export async function executeNativeAgentCompare(
           ? 'valid'
           : 'degraded'
         : 'invalid'
+    if (!nativeAgentReductionsAttributable(reportShell)) {
+      reportShell.reductions = null
+    }
     const answerQuality = evaluateNativeAgentAnswerQualityReport(
       answerQualityGates,
       question,
@@ -3353,13 +3370,27 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       madar.usage.cache_creation_input_tokens > 0 ||
       madar.cached_input_tokens_anthropic_exact > 0
 
+    lines.push(`- "${report.question}"`)
+    appendNativeAgentValidityLines(lines, report)
+    const derivedTokenRegressionReasons = collectTokenRegressionReasons(baseline, madar)
+    const tokenRegressionReasons =
+      report.token_regression_reasons && report.token_regression_reasons.length > 0
+        ? report.token_regression_reasons
+        : derivedTokenRegressionReasons
+    if (!nativeAgentReductionsAttributable(report)) {
+      lines.push('    Cannot attribute outcome differences to Madar. Raw numbers preserved in report.json.')
+      const tokenRegressionWarning = formatTokenRegressionWarning(baseline, madar, tokenRegressionReasons)
+      if (tokenRegressionWarning) {
+        lines.push(`    ${tokenRegressionWarning}`)
+      }
+      if (report.madar_trace) {
+        lines.push(`    madar_trace: ${report.madar_trace.exploration_outcome} · ${report.madar_trace.exploration_summary}`)
+      }
+      lines.push('    provider/runtime proof: Anthropic reported input, cache, and total tokens for both runs')
+      continue
+    }
+
     lines.push(
-      `- "${report.question}"`,
-      ...(() => {
-        const validityLines: string[] = []
-        appendNativeAgentValidityLines(validityLines, report)
-        return validityLines
-      })(),
       `    num_turns: baseline ${baseline.num_turns} → madar ${madar.num_turns}${formatDirectionalDelta(baseline.num_turns, madar.num_turns, 'fewer', 'more')}`,
       `    latency:   baseline ${baseline.duration_ms}ms → madar ${madar.duration_ms}ms${formatDirectionalDelta(baseline.duration_ms, madar.duration_ms, 'faster', 'slower')}`,
       `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → madar ${madar.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, madar.total_input_tokens_anthropic_exact, 'less', 'more', { noMeaningfulChangeThreshold: 0.1, neutralLabel: 'no meaningful change' })}`,
@@ -3376,11 +3407,6 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
         `    tool calls: baseline ${report.tool_call_counts.baseline.total} → madar ${report.tool_call_counts.madar.total}${formatDirectionalDelta(report.tool_call_counts.baseline.total, report.tool_call_counts.madar.total, 'fewer', 'more')}`,
       )
     }
-    const derivedTokenRegressionReasons = collectTokenRegressionReasons(baseline, madar)
-    const tokenRegressionReasons =
-      report.token_regression_reasons && report.token_regression_reasons.length > 0
-        ? report.token_regression_reasons
-        : derivedTokenRegressionReasons
     const tokenRegressionWarning = formatTokenRegressionWarning(baseline, madar, tokenRegressionReasons)
     if (tokenRegressionWarning) {
       lines.push(`    ${tokenRegressionWarning}`)

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -220,6 +220,35 @@ const VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD = [
   MADAR_USAGE_PAYLOAD,
 ] as const
 
+const VERBOSE_BASELINE_TOKEN_REGRESSION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'Read' },
+        { type: 'tool_use', name: 'Grep' },
+      ],
+    },
+  },
+  BASELINE_TOKEN_REGRESSION_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_TOKEN_REGRESSION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+      ],
+    },
+  },
+  MADAR_TOKEN_REGRESSION_PAYLOAD,
+] as const
+
 const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
   { type: 'system', subtype: 'init' },
   {
@@ -528,6 +557,40 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
+  it('marks no-trace provider-only runs degraded and suppresses derived reductions', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({ baseline: BASELINE_USAGE_PAYLOAD, madar: MADAR_USAGE_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+
+      expect(report.install_verified).toBe(true)
+      expect(report.measurement_validity).toBe('degraded')
+      expect(report.madar_mcp_call_count).toBe(0)
+      expect(report.madar_trace).toBeUndefined()
+      expect(report.reductions).toBeNull()
+      expect(savedReport.reductions).toBeNull()
+      expect(shareSafeReport.reductions).toBeNull()
+      expect(report.madar.kind).toBe('succeeded')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('marks verbose missing-install runs as no_install when trace data is present', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject({ installState: 'missing' })
     try {
@@ -694,7 +757,7 @@ describe('executeNativeAgentCompare', () => {
           baselineMode: 'native_agent',
         },
         {
-          runner: scriptedRunner({ baseline: BASELINE_USAGE_PAYLOAD, madar: MADAR_USAGE_PAYLOAD }),
+          runner: scriptedRunner({ baseline: VERBOSE_BASELINE_PAYLOAD, madar: VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD }),
           now: () => new Date('2026-05-01T00:00:00Z'),
         },
       )
@@ -704,6 +767,8 @@ describe('executeNativeAgentCompare', () => {
       expect(report.baseline_mode).toBe('native_agent')
       expect(report.exec_command.command).toBeNull()
       expect(report.exec_command.redacted).toBe(true)
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.madar_mcp_call_count).toBe(1)
 
       // Both Anthropic-reported usage blocks are preserved as-is.
       expect(report.baseline.kind).toBe('succeeded')
@@ -765,8 +830,8 @@ describe('executeNativeAgentCompare', () => {
         },
         {
           runner: scriptedRunner({
-            baseline: BASELINE_TOKEN_REGRESSION_PAYLOAD,
-            madar: MADAR_TOKEN_REGRESSION_PAYLOAD,
+            baseline: VERBOSE_BASELINE_TOKEN_REGRESSION_PAYLOAD,
+            madar: VERBOSE_MADAR_TOKEN_REGRESSION_PAYLOAD,
           }),
           now: () => new Date('2026-05-26T00:00:00Z'),
         },
@@ -778,6 +843,8 @@ describe('executeNativeAgentCompare', () => {
       const reductions = savedReport.reductions as Record<string, unknown>
       const shareSafeReductions = shareSafeReport.reductions as Record<string, unknown>
 
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.madar_mcp_call_count).toBe(1)
       expect(reductions.input_tokens).toBeCloseTo(1.06, 2)
       expect(reductions.uncached_input_tokens).toBeCloseTo(0.72, 2)
       expect(reductions.cache_creation_input_tokens).toBeCloseTo(0.6, 2)
@@ -1182,6 +1249,8 @@ describe('formatNativeAgentCompareSummary', () => {
         input_tokens: 3,
         cost_usd: 1,
       },
+      measurementValidity: 'valid',
+      madarMcpCallCount: 1,
     })
     const report = result.reports[0]
     if (!report || report.baseline.kind !== 'succeeded' || report.madar.kind !== 'succeeded') {
@@ -1229,6 +1298,8 @@ describe('formatNativeAgentCompareSummary', () => {
         input_tokens: 0.33,
         cost_usd: 1,
       },
+      measurementValidity: 'valid',
+      madarMcpCallCount: 1,
     }))
 
     expect(summary).toContain('num_turns: baseline 3 → madar 9 (3x more)')
@@ -1254,6 +1325,8 @@ describe('formatNativeAgentCompareSummary', () => {
         input_tokens: 3,
         cost_usd: 1,
       },
+      measurementValidity: 'valid',
+      madarMcpCallCount: 1,
     }))
 
     expect(summary).not.toContain('uncached_input_tokens (Anthropic-reported)')
@@ -1277,6 +1350,8 @@ describe('formatNativeAgentCompareSummary', () => {
           input_tokens: 3,
           cost_usd: 1,
         },
+        measurementValidity: 'valid',
+        madarMcpCallCount: 1,
       },
       {
         question: 'win b',
@@ -1292,6 +1367,8 @@ describe('formatNativeAgentCompareSummary', () => {
           input_tokens: 4,
           cost_usd: 1,
         },
+        measurementValidity: 'valid',
+        madarMcpCallCount: 1,
       },
     ]))
 
@@ -1316,6 +1393,8 @@ describe('formatNativeAgentCompareSummary', () => {
           input_tokens: 2,
           cost_usd: 1,
         },
+        measurementValidity: 'valid',
+        madarMcpCallCount: 1,
       },
       {
         question: 'loss case',
@@ -1331,6 +1410,8 @@ describe('formatNativeAgentCompareSummary', () => {
           input_tokens: 0.8,
           cost_usd: 1,
         },
+        measurementValidity: 'valid',
+        madarMcpCallCount: 1,
       },
     ]))
 
@@ -1355,6 +1436,8 @@ describe('formatNativeAgentCompareSummary', () => {
           input_tokens: 3,
           cost_usd: 1,
         },
+        measurementValidity: 'valid',
+        madarMcpCallCount: 1,
       },
       {
         question: 'win b',
@@ -1370,6 +1453,8 @@ describe('formatNativeAgentCompareSummary', () => {
           input_tokens: 4,
           cost_usd: 1,
         },
+        measurementValidity: 'valid',
+        madarMcpCallCount: 1,
       },
       {
         question: 'answer only',
@@ -1598,6 +1683,33 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).not.toContain('input_tokens (Anthropic-reported): baseline 1891943 → madar 1077831 (1.76x less)')
   })
 
+  it('suppresses favorable win lines for degraded runs without trace data', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'degraded no-trace case',
+      baselineTurns: 9,
+      madarTurns: 3,
+      baselineDurationMs: 9000,
+      madarDurationMs: 3000,
+      baselineInputTokens: 900,
+      madarInputTokens: 300,
+      reductions: {
+        num_turns: 3,
+        duration_ms: 3,
+        input_tokens: 3,
+        uncached_input_tokens: 3,
+        cache_creation_input_tokens: null,
+        cost_usd: 1,
+      },
+      measurementValidity: 'degraded',
+      madarMcpCallCount: 0,
+    }))
+
+    expect(summary).toContain('measurement_validity: degraded')
+    expect(summary).toContain('Cannot attribute outcome differences to Madar.')
+    expect(summary).not.toContain('num_turns: baseline 9 → madar 3 (3x fewer)')
+    expect(summary).not.toContain('input_tokens (Anthropic-reported): baseline 900 → madar 300 (3x less)')
+  })
+
   it('prints the tool-call delta when per-side tool counts are available', () => {
     const summary = formatNativeAgentCompareSummary(buildSummaryResult({
       question: 'tool counts',
@@ -1613,6 +1725,8 @@ describe('formatNativeAgentCompareSummary', () => {
         input_tokens: 2,
         cost_usd: 1,
       },
+      measurementValidity: 'valid',
+      madarMcpCallCount: 1,
       toolCallCounts: {
         baseline: {
           total: 6,
@@ -1655,6 +1769,8 @@ describe('formatNativeAgentCompareSummary', () => {
         input_tokens: 1.06,
         cost_usd: 0.87,
       },
+      measurementValidity: 'valid',
+      madarMcpCallCount: 1,
     })
     const report = result.reports[0]
     if (!report || report.baseline.kind !== 'succeeded' || report.madar.kind !== 'succeeded') {

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -514,10 +514,15 @@ describe('executeNativeAgentCompare', () => {
       expect(report.install_verified).toBe(true)
       expect(report.measurement_validity).toBe('degraded')
       expect(report.madar_mcp_call_count).toBe(0)
+      expect(report.reductions).toBeNull()
       expect(report.madar_trace).toEqual(expect.objectContaining({
         madar_mcp_call_count: 0,
         exploration_outcome: 'madar_available_but_unused',
       }))
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+      expect(savedReport.reductions).toBeNull()
+      expect(shareSafeReport.reductions).toBeNull()
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -1549,6 +1554,48 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).toContain('install_verified: true')
     expect(summary).toContain('madar_mcp_call_count: 0')
     expect(summary).toContain('runner error')
+  })
+
+  it('suppresses favorable win lines for degraded runs where Madar was never invoked', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'degraded case',
+      baselineTurns: 21,
+      madarTurns: 16,
+      baselineDurationMs: 108335,
+      madarDurationMs: 106420,
+      baselineInputTokens: 1891943,
+      madarInputTokens: 1077831,
+      reductions: {
+        num_turns: 1.31,
+        duration_ms: 1.02,
+        input_tokens: 1.76,
+        uncached_input_tokens: 0.95,
+        cache_creation_input_tokens: 0.95,
+        cost_usd: 1.29,
+      },
+      madarTrace: {
+        source: 'claude_messages_tool_use',
+        summary: '0 tool calls across 0 turns',
+        tool_call_count: 0,
+        tool_calls_by_name: {},
+        per_turn: [],
+        madar_mcp_call_count: 0,
+        madar_mcp_calls_by_name: {},
+        context_pack_call_count: 0,
+        focused_follow_up_tool_call_count: 0,
+        broad_exploration_tool_call_count: 0,
+        broad_exploration_tool_calls_by_name: {},
+        exploration_outcome: 'madar_available_but_unused',
+        exploration_summary: 'Madar tools were available but not used.',
+      },
+      measurementValidity: 'degraded',
+      madarMcpCallCount: 0,
+    }))
+
+    expect(summary).toContain('measurement_validity: degraded')
+    expect(summary).toContain('Cannot attribute outcome differences to Madar.')
+    expect(summary).not.toContain('num_turns: baseline 21 → madar 16 (1.31x fewer)')
+    expect(summary).not.toContain('input_tokens (Anthropic-reported): baseline 1891943 → madar 1077831 (1.76x less)')
   })
 
   it('prints the tool-call delta when per-side tool counts are available', () => {


### PR DESCRIPTION
## Summary\n- suppress derived reductions when trace data proves the Madar arm never invoked Madar\n- stop native-agent summaries from printing favorable win lines for degraded zero-call runs\n- add regressions covering persisted reports and terminal summary output\n\nCloses #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Only show reduction/delta metrics when attribution is valid; suppress detailed favorable delta lines and instead display an attribution warning when attribution is not possible.
  * Ensure persisted and in-memory reports record reductions as null when not attributable.

* **Tests**
  * Added and strengthened tests to cover non-attributable/degraded scenarios and summary formatting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->