### PR TITLE
Add benchmark-readiness preflight for native-agent compare

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,7 +4,7 @@ import { createInterface } from 'node:readline/promises'
 import { loadBenchmarkQuestions, type BenchmarkResult, printBenchmark, runBenchmark } from '../infrastructure/benchmark.js'
 import { runBenchmarkSuite } from '../infrastructure/benchmark/suite.js'
 import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure/benchmark/quality.js'
-import { NativeAgentInstallRequiredError, runCompareCommand } from '../infrastructure/compare.js'
+import { BenchmarkReadinessError, NativeAgentInstallRequiredError, runCompareCommand } from '../infrastructure/compare.js'
 import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
 import { runContextPromptCommand } from '../infrastructure/context-prompt-command.js'
 import { runDoctorCommand, runStatusCommand } from '../infrastructure/doctor.js'
@@ -202,12 +202,16 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
         perArmTimeoutSeconds: options.perArmTimeoutSeconds,
         heartbeatIntervalMs: options.heartbeatIntervalMs,
         strictMadarFirst: options.strictMadarFirst,
+        strictBenchmarkReadiness: options.strictBenchmarkReadiness,
         allowNoInstall: options.allowNoInstall,
         limit: options.limit,
         ...(options.why ? { why: true } : {}),
       })
     } catch (error) {
       if (error instanceof NativeAgentInstallRequiredError) {
+        throw new UsageError(error.message)
+      }
+      if (error instanceof BenchmarkReadinessError) {
         throw new UsageError(error.message)
       }
       throw error
@@ -418,6 +422,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --per-arm-timeout S   per-arm timeout seconds for native_agent runs (default 600)',
     '    --heartbeat-interval-ms N  stderr heartbeat interval for native_agent runs (default 30000; 0 disables)',
     '    --strict-madar-first  treat pre-Madar broad exploration as degraded/non-winning in native_agent mode',
+    '    --strict / --strict-benchmark-readiness  fail native_agent compare before runner spend when benchmark readiness is degraded or not_ready',
     '    --allow-no-install    allow native_agent compare without a verified Madar install and mark the run invalid',
     '    --yes                 skip confirmation before running the paid prompt comparison',
     '    --limit N             cap processed prompts/questions for the comparison run',

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -108,6 +108,7 @@ export interface CompareCliOptions {
   perArmTimeoutSeconds: number
   heartbeatIntervalMs: number
   strictMadarFirst: boolean
+  strictBenchmarkReadiness: boolean
   allowNoInstall: boolean
   yes: boolean
   limit: number | null
@@ -190,7 +191,7 @@ export interface InstallCliOptions {
   platform: InstallPlatform
 }
 
-const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--allow-no-install] [--yes] [--limit N] [--why]'
+const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'
 
 export interface PlatformActionCliOptions {
   action: 'install' | 'uninstall'
@@ -1084,6 +1085,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   let perArmTimeoutSeconds = 600
   let heartbeatIntervalMs = 30000
   let strictMadarFirst = false
+  let strictBenchmarkReadiness = false
   let allowNoInstall = false
   let yes = false
   let limit: number | null = null
@@ -1201,6 +1203,11 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
       continue
     }
 
+    if (argument === '--strict' || argument === '--strict-benchmark-readiness') {
+      strictBenchmarkReadiness = true
+      continue
+    }
+
     if (argument === '--allow-no-install') {
       allowNoInstall = true
       continue
@@ -1250,6 +1257,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
     perArmTimeoutSeconds,
     heartbeatIntervalMs,
     strictMadarFirst,
+    strictBenchmarkReadiness,
     allowNoInstall,
     yes,
     limit,

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1637,7 +1637,7 @@ function suggestBenchmarkGraphScope(graphPath: string, sourceFiles: readonly str
 
 function retrievalHasSpiEvidence(retrieval: RetrieveResult): boolean {
   return collectBenchmarkReadinessSourceFiles(retrieval).some((sourceFile) =>
-    sourceFile.includes('/spi/') || sourceFile.includes('.spi.'),
+    /(^|\/)spi(\/|$)|\.spi\./.test(sourceFile),
   )
 }
 
@@ -3512,7 +3512,7 @@ export async function executeNativeAgentCompare(
     throw new NativeAgentInstallRequiredError(installCheck)
   }
 
-  for (const [index, question] of questions.entries()) {
+  const preparedQuestions = questions.map((question, index) => {
     const questionDir = questions.length === 1 ? outputRoot : join(outputRoot, `question-${String(index + 1).padStart(3, '0')}`)
     mkdirSync(questionDir, { recursive: true })
 
@@ -3584,10 +3584,41 @@ export async function executeNativeAgentCompare(
       })
     }
     if (reportShell.benchmark_readiness) {
-      if (input.strictBenchmarkReadiness && reportShell.benchmark_readiness.status !== 'ready') {
-        throw new BenchmarkReadinessError(reportShell.benchmark_readiness)
-      }
+      reportShell.completed_at = now().toISOString()
     }
+    return {
+      question,
+      promptFile,
+      baselineAnswerPath,
+      madarAnswerPath,
+      reportPath,
+      shareSafeReportPath,
+      runStatePath,
+      reportShell,
+    }
+  })
+
+  const strictReadinessFailure =
+    input.strictBenchmarkReadiness
+      ? preparedQuestions.find((entry) => entry.reportShell.benchmark_readiness?.status !== 'ready')
+      : undefined
+  if (strictReadinessFailure?.reportShell.benchmark_readiness) {
+    for (const entry of preparedQuestions) {
+      writeNativeAgentReport(entry.reportShell)
+    }
+    throw new BenchmarkReadinessError(strictReadinessFailure.reportShell.benchmark_readiness)
+  }
+
+  for (const entry of preparedQuestions) {
+    const {
+      question,
+      promptFile,
+      baselineAnswerPath,
+      madarAnswerPath,
+      runStatePath,
+      reportShell,
+    } = entry
+
     writeNativeAgentRunState(runStatePath, {
       phase: 'baseline_pending',
       arm: 'baseline',

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
-import type { ContextPackRoutingDebug } from '../contracts/context-pack.js'
+import type { ContextPackExecutionPhase, ContextPackRoutingDebug } from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
@@ -229,6 +229,7 @@ export interface GenerateCompareArtifactsInput {
   perArmTimeoutSeconds?: number
   heartbeatIntervalMs?: number
   strictMadarFirst?: boolean
+  strictBenchmarkReadiness?: boolean
   allowNoInstall?: boolean
   why?: boolean
   corpusText?: string
@@ -1592,6 +1593,126 @@ function retrieveCompareContext(graph: KnowledgeGraph, question: string, budget:
   }
 }
 
+const BENCHMARK_READINESS_CRITICAL_PHASES = new Set<ContextPackExecutionPhase>([
+  'planner',
+  'external_research_or_api',
+  'report_builder',
+  'scoring',
+  'quality_gate',
+  'renderer_or_synthesis',
+  'persistence',
+])
+
+function collectBenchmarkReadinessSourceFiles(retrieval: RetrieveResult): string[] {
+  const sourceFiles = new Set<string>()
+  for (const node of retrieval.matched_nodes) {
+    sourceFiles.add(node.source_file)
+  }
+  for (const step of retrieval.execution_slice?.steps ?? []) {
+    sourceFiles.add(step.source_file)
+  }
+  for (const step of retrieval.execution_slice?.primary_path?.steps ?? []) {
+    sourceFiles.add(step.source_file)
+  }
+  return [...sourceFiles]
+}
+
+function suggestBenchmarkGraphScope(graphPath: string, sourceFiles: readonly string[]): string | null {
+  const scopes = new Set<string>()
+  for (const sourceFile of sourceFiles) {
+    const [scope] = sourceFile.split('/', 1)
+    if (scope && !['src', 'test', 'tests', 'docs'].includes(scope)) {
+      scopes.add(scope)
+    }
+  }
+
+  if (scopes.size !== 1) {
+    return null
+  }
+
+  const [scope] = [...scopes]
+  const suggested = `${scope}/out/graph.json`
+  return graphPath.endsWith(`/${suggested}`) ? null : suggested
+}
+
+function retrievalHasSpiEvidence(retrieval: RetrieveResult): boolean {
+  return collectBenchmarkReadinessSourceFiles(retrieval).some((sourceFile) =>
+    sourceFile.includes('/spi/') || sourceFile.includes('.spi.'),
+  )
+}
+
+function benchmarkReadinessSeverity(current: BenchmarkReadinessStatus, next: BenchmarkReadinessStatus): BenchmarkReadinessStatus {
+  const rank: Record<BenchmarkReadinessStatus, number> = {
+    ready: 0,
+    degraded: 1,
+    not_ready: 2,
+  }
+  return rank[next] > rank[current] ? next : current
+}
+
+export function assessBenchmarkReadinessFromRetrieveResult(input: {
+  graphPath: string
+  retrieval: RetrieveResult
+}): BenchmarkReadiness {
+  const { graphPath, retrieval } = input
+  const runtimeGeneration =
+    retrieval.answer_contract?.answer_focus === 'runtime_generation'
+    || retrieval.retrieval_gate?.signals.generation_intent === 'runtime_generation'
+  if (!runtimeGeneration) {
+    return {
+      status: 'ready',
+      reasons: [],
+      suggested_graph_scope: null,
+    }
+  }
+
+  let status: BenchmarkReadinessStatus = 'ready'
+  const reasons: string[] = []
+  const sourceFiles = collectBenchmarkReadinessSourceFiles(retrieval)
+  const suggestedGraphScope = suggestBenchmarkGraphScope(graphPath, sourceFiles)
+  const missingPhases = [...new Set([
+    ...(retrieval.answer_contract?.missing_phases ?? []),
+    ...(retrieval.execution_slice?.phase_coverage?.missing ?? []),
+  ])].filter((phase) => BENCHMARK_READINESS_CRITICAL_PHASES.has(phase))
+
+  if (missingPhases.length >= 3) {
+    status = benchmarkReadinessSeverity(status, 'not_ready')
+    reasons.push(`missing downstream runtime phases: ${missingPhases.join(', ')}`)
+  } else if (missingPhases.length > 0) {
+    status = benchmarkReadinessSeverity(status, 'degraded')
+    reasons.push(`missing downstream runtime phases: ${missingPhases.join(', ')}`)
+  }
+
+  const confidence = retrieval.answer_contract?.confidence ?? retrieval.execution_slice?.confidence
+  if (confidence === 'low') {
+    status = benchmarkReadinessSeverity(status, 'not_ready')
+    reasons.push('runtime slice confidence is low')
+  } else if (confidence === 'medium') {
+    status = benchmarkReadinessSeverity(status, 'degraded')
+    reasons.push('runtime slice confidence is medium')
+  }
+
+  if (!retrievalHasSpiEvidence(retrieval)) {
+    status = benchmarkReadinessSeverity(status, suggestedGraphScope ? 'not_ready' : 'degraded')
+    reasons.push(
+      suggestedGraphScope
+        ? `no SPI evidence found in the current pack; retry with ${suggestedGraphScope} or another SPI-scoped graph`
+        : 'no SPI evidence found in the current pack',
+    )
+  }
+
+  if (suggestedGraphScope) {
+    status = benchmarkReadinessSeverity(status, status === 'ready' ? 'degraded' : status)
+    reasons.push(`root graph is broad for this question; retrieved evidence is concentrated under ${suggestedGraphScope.replace('/out/graph.json', '/')}`)
+  }
+
+  return {
+    status,
+    reasons,
+    suggested_graph_scope: suggestedGraphScope,
+  }
+}
+
 function addBaselineCorpusFile(
   files: Map<string, string>,
   candidatePath: string,
@@ -2345,6 +2466,7 @@ export interface NativeAgentCompareReport {
   } | null
   token_regression: boolean
   token_regression_reasons: NativeAgentTokenRegressionMetric[]
+  benchmark_readiness?: BenchmarkReadiness
   prompt_contract?: NativeAgentPromptContractAssessment
   claim_assessment?: NativeAgentClaimAssessment
   prompt_token_source: {
@@ -2427,10 +2549,25 @@ export interface NativeAgentRunnerResult {
 
 export type NativeAgentRunner = (input: NativeAgentRunnerInput) => Promise<NativeAgentRunnerResult>
 
+export type BenchmarkReadinessStatus = 'ready' | 'degraded' | 'not_ready'
+
+export interface BenchmarkReadiness {
+  status: BenchmarkReadinessStatus
+  reasons: string[]
+  suggested_graph_scope: string | null
+}
+
+export interface BenchmarkReadinessInput {
+  graphPath: string
+  projectRoot: string
+  question: string
+}
+
 export interface ExecuteNativeAgentCompareDependencies {
   runner?: NativeAgentRunner
   now?: () => Date
   writeStderr?: (message: string) => void
+  assessBenchmarkReadiness?: (input: BenchmarkReadinessInput) => BenchmarkReadiness
 }
 
 interface NativeAgentRunStateRecord {
@@ -2560,6 +2697,16 @@ export class NativeAgentInstallRequiredError extends Error {
     super(formatNativeAgentInstallRequiredMessage(check))
     this.name = 'NativeAgentInstallRequiredError'
     this.check = check
+  }
+}
+
+export class BenchmarkReadinessError extends Error {
+  readonly readiness: BenchmarkReadiness
+
+  constructor(readiness: BenchmarkReadiness) {
+    super(`Native-agent benchmark readiness is ${readiness.status}.`)
+    this.name = 'BenchmarkReadinessError'
+    this.readiness = readiness
   }
 }
 
@@ -3350,9 +3497,12 @@ export async function executeNativeAgentCompare(
   const writeStderr = dependencies.writeStderr ?? ((message: string) => process.stderr.write(message))
   const timeoutMs = perArmTimeoutMs(input.perArmTimeoutSeconds)
   const heartbeatIntervalMs = compareHeartbeatIntervalMs(input.heartbeatIntervalMs)
+  const retrievalBudget = input.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET
   const timestamp = now()
   const outputRoot = createCompareOutputRoot(outputDir, timestamp)
   const runner = dependencies.runner ?? defaultNativeAgentRunner
+  const assessBenchmarkReadiness = dependencies.assessBenchmarkReadiness
+  const graph = assessBenchmarkReadiness ? null : loadGraph(graphPath)
   const reports: NativeAgentCompareReport[] = []
   const answerQualityGates = loadNativeAgentAnswerQualityGates(input.questionsPath)
   const environment = await captureBenchmarkEnvironment({ projectRoot })
@@ -3420,6 +3570,23 @@ export async function executeNativeAgentCompare(
         madar_answer: madarAnswerPath,
         prompt_file: promptFile,
       },
+    }
+    if (assessBenchmarkReadiness) {
+      reportShell.benchmark_readiness = assessBenchmarkReadiness({
+        graphPath,
+        projectRoot,
+        question,
+      })
+    } else if (graph) {
+      reportShell.benchmark_readiness = assessBenchmarkReadinessFromRetrieveResult({
+        graphPath,
+        retrieval: retrieveCompareContext(graph, question, retrievalBudget, projectRoot),
+      })
+    }
+    if (reportShell.benchmark_readiness) {
+      if (input.strictBenchmarkReadiness && reportShell.benchmark_readiness.status !== 'ready') {
+        throw new BenchmarkReadinessError(reportShell.benchmark_readiness)
+      }
     }
     writeNativeAgentRunState(runStatePath, {
       phase: 'baseline_pending',
@@ -3811,6 +3978,12 @@ function appendNativeAgentValidityLines(lines: string[], report: NativeAgentComp
     `    ${formatMadarMcpCallCountLine(report)}`,
     `    ${formatNativeAgentTraceStatusLine(report)}`,
   )
+  if (report.benchmark_readiness) {
+    lines.push(`    ${formatBenchmarkReadinessLine(report.benchmark_readiness)}`)
+    if (report.benchmark_readiness.suggested_graph_scope) {
+      lines.push(`    Next step: retry with ${report.benchmark_readiness.suggested_graph_scope}`)
+    }
+  }
 }
 
 function formatNativeAgentClaimAssessmentLine(assessment: NativeAgentClaimAssessment): string {
@@ -3826,6 +3999,11 @@ function formatNativeAgentClaimAssessmentLine(assessment: NativeAgentClaimAssess
 function formatNativeAgentPromptContractLine(assessment: NativeAgentPromptContractAssessment): string {
   const evidence = assessment.evidence.length > 0 ? ` (${assessment.evidence.join('; ')})` : ''
   return `prompt_contract: ${assessment.status}${evidence}`
+}
+
+function formatBenchmarkReadinessLine(readiness: BenchmarkReadiness): string {
+  const reasons = readiness.reasons.length > 0 ? ` (${readiness.reasons.join('; ')})` : ''
+  return `benchmark_readiness: ${readiness.status}${reasons}`
 }
 
 export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult): string {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -552,6 +552,7 @@ describe('cli parser', () => {
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
+      strictBenchmarkReadiness: false,
       allowNoInstall: false,
       yes: false,
       limit: null,
@@ -567,6 +568,7 @@ describe('cli parser', () => {
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
+      strictBenchmarkReadiness: false,
       allowNoInstall: false,
       yes: false,
       limit: null,
@@ -590,6 +592,7 @@ describe('cli parser', () => {
         '--heartbeat-interval-ms',
         '15000',
         '--strict-madar-first',
+        '--strict-benchmark-readiness',
         '--allow-no-install',
         '--yes',
         '--limit',
@@ -605,6 +608,7 @@ describe('cli parser', () => {
       perArmTimeoutSeconds: 900,
       heartbeatIntervalMs: 15000,
       strictMadarFirst: true,
+      strictBenchmarkReadiness: true,
       allowNoInstall: true,
       yes: true,
       limit: 5,
@@ -630,6 +634,32 @@ describe('cli parser', () => {
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
+      strictBenchmarkReadiness: false,
+      allowNoInstall: false,
+      yes: false,
+      limit: null,
+    })
+  })
+
+  it('parses compare args with --strict as a benchmark-readiness alias', () => {
+    expect(
+      parseCompareArgs([
+        'how does login work',
+        '--exec',
+        'claude -p "$(cat {prompt_file})"',
+        '--strict',
+      ]),
+    ).toEqual({
+      question: 'how does login work',
+      graphPath: 'out/graph.json',
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      questionsPath: null,
+      outputDir: resolve('out/compare'),
+      baselineMode: 'full',
+      perArmTimeoutSeconds: 600,
+      heartbeatIntervalMs: 30000,
+      strictMadarFirst: false,
+      strictBenchmarkReadiness: true,
       allowNoInstall: false,
       yes: false,
       limit: null,
@@ -654,6 +684,7 @@ describe('cli parser', () => {
     perArmTimeoutSeconds: 600,
     heartbeatIntervalMs: 30000,
     strictMadarFirst: false,
+    strictBenchmarkReadiness: false,
     allowNoInstall: false,
     yes: false,
     limit: null,
@@ -1085,6 +1116,7 @@ describe('cli main', () => {
     expect(help).toContain('    --per-arm-timeout S   per-arm timeout seconds for native_agent runs (default 600)')
     expect(help).toContain('    --heartbeat-interval-ms N  stderr heartbeat interval for native_agent runs (default 30000; 0 disables)')
     expect(help).toContain('    --strict-madar-first  treat pre-Madar broad exploration as degraded/non-winning in native_agent mode')
+    expect(help).toContain('    --strict / --strict-benchmark-readiness  fail native_agent compare before runner spend when benchmark readiness is degraded or not_ready')
     expect(help).toContain('    --yes                 skip confirmation before running the paid prompt comparison')
     expect(help).toContain('    --limit N             cap processed prompts/questions for the comparison run')
     expect(help).toContain('    --why                 include retrieval-routing debug metadata in the compare summary and reports')
@@ -1146,6 +1178,7 @@ describe('cli main', () => {
         '--heartbeat-interval-ms',
         '15000',
         '--strict-madar-first',
+        '--strict-benchmark-readiness',
         '--yes',
         '--limit',
         '5',
@@ -1173,6 +1206,7 @@ describe('cli main', () => {
       perArmTimeoutSeconds: 900,
       heartbeatIntervalMs: 15000,
       strictMadarFirst: true,
+      strictBenchmarkReadiness: true,
       allowNoInstall: false,
       yes: true,
       limit: 5,
@@ -1455,7 +1489,7 @@ describe('cli main', () => {
 
     expect(exitCode).toBe(2)
     expect(logs).toEqual([])
-    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--allow-no-install] [--yes] [--limit N] [--why]'])
+    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'])
   })
 
   it('prefers the explicit compare command over an implicit generate path match', async () => {

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -635,6 +635,7 @@ describe('executeNativeAgentCompare', () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     let runnerCalled = false
     try {
+      const reportPath = join(outputDir, '2026-05-01T00-00-00', 'report.json')
       const runner: NativeAgentRunner = async (input) => {
         runnerCalled = true
         return {
@@ -673,6 +674,14 @@ describe('executeNativeAgentCompare', () => {
         ),
       ).rejects.toThrow('benchmark readiness is not_ready')
       expect(runnerCalled).toBe(false)
+      expect(existsSync(reportPath)).toBe(true)
+      expect(JSON.parse(readFileSync(reportPath, 'utf8'))).toEqual(expect.objectContaining({
+        benchmark_readiness: {
+          status: 'not_ready',
+          reasons: ['SPI missing for runtime spine evidence'],
+          suggested_graph_scope: 'backend/out/graph.json',
+        },
+      }))
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -575,6 +575,109 @@ describe('parseAnthropicResultEvent', () => {
 })
 
 describe('executeNativeAgentCompare', () => {
+  it('records benchmark readiness in the native-agent report and summary', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'How idea report is being generated',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({ baseline: VERBOSE_BASELINE_PAYLOAD, madar: VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD }),
+          now: () => new Date('2026-05-01T00:00:00Z'),
+          assessBenchmarkReadiness: () => ({
+            status: 'not_ready',
+            reasons: ['SPI missing for runtime spine evidence', 'scope locality is weak'],
+            suggested_graph_scope: 'backend/out/graph.json',
+          }),
+        } as Parameters<typeof executeNativeAgentCompare>[1] & {
+          assessBenchmarkReadiness: () => {
+            status: 'ready' | 'degraded' | 'not_ready'
+            reasons: string[]
+            suggested_graph_scope: string | null
+          }
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport & {
+        benchmark_readiness?: {
+          status: 'ready' | 'degraded' | 'not_ready'
+          reasons: string[]
+          suggested_graph_scope: string | null
+        }
+      }
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const summary = formatNativeAgentCompareSummary(result)
+
+      expect(report.benchmark_readiness).toEqual({
+        status: 'not_ready',
+        reasons: ['SPI missing for runtime spine evidence', 'scope locality is weak'],
+        suggested_graph_scope: 'backend/out/graph.json',
+      })
+      expect(savedReport.benchmark_readiness).toEqual({
+        status: 'not_ready',
+        reasons: ['SPI missing for runtime spine evidence', 'scope locality is weak'],
+        suggested_graph_scope: 'backend/out/graph.json',
+      })
+      expect(summary).toContain('benchmark_readiness: not_ready')
+      expect(summary).toContain('SPI missing for runtime spine evidence')
+      expect(summary).toContain('Next step: retry with backend/out/graph.json')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails early when strict benchmark readiness is poor', async () => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    let runnerCalled = false
+    try {
+      const runner: NativeAgentRunner = async (input) => {
+        runnerCalled = true
+        return {
+          exitCode: 0,
+          stdout: `${JSON.stringify(input.mode === 'baseline' ? VERBOSE_BASELINE_PAYLOAD : VERBOSE_MADAR_MCP_RETRIEVE_PAYLOAD)}\n`,
+          stderr: '',
+          elapsedMs: 1,
+        }
+      }
+
+      await expect(
+        executeNativeAgentCompare(
+          {
+            graphPath,
+            question: 'How idea report is being generated',
+            outputDir,
+            execTemplate: 'mock-runner',
+            baselineMode: 'native_agent',
+            strictBenchmarkReadiness: true,
+          } as Parameters<typeof executeNativeAgentCompare>[0] & { strictBenchmarkReadiness: boolean },
+          {
+            runner,
+            now: () => new Date('2026-05-01T00:00:00Z'),
+            assessBenchmarkReadiness: () => ({
+              status: 'not_ready',
+              reasons: ['SPI missing for runtime spine evidence'],
+              suggested_graph_scope: 'backend/out/graph.json',
+            }),
+          } as Parameters<typeof executeNativeAgentCompare>[1] & {
+            assessBenchmarkReadiness: () => {
+              status: 'ready' | 'degraded' | 'not_ready'
+              reasons: string[]
+              suggested_graph_scope: string | null
+            }
+          },
+        ),
+      ).rejects.toThrow('benchmark readiness is not_ready')
+      expect(runnerCalled).toBe(false)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('writes a native-agent prompt that enforces the Madar pack contract', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     try {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -4569,4 +4569,31 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
       suggested_graph_scope: null,
     })
   })
+
+  it('treats top-level spi paths as SPI evidence', () => {
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath: '/repo/spi/out/graph.json',
+      retrieval: makeRuntimeGenerationRetrieval({
+        matched_nodes: [
+          {
+            label: 'SpiRuntime.generate',
+            source_file: 'spi/runtime.ts',
+            line_number: 12,
+            file_type: 'code',
+            snippet: null,
+            match_score: 11,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+      }),
+    })
+
+    expect(readiness).toEqual({
+      status: 'ready',
+      reasons: [],
+      suggested_graph_scope: null,
+    })
+  })
 })

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -6,6 +6,7 @@ import { vi } from 'vitest'
 
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import {
+  assessBenchmarkReadinessFromRetrieveResult,
   buildBaselinePromptPack,
   buildMadarPromptPack,
   buildNativeAgentPrompt,
@@ -4355,5 +4356,217 @@ describe('compare runtime', () => {
         limit: 0,
       }),
     ).toThrow(/positive integer/i)
+  })
+})
+
+describe('assessBenchmarkReadinessFromRetrieveResult', () => {
+  function makeRuntimeGenerationRetrieval(overrides: Partial<MadarPromptPackRetrieval> = {}): MadarPromptPackRetrieval {
+    return {
+      question: 'How idea report is being generated',
+      token_count: 120,
+      matched_nodes: [
+        {
+          label: 'GenerateIdeaReportService.handle',
+          source_file: 'backend/src/modules/ideas/application/generate-idea-report.service.ts',
+          line_number: 42,
+          file_type: 'code',
+          snippet: null,
+          match_score: 12,
+          relevance_band: 'direct',
+          community: null,
+          community_label: null,
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      retrieval_gate: {
+        level: 3,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        skipped_retrieval: false,
+        intent: 'unknown',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation',
+          target_domain_hint: 'backend_runtime',
+        },
+      },
+      coverage: {
+        required_evidence: [],
+        semantic_required: [],
+        semantic_optional: [],
+        entries: [],
+        semantic_entries: [],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 0,
+        selected_relationships: 0,
+      },
+      selection_diagnostics: {
+        selection_strategy: 'value-per-token',
+        budget: 4000,
+        used_tokens: 1200,
+        required_overflow: false,
+        ranking: [],
+      },
+      execution_slice: {
+        status: 'complete',
+        confidence: 'high',
+        steps: [
+          {
+            label: 'GenerateIdeaReportService.handle',
+            source_file: 'backend/src/modules/ideas/application/generate-idea-report.service.ts',
+            line_number: 42,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+          observed: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+          missing: [],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: [],
+        observed_phases: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+        missing_phases: [],
+        confidence: 'high',
+      },
+      ...overrides,
+    }
+  }
+
+  it('marks root non-SPI runtime-generation packs not ready and suggests a scoped backend graph', () => {
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath: '/repo/out/graph.json',
+      retrieval: makeRuntimeGenerationRetrieval({
+        execution_slice: {
+          status: 'partial',
+          confidence: 'low',
+          confidence_reasons: ['no_runtime_handoff'],
+          steps: [
+            {
+              label: 'IdeaGenerationController.generateFromProblem',
+              source_file: 'backend/src/modules/ideas/interface/http/idea-generation.controller.ts',
+              line_number: 58,
+              node_kind: 'method',
+            },
+          ],
+          phase_coverage: {
+            expected: ['planner', 'external_research_or_api', 'report_builder', 'scoring', 'quality_gate', 'renderer_or_synthesis', 'persistence'],
+            observed: ['controller', 'service'],
+            missing: ['planner', 'external_research_or_api', 'report_builder', 'scoring', 'quality_gate', 'renderer_or_synthesis', 'persistence'],
+          },
+        },
+        answer_contract: {
+          version: 1,
+          answer_focus: 'runtime_generation',
+          entrypoint_scope: 'setup_context',
+          required_elements: ['main_pipeline_phases'],
+          do_not_claim: ['full_runtime_certainty_when_slice_is_partial'],
+          observed_phases: ['controller', 'service'],
+          missing_phases: ['planner', 'external_research_or_api', 'report_builder', 'scoring', 'quality_gate', 'renderer_or_synthesis', 'persistence'],
+          confidence: 'low',
+        },
+      }),
+    })
+
+    expect(readiness.status).toBe('not_ready')
+    expect(readiness.reasons).toEqual(expect.arrayContaining([
+      expect.stringContaining('missing downstream runtime phases'),
+      expect.stringContaining('no SPI evidence'),
+      expect.stringContaining('backend/'),
+    ]))
+    expect(readiness.suggested_graph_scope).toBe('backend/out/graph.json')
+  })
+
+  it('marks root SPI runtime-generation packs degraded when downstream phases are still missing', () => {
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath: '/repo/out/graph.json',
+      retrieval: makeRuntimeGenerationRetrieval({
+        matched_nodes: [
+          {
+            label: 'IdeaReportSpi.generate',
+            source_file: 'backend/src/spi/idea-report.spi.ts',
+            line_number: 12,
+            file_type: 'code',
+            snippet: null,
+            match_score: 11,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+        execution_slice: {
+          status: 'partial',
+          confidence: 'medium',
+          confidence_reasons: ['persistence_boundary_not_traced'],
+          steps: [
+            {
+              label: 'IdeaReportSpi.generate',
+              source_file: 'backend/src/spi/idea-report.spi.ts',
+              line_number: 12,
+              node_kind: 'method',
+            },
+          ],
+          phase_coverage: {
+            expected: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+            observed: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis'],
+            missing: ['persistence'],
+          },
+        },
+        answer_contract: {
+          version: 1,
+          answer_focus: 'runtime_generation',
+          entrypoint_scope: 'setup_context',
+          required_elements: ['main_pipeline_phases'],
+          do_not_claim: [],
+          observed_phases: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis'],
+          missing_phases: ['persistence'],
+          confidence: 'medium',
+        },
+      }),
+    })
+
+    expect(readiness.status).toBe('degraded')
+    expect(readiness.reasons).toEqual(expect.arrayContaining([
+      expect.stringContaining('missing downstream runtime phases'),
+      expect.stringContaining('root graph'),
+    ]))
+    expect(readiness.suggested_graph_scope).toBe('backend/out/graph.json')
+  })
+
+  it('marks backend SPI runtime-generation packs ready when runtime spine evidence is covered', () => {
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath: '/repo/backend/out/graph.json',
+      retrieval: makeRuntimeGenerationRetrieval({
+        matched_nodes: [
+          {
+            label: 'IdeaReportSpi.generate',
+            source_file: 'backend/src/spi/idea-report.spi.ts',
+            line_number: 12,
+            file_type: 'code',
+            snippet: null,
+            match_score: 11,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+      }),
+    })
+
+    expect(readiness).toEqual({
+      status: 'ready',
+      reasons: [],
+      suggested_graph_scope: null,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add retrieval-backed benchmark-readiness assessment for native-agent compare
- record readiness in report JSON/summary and fail early under strict mode before runner spend
- expose strict readiness via `madar compare --strict` / `--strict-benchmark-readiness`

Closes #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--strict` / `--strict-benchmark-readiness` flag to the compare command to enforce benchmark-readiness checks.
  * Compare output now shows a benchmark readiness status, reasons, and suggested next-step graph scope.

* **Documentation**
  * CLI help and usage updated to document the new `--strict / --strict-benchmark-readiness` flag and usage string.

* **Tests**
  * Added unit tests covering benchmark-readiness assessment, reporting, strict-mode behavior, and CLI parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->