### PR TITLE
Add compact answer-ready pack mode

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -31,6 +31,7 @@ export interface PackCliOptions {
   graphPath: string
   format?: ContextPackFormat
   why?: boolean
+  verbose?: boolean
   /** #75 manual override for the retrieval gate. When set (0-5), the gate
    *  emits a decision with reason 'manual override' at the supplied level
    *  instead of running its heuristic classifier on the prompt. */
@@ -432,7 +433,7 @@ export function parseQueryArgs(args: string[]): QueryCliOptions {
 }
 
 export function parsePackArgs(args: string[]): PackCliOptions {
-  const usage = 'Usage: madar pack "<prompt>" [--budget N] [--task KIND] [--graph path] [--format json|text|markdown|claude|copilot] [--retrieval-level 0-5] [--retrieval-strategy default|slice-v1]'
+  const usage = 'Usage: madar pack "<prompt>" [--budget N] [--task KIND] [--graph path] [--format json|text|markdown|claude|copilot] [--verbose] [--retrieval-level 0-5] [--retrieval-strategy default|slice-v1]'
   const prompt = args[0]?.trim()
   if (!prompt) {
     throw new UsageError(usage)
@@ -444,6 +445,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
   let graphPath = 'out/graph.json'
   let format: PackCliOptions['format'] | undefined
   let why = false
+  let verbose = false
   let retrievalLevel: PackCliOptions['retrievalLevel'] | undefined
   let retrievalStrategy: PackCliOptions['retrievalStrategy'] | undefined
 
@@ -538,6 +540,11 @@ export function parsePackArgs(args: string[]): PackCliOptions {
       continue
     }
 
+    if (argument === '--verbose') {
+      verbose = true
+      continue
+    }
+
     throw new UsageError(`error: unknown option for pack: ${argument}`)
   }
 
@@ -549,6 +556,7 @@ export function parsePackArgs(args: string[]): PackCliOptions {
     graphPath,
     ...(format ? { format } : {}),
     ...(why ? { why: true } : {}),
+    ...(verbose ? { verbose: true } : {}),
     ...(retrievalLevel !== undefined ? { retrievalLevel } : {}),
     ...(retrievalStrategy !== undefined ? { retrievalStrategy } : {}),
   }

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -91,6 +91,7 @@ export interface ContextPackSliceMetadata {
   anchors: ContextPackSliceAnchor[]
   directions: Array<'forward' | 'backward'>
   selected_paths: ContextPackSlicePath[]
+  selected_path_count?: number
 }
 
 export type ContextPackExecutionPhase =
@@ -157,8 +158,11 @@ export interface ContextPackExecutionSlice {
   steps: ContextPackExecutionSliceStep[]
   primary_path?: ContextPackExecutionSlicePrimaryPath
   side_effects?: ContextPackExecutionSliceBranch[]
+  side_effect_count?: number
   terminal_boundaries?: ContextPackExecutionSliceBranch[]
+  terminal_boundary_count?: number
   omitted_branches?: ContextPackExecutionSliceOmittedBranch[]
+  omitted_branch_count?: number
   phase_coverage?: ContextPackExecutionSlicePhaseCoverage
 }
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -6,7 +6,7 @@ import type { ContextPackRoutingDebug } from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
-import { buildExplainPackPayloadCore } from './context-pack-command.js'
+import { buildAnswerReadyPackSchema, buildExplainPackPayloadCore } from './context-pack-command.js'
 import { isMadarProjectHook } from './install.js'
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
@@ -1684,11 +1684,12 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
 }
 
 export function buildMadarPromptPack(input: BuildMadarPromptPackInput): ComparePromptPack {
-  const explainPayload = JSON.stringify(
+  const explainPayloadCore = buildAnswerReadyPackSchema(
     buildExplainPackPayloadCore(compactRetrieveResult(input.retrieval), input.retrieval),
-    null,
-    2,
+    Math.max(input.retrieval.task_contract?.budget ?? 3000, 3000),
   )
+  delete explainPayloadCore.serialized_budget
+  const explainPayload = JSON.stringify(explainPayloadCore, null, 2)
   const builtPrompt = buildContextPrompt({
     instructions: [
       'Answer the question using only the provided graph-guided retrieval output.',

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1686,7 +1686,7 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
 export function buildMadarPromptPack(input: BuildMadarPromptPackInput): ComparePromptPack {
   const explainPayloadCore = buildAnswerReadyPackSchema(
     buildExplainPackPayloadCore(compactRetrieveResult(input.retrieval), input.retrieval),
-    Math.max(input.retrieval.task_contract?.budget ?? 3000, 3000),
+    input.retrieval.task_contract?.budget ?? 3000,
   )
   delete explainPayloadCore.serialized_budget
   const explainPayload = JSON.stringify(explainPayloadCore, null, 2)

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -34,7 +34,7 @@ import {
   type MadarResponseEvidence,
 } from '../runtime/mcp-response-evidence.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
-import { communitiesFromGraph, loadGraph } from '../runtime/serve.js'
+import { communitiesFromGraph, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 
 const DEFAULT_IMPACT_DEPTH = 3
 const IMPLEMENTATION_DISTRACTOR_PATTERN = /(?:helper|util|formatter|serializer|mapper|constant|generated|dist\/|build\/|lockfile|migration)/i
@@ -97,6 +97,21 @@ interface PackGuidanceCompatibilityFields {
 
 type PackPayloadWithCompatibility<TPack extends PackPayload> = TPack & PackGuidanceCompatibilityFields
 
+interface SerializedBudgetReport {
+  max_tokens: number
+  token_count: number
+  enforced: boolean
+}
+
+type JsonRecord = Record<string, unknown>
+
+const ANSWER_READY_MATCHED_NODE_CAP = 8
+const ANSWER_READY_RELATIONSHIP_CAP = 12
+const ANSWER_READY_COMMUNITY_CAP = 6
+const ANSWER_READY_EXPLANATION_CAP = 3
+const ANSWER_READY_FIRST_READ_CAP = 3
+const ANSWER_READY_WORKFLOW_CENTER_CAP = 4
+
 function packWithCompatibilityFields<TPack extends PackPayload>(
   pack: TPack,
   fields: PackGuidanceCompatibilityFields,
@@ -117,6 +132,216 @@ function packForSchema<TPack extends PackPayload>(
   }
 
   return packWithCompatibilityFields(pack, fields)
+}
+
+function cloneJsonRecord(value: object): JsonRecord {
+  return JSON.parse(JSON.stringify(value)) as JsonRecord
+}
+
+function asJsonRecord(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : null
+}
+
+function asUnknownArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}
+
+function trimArrayField(record: JsonRecord, field: string, cap: number, trimmedFields: string[]): void {
+  const values = asUnknownArray(record[field])
+  if (values.length <= cap) {
+    return
+  }
+  record[field] = values.slice(0, cap)
+  trimmedFields.push(field)
+}
+
+function deleteEmptyArrayField(record: JsonRecord, field: string, trimmedFields: string[]): void {
+  const values = asUnknownArray(record[field])
+  if (values.length > 0) {
+    return
+  }
+  delete record[field]
+  trimmedFields.push(field)
+}
+
+function compactAnswerReadyPack(pack: JsonRecord, trimmedFields: string[]): void {
+  delete pack.workflow_centers
+  delete pack.recommended_first_read
+  delete pack.confidence_score
+  trimmedFields.push('pack.workflow_centers', 'pack.recommended_first_read', 'pack.confidence_score')
+
+  const slice = asJsonRecord(pack.slice)
+  if (slice) {
+    const selectedPaths = asUnknownArray(slice.selected_paths)
+    if (selectedPaths.length > 0) {
+      delete slice.selected_paths
+      slice.selected_path_count = selectedPaths.length
+      trimmedFields.push('pack.slice.selected_paths')
+    }
+  }
+
+  const executionSlice = asJsonRecord(pack.execution_slice)
+  if (executionSlice) {
+    const sideEffects = asUnknownArray(executionSlice.side_effects)
+    if (sideEffects.length > 0) {
+      delete executionSlice.side_effects
+      executionSlice.side_effect_count = sideEffects.length
+      trimmedFields.push('pack.execution_slice.side_effects')
+    }
+    const terminalBoundaries = asUnknownArray(executionSlice.terminal_boundaries)
+    if (terminalBoundaries.length > 0) {
+      delete executionSlice.terminal_boundaries
+      executionSlice.terminal_boundary_count = terminalBoundaries.length
+      trimmedFields.push('pack.execution_slice.terminal_boundaries')
+    }
+    const omittedBranches = asUnknownArray(executionSlice.omitted_branches)
+    if (omittedBranches.length > 0) {
+      delete executionSlice.omitted_branches
+      executionSlice.omitted_branch_count = omittedBranches.length
+      trimmedFields.push('pack.execution_slice.omitted_branches')
+    }
+  }
+
+  trimArrayField(pack, 'matched_nodes', ANSWER_READY_MATCHED_NODE_CAP, trimmedFields)
+  trimArrayField(pack, 'relationships', ANSWER_READY_RELATIONSHIP_CAP, trimmedFields)
+  trimArrayField(pack, 'community_context', ANSWER_READY_COMMUNITY_CAP, trimmedFields)
+}
+
+function estimatedJsonTokens(payload: JsonRecord): number {
+  return estimateQueryTokens(JSON.stringify(payload))
+}
+
+function attachSerializedBudget(
+  payload: JsonRecord,
+  maxTokens: number,
+  _trimmedFields: readonly string[],
+): void {
+  payload.serialized_budget = {
+    max_tokens: maxTokens,
+    token_count: 0,
+    enforced: false,
+  } satisfies SerializedBudgetReport
+
+  let tokenCount = estimatedJsonTokens(payload)
+  for (let index = 0; index < 2; index += 1) {
+    payload.serialized_budget = {
+      max_tokens: maxTokens,
+      token_count: tokenCount,
+      enforced: tokenCount <= maxTokens,
+    } satisfies SerializedBudgetReport
+    const nextTokenCount = estimatedJsonTokens(payload)
+    if (nextTokenCount === tokenCount) {
+      break
+    }
+    tokenCount = nextTokenCount
+  }
+  const budget = asJsonRecord(payload.serialized_budget)
+  if (budget) {
+    budget.token_count = tokenCount
+    budget.enforced = tokenCount <= maxTokens
+  }
+}
+
+export function buildAnswerReadyPackSchema(
+  schema: object,
+  maxTokens: number,
+): JsonRecord {
+  const payload = cloneJsonRecord(schema)
+  const trimmedFields: string[] = []
+  if (Object.hasOwn(payload, 'diagnostics')) {
+    delete payload.diagnostics
+    trimmedFields.push('diagnostics')
+  }
+  const pack = asJsonRecord(payload.pack)
+  if (pack) {
+    const packFirstRead = asUnknownArray(pack.recommended_first_read)
+    const payloadFirstRead = asUnknownArray(payload.recommended_first_read)
+    if (payloadFirstRead.length === 0 && packFirstRead.length > 0) {
+      payload.recommended_first_read = packFirstRead.slice(0, ANSWER_READY_FIRST_READ_CAP)
+      trimmedFields.push('pack.recommended_first_read promoted')
+    }
+    const packWorkflowCenters = asUnknownArray(pack.workflow_centers)
+    const payloadWorkflowCenters = asUnknownArray(payload.workflow_centers)
+    if (payloadWorkflowCenters.length === 0 && packWorkflowCenters.length > 0) {
+      payload.workflow_centers = packWorkflowCenters.slice(0, ANSWER_READY_WORKFLOW_CENTER_CAP)
+      trimmedFields.push('pack.workflow_centers promoted')
+    }
+    if (!Object.hasOwn(payload, 'confidence_score') && typeof pack.confidence_score === 'number') {
+      payload.confidence_score = pack.confidence_score
+      trimmedFields.push('pack.confidence_score promoted')
+    }
+    compactAnswerReadyPack(pack, trimmedFields)
+  }
+
+  trimArrayField(payload, 'workflow_centers', ANSWER_READY_WORKFLOW_CENTER_CAP, trimmedFields)
+  trimArrayField(payload, 'recommended_first_read', ANSWER_READY_FIRST_READ_CAP, trimmedFields)
+  trimArrayField(payload, 'why_explanation', ANSWER_READY_EXPLANATION_CAP, trimmedFields)
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
+  delete payload.plan
+  trimmedFields.push('plan')
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
+  delete payload.coverage
+  trimmedFields.push('coverage')
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
+  for (const field of [
+    'claims',
+    'expandable',
+    'likely_edit_files',
+    'likely_test_files',
+    'public_contracts',
+    'risk_boundaries',
+    'validation_commands',
+  ]) {
+    deleteEmptyArrayField(payload, field, trimmedFields)
+  }
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
+  if (pack) {
+    trimArrayField(pack, 'matched_nodes', 4, trimmedFields)
+    trimArrayField(pack, 'relationships', 4, trimmedFields)
+    trimArrayField(pack, 'community_context', 3, trimmedFields)
+  }
+  trimArrayField(payload, 'expandable', 3, trimmedFields)
+  trimArrayField(payload, 'claims', 3, trimmedFields)
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
+  if (pack) {
+    delete pack.relationships
+    delete pack.graph_signals
+    delete pack.snippet_budget_tokens_used
+    delete pack.snippet_budget_tokens_remaining
+    trimmedFields.push(
+      'pack.relationships',
+      'pack.graph_signals',
+      'pack.snippet_budget_tokens_used',
+      'pack.snippet_budget_tokens_remaining',
+    )
+  }
+  delete payload.retrieval_gate
+  delete payload.why_explanation
+  trimmedFields.push('retrieval_gate', 'why_explanation')
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  return payload
 }
 
 function emptyCoverage(): ContextPackCoverage {
@@ -1002,6 +1227,7 @@ function renderCopilotPack(schema: PackSchemaEnvelope): string {
 function renderContextPackOutput(
   format: ContextPackFormat | undefined,
   schema: PackSchemaEnvelope,
+  options: { verbose?: boolean } = {},
 ): string {
   switch (format) {
     case 'text':
@@ -1014,7 +1240,7 @@ function renderContextPackOutput(
       return renderCopilotPack(schema)
     case 'json':
     case undefined:
-      return JSON.stringify(schema)
+      return JSON.stringify(options.verbose === true || schema.task !== 'explain' ? schema : buildAnswerReadyPackSchema(schema, schema.budget))
   }
 }
 
@@ -1035,6 +1261,7 @@ export async function runContextPackCommand(
     budget: plannerBudget,
     task_intent: resolvedTask.task_intent,
   })
+  const renderOptions = options.verbose === undefined ? {} : { verbose: options.verbose }
 
   if (resolvedTask.task_kind === 'review') {
     if (options.retrievalStrategy !== undefined) {
@@ -1061,7 +1288,7 @@ export async function runContextPackCommand(
       ...baseResponse(options, plan, plannerBudget, resolvedTask.task_kind),
       pack: reviewPack,
       ...contextMetadata(reviewResult.review_bundle ?? {}),
-    }))
+    }), renderOptions)
   }
 
   if (resolvedTask.task_kind === 'impact') {
@@ -1087,7 +1314,7 @@ export async function runContextPackCommand(
       pack: impactPack,
       ...impactMetadata(impactResult, plannerBudget, options.prompt, initialPlan.evidence.recipe_id, options.retrievalLevel),
       ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
-    }))
+    }), renderOptions)
   }
 
   const effectivePackRetrievalStrategy =
@@ -1118,5 +1345,5 @@ export async function runContextPackCommand(
     ),
     retrieval,
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
-  }))
+  }), renderOptions)
 }

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -1,6 +1,7 @@
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path'
 
 import { buildMadarPromptPack } from '../../infrastructure/compare.js'
