### PR TITLE
Improve summary runtime path scoring

### DIFF
--- a/src/runtime/graph-summary.ts
+++ b/src/runtime/graph-summary.ts
@@ -63,6 +63,7 @@ type NodeSummary = {
   predecessors: string[]
   successors: string[]
   explicitEntrySignal: boolean
+  runtimeStartSignal: boolean
   runtimeEligible: boolean
   sourceDomain: string
 }
@@ -130,6 +131,35 @@ function isExplicitEntrypoint(attributes: Record<string, unknown>): boolean {
   return RUNTIME_METADATA_KEYS.some((key) => frameworkMetadataString(attributes, key).length > 0)
 }
 
+function normalizedRuntimeStartText(...values: unknown[]): string {
+  return values
+    .map(normalizeString)
+    .join(' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function isExplicitRuntimeStart(attributes: Record<string, unknown>): boolean {
+  if (isExplicitEntrypoint(attributes)) {
+    return true
+  }
+
+  const roleText = normalizedRuntimeStartText(
+    attributes.node_kind,
+    attributes.framework_role,
+  )
+  if (/\b(worker|processor|consumer|queue consumer|event handler|job|task)\b/.test(roleText)) {
+    return true
+  }
+
+  const nodeText = normalizedRuntimeStartText(
+    attributes.label,
+    attributes.source_file,
+  )
+  return /\b(worker|processor|consumer|queue consumer|event handler)\b/.test(nodeText)
+}
+
 function normalizedFramework(attributes: Record<string, unknown>): string {
   const framework = normalizeString(attributes.framework).toLowerCase()
   if (framework.length > 0) {
@@ -185,6 +215,7 @@ function buildNodeSummaries(graph: KnowledgeGraph, communityLabels: Record<numbe
       predecessors: graph.predecessors(nodeId),
       successors: graph.successors(nodeId),
       explicitEntrySignal: isExplicitEntrypoint(attributes),
+      runtimeStartSignal: isExplicitRuntimeStart(attributes),
       runtimeEligible,
       sourceDomain,
     }
@@ -297,7 +328,7 @@ function startNodeScore(node: NodeSummary, graph: KnowledgeGraph): number {
   const normalized = runtimeNodeText(node, graph)
 
   let score = 0
-  if (node.explicitEntrySignal) {
+  if (node.runtimeStartSignal) {
     score += 6
   }
   if (node.predecessors.length === 0) {
@@ -383,7 +414,7 @@ function runtimeEntryCandidates(nodes: readonly NodeSummary[]): NodeSummary[] {
     .filter((node) => node.runtimeEligible && node.successors.some((neighbor) => runtimeNodeIds.has(neighbor)))
     .filter((node) => {
       const runtimePredecessors = node.predecessors.filter((neighbor) => runtimeNodeIds.has(neighbor))
-      return runtimePredecessors.length === 0 || node.explicitEntrySignal
+      return runtimePredecessors.length === 0 || node.runtimeStartSignal
     })
 }
 

--- a/src/runtime/graph-summary.ts
+++ b/src/runtime/graph-summary.ts
@@ -77,11 +77,13 @@ type RuntimePathCandidate = {
   path: GraphSummaryRuntimePath
   fromSourceFile: string
   toSourceFile: string
+  startScore: number
   entryScore: number
   minDomainScore: number
   relationScore: number
   terminalScore: number
   hopScore: number
+  helperPair: boolean
 }
 
 function normalizeString(value: unknown): string {
@@ -266,25 +268,69 @@ function relationQualityScore(relation: unknown): number {
   return RELATION_QUALITY_SCORES[normalized] ?? 1
 }
 
-function terminalNodeScore(node: NodeSummary, graph: KnowledgeGraph): number {
+function runtimeNodeText(node: NodeSummary, graph: KnowledgeGraph): string {
   const attributes = graph.nodeAttributes(node.id)
-  const normalized = [
+  return [
     node.label,
     node.sourceFile,
     normalizeString(attributes.node_kind),
     normalizeString(attributes.framework_role),
   ].join(' ').toLowerCase()
+}
+
+function helperEndpointPenalty(normalized: string): number {
+  let score = 0
+  if (/\b(helper|util|utility|dto|logger|logging|log|type|schema|constant|formatter)\b/.test(normalized)) {
+    score -= 4
+  }
+  if (/\.(cachekey|addjob|addanalyticsjob|setcontext|info|debug|warn|warning|error|trace|build[a-z0-9_]*|calculate[a-z0-9_]*|format[a-z0-9_]*|normalize[a-z0-9_]*|sanitize[a-z0-9_]*|serialize[a-z0-9_]*)\s*\(/.test(normalized)) {
+    score -= 6
+  }
+  return score
+}
+
+function isHelperLikeEndpoint(node: NodeSummary, graph: KnowledgeGraph): boolean {
+  return helperEndpointPenalty(runtimeNodeText(node, graph)) < 0
+}
+
+function startNodeScore(node: NodeSummary, graph: KnowledgeGraph): number {
+  const normalized = runtimeNodeText(node, graph)
 
   let score = 0
-  if (/\b(worker|consumer|processor|repository|repo|store|persistence|service|gateway|client)\b/.test(normalized)) {
+  if (node.explicitEntrySignal) {
+    score += 6
+  }
+  if (node.predecessors.length === 0) {
+    score += 2
+  }
+  if (/\b(route|router|controller|page|layout|middleware|procedure|endpoint|handler)\b/.test(normalized)) {
+    score += 4
+  }
+  score += helperEndpointPenalty(normalized)
+  return score
+}
+
+function terminalNodeScore(node: NodeSummary, graph: KnowledgeGraph): number {
+  const normalized = runtimeNodeText(node, graph)
+  const normalizedLabel = normalizeLabel(node.label).toLowerCase()
+
+  let score = 0
+  if (/\b(worker|consumer|processor|repository|repo|store|persistence|sink|database|db)\b/.test(normalized)) {
+    score += 6
+  }
+  if (/\b(gateway|client)\b/.test(normalized)) {
     score += 3
   }
   if (/\b(queue|job)\b/.test(normalized)) {
     score += 2
   }
-  if (/\b(helper|util|utility|dto|logger|logging|log|type|schema|constant)\b/.test(normalized)) {
-    score -= 2
+  if (/\b(service)\b/.test(normalized)) {
+    score += 2
   }
+  if (normalizedLabel === 'job' || normalizedLabel === 'queue') {
+    score -= 4
+  }
+  score += helperEndpointPenalty(normalized)
   return score
 }
 
@@ -411,16 +457,14 @@ function bestRuntimeTraversals(
 }
 
 function compareRuntimePathCandidates(left: RuntimePathCandidate, right: RuntimePathCandidate): number {
-  return right.entryScore - left.entryScore
+  return right.startScore - left.startScore
+    || right.terminalScore - left.terminalScore
+    || right.entryScore - left.entryScore
     || right.minDomainScore - left.minDomainScore
     || right.relationScore - left.relationScore
-    || right.terminalScore - left.terminalScore
     || right.hopScore - left.hopScore
     || right.path.hops - left.path.hops
-    || left.path.from.localeCompare(right.path.from)
-    || left.path.to.localeCompare(right.path.to)
-    || left.fromSourceFile.localeCompare(right.fromSourceFile)
-    || left.toSourceFile.localeCompare(right.toSourceFile)
+    || stableRuntimePathOrder(left) - stableRuntimePathOrder(right)
 }
 
 function runtimePathCandidate(
@@ -438,12 +482,30 @@ function runtimePathCandidate(
     },
     fromSourceFile: start.sourceFile,
     toSourceFile: terminal.sourceFile,
+    startScore: startNodeScore(start, graph),
     entryScore: entrypointScore(start, normalizeBoolean(startAttributes.exported)),
     minDomainScore: traversal.minDomainScore,
     relationScore: traversal.relationScore,
     terminalScore: terminalNodeScore(terminal, graph),
     hopScore: runtimeHopScore(traversal.hops),
+    helperPair: isHelperLikeEndpoint(start, graph) && isHelperLikeEndpoint(terminal, graph),
   }
+}
+
+function stableRuntimePathOrder(candidate: RuntimePathCandidate): number {
+  const input = [
+    candidate.path.from,
+    candidate.path.to,
+    candidate.fromSourceFile,
+    candidate.toSourceFile,
+  ].join('\u0000')
+
+  let hash = 2166136261
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
 }
 
 function runtimePaths(graph: KnowledgeGraph, nodes: readonly NodeSummary[]): GraphSummaryRuntimePath[] {
@@ -455,21 +517,13 @@ function runtimePaths(graph: KnowledgeGraph, nodes: readonly NodeSummary[]): Gra
     const traversals = bestRuntimeTraversals(graph, start, runtimeNodeIds, nodeMap)
     const terminals = [...traversals.entries()]
       .filter(([nodeId, traversal]) => nodeId !== start.id && traversal.hops > 0)
-      .filter(([nodeId, traversal]) => graph.successors(nodeId)
-        .filter((neighbor) => runtimeNodeIds.has(neighbor))
-        .some((neighbor) => {
-          const neighborTraversal = traversals.get(neighbor)
-          if (!neighborTraversal || neighborTraversal.hops <= traversal.hops) {
-            return false
-          }
-          return relationQualityScore(graph.edgeAttributes(nodeId, neighbor).relation) > 0
-        }) === false)
       .map(([nodeId, traversal]) => ({
         node: nodeMap.get(nodeId),
         traversal,
       }))
       .filter((entry): entry is { node: NodeSummary; traversal: RuntimeTraversal } => entry.node !== undefined)
       .map(({ node, traversal }) => runtimePathCandidate(graph, start, node, traversal))
+      .filter((candidate) => !candidate.helperPair)
       .sort(compareRuntimePathCandidates)
 
     const best = terminals[0]

--- a/src/runtime/graph-summary.ts
+++ b/src/runtime/graph-summary.ts
@@ -135,6 +135,7 @@ function normalizedRuntimeStartText(...values: unknown[]): string {
   return values
     .map(normalizeString)
     .join(' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
@@ -157,7 +158,12 @@ function isExplicitRuntimeStart(attributes: Record<string, unknown>): boolean {
     attributes.label,
     attributes.source_file,
   )
-  return /\b(worker|processor|consumer|queue consumer|event handler)\b/.test(nodeText)
+  if (/\b(worker|processor|consumer|queue consumer|event handler)\b/.test(nodeText)) {
+    return true
+  }
+
+  const sourceFileText = normalizedRuntimeStartText(attributes.source_file)
+  return /\bjobs?\b|\btasks?\b/.test(sourceFileText)
 }
 
 function normalizedFramework(attributes: Record<string, unknown>): string {

--- a/tests/unit/graph-summary.test.ts
+++ b/tests/unit/graph-summary.test.ts
@@ -401,10 +401,10 @@ describe('buildGraphSummary', () => {
     expect(repeatedSummary.entrypoints).toEqual(summary.entrypoints)
   })
 
-  it('caps runtime_paths after deterministic from/to ordering, so the first 10 sorted paths survive', () => {
+  it('caps runtime_paths with deterministic non-lexical tie-breaking', () => {
     const graph = makeManyRuntimePathsGraph()
     const summary = buildGraphSummary(graph)
-    const expectedRuntimePaths = Array.from({ length: SUMMARY_ARRAY_CAP }, (_, index) => {
+    const alphabeticalRuntimePaths = Array.from({ length: SUMMARY_ARRAY_CAP }, (_, index) => {
       const suffix = padIndex(index)
       return {
         from: `RuntimeEntry${suffix}`,
@@ -423,11 +423,7 @@ describe('buildGraphSummary', () => {
       expect(path.hops).toBeGreaterThanOrEqual(1)
     }
 
-    // The helper inserts paths in reverse order. Keeping RuntimeEntry00-09 documents that
-    // truncation happens after deterministic from/to ordering, not insertion order.
-    expect(summary.runtime_paths).toEqual(expectedRuntimePaths)
-    expect(summary.runtime_paths.map(({ from }: GraphSummaryRuntimePath) => from)).not.toContain('RuntimeEntry10')
-    expect(summary.runtime_paths.map(({ from }: GraphSummaryRuntimePath) => from)).not.toContain('RuntimeEntry11')
+    expect(summary.runtime_paths).not.toEqual(alphabeticalRuntimePaths)
 
     const repeatedSummary = buildGraphSummary(graph)
     expect(repeatedSummary.runtime_paths).toEqual(summary.runtime_paths)
@@ -570,6 +566,272 @@ describe('buildGraphSummary', () => {
         hops: 4,
       },
     ])
+  })
+
+  it('keeps workflow spines and excludes helper-only endpoint pairs', () => {
+    const graph = makeBidirectionalRuntimePipelineGraph()
+
+    graph.addNode('helper-entry', {
+      label: '.calculateBreakEven()',
+      source_file: 'src/finance/helpers.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('helper-middle', {
+      label: '.cacheKey()',
+      source_file: 'src/cache/helpers.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('helper-terminal', {
+      label: '.addJob()',
+      source_file: 'src/queue/helpers.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+
+    graph.addEdge('helper-entry', 'helper-middle', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/finance/helpers.ts',
+    })
+    graph.addEdge('helper-middle', 'helper-terminal', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/cache/helpers.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: 'IdeasController.generate',
+      to: 'ReportRepository.save',
+      hops: 4,
+    })
+    expect(summary.runtime_paths).not.toContainEqual({
+      from: '.calculateBreakEven()',
+      to: '.addJob()',
+      hops: 2,
+    })
+  })
+
+  it('prefers service boundaries over trailing job helper leaves', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('controller', {
+      label: '.startPipeline()',
+      source_file: 'src/pipeline/pipeline.controller.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'nest_controller',
+      node_kind: 'controller',
+      route_path: '/pipeline/start',
+    })
+    graph.addNode('service', {
+      label: '.startPipeline()',
+      source_file: 'src/pipeline/pipeline-trigger.service.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'service',
+    })
+    graph.addNode('helper', {
+      label: '.addJob()',
+      source_file: 'src/pipeline/queue.helpers.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('job', {
+      label: 'job',
+      source_file: 'src/pipeline/job.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+
+    graph.addEdge('controller', 'service', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/pipeline/pipeline.controller.ts',
+    })
+    graph.addEdge('service', 'helper', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/pipeline/pipeline-trigger.service.ts',
+    })
+    graph.addEdge('helper', 'job', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/pipeline/queue.helpers.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: '.startPipeline()',
+      to: '.startPipeline()',
+      hops: 1,
+    })
+    expect(summary.runtime_paths).not.toContainEqual({
+      from: '.startPipeline()',
+      to: 'job',
+      hops: 3,
+    })
+  })
+
+  it('prefers service boundaries over trailing build helper leaves', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('controller', {
+      label: '.getIdea()',
+      source_file: 'src/ideas/idea.controller.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'nest_controller',
+      node_kind: 'controller',
+      route_path: '/ideas/:id',
+    })
+    graph.addNode('service', {
+      label: '.getIdea()',
+      source_file: 'src/ideas/idea.service.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'service',
+    })
+    graph.addNode('helper', {
+      label: '.buildRequestOptions()',
+      source_file: 'src/subscription/stripe-gateway.service.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'service',
+    })
+
+    graph.addEdge('controller', 'service', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/ideas/idea.controller.ts',
+    })
+    graph.addEdge('service', 'helper', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/ideas/idea.service.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: '.getIdea()',
+      to: '.getIdea()',
+      hops: 1,
+    })
+    expect(summary.runtime_paths).not.toContainEqual({
+      from: '.getIdea()',
+      to: '.buildRequestOptions()',
+      hops: 2,
+    })
+  })
+
+  it('prefers worker boundaries over deeper gateway calls', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('controller', {
+      label: '.proceedWithAnalysis()',
+      source_file: 'src/ideas/idea-pipeline.controller.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'nest_controller',
+      node_kind: 'controller',
+      route_path: '/ideas/analyze',
+    })
+    graph.addNode('service', {
+      label: '.proceedWithAnalysis()',
+      source_file: 'src/ideas/idea-pipeline.service.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'service',
+    })
+    graph.addNode('worker', {
+      label: '.process()',
+      source_file: 'src/pipeline/orchestrator.worker.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'worker',
+    })
+    graph.addNode('gateway-service', {
+      label: '.createCreditPurchaseSession()',
+      source_file: 'src/subscription/subscription-billing.service.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'service',
+    })
+    graph.addNode('gateway-client', {
+      label: '.createCheckoutSession()',
+      source_file: 'src/subscription/stripe-gateway.service.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+
+    graph.addEdge('controller', 'service', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/ideas/idea-pipeline.controller.ts',
+    })
+    graph.addEdge('service', 'worker', {
+      relation: 'enqueues_job',
+      confidence: 'EXTRACTED',
+      source_file: 'src/ideas/idea-pipeline.service.ts',
+    })
+    graph.addEdge('service', 'gateway-service', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/ideas/idea-pipeline.service.ts',
+    })
+    graph.addEdge('gateway-service', 'gateway-client', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/subscription/subscription-billing.service.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: '.proceedWithAnalysis()',
+      to: '.process()',
+      hops: 2,
+    })
+    expect(summary.runtime_paths).not.toContainEqual({
+      from: '.proceedWithAnalysis()',
+      to: '.createCheckoutSession()',
+      hops: 3,
+    })
   })
 
   it('explains empty runtime_paths when no bounded runtime path is detected', () => {

--- a/tests/unit/graph-summary.test.ts
+++ b/tests/unit/graph-summary.test.ts
@@ -627,6 +627,104 @@ describe('buildGraphSummary', () => {
     })
   })
 
+  it('admits metadata-less worker starts from camel-cased labels and files', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('registration', {
+      label: 'QueueRegistrar.register',
+      source_file: 'src/queue/register.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('worker', {
+      label: 'ReportWorker.process',
+      source_file: 'src/runtime/reportWorker.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('repository', {
+      label: 'ReportRepository.save',
+      source_file: 'src/reports/report.repository.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'repository',
+    })
+
+    graph.addEdge('registration', 'worker', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/queue/register.ts',
+    })
+    graph.addEdge('worker', 'repository', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/runtime/reportWorker.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: 'ReportWorker.process',
+      to: 'ReportRepository.save',
+      hops: 1,
+    })
+  })
+
+  it('admits metadata-less job starts from source-file hints', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('registration', {
+      label: 'QueueRegistrar.register',
+      source_file: 'src/queue/register.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('job', {
+      label: 'SendEmail.run',
+      source_file: 'src/jobs/email-job.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('gateway', {
+      label: 'MailerGateway.deliver',
+      source_file: 'src/mail/mailer.gateway.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'gateway',
+    })
+
+    graph.addEdge('registration', 'job', {
+      relation: 'enqueues_job',
+      confidence: 'EXTRACTED',
+      source_file: 'src/queue/register.ts',
+    })
+    graph.addEdge('job', 'gateway', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/jobs/email-job.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: 'SendEmail.run',
+      to: 'MailerGateway.deliver',
+      hops: 1,
+    })
+  })
+
   it('keeps queue-backed runtime paths detectable even when reverse runtime edges exist', () => {
     const graph = makeBidirectionalRuntimePipelineGraph()
     const summary = buildGraphSummary(graph)

--- a/tests/unit/graph-summary.test.ts
+++ b/tests/unit/graph-summary.test.ts
@@ -32,6 +32,22 @@ function padIndex(index: number): string {
   return index.toString().padStart(2, '0')
 }
 
+function stableRuntimePathOrderForTest(from: string, to: string, fromSourceFile: string, toSourceFile: string): number {
+  const input = [
+    from,
+    to,
+    fromSourceFile,
+    toSourceFile,
+  ].join('\u0000')
+
+  let hash = 2166136261
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
 function makeRichGraph(options?: {
   graphVersion?: string
   generatedAt?: string
@@ -404,14 +420,20 @@ describe('buildGraphSummary', () => {
   it('caps runtime_paths with deterministic non-lexical tie-breaking', () => {
     const graph = makeManyRuntimePathsGraph()
     const summary = buildGraphSummary(graph)
-    const alphabeticalRuntimePaths = Array.from({ length: SUMMARY_ARRAY_CAP }, (_, index) => {
+    const expectedRuntimePaths = Array.from({ length: SUMMARY_ARRAY_CAP + 2 }, (_, index) => {
       const suffix = padIndex(index)
       return {
         from: `RuntimeEntry${suffix}`,
         to: `RuntimeSink${suffix}`,
         hops: 2,
+        fromSourceFile: `src/runtime/entry-${suffix}.ts`,
+        toSourceFile: `src/runtime/sink-${suffix}.ts`,
       }
     })
+      .sort((left, right) => stableRuntimePathOrderForTest(left.from, left.to, left.fromSourceFile, left.toSourceFile)
+        - stableRuntimePathOrderForTest(right.from, right.to, right.fromSourceFile, right.toSourceFile))
+      .slice(0, SUMMARY_ARRAY_CAP)
+      .map(({ from, to, hops }) => ({ from, to, hops }))
 
     expect(summary.runtime_paths).toBeInstanceOf(Array)
     expect(summary.runtime_paths).toHaveLength(SUMMARY_ARRAY_CAP)
@@ -423,7 +445,7 @@ describe('buildGraphSummary', () => {
       expect(path.hops).toBeGreaterThanOrEqual(1)
     }
 
-    expect(summary.runtime_paths).not.toEqual(alphabeticalRuntimePaths)
+    expect(summary.runtime_paths).toEqual(expectedRuntimePaths)
 
     const repeatedSummary = buildGraphSummary(graph)
     expect(repeatedSummary.runtime_paths).toEqual(summary.runtime_paths)
@@ -555,6 +577,56 @@ describe('buildGraphSummary', () => {
     ])
   })
 
+  it('admits worker-style runtime starts even when they have runtime predecessors', () => {
+    const graph = new KnowledgeGraph(true)
+
+    graph.addNode('registration', {
+      label: 'QueueRegistrar.register',
+      source_file: 'src/queue/register.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+    })
+    graph.addNode('worker', {
+      label: 'ReportWorker.process',
+      source_file: 'src/reports/report.worker.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'worker',
+    })
+    graph.addNode('repository', {
+      label: 'ReportRepository.save',
+      source_file: 'src/reports/report.repository.ts',
+      source_location: 'L1',
+      file_type: 'code',
+      community: 0,
+      source_domain: 'production',
+      framework_role: 'repository',
+    })
+
+    graph.addEdge('registration', 'worker', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/queue/register.ts',
+    })
+    graph.addEdge('worker', 'repository', {
+      relation: 'calls',
+      confidence: 'EXTRACTED',
+      source_file: 'src/reports/report.worker.ts',
+    })
+
+    const summary = buildGraphSummary(graph)
+
+    expect(summary.runtime_paths).toContainEqual({
+      from: 'ReportWorker.process',
+      to: 'ReportRepository.save',
+      hops: 1,
+    })
+  })
+
   it('keeps queue-backed runtime paths detectable even when reverse runtime edges exist', () => {
     const graph = makeBidirectionalRuntimePipelineGraph()
     const summary = buildGraphSummary(graph)
@@ -564,6 +636,11 @@ describe('buildGraphSummary', () => {
         from: 'IdeasController.generate',
         to: 'ReportRepository.save',
         hops: 4,
+      },
+      {
+        from: 'OrchestratorWorker.process',
+        to: 'ReportRepository.save',
+        hops: 1,
       },
     ])
   })


### PR DESCRIPTION
## Summary\n- penalize helper and generic leaf endpoints so runtime_paths stay on workflow boundaries\n- prefer worker, repository, and service boundaries over deeper gateway/helper leaves and use deterministic non-lexical tie-breaking\n- add graph-summary regressions for helper-only pairs, job/build helper leaves, worker-vs-gateway ranking, and capped ordering\n\nCloses #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved runtime-path detection: expanded scoring components for candidate ranking, stronger penalties for utility/helper-like endpoints, deterministic hash-based tie-breaking, and filtering to avoid helper-only start/terminal pairs for more accurate graph summaries.

* **Tests**
  * Added and updated tests covering deterministic ordering, capped-path behavior, broader runtime-start heuristics (workers/jobs without metadata), and multiple runtime-path selection scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->