### PR TITLE
Tighten native-agent benchmark outcome gates

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -3183,7 +3183,7 @@ function assessNativeAgentBenchmarkOutcome(report: NativeAgentCompareReport): Na
   const routingToolLatency =
     toolCallsImproved || latencyImproved
       ? 'win'
-      : latencyRegressed && (!report.tool_call_counts || toolCallsRegressed)
+      : toolCallsRegressed || latencyRegressed
         ? 'loss'
         : 'flat'
 

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2310,6 +2310,21 @@ export interface NativeAgentClaimAssessment {
   }
 }
 
+export type NativeAgentBenchmarkCheckStatus = 'win' | 'loss' | 'flat' | 'not_measured'
+export type NativeAgentBenchmarkOverallOutcome = 'full_win' | 'partial_win' | 'regression' | 'not_measured'
+
+export interface NativeAgentBenchmarkOutcome {
+  outcome: NativeAgentBenchmarkOverallOutcome
+  checks: {
+    routing_tool_latency: NativeAgentBenchmarkCheckStatus
+    token: NativeAgentBenchmarkCheckStatus
+    fresh_token: NativeAgentBenchmarkCheckStatus
+    cost: NativeAgentBenchmarkCheckStatus
+    turns: NativeAgentBenchmarkCheckStatus
+  }
+  evidence: string[]
+}
+
 export interface NativeAgentToolCallCountsEntry {
   total: number
   Read: number
@@ -2352,6 +2367,7 @@ export interface NativeAgentCompareReport {
   token_regression: boolean
   token_regression_reasons: NativeAgentTokenRegressionMetric[]
   claim_assessment?: NativeAgentClaimAssessment
+  benchmark_outcome?: NativeAgentBenchmarkOutcome
   prompt_token_source: {
     baseline: 'anthropic_provider_reported' | 'unknown'
     madar: 'anthropic_provider_reported' | 'unknown'
@@ -3104,6 +3120,114 @@ function assessNativeAgentClaims(report: NativeAgentCompareReport): NativeAgentC
   }
 }
 
+function benchmarkMetricStatus(
+  baseline: number | null,
+  madar: number | null,
+): NativeAgentBenchmarkCheckStatus {
+  if (baseline === null || madar === null) {
+    return 'not_measured'
+  }
+  if (madar < baseline) {
+    return 'win'
+  }
+  if (madar > baseline) {
+    return 'loss'
+  }
+  return 'flat'
+}
+
+function benchmarkFreshTokenStatus(
+  baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+  madar: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>,
+  tokenRegressionReasons: readonly NativeAgentTokenRegressionMetric[],
+): NativeAgentBenchmarkCheckStatus {
+  if (tokenRegressionReasons.length > 0) {
+    return 'loss'
+  }
+  if (madar.uncached_input_tokens_anthropic_exact < baseline.uncached_input_tokens_anthropic_exact) {
+    return 'win'
+  }
+  if (madar.uncached_input_tokens_anthropic_exact === baseline.uncached_input_tokens_anthropic_exact) {
+    return 'flat'
+  }
+  return 'loss'
+}
+
+function assessNativeAgentBenchmarkOutcome(report: NativeAgentCompareReport): NativeAgentBenchmarkOutcome | undefined {
+  if (report.baseline.kind !== 'succeeded' || report.madar.kind !== 'succeeded') {
+    return undefined
+  }
+
+  if (!nativeAgentReductionsAttributable(report)) {
+    return {
+      outcome: 'not_measured',
+      checks: {
+        routing_tool_latency: 'not_measured',
+        token: 'not_measured',
+        fresh_token: 'not_measured',
+        cost: 'not_measured',
+        turns: 'not_measured',
+      },
+      evidence: ['Madar MCP attribution is missing.'],
+    }
+  }
+
+  const toolCallsImproved = report.tool_call_counts
+    ? report.tool_call_counts.madar.total < report.tool_call_counts.baseline.total
+    : false
+  const latencyImproved = report.madar.duration_ms < report.baseline.duration_ms
+  const toolCallsRegressed = report.tool_call_counts
+    ? report.tool_call_counts.madar.total > report.tool_call_counts.baseline.total
+    : false
+  const latencyRegressed = report.madar.duration_ms > report.baseline.duration_ms
+  const routingToolLatency =
+    toolCallsImproved || latencyImproved
+      ? 'win'
+      : latencyRegressed && (!report.tool_call_counts || toolCallsRegressed)
+        ? 'loss'
+        : 'flat'
+
+  const checks: NativeAgentBenchmarkOutcome['checks'] = {
+    routing_tool_latency: routingToolLatency,
+    token: benchmarkMetricStatus(report.baseline.total_input_tokens_anthropic_exact, report.madar.total_input_tokens_anthropic_exact),
+    fresh_token: benchmarkFreshTokenStatus(report.baseline, report.madar, report.token_regression_reasons),
+    cost: benchmarkMetricStatus(report.baseline.total_cost_usd, report.madar.total_cost_usd),
+    turns: benchmarkMetricStatus(report.baseline.num_turns, report.madar.num_turns),
+  }
+
+  const evidence: string[] = [
+    `routing/tool/latency ${checks.routing_tool_latency}: tool calls ${report.tool_call_counts ? `${report.tool_call_counts.baseline.total} → ${report.tool_call_counts.madar.total}` : 'not measured'}, latency ${report.baseline.duration_ms}ms → ${report.madar.duration_ms}ms`,
+    `provider input ${checks.token}: baseline ${report.baseline.total_input_tokens_anthropic_exact} → madar ${report.madar.total_input_tokens_anthropic_exact}`,
+    `turns ${checks.turns === 'loss' ? 'regressed' : checks.turns}: baseline ${report.baseline.num_turns} → madar ${report.madar.num_turns}`,
+  ]
+  if (checks.fresh_token === 'loss') {
+    evidence.push(`fresh-token regression: ${report.token_regression_reasons.join(', ')}`)
+  } else {
+    evidence.push(`fresh_token ${checks.fresh_token}: baseline ${report.baseline.uncached_input_tokens_anthropic_exact} → madar ${report.madar.uncached_input_tokens_anthropic_exact}`)
+  }
+  if (checks.cost === 'not_measured') {
+    evidence.push('cost not measured: provider cost was unavailable for one or both runs')
+  } else {
+    evidence.push(`cost ${checks.cost === 'loss' ? 'regressed' : checks.cost}: baseline ${report.baseline.total_cost_usd} → madar ${report.madar.total_cost_usd}`)
+  }
+
+  const statuses = Object.values(checks)
+  const hasWin = statuses.includes('win')
+  const hasLoss = statuses.includes('loss')
+  const fullWin =
+    checks.routing_tool_latency === 'win'
+    && checks.token !== 'loss'
+    && checks.fresh_token !== 'loss'
+    && checks.cost !== 'loss'
+    && checks.turns !== 'loss'
+
+  return {
+    outcome: fullWin ? 'full_win' : hasWin ? 'partial_win' : hasLoss ? 'regression' : 'not_measured',
+    checks,
+    evidence,
+  }
+}
+
 type NativeAgentComparableReport = NativeAgentCompareReport & {
   baseline: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>
   madar: Extract<NativeAgentRunStatus, { kind: 'succeeded' }>
@@ -3624,6 +3748,12 @@ export async function executeNativeAgentCompare(
     } else {
       delete reportShell.claim_assessment
     }
+    const benchmarkOutcome = assessNativeAgentBenchmarkOutcome(reportShell)
+    if (benchmarkOutcome !== undefined) {
+      reportShell.benchmark_outcome = benchmarkOutcome
+    } else {
+      delete reportShell.benchmark_outcome
+    }
     if (!nativeAgentReductionsAttributable(reportShell)) {
       reportShell.reductions = null
     }
@@ -3734,6 +3864,14 @@ function formatNativeAgentClaimAssessmentLine(assessment: NativeAgentClaimAssess
   return `claim_assessment: routing_efficiency ${assessment.routing_efficiency.status}${routingEvidence}; token_reduction ${assessment.token_reduction.status}${tokenEvidence}`
 }
 
+function formatNativeAgentBenchmarkOutcomeLine(outcome: NativeAgentBenchmarkOutcome): string {
+  const checks = Object.entries(outcome.checks)
+    .map(([name, status]) => `${name} ${status}`)
+    .join('; ')
+  const evidence = outcome.evidence.length > 0 ? ` (${outcome.evidence.join('; ')})` : ''
+  return `benchmark_outcome: ${outcome.outcome} (${checks})${evidence}`
+}
+
 function formatNativeAgentMadarTraceOutcomeSummary(reports: NativeAgentCompareReport[]): string | null {
   const traces = reports.flatMap((report) => (report.madar_trace ? [report.madar_trace] : []))
   if (traces.length === 0) {
@@ -3841,6 +3979,9 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
     if (report.claim_assessment) {
       lines.push(`    ${formatNativeAgentClaimAssessmentLine(report.claim_assessment)}`)
     }
+    if (report.benchmark_outcome) {
+      lines.push(`    ${formatNativeAgentBenchmarkOutcomeLine(report.benchmark_outcome)}`)
+    }
     const derivedTokenRegressionReasons = collectTokenRegressionReasons(baseline, madar)
     const tokenRegressionReasons =
       report.token_regression_reasons && report.token_regression_reasons.length > 0
@@ -3864,6 +4005,11 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       `    latency:   baseline ${baseline.duration_ms}ms → madar ${madar.duration_ms}ms${formatDirectionalDelta(baseline.duration_ms, madar.duration_ms, 'faster', 'slower')}`,
       `    input_tokens (Anthropic-reported): baseline ${baseline.total_input_tokens_anthropic_exact} → madar ${madar.total_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.total_input_tokens_anthropic_exact, madar.total_input_tokens_anthropic_exact, 'less', 'more', { noMeaningfulChangeThreshold: 0.1, neutralLabel: 'no meaningful change' })}`,
     )
+    if (baseline.total_cost_usd !== null && madar.total_cost_usd !== null) {
+      lines.push(
+        `    cost_usd: baseline ${baseline.total_cost_usd} → madar ${madar.total_cost_usd}${formatDirectionalDelta(baseline.total_cost_usd, madar.total_cost_usd, 'less', 'more')}`,
+      )
+    }
     if (hasCacheActivity) {
       lines.push(
         `    uncached_input_tokens (Anthropic-reported): baseline ${baseline.uncached_input_tokens_anthropic_exact} → madar ${madar.uncached_input_tokens_anthropic_exact}${formatDirectionalDelta(baseline.uncached_input_tokens_anthropic_exact, madar.uncached_input_tokens_anthropic_exact, 'less', 'more')}`,

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -210,6 +210,22 @@ const MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD = {
   },
 }
 
+const MADAR_TOOL_COUNT_REGRESSION_FLAT_LATENCY_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 30000,
+  num_turns: 3,
+  result: 'madar answer',
+  total_cost_usd: 0.3,
+  usage: {
+    input_tokens: 10000,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    output_tokens: 1000,
+  },
+}
+
 function toolUses(name: string, count: number): Array<{ type: 'tool_use'; name: string }> {
   return Array.from({ length: count }, () => ({ type: 'tool_use', name }))
 }
@@ -434,6 +450,35 @@ const VERBOSE_MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD = [
     },
   },
   MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD,
+] as const
+
+const VERBOSE_BASELINE_TOOL_COUNT_REGRESSION_FLAT_LATENCY_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'Read' },
+      ],
+    },
+  },
+  BASELINE_NO_TOOL_COUNT_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_TOOL_COUNT_REGRESSION_FLAT_LATENCY_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+        { type: 'tool_use', name: 'Read' },
+      ],
+    },
+  },
+  MADAR_TOOL_COUNT_REGRESSION_FLAT_LATENCY_PAYLOAD,
 ] as const
 
 const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
