### PR TITLE
Improve runtime spine branch selection

### DIFF
--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -1552,6 +1552,10 @@ function promptWantsNotificationOrEventPhase(question: string): boolean {
   return /\b(?:notify|notification|notifications|event|events|emit|emits|broadcast|webhook|publish)\b/i.test(question)
 }
 
+function promptWantsFailureHandling(question: string): boolean {
+  return /\b(?:fail(?:s|ed|ure|ures|ing)?|error|errors|exception|exceptions|quality(?:\s|-)?gate|fallback|dead(?:\s|-)?letter)\b/i.test(question)
+}
+
 function promptExplicitlyWantsRuntimeHandoff(question: string): boolean {
   return /\b(?:runtime|pipeline|job|jobs|queue|worker|workers|enqueue|enqueues|enqueued|processed|processing|orchestrator)\b/i.test(question)
 }
@@ -2063,6 +2067,9 @@ function executionSliceStepPriority(
   )) {
     value += 15
   }
+  if (promptWantsFailureHandling(question) && (failureHandlingLikeExecutionStep(node) || qualityGateLikeExecutionStep(node))) {
+    value += 140
+  }
   if (/\b(?:route|controller|service|queue|worker|job|pipeline|orchestrator|repository|store)\b/.test(lower)) {
     value += 10
   }
@@ -2074,6 +2081,9 @@ function executionSliceStepPriority(
     || /\b(?:cancel|claim|status|suggest)\b/.test(lower)
   )) {
     value -= 20
+  }
+  if (!promptWantsFailureHandling(question) && failureHandlingLikeExecutionStep(node)) {
+    value -= 90
   }
 
   return value
