### PR TITLE
Strengthen Madar-first agent guidance

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -117,6 +117,7 @@ export interface CompareMadarTraceTurnSummary {
 type CompareMadarTraceOutcome =
   | 'no_install'
   | 'madar_available_but_unused'
+  | 'madar_first_bounded'
   | 'madar_invoked'
   | 'madar_invoked_after_broad_exploration'
   | 'madar_invoked_with_followup_exploration'
@@ -892,6 +893,19 @@ function traceToolCountSummary(toolCallsByName: Record<string, number>): string 
     .join(', ')
 }
 
+function traceHasAnswerReadyDirectiveOnFirstMadarTurn(
+  perTurn: CompareMadarTraceTurnSummary[],
+  firstMadarTurn: number | null,
+): boolean {
+  if (firstMadarTurn === null) {
+    return false
+  }
+  const firstTurn = perTurn.find((turn) => turn.turn === firstMadarTurn)
+  return (firstTurn?.agent_directive_seen ?? []).some((directive) =>
+    directive === 'answer_from_pack' || directive === 'verify_one_targeted_file',
+  )
+}
+
 function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): {
   madar_mcp_call_count: number
   madar_mcp_calls_by_name: Record<string, number>
@@ -1038,6 +1052,25 @@ function analyzeMadarTraceExploration(perTurn: CompareMadarTraceTurnSummary[]): 
       summaryParts.push(focusedSummary)
     }
     summaryParts.push('no broad exploration after the first Madar call.')
