### PR TITLE
Prepare 0.27.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.1] - 2026-05-28
+
+### Fixed
+
+- **Native-agent compare no longer reports favorable reductions for degraded no-trace runs**: `report.json.reductions` and suite-summary win lines now stay suppressed unless the run is attributable to a valid Madar invocation. Closes #361.
+- **`madar summary` runtime paths stay closer to real workflow spines**: runtime-path scoring now admits worker-style starts with runtime predecessors, recognizes metadata-less worker/job file hints, and keeps helper-style endpoint pairs from outranking backend workflow boundaries. Closes #362.
+- **Native-agent compare no longer stalls silently on hung arms**: `compare --baseline-mode native_agent` now supports per-arm timeouts, stderr heartbeats, and `run-state.json` progress receipts, and it writes partial reports instead of hanging forever when the baseline or Madar arm gets stuck. Closes #363.
+
 ## [0.27.0] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Want a broader local-first walkthrough that also covers install, `prompt`, and a
 
 ---
 
-## What's new in 0.27.0
+## What's new in 0.27.1
 
-- Pack Schema v1 is now the stable implementation-pack surface: workflow centers, likely edit/test files, validation commands, negative guidance, and agent-ready brief renderers all ship from one release line instead of a prerelease-only path.
-- The benchmark suite is now part of the public product surface: `madar bench:suite` ships with fixed manifests, isolation assets, share-safe artifacts, and the first measured suite row under `docs/benchmarks/suite/`.
-- Installed-agent and compare flows are more reliable: strict guidance keys off top-level response evidence, managed hook detection now matches the real generated structure, and Claude/Gemini/Codex installs share stable Madar identity markers.
+- `compare --baseline-mode native_agent` now stays honest when Madar was not actually invoked: degraded provider-only runs no longer print favorable reduction percentages or suite-summary wins.
+- Native-agent compare is more failure-tolerant: stalled baseline or Madar arms can time out, emit stderr heartbeat lines, and leave a `run-state.json` breadcrumb plus partial report artifacts instead of hanging forever.
+- `madar summary` runtime paths now stay closer to backend workflow spines instead of drifting toward helper-style endpoint chains.
 
-See the [`0.27.0` changelog entry](CHANGELOG.md#0270---2026-05-27) for the full release notes.
+See the [`0.27.1` changelog entry](CHANGELOG.md#0271---2026-05-28) for the full release notes.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -102,7 +102,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.0. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.1. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/docs/proof-workflows.md
+++ b/docs/proof-workflows.md
@@ -44,6 +44,8 @@ For runtime-generation prompts, those compact explain packs now also preserve Ne
 
 If you switch to `--baseline-mode native_agent`, prefer a structured Anthropic runner such as `cat {prompt_file} | claude -p --output-format json`. Plain-text Claude runs still save paired answers, but the report cannot compute Anthropic-billed reductions without the trailing JSON usage block. Multi-question native-agent runs also emit suite-level comparable-question wins/losses for input tokens, turns, and latency, plus mean/median input-token reduction, comparable-question denominators when some runs are excluded from the aggregate, and best/worst prompt outcomes in the terminal summary. When the `--questions` file sits beside a `quality-gates.json`, the same summary also rolls up deterministic answer-quality pass/fail counts from the saved `*-answer.txt` artifacts; treat those substring gates as a smoke test, not a full semantic grader, and keep the manual-review notes.
 
+For long-running or flaky provider runs, `native_agent` also accepts `--per-arm-timeout <seconds>` and `--heartbeat-interval-ms <ms>`. Those controls let `compare` fail fast on stuck baseline/Madar arms, print periodic stderr progress lines while an arm is still running, and persist a `run-state.json` breadcrumb in the output directory when a timeout happens.
+
 Gemini-safe installed-CLI invocation:
 
 ```bash
@@ -58,6 +60,7 @@ What gets saved under `out/compare/<timestamp>/`:
 - `madar-prompt.txt`
 - `baseline-answer.txt`
 - `madar-answer.txt`
+- `run-state.json`
 - `report.json`
 - `report.share-safe.json`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.0",
+            "version": "0.27.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump package metadata to 0.27.1
- add 0.27.1 release notes for the #361, #362, and #363 fixes
- update the native-agent compare docs to mention timeout/heartbeat controls and run-state artifacts

## Verification
- npm install --prefer-offline --no-audit
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- manual CLI smoke in a temp workspace (`--version`, `generate`, `claude install`, `codex install`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native-agent comparison handling for degraded runs
  * Improved madar summary runtime-path scoring accuracy
  * Prevented compare baseline mode from hanging with per-arm timeout and heartbeat features

* **Documentation**
  * Updated CLI guidance for compare baseline mode options
  * Refreshed version references across documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->