@@ -2293,6 +2303,14 @@ function qualityGateLikeExecutionStep(
 ): boolean {
   const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
   return /\b(?:quality(?:\s|-)?gate|guardrail|validate(?:report|output))\b/.test(lower)
+}
+
+function failureHandlingLikeExecutionStep(
+  node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
+  return /\b(?:fail(?:ed|ure|ures|ing)?|error|exception|fallback|dead(?:\s|-)?letter|write(?:raw|failure)|rawfailure)\b/.test(lower)
+    || /(?:^|[.#])(?:handle|write|store|record)[A-Za-z_$\w]*(?:fail|failure|error|exception|raw)[A-Za-z_$\w]*\(?\)?$/i.test(node.label)
 }
 
 function rendererOrSynthesisLikeExecutionStep(

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -2309,7 +2309,7 @@ function failureHandlingLikeExecutionStep(
   node: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
 ): boolean {
   const lower = `${node.label} ${node.source_file} ${node.node_kind ?? ''} ${node.framework_role ?? ''}`.toLowerCase()
-  return /\b(?:fail(?:ed|ure|ures|ing)?|error|exception|fallback|dead(?:\s|-)?letter|write(?:raw|failure)|rawfailure)\b/.test(lower)
+  return /\b(?:fail(?:s|ed|ure|ures|ing)?|error|exception|fallback|dead(?:\s|-)?letter|write(?:raw|failure)|rawfailure)\b/.test(lower)
     || /(?:^|[.#])(?:handle|write|store|record)[A-Za-z_$\w]*(?:fail|failure|error|exception|raw)[A-Za-z_$\w]*\(?\)?$/i.test(node.label)
 }
 

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/failure-storage.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/failure-storage.service.ts
@@ -1,0 +1,6 @@
+export async function writeRawFailureReport(
+  ideaId: string,
+  reason: string,
+): Promise<{ saved: boolean }> {
+  return { saved: ideaId.length > 0 && reason.length > 0 }
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/orchestrator.worker.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/pipeline/workers/orchestrator.worker.ts
@@ -3,6 +3,7 @@ import { planIdeaReport } from '../../planning/planner.service.js'
 import { processIdeaReportSection } from '../../research/workers/section-research.worker.js'
 import { assembleIdeaReport } from '../../reports/assembly.service.js'
 import { saveStructuredReport } from './db-sync.worker.js'
+import { handleQualityGateFailure, validateIdeaReportQuality } from '../../reports/quality-gate.service.js'
 
 type BullJob<T> = {
   data: T
@@ -23,6 +24,10 @@ export class OrchestratorWorker {
     const plan = await planIdeaReport(job.data.problem)
     const researchedSection = await processIdeaReportSection(plan.sections[0] ?? 'summary')
     const report = await assembleIdeaReport(plan.sections, researchedSection)
+    const quality = await validateIdeaReportQuality(report)
+    if (!quality.passed) {
+      return handleQualityGateFailure(job.data.ideaId, quality)
+    }
     return saveStructuredReport(job.data.ideaId, report)
   }
 }

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/reports/quality-gate.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/reports/quality-gate.service.ts
@@ -1,0 +1,15 @@
+import { writeRawFailureReport } from '../pipeline/workers/failure-storage.service.js'
+
+export async function validateIdeaReportQuality(report: { content: string }): Promise<{ passed: boolean; reason: string }> {
+  return {
+    passed: report.content.length > 0,
+    reason: 'empty report',
+  }
+}
+
+export async function handleQualityGateFailure(
+  ideaId: string,
+  quality: { reason: string },
+): Promise<{ saved: boolean }> {
+  return writeRawFailureReport(ideaId, quality.reason)
+}

--- a/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/reports/quality-gate.service.ts
+++ b/tests/fixtures/pack-quality/runtime-generation-explain-report-flow/workspace/src/modules/reports/quality-gate.service.ts
@@ -1,9 +1,10 @@
 import { writeRawFailureReport } from '../pipeline/workers/failure-storage.service.js'
 
 export async function validateIdeaReportQuality(report: { content: string }): Promise<{ passed: boolean; reason: string }> {
+  const passed = report.content.length > 0
   return {
-    passed: report.content.length > 0,
-    reason: 'empty report',
+    passed,
+    reason: passed ? '' : 'empty report',
   }
 }
 

--- a/tests/unit/helpers/pack-quality.ts
+++ b/tests/unit/helpers/pack-quality.ts
@@ -205,23 +205,30 @@ export function listPackQualityFixtures(): string[] {
     fixtureNames.includes(name) && existsSync(fixtureManifestPath(name)) && existsSync(fixtureWorkspaceRoot(name)))
 }
 
-export async function runPackQualityFixture(name: string): Promise<PackQualityFixtureRunResult> {
+export async function runPackQualityFixture(
+  name: string,
+  overrides: Partial<Pick<PackQualityFixtureManifest, 'prompt' | 'budget' | 'task'>> = {},
+): Promise<PackQualityFixtureRunResult> {
   const fixture = loadPackQualityFixture(name)
+  const runFixture = {
+    ...fixture,
+    ...overrides,
+  }
   return withTempDir(async (tempDir) => {
     const workspaceRoot = copyFixtureWorkspace(name, tempDir)
     const graph = generateGraph(workspaceRoot, { noHtml: true })
     const graphPath = join(workspaceRoot, 'out', 'graph.json')
     const packOutput = await runContextPackCommand({
-      prompt: fixture.prompt,
-      budget: fixture.budget ?? 1800,
-      task: fixture.task ?? 'implement',
+      prompt: runFixture.prompt,
+      budget: runFixture.budget ?? 1800,
+      task: runFixture.task ?? 'implement',
       taskExplicit: true,
       graphPath,
       format: 'json',
     } as never)
 
     return {
-      fixture,
+      fixture: runFixture,
       graph,
       payload: normalizePayload(JSON.parse(packOutput) as PackSchemaPayload),
     }

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -75,6 +75,9 @@ describe('pack-quality fixtures (#298)', () => {
         recommended_first_read?: Array<{ path?: string }>
         execution_slice?: {
           steps?: Array<{ label?: string }>
+          primary_path?: {
+            steps?: Array<{ label?: string }>
+          }
           phase_coverage?: {
             expected?: string[]
             observed?: string[]
@@ -125,6 +128,17 @@ describe('pack-quality fixtures (#298)', () => {
         'saveStructuredReport()',
       ]),
     )
+    expect(payload.pack?.execution_slice?.primary_path?.steps?.map((entry) => entry.label)).not.toEqual(
+      expect.arrayContaining([
+        'handleQualityGateFailure()',
+        'writeRawFailureReport()',
+      ]),
+    )
+    expect(payload.pack?.execution_slice?.primary_path?.steps?.map((entry) => entry.label)).toEqual(
+      expect.arrayContaining([
+        'saveStructuredReport()',
+      ]),
+    )
     expect(payload.pack?.execution_slice?.phase_coverage).toEqual(expect.objectContaining({
       expected: expect.arrayContaining([
         'planner',
@@ -147,5 +161,28 @@ describe('pack-quality fixtures (#298)', () => {
         '.buildQueuedIdeaReportResponse()',
       ]),
     )
+  })
+
+  it('promotes the quality-gate failure branch when the explain prompt asks what happens if it fails', async () => {
+    const result = await runPackQualityFixture('runtime-generation-explain-report-flow', {
+      prompt: 'How is idea report handled when it fails',
+      task: 'explain',
+      budget: 1800,
+    })
+    const payload = result.payload as typeof result.payload & {
+      pack?: {
+        execution_slice?: {
+          primary_path?: {
+            steps?: Array<{ label?: string }>
+          }
+        }
+      }
+    }
+    const primaryLabels = payload.pack?.execution_slice?.primary_path?.steps?.map((entry) => entry.label) ?? []
+
+    expect(primaryLabels).toEqual(expect.arrayContaining([
+      'handleQualityGateFailure()',
+    ]))
+    expect(primaryLabels).not.toContain('saveStructuredReport()')
   })
 })

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -128,13 +128,10 @@ describe('pack-quality fixtures (#298)', () => {
         'saveStructuredReport()',
       ]),
     )
-    expect(payload.pack?.execution_slice?.primary_path?.steps?.map((entry) => entry.label)).not.toEqual(
-      expect.arrayContaining([
-        'handleQualityGateFailure()',
-        'writeRawFailureReport()',
-      ]),
-    )
-    expect(payload.pack?.execution_slice?.primary_path?.steps?.map((entry) => entry.label)).toEqual(
+    const normalPrimaryLabels = payload.pack?.execution_slice?.primary_path?.steps?.map((entry) => entry.label) ?? []
+    expect(normalPrimaryLabels).not.toContain('handleQualityGateFailure()')
+    expect(normalPrimaryLabels).not.toContain('writeRawFailureReport()')
+    expect(normalPrimaryLabels).toEqual(
       expect.arrayContaining([
         'saveStructuredReport()',
       ]),


### PR DESCRIPTION
## Summary
- make runtime-generation execution-slice ranking prompt-aware for failure/quality-gate branches
- keep normal report-generation prompts on the success persistence spine while demoting failure handlers
- extend the pack-quality fixture with a realistic quality-gate failure branch and prompt override regression coverage

Closes #377

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of failure-handling prompts to adjust execution priorities.
  * Added quality validation for generated reports and a fallback that captures/stores failures when validation fails.

* **Tests**
  * Expanded test coverage for failure-handling and quality validation.
  * Test helpers now support overriding fixture inputs to run varied prompt/budget/task scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->