+    if (
+      firstMadarTurn !== null
+      && firstMadarTurn <= 2
+      && contextPackCallCount > 0
+      && focusedFollowUpToolCallCount <= 1
+      && traceHasAnswerReadyDirectiveOnFirstMadarTurn(perTurn, firstMadarTurn)
+    ) {
+      return {
+        madar_mcp_call_count: madarMcpCallCount,
+        madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
+        ...baseTraceFields,
+        context_pack_call_count: contextPackCallCount,
+        focused_follow_up_tool_call_count: focusedFollowUpToolCallCount,
+        broad_exploration_tool_call_count: 0,
+        broad_exploration_tool_calls_by_name: {},
+        exploration_outcome: 'madar_first_bounded',
+        exploration_summary: `Madar-first bounded path: ${summaryParts.join('; ')}`,
+      }
+    }
     return {
       madar_mcp_call_count: madarMcpCallCount,
       madar_mcp_calls_by_name: sortedMadarMcpCallsByName,
@@ -3701,6 +3734,28 @@ function formatNativeAgentClaimAssessmentLine(assessment: NativeAgentClaimAssess
   return `claim_assessment: routing_efficiency ${assessment.routing_efficiency.status}${routingEvidence}; token_reduction ${assessment.token_reduction.status}${tokenEvidence}`
 }
 
+function formatNativeAgentMadarTraceOutcomeSummary(reports: NativeAgentCompareReport[]): string | null {
+  const traces = reports.flatMap((report) => (report.madar_trace ? [report.madar_trace] : []))
+  if (traces.length === 0) {
+    return null
+  }
+
+  const outcomeLabels: Array<[CompareMadarTraceOutcome, string]> = [
+    ['madar_first_bounded', 'madar-first bounded'],
+    ['madar_invoked', 'madar invoked'],
+    ['madar_invoked_after_broad_exploration', 'madar invoked after broad exploration'],
+    ['madar_invoked_with_followup_exploration', 'madar invoked with follow-up exploration'],
+    ['madar_available_but_unused', 'available but unused'],
+    ['no_install', 'no install'],
+  ]
+  const outcomeParts = outcomeLabels.flatMap(([outcome, label]) => {
+    const count = traces.filter((trace) => trace.exploration_outcome === outcome).length
+    return count > 0 ? [`${count} ${label}`] : []
+  })
+
+  return outcomeParts.length > 0 ? `Madar trace outcomes: ${outcomeParts.join(', ')}` : null
+}
+
 export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult): string {
   const lines: string[] = [
     `[madar compare] completed ${result.reports.length} native_agent question(s)`,
@@ -3749,6 +3804,10 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
     lines.push(
       `- Answer quality: madar ${result.answer_quality.madar_passed}/${result.answer_quality.questions_checked} passed deterministic gates · baseline ${result.answer_quality.baseline_passed}/${result.answer_quality.questions_checked} passed deterministic gates · ${formatCount(result.answer_quality.manual_review_required, 'manual-review note', 'manual-review notes')}`,
     )
+  }
+  const traceOutcomeSummary = formatNativeAgentMadarTraceOutcomeSummary(result.reports)
+  if (traceOutcomeSummary !== null) {
+    lines.push(`- ${traceOutcomeSummary}`)
   }
   for (const report of result.reports) {
     if (isNativeAgentRunFailure(report.baseline) || isNativeAgentRunFailure(report.madar)) {

--- a/src/infrastructure/install-routing-guidance.ts
+++ b/src/infrastructure/install-routing-guidance.ts
@@ -87,6 +87,8 @@ function renderMarkdownTable(lead: string, rows: RoutingRow[], toolSearchSentenc
     '| --- | --- |',
     ...rows.map((row) => `| ${row.promptType} | ${row.markdownTarget} |`),
     '',
+    'Inspect `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive` before deciding whether to read files.',
+    'If `evidence.pack_confidence` is low, make one focused follow-up Madar call before broad raw search.',
     toolSearchSentence,
   ]
   return lines.join('\n')
@@ -98,7 +100,7 @@ function renderPlainGuide(
   toolSearchSentence: string,
 ): string {
   const rules = rows.map((row) => `${row.plainTarget} for ${row.plainPromptType ?? row.promptType}`).join('; ')
-  return `${lead}: ${rules}. ${toolSearchSentence}`
+  return `${lead}: ${rules}. Inspect evidence.pack_confidence, recommended_first_read, and evidence.agent_directive before deciding whether to read files. If evidence.pack_confidence is low, make one focused follow-up Madar call before broad raw search. ${toolSearchSentence}`
 }
 
 export function renderMarkdownMcpRoutingTable(): string {

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -268,10 +268,10 @@ function strictSkillOverrideRule(markdown: boolean): string {
 }
 function strictContextPackStopRule(markdown: boolean): string {
   if (markdown) {
-    return 'After calling a Madar tool, inspect the response\'s `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and do not read files unless `recommended_first_read` names a specific file; `verify_one_targeted_file` means answer using the pack and `Read` at most one file from `recommended_first_read`; `explore_with_caution` means the pack is low-confidence or partial.'
+    return 'After calling a Madar tool, inspect the response\'s `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and do not read files unless `recommended_first_read` names a specific file; `verify_one_targeted_file` means answer using the pack and `Read` at most one file from `recommended_first_read`; `explore_with_caution` means the pack is low-confidence or coverage is unknown.'
   }
 
-  return 'after calling a Madar tool, inspect the response\'s evidence.pack_confidence, recommended_first_read, and evidence.agent_directive: answer_from_pack means answer using the pack snippets and do not read files unless recommended_first_read names a specific file; verify_one_targeted_file means answer using the pack and Read at most one file from recommended_first_read; explore_with_caution means the pack is low-confidence or partial'
+  return 'after calling a Madar tool, inspect the response\'s evidence.pack_confidence, recommended_first_read, and evidence.agent_directive: answer_from_pack means answer using the pack snippets and do not read files unless recommended_first_read names a specific file; verify_one_targeted_file means answer using the pack and Read at most one file from recommended_first_read; explore_with_caution means the pack is low-confidence or coverage is unknown'
 }
 
 function strictContextPackExpandRule(markdown: boolean): string {

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -268,18 +268,18 @@ function strictSkillOverrideRule(markdown: boolean): string {
 }
 function strictContextPackStopRule(markdown: boolean): string {
   if (markdown) {
-    return 'After calling a Madar tool, inspect the response\'s `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and you may `Read` at most ONE file for verification; `verify_one_targeted_file` means answer using the pack and `Read` at most one specific supporting file; `explore_with_caution` means the pack is partial and permits at most ONE targeted `Glob` or `Grep` scoped to a single directory.'
+    return 'After calling a Madar tool, inspect the response\'s `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and do not read files unless `recommended_first_read` names a specific file; `verify_one_targeted_file` means answer using the pack and `Read` at most one file from `recommended_first_read`; `explore_with_caution` means the pack is low-confidence or partial.'
   }
 
-  return 'after calling a Madar tool, inspect the response\'s evidence.agent_directive: answer_from_pack means answer using the pack snippets and you may Read at most ONE file for verification; verify_one_targeted_file means answer using the pack and Read at most one specific supporting file; explore_with_caution means the pack is partial and permits at most ONE targeted Glob or Grep scoped to a single directory'
+  return 'after calling a Madar tool, inspect the response\'s evidence.pack_confidence, recommended_first_read, and evidence.agent_directive: answer_from_pack means answer using the pack snippets and do not read files unless recommended_first_read names a specific file; verify_one_targeted_file means answer using the pack and Read at most one file from recommended_first_read; explore_with_caution means the pack is low-confidence or partial'
 }
 
 function strictContextPackExpandRule(markdown: boolean): string {
   if (markdown) {
-    return 'Only widen exploration for deeper verification when `evidence.agent_directive` is `explore_with_caution`; if `missing_context` or `missing_semantic` is still non-empty, use at most ONE targeted `Glob` or `Grep` scoped to a single directory before answering.'
+    return 'If `evidence.pack_confidence` is low or `missing_context` / `missing_semantic` is non-empty, make ONE focused follow-up Madar call (`context_expand`, `retrieve`, or `relevant_files`) before raw search; only when the follow-up still says `explore_with_caution`, use at most ONE targeted `Glob` or `Grep` scoped to a single directory before answering.'
   }
 
-  return 'only widen exploration for deeper verification when evidence.agent_directive is explore_with_caution; if missing_context or missing_semantic is still non-empty, use at most ONE targeted Glob or Grep scoped to a single directory before answering'
+  return 'if evidence.pack_confidence is low or missing_context / missing_semantic is non-empty, make ONE focused follow-up Madar call (context_expand, retrieve, or relevant_files) before raw search; only when the follow-up still says explore_with_caution, use at most ONE targeted Glob or Grep scoped to a single directory before answering'
 }
 
 function strictGraphReportFallbackRule(markdown: boolean): string {

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -349,6 +349,103 @@ const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
   MADAR_USAGE_PAYLOAD,
 ] as const
 
+const VERBOSE_MADAR_FIRST_BOUNDED_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__context_pack' },
+        {
+          type: 'tool_result',
+          tool_name: 'mcp__madar__context_pack',
+          content: JSON.stringify({
+            evidence: {
+              pack_confidence: 'high',
+              agent_directive: 'answer_from_pack',
+            },
+            recommended_first_read: [
+              { path: 'src/runtime/retrieve.ts', reason: 'primary runtime context' },
+            ],
+          }),
+        },
+        { type: 'tool_use', name: 'Read' },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_FIRST_LOW_CONFIDENCE_THEN_READY_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__context_pack' },
+        {
+          type: 'tool_result',
+          tool_name: 'mcp__madar__context_pack',
+          content: JSON.stringify({
+            evidence: {
+              pack_confidence: 'low',
+              agent_directive: 'explore_with_caution',
+            },
+          }),
+        },
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 2,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+        {
+          type: 'tool_result',
+          tool_name: 'mcp__madar__retrieve',
+          content: JSON.stringify({
+            evidence: {
+              pack_confidence: 'high',
+              agent_directive: 'answer_from_pack',
+            },
+          }),
+        },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_FIRST_WITH_TWO_READS_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__context_pack' },
+        {
+          type: 'tool_result',
+          tool_name: 'mcp__madar__context_pack',
+          content: JSON.stringify({
+            evidence: {
+              pack_confidence: 'high',
+              agent_directive: 'answer_from_pack',
+            },
+          }),
+        },
+        { type: 'tool_use', name: 'Read' },
+        { type: 'tool_use', name: 'Read' },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
 const VERBOSE_MADAR_MCP_RETRIEVE_AFTER_PRE_EXPLORATION_PAYLOAD = [
   { type: 'system', subtype: 'init' },
   {
@@ -857,6 +954,103 @@ describe('executeNativeAgentCompare', () => {
       expect(report.madar_trace).toEqual(expect.objectContaining({
         madar_mcp_call_count: 1,
         exploration_outcome: 'madar_invoked_with_followup_exploration',
+      }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('distinguishes Madar-first bounded traces from generic Madar invocation', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How does runtime retrieval work?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_PAYLOAD,
+            madar: VERBOSE_MADAR_FIRST_BOUNDED_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        first_madar_turn: 1,
+        context_pack_call_count: 1,
+        focused_follow_up_tool_call_count: 1,
+        broad_exploration_tool_call_count: 0,
+        agent_directive_seen: ['answer_from_pack'],
+        exploration_outcome: 'madar_first_bounded',
+      }))
+      expect(report.madar_trace?.exploration_summary).toContain('Madar-first bounded path')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not classify low-confidence first packs as Madar-first bounded even when follow-up is answer-ready', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How does runtime retrieval work?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_PAYLOAD,
+            madar: VERBOSE_MADAR_FIRST_LOW_CONFIDENCE_THEN_READY_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        first_madar_turn: 1,
+        agent_directive_seen: ['explore_with_caution', 'answer_from_pack'],
+        exploration_outcome: 'madar_invoked',
+      }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not classify multiple focused reads after a pack as Madar-first bounded', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How does runtime retrieval work?',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_PAYLOAD,
+            madar: VERBOSE_MADAR_FIRST_WITH_TWO_READS_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.madar_trace).toEqual(expect.objectContaining({
+        first_madar_turn: 1,
+        focused_follow_up_tool_call_count: 2,
+        exploration_outcome: 'madar_invoked',
       }))
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
@@ -1927,6 +2121,56 @@ describe('formatNativeAgentCompareSummary', () => {
     expect(summary).toContain('measurement_validity: valid')
     expect(summary).toContain('install_verified: true')
     expect(summary).toContain('madar_mcp_call_count: 2 (mcp__madar__retrieve)')
+  })
+
+  it('summarizes Madar-first bounded traces in suite output', () => {
+    const summary = formatNativeAgentCompareSummary(buildSummaryResult({
+      question: 'ideal trace case',
+      baselineTurns: 6,
+      madarTurns: 2,
+      baselineDurationMs: 6000,
+      madarDurationMs: 2000,
+      baselineInputTokens: 600,
+      madarInputTokens: 200,
+      reductions: {
+        num_turns: 3,
+        duration_ms: 3,
+        input_tokens: 3,
+        cost_usd: 1,
+      },
+      madarTrace: {
+        source: 'claude_messages_tool_use',
+        summary: '2 tool calls across 1 turn',
+        tool_call_count: 2,
+        tool_calls_by_name: {
+          'mcp__madar__context_pack': 1,
+          Read: 1,
+        },
+        per_turn: [
+          {
+            turn: 1,
+            tool_call_count: 2,
+            tools: ['mcp__madar__context_pack', 'Read'],
+            agent_directive_seen: ['answer_from_pack'],
+          },
+        ],
+        agent_directive_seen: ['answer_from_pack'],
+        madar_mcp_call_count: 1,
+        madar_mcp_calls_by_name: {
+          'mcp__madar__context_pack': 1,
+        },
+        first_madar_turn: 1,
+        context_pack_call_count: 1,
+        focused_follow_up_tool_call_count: 1,
+        broad_exploration_tool_call_count: 0,
+        broad_exploration_tool_calls_by_name: {},
+        exploration_outcome: 'madar_first_bounded',
+        exploration_summary: 'Madar-first bounded path: no broad exploration after the first Madar call.',
+      },
+    }))
+
+    expect(summary).toContain('madar_trace: madar_first_bounded')
+    expect(summary).toContain('outcomes: 1 madar-first bounded')
   })
 
   it('prints invalid measurement warnings when install is missing', () => {

--- a/tests/unit/install-templates.test.ts
+++ b/tests/unit/install-templates.test.ts
@@ -70,6 +70,8 @@ function expectMarkdownRoutingTable(content: string): void {
   expect(normalized).toContain('`relevant_files`')
   expect(normalized).toContain('`graph_summary`')
   expect(normalized).toContain('Do not run ToolSearch before calling a Madar tool')
+  expect(normalized).toContain('Inspect `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive` before deciding whether to read files.')
+  expect(normalized).toContain('If `evidence.pack_confidence` is low, make one focused follow-up Madar call before broad raw search.')
 }
 
 function expectPlainRoutingGuide(content: string): void {
@@ -80,6 +82,8 @@ function expectPlainRoutingGuide(content: string): void {
   expect(normalized).toContain('relevant_files for "which files should I open first?"')
   expect(normalized).toContain('graph_summary for "give me a repo overview?"')
   expect(normalized).toContain('Do not run ToolSearch before calling a Madar tool')
+  expect(normalized).toContain('Inspect evidence.pack_confidence, recommended_first_read, and evidence.agent_directive before deciding whether to read files.')
+  expect(normalized).toContain('If evidence.pack_confidence is low, make one focused follow-up Madar call before broad raw search.')
 }
 
 function expectMarkdownPackRoutingTable(content: string): void {
@@ -99,6 +103,8 @@ function expectMarkdownPackRoutingTable(content: string): void {
   expect(normalized).toContain('`risk_map` before editing')
   expect(normalized).toContain('`implementation_checklist` for edit order and validation checkpoints')
   expect(normalized).toContain('Do not run ToolSearch before calling a Madar command or graph tool')
+  expect(normalized).toContain('Inspect `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive` before deciding whether to read files.')
+  expect(normalized).toContain('If `evidence.pack_confidence` is low, make one focused follow-up Madar call before broad raw search.')
 }
 
 function expectPlainPackRoutingGuide(content: string): void {
@@ -109,6 +115,8 @@ function expectPlainPackRoutingGuide(content: string): void {
   expect(normalized).toContain('relevant_files when MCP graph tools are available; otherwise madar pack "<task or question>" --task explain for "which files should I open first?"')
   expect(normalized).toContain('graph_summary when MCP graph tools are available; otherwise madar pack "<task or question>" --task explain for "give me a repo overview?"')
   expect(normalized).toContain('Do not run ToolSearch before calling a Madar command or graph tool')
+  expect(normalized).toContain('Inspect evidence.pack_confidence, recommended_first_read, and evidence.agent_directive before deciding whether to read files.')
+  expect(normalized).toContain('If evidence.pack_confidence is low, make one focused follow-up Madar call before broad raw search.')
 }
 
 describe('install hook payload', () => {

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -25,7 +25,7 @@ import { normalizeAssertionPath, normalizeAssertionPaths } from './helpers/platf
 
 const PACKAGE_CLI_RELATIVE_PATH = join('dist', 'src', 'cli', 'bin.js')
 const STRICT_STOP_RULE_MD =
-  'After calling a Madar tool, inspect the response\'s `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and do not read files unless `recommended_first_read` names a specific file; `verify_one_targeted_file` means answer using the pack and `Read` at most one file from `recommended_first_read`; `explore_with_caution` means the pack is low-confidence or partial.'
+  'After calling a Madar tool, inspect the response\'s `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and do not read files unless `recommended_first_read` names a specific file; `verify_one_targeted_file` means answer using the pack and `Read` at most one file from `recommended_first_read`; `explore_with_caution` means the pack is low-confidence or coverage is unknown.'
 const STRICT_EXPAND_RULE_MD =
   'If `evidence.pack_confidence` is low or `missing_context` / `missing_semantic` is non-empty, make ONE focused follow-up Madar call (`context_expand`, `retrieve`, or `relevant_files`) before raw search; only when the follow-up still says `explore_with_caution`, use at most ONE targeted `Glob` or `Grep` scoped to a single directory before answering.'
 const STRICT_GRAPH_REPORT_RULE_MD =
@@ -37,7 +37,7 @@ const STRICT_NON_MADAR_MCP_RULE_MD =
 const STRICT_SKILL_OVERRIDE_RULE_MD =
   'If an auto-activated skill recommends broad `Read` / `Grep` / `Glob` exploration or another MCP for a codebase question, defer to Madar\'s `evidence.agent_directive` first. A high- or medium-confidence Madar pack overrides that conflicting skill guidance.'
 const STRICT_STOP_RULE_PLAIN =
-  'after calling a Madar tool, inspect the response\'s evidence.pack_confidence, recommended_first_read, and evidence.agent_directive: answer_from_pack means answer using the pack snippets and do not read files unless recommended_first_read names a specific file; verify_one_targeted_file means answer using the pack and Read at most one file from recommended_first_read; explore_with_caution means the pack is low-confidence or partial'
+  'after calling a Madar tool, inspect the response\'s evidence.pack_confidence, recommended_first_read, and evidence.agent_directive: answer_from_pack means answer using the pack snippets and do not read files unless recommended_first_read names a specific file; verify_one_targeted_file means answer using the pack and Read at most one file from recommended_first_read; explore_with_caution means the pack is low-confidence or coverage is unknown'
 const STRICT_EXPAND_RULE_PLAIN =
   'if evidence.pack_confidence is low or missing_context / missing_semantic is non-empty, make ONE focused follow-up Madar call (context_expand, retrieve, or relevant_files) before raw search; only when the follow-up still says explore_with_caution, use at most ONE targeted Glob or Grep scoped to a single directory before answering'
 const STRICT_GRAPH_REPORT_RULE_PLAIN =

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -25,9 +25,9 @@ import { normalizeAssertionPath, normalizeAssertionPaths } from './helpers/platf
 
 const PACKAGE_CLI_RELATIVE_PATH = join('dist', 'src', 'cli', 'bin.js')
 const STRICT_STOP_RULE_MD =
-  'After calling a Madar tool, inspect the response\'s `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and you may `Read` at most ONE file for verification; `verify_one_targeted_file` means answer using the pack and `Read` at most one specific supporting file; `explore_with_caution` means the pack is partial and permits at most ONE targeted `Glob` or `Grep` scoped to a single directory.'
+  'After calling a Madar tool, inspect the response\'s `evidence.pack_confidence`, `recommended_first_read`, and `evidence.agent_directive`: `answer_from_pack` means answer using the pack snippets and do not read files unless `recommended_first_read` names a specific file; `verify_one_targeted_file` means answer using the pack and `Read` at most one file from `recommended_first_read`; `explore_with_caution` means the pack is low-confidence or partial.'
 const STRICT_EXPAND_RULE_MD =
-  'Only widen exploration for deeper verification when `evidence.agent_directive` is `explore_with_caution`; if `missing_context` or `missing_semantic` is still non-empty, use at most ONE targeted `Glob` or `Grep` scoped to a single directory before answering.'
+  'If `evidence.pack_confidence` is low or `missing_context` / `missing_semantic` is non-empty, make ONE focused follow-up Madar call (`context_expand`, `retrieve`, or `relevant_files`) before raw search; only when the follow-up still says `explore_with_caution`, use at most ONE targeted `Glob` or `Grep` scoped to a single directory before answering.'
 const STRICT_GRAPH_REPORT_RULE_MD =
   'Do not open `out/GRAPH_REPORT.md` unless the context pack or graph tools are unavailable, stale, or insufficient. Treat it as a fallback before broader raw file exploration, not a default first read.'
 const STRICT_NO_BROAD_EXPLORATION_RULE_MD =
@@ -37,9 +37,9 @@ const STRICT_NON_MADAR_MCP_RULE_MD =
 const STRICT_SKILL_OVERRIDE_RULE_MD =
   'If an auto-activated skill recommends broad `Read` / `Grep` / `Glob` exploration or another MCP for a codebase question, defer to Madar\'s `evidence.agent_directive` first. A high- or medium-confidence Madar pack overrides that conflicting skill guidance.'
 const STRICT_STOP_RULE_PLAIN =
-  'after calling a Madar tool, inspect the response\'s evidence.agent_directive: answer_from_pack means answer using the pack snippets and you may Read at most ONE file for verification; verify_one_targeted_file means answer using the pack and Read at most one specific supporting file; explore_with_caution means the pack is partial and permits at most ONE targeted Glob or Grep scoped to a single directory'
+  'after calling a Madar tool, inspect the response\'s evidence.pack_confidence, recommended_first_read, and evidence.agent_directive: answer_from_pack means answer using the pack snippets and do not read files unless recommended_first_read names a specific file; verify_one_targeted_file means answer using the pack and Read at most one file from recommended_first_read; explore_with_caution means the pack is low-confidence or partial'
 const STRICT_EXPAND_RULE_PLAIN =
-  'only widen exploration for deeper verification when evidence.agent_directive is explore_with_caution; if missing_context or missing_semantic is still non-empty, use at most ONE targeted Glob or Grep scoped to a single directory before answering'
+  'if evidence.pack_confidence is low or missing_context / missing_semantic is non-empty, make ONE focused follow-up Madar call (context_expand, retrieve, or relevant_files) before raw search; only when the follow-up still says explore_with_caution, use at most ONE targeted Glob or Grep scoped to a single directory before answering'
 const STRICT_GRAPH_REPORT_RULE_PLAIN =
   'do not open out/GRAPH_REPORT.md unless the context pack or graph tools are unavailable, stale, or insufficient; treat it as a fallback before broader raw file exploration, not a default first read'
 const STRICT_GRAPH_REPORT_RULE_PLAIN_SENTENCE =


### PR DESCRIPTION
## Summary
- tighten installed guidance to inspect evidence.pack_confidence, recommended_first_read, and agent directives before raw reads
- require one focused Madar follow-up before broad raw search when packs are low-confidence or incomplete
- add native-agent trace classification for the ideal Madar-first bounded path

## Test Plan
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new trace classification for Madar-first bounded runs and aggregate reporting of trace outcomes across runs.
  * Enhanced guidance to recommend inspecting pack confidence, recommended first read, and agent directives before reading files, and to perform one focused follow-up when pack confidence is low.

* **Tests**
  * Expanded tests to cover new trace classifications and the updated guidance text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->