### PR TITLE
Separate native compare routing wins from token proof

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2265,6 +2265,17 @@ export type NativeAgentTokenRegressionMetric =
   | 'uncached_input_tokens'
   | 'cache_creation_input_tokens'
 
+export interface NativeAgentClaimAssessment {
+  routing_efficiency: {
+    status: 'improved' | 'not_improved' | 'not_measured'
+    evidence: string[]
+  }
+  token_reduction: {
+    status: 'proven' | 'not_proven' | 'not_measured'
+    evidence: string[]
+  }
+}
+
 export interface NativeAgentToolCallCountsEntry {
   total: number
   Read: number
@@ -2306,6 +2317,7 @@ export interface NativeAgentCompareReport {
   } | null
   token_regression: boolean
   token_regression_reasons: NativeAgentTokenRegressionMetric[]
+  claim_assessment?: NativeAgentClaimAssessment
   prompt_token_source: {
     baseline: 'anthropic_provider_reported' | 'unknown'
     madar: 'anthropic_provider_reported' | 'unknown'
@@ -3004,6 +3016,60 @@ function formatTokenRegressionWarning(
   return `WARNING: fresh-token regression — ${reasons.map((metric) => formatTokenRegressionMetric(metric, baseline, madar)).join('; ')}`
 }
 
+function assessNativeAgentClaims(report: NativeAgentCompareReport): NativeAgentClaimAssessment | undefined {
+  if (report.baseline.kind !== 'succeeded' || report.madar.kind !== 'succeeded') {
+    return undefined
+  }
+
+  if (!nativeAgentReductionsAttributable(report)) {
+    return {
+      routing_efficiency: {
+        status: 'not_measured',
+        evidence: ['Madar MCP attribution is missing.'],
+      },
+      token_reduction: {
+        status: 'not_measured',
+        evidence: ['Madar MCP attribution is missing.'],
+      },
+    }
+  }
+
+  const routingEvidence: string[] = []
+  const toolCallsImproved = report.tool_call_counts
+    ? report.tool_call_counts.madar.total < report.tool_call_counts.baseline.total
+    : false
+  if (report.tool_call_counts) {
+    routingEvidence.push(
+      `tool calls ${toolCallsImproved ? 'decreased' : 'did not decrease'}: baseline ${report.tool_call_counts.baseline.total} → madar ${report.tool_call_counts.madar.total}${formatDirectionalDelta(report.tool_call_counts.baseline.total, report.tool_call_counts.madar.total, 'fewer', 'more')}`,
+    )
+  }
+
+  const latencyImproved = report.madar.duration_ms < report.baseline.duration_ms
+  routingEvidence.push(
+    `latency ${latencyImproved ? 'improved' : 'did not improve'}: baseline ${report.baseline.duration_ms}ms → madar ${report.madar.duration_ms}ms${formatDirectionalDelta(report.baseline.duration_ms, report.madar.duration_ms, 'faster', 'slower')}`,
+  )
+
+  const tokenEvidence: string[] = []
+  const totalInputImproved = report.madar.total_input_tokens_anthropic_exact < report.baseline.total_input_tokens_anthropic_exact
+  tokenEvidence.push(
+    `provider input ${totalInputImproved ? 'decreased' : report.madar.total_input_tokens_anthropic_exact > report.baseline.total_input_tokens_anthropic_exact ? 'grew' : 'did not decrease'}: baseline ${report.baseline.total_input_tokens_anthropic_exact} → madar ${report.madar.total_input_tokens_anthropic_exact}${formatDirectionalDelta(report.baseline.total_input_tokens_anthropic_exact, report.madar.total_input_tokens_anthropic_exact, 'less', 'more')}`,
+  )
+  if (report.token_regression_reasons.length > 0) {
+    tokenEvidence.push(`fresh-token regression: ${report.token_regression_reasons.join(', ')}`)
+  }
+
+  return {
+    routing_efficiency: {
+      status: toolCallsImproved || latencyImproved ? 'improved' : 'not_improved',
+      evidence: routingEvidence,
+    },
+    token_reduction: {
+      status: totalInputImproved && report.token_regression_reasons.length === 0 ? 'proven' : 'not_proven',
+      evidence: tokenEvidence,
+    },
+  }
+}
+
 type NativeAgentComparableReport = NativeAgentCompareReport & {
   baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>
   madar: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>
@@ -3518,6 +3584,12 @@ export async function executeNativeAgentCompare(
           ? 'valid'
           : 'degraded'
         : 'invalid'
+    const claimAssessment = assessNativeAgentClaims(reportShell)
+    if (claimAssessment !== undefined) {
+      reportShell.claim_assessment = claimAssessment
+    } else {
+      delete reportShell.claim_assessment
+    }
     if (!nativeAgentReductionsAttributable(reportShell)) {
       reportShell.reductions = null
     }
@@ -3618,6 +3690,16 @@ function appendNativeAgentValidityLines(lines: string[], report: NativeAgentComp
   )
 }
 
+function formatNativeAgentClaimAssessmentLine(assessment: NativeAgentClaimAssessment): string {
+  const routingEvidence = assessment.routing_efficiency.evidence.length > 0
+    ? ` (${assessment.routing_efficiency.evidence.join('; ')})`
+    : ''
+  const tokenEvidence = assessment.token_reduction.evidence.length > 0
+    ? ` (${assessment.token_reduction.evidence.join('; ')})`
+    : ''
+  return `claim_assessment: routing_efficiency ${assessment.routing_efficiency.status}${routingEvidence}; token_reduction ${assessment.token_reduction.status}${tokenEvidence}`
+}
+
 export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult): string {
   const lines: string[] = [
     `[madar compare] completed ${result.reports.length} native_agent question(s)`,
@@ -3696,6 +3778,9 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
 
     lines.push(`- "${report.question}"`)
     appendNativeAgentValidityLines(lines, report)
+    if (report.claim_assessment) {
+      lines.push(`    ${formatNativeAgentClaimAssessmentLine(report.claim_assessment)}`)
+    }
     const derivedTokenRegressionReasons = collectTokenRegressionReasons(baseline, madar)
     const tokenRegressionReasons =
       report.token_regression_reasons && report.token_regression_reasons.length > 0

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -1045,6 +1045,10 @@ describe('executeNativeAgentCompare', () => {
       expect(report.measurement_validity).toBe('valid')
       expect(report.tool_call_counts?.baseline.total).toBe(28)
       expect(report.tool_call_counts?.madar.total).toBe(6)
+      if (report.baseline.kind !== 'succeeded' || report.madar.kind !== 'succeeded') {
+        throw new Error('GoValidate fixture should produce succeeded runs')
+      }
+      expect(report.madar.duration_ms).toBeLessThan(report.baseline.duration_ms)
       expect(savedReport.token_regression).toBe(true)
       expect(claimAssessment).toEqual(expect.objectContaining({
         routing_efficiency: expect.objectContaining({

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -114,6 +114,42 @@ const MADAR_TOKEN_REGRESSION_PAYLOAD = {
   },
 }
 
+const GOVALIDATE_BASELINE_TOKEN_REGRESSION_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 166206,
+  num_turns: 5,
+  result: 'baseline answer',
+  total_cost_usd: 0.8682259,
+  usage: {
+    input_tokens: 13,
+    cache_creation_input_tokens: 38851,
+    cache_read_input_tokens: 232864,
+    output_tokens: 1200,
+  },
+}
+
+const GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 66381,
+  num_turns: 7,
+  result: 'madar answer',
+  total_cost_usd: 0.95262875,
+  usage: {
+    input_tokens: 17,
+    cache_creation_input_tokens: 96575,
+    cache_read_input_tokens: 487900,
+    output_tokens: 1000,
+  },
+}
+
+function toolUses(name: string, count: number): Array<{ type: 'tool_use'; name: string }> {
+  return Array.from({ length: count }, () => ({ type: 'tool_use', name }))
+}
+
 const VERBOSE_BASELINE_PAYLOAD = [
   { type: 'system', subtype: 'init' },
   {
@@ -247,6 +283,46 @@ const VERBOSE_MADAR_TOKEN_REGRESSION_PAYLOAD = [
     },
   },
   MADAR_TOKEN_REGRESSION_PAYLOAD,
+] as const
+
+const VERBOSE_GOVALIDATE_BASELINE_TOKEN_REGRESSION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        ...toolUses('Read', 12),
+        ...toolUses('Grep', 10),
+        ...toolUses('Glob', 6),
+      ],
+    },
+  },
+  GOVALIDATE_BASELINE_TOKEN_REGRESSION_PAYLOAD,
+] as const
+
+const VERBOSE_GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+        ...toolUses('Read', 3),
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 2,
+    message: {
+      content: [
+        ...toolUses('Grep', 2),
+      ],
+    },
+  },
+  GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD,
 ] as const
 
 const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
@@ -936,6 +1012,52 @@ describe('executeNativeAgentCompare', () => {
       ]))
       expect(shareSafeReductions.uncached_input_tokens).toBeCloseTo(0.72, 2)
       expect(shareSafeReport.token_regression).toBe(true)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('separates routing wins from token-reduction proof for GoValidate-style token regressions', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How idea report is being generated',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_GOVALIDATE_BASELINE_TOKEN_REGRESSION_PAYLOAD,
+            madar: VERBOSE_GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-27T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const claimAssessment = savedReport.claim_assessment as Record<string, unknown> | undefined
+      const summary = formatNativeAgentCompareSummary(result)
+
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.tool_call_counts?.baseline.total).toBe(28)
+      expect(report.tool_call_counts?.madar.total).toBe(6)
+      expect(savedReport.token_regression).toBe(true)
+      expect(claimAssessment).toEqual(expect.objectContaining({
+        routing_efficiency: expect.objectContaining({
+          status: 'improved',
+        }),
+        token_reduction: expect.objectContaining({
+          status: 'not_proven',
+        }),
+      }))
+      expect(summary).toContain('claim_assessment: routing_efficiency improved')
+      expect(summary).toContain('token_reduction not_proven')
+      expect(summary).toContain('provider input grew')
+      expect(summary).toContain('fresh-token regression')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- add native-agent claim_assessment to separate routing efficiency from token-reduction proof
- report token_reduction as not_proven when valid attributed runs still grow provider or fresh-token usage
- add a GoValidate-style regression covering fewer tools, faster latency, and a fresh-token regression

Closes #370

## Verification
- npm run test:run -- tests/unit/compare-native-agent.test.ts -t "separates routing wins"
- npm run test:run -- tests/unit/compare-native-agent.test.ts tests/unit/benchmark-suite.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added claim assessment reporting for native agent runs, showing routing efficiency and token reduction statuses with supporting evidence.
  * Assessment determines improvement/not improved/not measured from routing, latency, tool-call counts, and token usage signals.

* **Tests**
  * Added unit tests covering token-regression scenarios.
  * Tests confirm routing and token-reduction assessments are evaluated independently and verify formatted summary output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->