+import { buildAnswerReadyPackSchema, buildExplainPackPayloadCore } from '../../infrastructure/context-pack-command.js'
 import type { TaskContextPlan } from '../../contracts/task-context-plan.js'
 import type { CompareRefsInput } from '../../infrastructure/time-travel.js'
 import type {
@@ -1223,6 +1224,9 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       // detect bad runs (missing required evidence, zero claims, weak
       // retrieval, etc.) without re-implementing the heuristics.
       const diagnostics = computeContextPackDiagnostics(fullPack)
+      const explainPayload = task === 'explain'
+        ? buildExplainPackPayloadCore(compactPack, retrieval, implementation)
+        : undefined
 
       // Slice #76/#135: multi-resolution context. Default 'detail'
       // preserves existing behavior; 'summary' drops snippet bodies;
@@ -1315,7 +1319,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
         resolution,
         pack: {
-          ...compactPack,
+          ...(explainPayload?.pack ?? compactPack),
           matched_nodes: resolvedNodes.nodes,
         },
         ...(resolvedNodes.bytes_saved > 0
@@ -1333,10 +1337,13 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           coveredWorkflowOwners: collectWorkflowOwners(resolvedNodes.nodes.map((node) => node.source_file)),
         }),
       }
+      const responsePayload = task === 'explain' && !includeSelectionDiagnostics
+        ? buildAnswerReadyPackSchema(basePayload, Math.max(plannerBudget, 3000))
+        : basePayload
       if (!cacheKey || !cacheGraphVersion) {
-        return helpers.ok(id, helpers.textToolResult(JSON.stringify(basePayload)))
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(responsePayload)))
       }
