### PR TITLE
Prepare 0.27.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.2] - 2026-05-28
+
+### Changed
+
+- **Native-agent compare now explains missing verbose traces explicitly**: `report.json` records whether Claude verbose trace data was available, and the CLI/docs clarify that `--verbose` is required for MCP-call attribution while provider usage can still come from `--output-format json`. Closes #368.
+- **Native-agent traces distinguish pre-Madar broad exploration**: verbose compare reports now classify `ToolSearch`/`Glob`/`Grep`/`Bash` before the first Madar MCP call as `madar_invoked_after_broad_exploration`, preserving valid attribution while surfacing the routing drift. Closes #369.
+- **Native-agent benchmark summaries separate routing wins from token proof**: valid attributed runs now carry `claim_assessment` so fewer tools/faster latency can be reported separately from provider-token reduction, and fresh-token regressions keep token-reduction claims marked `not_proven`. Closes #370.
+
 ## [0.27.1] - 2026-05-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.1",
+            "version": "0.27.2",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump @lubab/madar to 0.27.2
- add changelog entry for native-agent compare attribution and claim-assessment fixes
- verify release packaging with npm pack --dry-run

## Verification
- npm run test:run -- tests/unit/package-metadata.test.ts tests/unit/release-docs.test.ts
- npm install
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Enhanced reporting of missing Claude verbose trace data in native-agent compare/tracing workflows
  * Implemented new verbose-compare trace classification for tool activity before initial API calls
  * Refined benchmark summary accounting to distinguish routing wins from token validation while preserving regression tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->