### PR TITLE
Flag pre-Madar broad exploration in native compare traces

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -118,6 +118,7 @@ type CompareMadarTraceOutcome =
   | 'no_install'
   | 'madar_available_but_unused'
   | 'madar_invoked'
+  | 'madar_invoked_after_broad_exploration'
   | 'madar_invoked_with_followup_exploration'
 
 export interface CompareMadarTrace {
@@ -129,6 +130,9 @@ export interface CompareMadarTrace {
   agent_directive_seen?: string[]
   madar_mcp_call_count: number
   madar_mcp_calls_by_name: Record<string, number>
+  first_madar_turn?: number
+  pre_madar_broad_exploration_tool_call_count?: number
+  pre_madar_broad_exploration_tool_calls_by_name?: Record<string, number>
   context_pack_call_count: number
   focused_follow_up_tool_call_count: number
   broad_exploration_tool_call_count: number
@@ -891,6 +895,9 @@ function traceToolCountSummary(toolCallsByName: Record<string, number>): string 
 function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): {
   madar_mcp_call_count: number
   madar_mcp_calls_by_name: Record<string, number>
+  first_madar_turn?: number
+  pre_madar_broad_exploration_tool_call_count: number
+  pre_madar_broad_exploration_tool_calls_by_name: Record<string, number>
   context_pack_call_count: number
   focused_follow_up_tool_call_count: number
   broad_exploration_tool_call_count: number
@@ -900,9 +907,12 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
 } {
   let madarMcpCallCount = 0
   let contextPackCallCount = 0
+  let firstMadarTurn: number | null = null
+  let preMadarBroadExplorationToolCallCount = 0
   let focusedFollowUpToolCallCount = 0
   let broadExplorationToolCallCount = 0
   const madarMcpCallsByName: Record<string, number> = {}
+  const preMadarBroadExplorationToolCallsByName: Record<string, number> = {}
   const focusedFollowUpToolCallsByName: Record<string, number> = {}
   const broadExplorationToolCallsByName: Record<string, number> = {}
   let sawFirstMadarCall = false
@@ -914,6 +924,9 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
       if (isMadarTraceToolName(toolName)) {
         madarMcpCallCount += 1
         madarMcpCallsByName[toolName] = (madarMcpCallsByName[toolName] ?? 0) + 1
+        if (!hadSeenMadarCall) {
+          firstMadarTurn = turn.turn
+        }
         if (MADAR_CONTEXT_PACK_TOOL_NAMES.has(canonicalName)) {
           contextPackCallCount += 1
         } else if (hadSeenMadarCall) {
@@ -925,6 +938,10 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
       }
 
       if (!hadSeenMadarCall) {
+        if (isBroadExplorationTraceToolName(toolName)) {
+          preMadarBroadExplorationToolCallCount += 1
+          preMadarBroadExplorationToolCallsByName[toolName] = (preMadarBroadExplorationToolCallsByName[toolName] ?? 0) + 1
+        }
         continue
       }
 
@@ -946,6 +963,9 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
   const sortedMadarMcpCallsByName = Object.fromEntries(
     Object.entries(madarMcpCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
   )
+  const sortedPreMadarBroadExplorationToolCallsByName = Object.fromEntries(
+    Object.entries(preMadarBroadExplorationToolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
+  )
   const sortedFocusedFollowUpToolCallsByName = Object.fromEntries(
     Object.entries(focusedFollowUpToolCallsByName).sort(([leftName], [rightName]) => leftName.localeCompare(rightName)),
   )
@@ -957,6 +977,8 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
     return {
       madar_mcp_call_count: madarMcpCallCount,
       madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
+      pre_madar_broad_exploration_tool_call_count: preMadarBroadExplorationToolCallCount,
+      pre_madar_broad_exploration_tool_calls_by_name: sortedPreMadarBroadExplorationToolCallsByName,
       context_pack_call_count: 0,
       focused_follow_up_tool_call_count: 0,
       broad_exploration_tool_call_count: 0,
@@ -976,6 +998,37 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
     focusedFollowUpToolCallCount > 0
       ? `${focusedFollowUpToolCallCount} focused follow-up ${focusedFollowUpToolCallCount === 1 ? 'call' : 'calls'}`
       : null
+  const preMadarBroadSummary =
+    preMadarBroadExplorationToolCallCount > 0
+      ? `${preMadarBroadExplorationToolCallCount} broad exploration ${preMadarBroadExplorationToolCallCount === 1 ? 'call' : 'calls'} before the first Madar call${Object.keys(sortedPreMadarBroadExplorationToolCallsByName).length > 0 ? ` (${traceToolCountSummary(sortedPreMadarBroadExplorationToolCallsByName)})` : ''}`
+      : null
+  const baseTraceFields = {
+    ...(firstMadarTurn !== null ? { first_madar_turn: firstMadarTurn } : {}),
+    pre_madar_broad_exploration_tool_call_count: preMadarBroadExplorationToolCallCount,
+    pre_madar_broad_exploration_tool_calls_by_name: sortedPreMadarBroadExplorationToolCallsByName,
+  }
+  if (preMadarBroadSummary !== null) {
+    const summaryParts = [madarInvocationSummary, preMadarBroadSummary]
+    if (focusedSummary !== null) {
+      summaryParts.push(focusedSummary)
+    }
+    if (broadExplorationToolCallCount > 0) {
+      summaryParts.push(`${broadExplorationToolCallCount} broad exploration ${broadExplorationToolCallCount === 1 ? 'call' : 'calls'} after the first Madar call${Object.keys(sortedBroadExplorationToolCallsByName).length > 0 ? ` (${traceToolCountSummary(sortedBroadExplorationToolCallsByName)})` : ''}`)
+    } else {
+      summaryParts.push('no broad exploration after the first Madar call.')
+    }
+    return {
+      madar_mcp_call_count: madarMcpCallCount,
+      madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
+      ...baseTraceFields,
+      context_pack_call_count: contextPackCallCount,
+      focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
+      broad_exploration_tool_call_count: broadExplorationToolCallCount,
+      broad_exploration_tool_calls_by_name: sortedBroadExplorationToolCallsByName,
+      exploration_outcome: 'madar_invoked_after_broad_exploration',
+      exploration_summary: summaryParts.join('; '),
+    }
+  }
   if (broadExplorationToolCallCount === 0) {
     const summaryParts = [madarInvocationSummary]
     if (contextPackSummary !== null) {
@@ -988,6 +1041,7 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
     return {
       madar_mcp_call_count: madarMcpCallCount,
       madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
+      ...baseTraceFields,
       context_pack_call_count: contextPackCallCount,
       focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
       broad_exploration_tool_call_count: 0,
@@ -1010,6 +1064,7 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
   return {
     madar_mcp_call_count: madarMcpCallCount,
     madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
+    ...baseTraceFields,
     context_pack_call_count: contextPackCallCount,
     focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
     broad_exploration_tool_call_count: broadExplorationToolCallCount,
@@ -2032,6 +2087,8 @@ function formatCompareMadarTraceSummary(result: GenerateCompareArtifactsResult):
   const noInstallRuns = traces.filter((trace) => trace.exploration_outcome === 'no_install').length
   const madarAvailableButUnusedRuns = traces.filter((trace) => trace.exploration_outcome === 'madar_available_but_unused').length
   const madarInvokedRuns = traces.filter((trace) => trace.exploration_outcome === 'madar_invoked').length
+  const madarInvokedAfterBroadExplorationRuns =
+    traces.filter((trace) => trace.exploration_outcome === 'madar_invoked_after_broad_exploration').length
   const madarInvokedWithFollowUpExplorationRuns =
     traces.filter((trace) => trace.exploration_outcome === 'madar_invoked_with_followup_exploration').length
   const topTools = [...toolCallsByName.entries()]
@@ -2049,6 +2106,9 @@ function formatCompareMadarTraceSummary(result: GenerateCompareArtifactsResult):
   }
   if (madarInvokedRuns > 0) {
     outcomeParts.push(`${madarInvokedRuns} madar invoked`)
+  }
+  if (madarInvokedAfterBroadExplorationRuns > 0) {
+    outcomeParts.push(`${madarInvokedAfterBroadExplorationRuns} madar invoked after broad exploration`)
   }
   if (madarInvokedWithFollowUpExplorationRuns > 0) {
     outcomeParts.push(`${madarInvokedWithFollowUpExplorationRuns} madar invoked with follow-up exploration`)

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -256,7 +256,7 @@ const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
     turn: 1,
     message: {
       content: [
-        { type: 'tool_use', name: 'ToolSearch' },
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
       ],
     },
   },
@@ -265,7 +265,22 @@ const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
     turn: 2,
     message: {
       content: [
-        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+        { type: 'tool_use', name: 'Glob' },
+        { type: 'tool_use', name: 'Read' },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_MCP_RETRIEVE_AFTER_PRE_EXPLORATION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 2,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'ToolSearch' },
       ],
     },
   },
@@ -274,7 +289,24 @@ const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
     turn: 3,
     message: {
       content: [
-        { type: 'tool_use', name: 'Glob' },
+        { type: 'tool_use', name: 'ToolSearch' },
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 6,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 9,
+    message: {
+      content: [
         { type: 'tool_use', name: 'Read' },
       ],
     },
@@ -750,6 +782,45 @@ describe('executeNativeAgentCompare', () => {
         madar_mcp_call_count: 1,
         exploration_outcome: 'madar_invoked_with_followup_exploration',
       }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('flags broad exploration before the first Madar MCP call', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'What is the cluster module?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_PAYLOAD,
+            madar: VERBOSE_MADAR_MCP_RETRIEVE_AFTER_PRE_EXPLORATION_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        first_madar_turn: 6,
+        pre_madar_broad_exploration_tool_call_count: 2,
+        pre_madar_broad_exploration_tool_calls_by_name: {
+          ToolSearch: 2,
+        },
+        exploration_outcome: 'madar_invoked_after_broad_exploration',
+      }))
+
+      const summary = formatNativeAgentCompareSummary(result)
+      expect(summary).toContain('madar_invoked_after_broad_exploration')
+      expect(summary).toContain('2 broad exploration calls before the first Madar call')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1798,6 +1798,73 @@ describe('compare runtime', () => {
     expect(formatCompareSummary(result)).toContain('outcomes: 1 madar invoked')
   })
 
+  it('summarizes broad exploration before the first Madar MCP call separately', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+
+    const result = await executeCompareRuns(
+      {
+        graphPath,
+        question: 'how does login create a session',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      },
+      {
+        runner: async (execution) => ({
+          exitCode: 0,
+          stdout:
+            execution.mode === 'baseline'
+              ? makeClaudeStructuredCompareStdout({
+                  result: 'baseline answer\n',
+                  usage: {
+                    input_tokens: 1200,
+                    output_tokens: 90,
+                    cache_creation_input_tokens: 100,
+                    cache_read_input_tokens: 20,
+                  },
+                })
+              : makeClaudeStructuredCompareStdout({
+                  result: 'madar answer\n',
+                  usage: {
+                    input_tokens: 400,
+                    output_tokens: 70,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 10,
+                  },
+                  assistant_turns: [
+                    {
+                      turn: 1,
+                      content: [{ type: 'tool_use', name: 'ToolSearch', input: { query: 'login session' } }],
+                    },
+                    {
+                      turn: 2,
+                      content: [{ type: 'tool_use', name: 'mcp__madar__retrieve', input: { question: 'auth flow' } }],
+                    },
+                  ],
+                }),
+          stderr: '',
+          elapsedMs: execution.mode === 'baseline' ? 11 : 17,
+        }),
+      },
+    )
+
+    const report = result.reports[0]!
+    expect(report.madar_trace).toEqual(
+      expect.objectContaining({
+        exploration_outcome: 'madar_invoked_after_broad_exploration',
+        first_madar_turn: 2,
+        pre_madar_broad_exploration_tool_call_count: 1,
+        pre_madar_broad_exploration_tool_calls_by_name: {
+          ToolSearch: 1,
+        },
+      }),
+    )
+    expect(formatCompareSummary(result)).toContain('outcomes: 1 madar invoked after broad exploration')
+  })
+
   it('records when a context pack only added context before broad raw exploration continued', async () => {
     const graph = makeGraph()
     writeProjectFiles()


### PR DESCRIPTION
## Summary
- classify traces as madar_invoked_after_broad_exploration when broad tools run before the first Madar MCP call
- persist first-Madar-turn and pre-Madar broad exploration counts in trace artifacts
- include the new outcome in native-agent and aggregate compare summaries

Closes #369

## Verification
- npm run test:run -- tests/unit/compare-native-agent.test.ts tests/unit/compare.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced exploration analysis to distinguish scenarios where broad exploration precedes Madar invocation, with improved tool usage tracking and sequence reporting.

* **Tests**
  * Added coverage for new exploration pattern analysis scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->