-      const payloadText = JSON.stringify(withContextPackCache(basePayload, {
+      const payloadText = JSON.stringify(withContextPackCache(responsePayload, {
         status: 'miss',
         graph_version: cacheGraphVersion,
       }))

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -806,6 +806,9 @@ describe('compare runtime', () => {
       missing_context: explainPayload.missing_context,
       missing_semantic: explainPayload.missing_semantic,
       retrieval_gate: explainPayload.retrieval_gate,
+      recommended_first_read: explainPayload.recommended_first_read,
+      workflow_centers: explainPayload.workflow_centers,
+      confidence_score: explainPayload.confidence_score,
     }, null, 2)
 
     expect(pack.prompt).toContain(expectedPromptCore)

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -8,6 +8,7 @@ import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
 import { build } from '../../src/pipeline/build.js'
 import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+import { estimateQueryTokens } from '../../src/runtime/serve.js'
 
 const tempFixtureRoots: string[] = []
 
@@ -462,6 +463,214 @@ describe('context-pack-command', () => {
       expect.stringContaining('src/ideas/report-status.ts'),
       expect.stringContaining('src/ideas/next-steps.ts'),
     ]))
+  })
+
+  it('defaults runtime-generation explain JSON to an answer-ready payload with serialized budget enforcement', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const noisySelectedPaths = Array.from({ length: 80 }, (_, index) => ({
+      from_id: `helper_${index}`,
+      from: `Helper${index}.formatStatus`,
+      to_id: `target_${index}`,
+      to: `Target${index}.renderSummary`,
+      relation: 'calls',
+      direction: 'forward' as const,
+    }))
+    const retrieval = {
+      question: 'How idea report is being generated',
+      token_count: 220,
+      matched_nodes: [
+        {
+          node_id: 'controller_entry',
+          label: 'IdeasController.generateReport',
+          source_file: 'src/ideas/controller.ts',
+          line_number: 40,
+          file_type: 'code',
+          snippet: 'return this.reportService.generateReport(id)',
+          match_score: 0.92,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+        {
+          node_id: 'service_handoff',
+          label: 'IdeaReportService.generateReport',
+          source_file: 'src/ideas/report-service.ts',
+          line_number: 58,
+          file_type: 'code',
+          snippet: 'await queue.enqueue(reportJob)',
+          match_score: 0.88,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+      ],
+      relationships: [
+        { from_id: 'controller_entry', from: 'IdeasController.generateReport', to_id: 'service_handoff', to: 'IdeaReportService.generateReport', relation: 'calls' },
+      ],
+      community_context: [
+        { id: 0, label: 'Idea report runtime', node_count: 12 },
+      ],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['contracts', 'configuration', 'tests'] as const,
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 1,
+        selected_relationships: 1,
+      },
+      retrieval_gate: {
+        level: 4,
+        skipped_retrieval: false,
+        reason: 'manual override',
+        intent: 'explain',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation' as const,
+          target_domain_hint: 'backend_runtime' as const,
+        },
+      },
+      retrieval_strategy: 'slice-v1' as const,
+      slice: {
+        mode: 'explain' as const,
+        anchors: [
+          { node_id: 'controller_entry', label: 'IdeasController.generateReport', reason: 'source path token match' },
+        ],
+        directions: ['forward' as const],
+        selected_paths: noisySelectedPaths,
+      },
+      execution_slice: {
+        status: 'complete' as const,
+        confidence: 'high' as const,
+        confidence_reasons: ['explicit_anchor', 'runtime_handoff_evidence', 'expected_phases_covered'],
+        steps: [
+          {
+            node_id: 'controller_entry',
+            label: 'IdeasController.generateReport',
+            source_file: 'src/ideas/controller.ts',
+            line_number: 40,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'service_handoff',
+            label: 'IdeaReportService.generateReport',
+            source_file: 'src/ideas/report-service.ts',
+            line_number: 58,
+            node_kind: 'method',
+          },
+        ],
+        side_effects: Array.from({ length: 20 }, (_, index) => ({
+          steps: [
+            {
+              label: `Helper${index}.formatStatus`,
+              source_file: `src/ideas/helpers/${index}.ts`,
+              line_number: index + 1,
+            },
+          ],
+        })),
+        phase_coverage: {
+          expected: ['controller', 'service'],
+          observed: ['controller', 'service'],
+          missing: [],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation' as const,
+        entrypoint_scope: 'setup_context' as const,
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: ['irrelevant_model_or_provider_details'],
+        observed_phases: ['controller', 'service'],
+        missing_phases: [],
+        confidence: 'high' as const,
+      },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: retrieval.question,
+      budget: 800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      retrievalStrategy: 'slice-v1',
+      format: 'json',
+    }, dependencies)
+    const payload = JSON.parse(output) as {
+      serialized_budget?: { token_count?: number; max_tokens?: number; enforced?: boolean }
+      pack?: {
+        slice?: { selected_paths?: unknown[]; selected_path_count?: number }
+        execution_slice?: { side_effects?: unknown[] }
+      }
+      evidence?: { agent_directive?: string }
+      recommended_first_read?: Array<{ path?: string }>
+    }
+
+    expect(estimateQueryTokens(output)).toBeLessThanOrEqual(800)
+    expect(payload.serialized_budget).toEqual(expect.objectContaining({
+      max_tokens: 800,
+      enforced: true,
+    }))
+    expect(payload.serialized_budget?.token_count).toBeLessThanOrEqual(800)
+    expect(payload.pack?.slice?.selected_paths).toBeUndefined()
+    expect(payload.pack?.slice?.selected_path_count).toBe(noisySelectedPaths.length)
+    expect(payload.pack?.execution_slice?.side_effects).toBeUndefined()
+    expect(payload.evidence?.agent_directive).toBe('answer_from_pack')
+    expect(payload.recommended_first_read?.map((entry) => entry.path)).toEqual([
+      'src/ideas/controller.ts',
+      'src/ideas/report-service.ts',
+    ])
+  })
+
+  it('keeps debug-heavy path details when pack verbose mode is explicitly requested', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const retrieval = retrieveContext(graph, {
+      question: 'Trace how `POST /login` reaches persistence in the backend runtime pipeline',
+      budget: 1800,
+      taskKind: 'explain',
+      taskIntent: 'explain',
+      retrievalStrategy: 'slice-v1',
+    })
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: retrieval.question,
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      retrievalStrategy: 'slice-v1',
+      format: 'json',
+      verbose: true,
+    } as never, dependencies)
+    const payload = JSON.parse(output) as {
+      pack?: { slice?: { selected_paths?: unknown[]; selected_path_count?: number } }
+    }
+
+    expect(payload.pack?.slice?.selected_paths?.length).toBeGreaterThan(0)
+    expect(payload.pack?.slice?.selected_path_count).toBeUndefined()
   })
 
   it('deprioritizes helper-like matched nodes when runtime-generation explain falls back without an execution spine', async () => {

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -103,14 +103,9 @@ describe('pack-quality fixtures (#298)', () => {
     expect(payload.confidence_score).toEqual(expect.any(Number))
     expect(payload.confidence_score).toBeGreaterThanOrEqual(0)
     expect(payload.confidence_score).toBeLessThanOrEqual(1)
-    expect(payload.pack?.confidence_score).toEqual(expect.any(Number))
-    expect(payload.pack?.confidence_score).toBeGreaterThanOrEqual(0)
-    expect(payload.pack?.confidence_score).toBeLessThanOrEqual(1)
-    expect(payload.pack?.confidence_score).toBe(payload.confidence_score)
-    expect(payload.pack?.workflow_centers?.map((entry) => entry.path)).toEqual(payload.workflow_centers?.map((entry) => entry.path))
-    expect(payload.pack?.recommended_first_read?.map((entry) => entry.path)).toEqual(
-      payload.recommended_first_read?.map((entry) => entry.path),
-    )
+    expect(payload.pack?.confidence_score).toBeUndefined()
+    expect(payload.pack?.workflow_centers).toBeUndefined()
+    expect(payload.pack?.recommended_first_read).toBeUndefined()
     expect(payload.recommended_first_read?.map((entry) => entry.path)).not.toEqual(
       expect.arrayContaining([
         'src/modules/ideas/application/helpers/idea-report-status-message.helper.ts',
@@ -145,12 +140,11 @@ describe('pack-quality fixtures (#298)', () => {
       ]),
       missing: [],
     }))
+    expect(payload.pack?.matched_nodes?.length).toBeLessThanOrEqual(8)
     expect(payload.pack?.matched_nodes?.map((entry) => entry.label)).toEqual(
       expect.arrayContaining([
-        'planIdeaReport()',
-        'processIdeaReportSection()',
-        'assembleIdeaReport()',
-        'saveStructuredReport()',
+        '.generateFromProblem()',
+        '.buildQueuedIdeaReportResponse()',
       ]),
     )
   })

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { handleStdioRequest } from '../../src/runtime/stdio-server.js'
+import { estimateQueryTokens } from '../../src/runtime/serve.js'
 
 const tempRoots: string[] = []
 const scratchRoot = join(process.cwd(), '.test-artifacts', 'stdio-slice-surface')
@@ -247,6 +248,68 @@ describe('stdio slice-v1 surface', () => {
     expect(contextPackText).toContain('"execution_slice"')
     expect(contextPackText).toContain('"confidence"')
     expect(contextPackText).toContain('"confidence_reasons"')
+  })
+
+  it('defaults context_pack runtime-generation output to answer-ready compact JSON and keeps verbose debug paths', async () => {
+    const graphPath = createGraphPath()
+
+    const compactResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 8,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Trace how `AuthController.login` reaches persistence in the backend runtime pipeline',
+          budget: 3000,
+          task: 'explain',
+          retrieval_level: 4,
+          retrieval_strategy: 'slice-v1',
+        },
+      },
+    }))
+    const verboseResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 9,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Trace how `AuthController.login` reaches persistence in the backend runtime pipeline',
+          budget: 3000,
+          task: 'explain',
+          retrieval_level: 4,
+          retrieval_strategy: 'slice-v1',
+          verbose: true,
+        },
+      },
+    }))
+
+    const compactText = ((compactResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? ''
+    const verboseText = ((verboseResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? ''
+    const compactPayload = JSON.parse(compactText) as {
+      serialized_budget?: { max_tokens?: number; token_count?: number; enforced?: boolean }
+      diagnostics?: unknown
+      pack?: { slice?: { selected_paths?: unknown[]; selected_path_count?: number } }
+      recommended_first_read?: Array<{ path?: string }>
+    }
+    const verbosePayload = JSON.parse(verboseText) as {
+      serialized_budget?: unknown
+      diagnostics?: unknown
+      pack?: { slice?: { selected_paths?: unknown[]; selected_path_count?: number } }
+    }
+
+    expect(estimateQueryTokens(compactText)).toBeLessThanOrEqual(3000)
+    expect(compactPayload.serialized_budget).toEqual(expect.objectContaining({
+      max_tokens: 3000,
+      enforced: true,
+    }))
+    expect(compactPayload.diagnostics).toBeUndefined()
+    expect(compactPayload.pack?.slice?.selected_paths).toBeUndefined()
+    expect(compactPayload.pack?.slice?.selected_path_count).toBeGreaterThan(0)
+    expect(compactPayload.recommended_first_read?.length).toBeGreaterThan(0)
+    expect(verbosePayload.serialized_budget).toBeUndefined()
+    expect(verbosePayload.diagnostics).toBeDefined()
+    expect(verbosePayload.pack?.slice?.selected_paths?.length).toBeGreaterThan(0)
+    expect(verbosePayload.pack?.slice?.selected_path_count).toBeUndefined()
   })
 
   it('rejects retrieval_strategy for review context packs instead of ignoring it', async () => {


### PR DESCRIPTION
## Summary
- default explain context packs to compact answer-ready JSON with serialized budget metadata
- preserve detailed debug payloads behind `--verbose` / `verbose: true`
- align MCP context_pack and compare prompt packs with the compact explain surface

Closes #376

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` flag to the `madar pack` command to toggle full vs. compact output.

* **Improvements**
  * Explain/pack JSON now defaults to a compact "answer-ready" shape; verbose mode returns full diagnostics and selected-path details.
  * Responses include enforced token-budget metadata to ensure payload size stays within requested limits.

* **Tests**
  * Unit tests updated to cover compact vs. verbose output, budget enforcement, and answer-ready defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->