@@ -1396,6 +1441,48 @@ describe('executeNativeAgentCompare', () => {
 
       expect(report.measurement_validity).toBe('valid')
       expect(report.tool_call_counts).toBeUndefined()
+      expect(benchmarkOutcome).toEqual(expect.objectContaining({
+        outcome: 'regression',
+        checks: expect.objectContaining({
+          routing_tool_latency: 'loss',
+          token: 'flat',
+          fresh_token: 'flat',
+          cost: 'flat',
+          turns: 'flat',
+        }),
+      }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks routing tool usage as a loss when tool counts regress and latency is flat', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How idea report is being generated',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_TOOL_COUNT_REGRESSION_FLAT_LATENCY_PAYLOAD,
+            madar: VERBOSE_MADAR_TOOL_COUNT_REGRESSION_FLAT_LATENCY_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-27T01:30:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const benchmarkOutcome = savedReport.benchmark_outcome as Record<string, unknown> | undefined
+
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.tool_call_counts?.baseline.total).toBe(1)
+      expect(report.tool_call_counts?.madar.total).toBe(2)
       expect(benchmarkOutcome).toEqual(expect.objectContaining({
         outcome: 'regression',
         checks: expect.objectContaining({

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -146,6 +146,70 @@ const GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD = {
   },
 }
 
+const BASELINE_FULL_WIN_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 80000,
+  num_turns: 6,
+  result: 'baseline answer',
+  total_cost_usd: 0.8,
+  usage: {
+    input_tokens: 20000,
+    cache_creation_input_tokens: 30000,
+    cache_read_input_tokens: 100000,
+    output_tokens: 1200,
+  },
+}
+
+const MADAR_FULL_WIN_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 30000,
+  num_turns: 2,
+  result: 'madar answer',
+  total_cost_usd: 0.3,
+  usage: {
+    input_tokens: 10000,
+    cache_creation_input_tokens: 5000,
+    cache_read_input_tokens: 50000,
+    output_tokens: 1000,
+  },
+}
+
+const BASELINE_NO_TOOL_COUNT_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 30000,
+  num_turns: 3,
+  result: 'baseline answer',
+  total_cost_usd: 0.3,
+  usage: {
+    input_tokens: 10000,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    output_tokens: 1000,
+  },
+}
+
+const MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD = {
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  duration_ms: 60000,
+  num_turns: 3,
+  result: 'madar answer',
+  total_cost_usd: 0.3,
+  usage: {
+    input_tokens: 10000,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    output_tokens: 1000,
+  },
+}
+
 function toolUses(name: string, count: number): Array<{ type: 'tool_use'; name: string }> {
   return Array.from({ length: count }, () => ({ type: 'tool_use', name }))
 }
@@ -323,6 +387,53 @@ const VERBOSE_GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD = [
     },
   },
   GOVALIDATE_MADAR_TOKEN_REGRESSION_PAYLOAD,
+] as const
+
+const VERBOSE_BASELINE_FULL_WIN_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        ...toolUses('Read', 6),
+        ...toolUses('Grep', 4),
+      ],
+    },
+  },
+  BASELINE_FULL_WIN_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_FULL_WIN_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+      ],
+    },
+  },
+  MADAR_FULL_WIN_PAYLOAD,
+] as const
+
+const RESULT_ONLY_BASELINE_NO_TOOL_COUNT_PAYLOAD = [
+  BASELINE_NO_TOOL_COUNT_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        { type: 'tool_use', name: 'mcp__madar__retrieve' },
+      ],
+    },
+  },
+  MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD,
 ] as const
 
 const VERBOSE_MADAR_MCP_RETRIEVE_WITH_FOLLOWUP_EXPLORATION_PAYLOAD = [
@@ -1211,6 +1322,95 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
+  it('classifies native-agent benchmark outcomes as full wins only when every measured gate passes', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How idea report is being generated',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_FULL_WIN_PAYLOAD,
+            madar: VERBOSE_MADAR_FULL_WIN_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-27T00:30:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const benchmarkOutcome = savedReport.benchmark_outcome as Record<string, unknown> | undefined
+      const summary = formatNativeAgentCompareSummary(result)
+
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.tool_call_counts?.baseline.total).toBe(10)
+      expect(report.tool_call_counts?.madar.total).toBe(1)
+      expect(savedReport.token_regression).toBe(false)
+      expect(benchmarkOutcome).toEqual(expect.objectContaining({
+        outcome: 'full_win',
+        checks: expect.objectContaining({
+          routing_tool_latency: 'win',
+          token: 'win',
+          fresh_token: 'win',
+          cost: 'win',
+          turns: 'win',
+        }),
+      }))
+      expect(summary).toContain('benchmark_outcome: full_win')
+      expect(summary).toContain('turns win')
+      expect(summary).toContain('fresh_token win')
+      expect(summary).toContain('cost win')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('marks routing latency as a loss when latency regresses and tool counts are unavailable', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How idea report is being generated',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: RESULT_ONLY_BASELINE_NO_TOOL_COUNT_PAYLOAD,
+            madar: VERBOSE_MADAR_NO_TOOL_COUNT_LATENCY_REGRESSION_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-27T01:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const benchmarkOutcome = savedReport.benchmark_outcome as Record<string, unknown> | undefined
+
+      expect(report.measurement_validity).toBe('valid')
+      expect(report.tool_call_counts).toBeUndefined()
+      expect(benchmarkOutcome).toEqual(expect.objectContaining({
+        outcome: 'regression',
+        checks: expect.objectContaining({
+          routing_tool_latency: 'loss',
+          token: 'flat',
+          fresh_token: 'flat',
+          cost: 'flat',
+          turns: 'flat',
+        }),
+      }))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('separates routing wins from token-reduction proof for GoValidate-style token regressions', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     try {
@@ -1234,6 +1434,7 @@ describe('executeNativeAgentCompare', () => {
       const report = result.reports[0] as NativeAgentCompareReport
       const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
       const claimAssessment = savedReport.claim_assessment as Record<string, unknown> | undefined
+      const benchmarkOutcome = savedReport.benchmark_outcome as Record<string, unknown> | undefined
       const summary = formatNativeAgentCompareSummary(result)
 
       expect(report.measurement_validity).toBe('valid')
@@ -1252,10 +1453,30 @@ describe('executeNativeAgentCompare', () => {
           status: 'not_proven',
         }),
       }))
+      expect(benchmarkOutcome).toEqual(expect.objectContaining({
+        outcome: 'partial_win',
+        checks: expect.objectContaining({
+          routing_tool_latency: 'win',
+          token: 'loss',
+          fresh_token: 'loss',
+          cost: 'loss',
+          turns: 'loss',
+        }),
+      }))
+      expect(benchmarkOutcome?.evidence).toEqual(expect.arrayContaining([
+        expect.stringContaining('turns regressed'),
+        expect.stringContaining('fresh-token regression'),
+        expect.stringContaining('cost regressed'),
+      ]))
       expect(summary).toContain('claim_assessment: routing_efficiency improved')
       expect(summary).toContain('token_reduction not_proven')
+      expect(summary).toContain('benchmark_outcome: partial_win')
+      expect(summary).toContain('turns loss')
+      expect(summary).toContain('fresh_token loss')
+      expect(summary).toContain('cost loss')
       expect(summary).toContain('provider input grew')
       expect(summary).toContain('fresh-token regression')
+      expect(summary).toContain('cost_usd')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
Closes #379.\n\n## Summary\n- add a typed benchmark_outcome block for native-agent compare reports\n- gate full wins on routing/tool/latency plus token, fresh-token, cost, and turn checks\n- surface benchmark outcome and cost in native-agent summary output\n- cover full-win, partial-win, and missing-tool-count latency regression cases\n\n## Verification\n- npm run test:run -- tests/unit/compare-native-agent.test.ts tests/unit/benchmark-quality.test.ts tests/unit/compare.test.ts\n- npm run typecheck\n- npm run build\n- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comparison reports now include per-question benchmark outcome classifications (win/loss/flat/not_measured) across routing latency, token usage, fresh-token behavior, cost, and turns, with evidence.
  * Human-readable summaries show per-question benchmark lines and a baseline→Madar USD cost delta when available.

* **Tests**
  * Expanded test coverage for full-win, partial-win, and regression benchmark scenarios and summary output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->