### PR TITLE
Tighten runtime pack confidence gating

### DIFF
--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -199,6 +199,7 @@ export async function runBenchmarkPrompt(options: RunBenchmarkPromptOptions): Pr
       options.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET,
   )
   const promptPack = buildMadarPromptPack({
+    graphPath: options.graphPath,
     question: options.question,
     retrieval,
     ...(options.session ? { session: options.session } : {}),

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -69,6 +69,7 @@ export interface BuildBaselinePromptPackInput {
 }
 
 export interface BuildMadarPromptPackInput {
+  graphPath?: string
   question: string
   retrieval: RetrieveResult
   session?: ContextSessionState
@@ -1817,7 +1818,7 @@ export function buildBaselinePromptPack(input: BuildBaselinePromptPackInput): Co
 
 export function buildMadarPromptPack(input: BuildMadarPromptPackInput): ComparePromptPack {
   const explainPayload = JSON.stringify(
-    buildExplainPackPayloadCore(compactRetrieveResult(input.retrieval), input.retrieval),
+    buildExplainPackPayloadCore(compactRetrieveResult(input.retrieval), input.retrieval, undefined, input.graphPath),
     null,
     2,
   )
@@ -1921,6 +1922,7 @@ export function generateCompareArtifacts(input: GenerateCompareArtifactsInput): 
 
     const retrieval = retrieveCompareContext(graph, question, retrievalBudget, projectRoot)
     const madarPrompt = buildMadarPromptPack({
+      graphPath: input.graphPath,
       question,
       retrieval,
       ...(madarSession ? { session: madarSession } : {}),

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -28,7 +28,7 @@ import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
 import {
-  buildMadarResponseEvidence,
+  assessMadarResponseEvidence,
   collectWorkflowOwners,
   missingPhasesFromPayload,
   type MadarResponseEvidence,
@@ -179,6 +179,7 @@ export function buildExplainPackPayloadCore(
     question: string
   },
   implementation?: ImplementationPackGuidance,
+  graphPath?: string,
 ): ExplainPackPayload {
   const payload = buildExplainPackPayload(pack, retrieval, implementation)
   const plan = buildTaskContextPlan({
@@ -189,7 +190,23 @@ export function buildExplainPackPayloadCore(
   })
   const centers = workflowCenters('explain', pack, plan, implementation, retrieval as RetrieveResult)
   const firstRead = recommendedFirstRead('explain', pack, implementation, retrieval as RetrieveResult)
-  const score = confidenceScore(payload.coverage, pack, implementation)
+  const evidenceAssessment = assessMadarResponseEvidence({
+    answerContract: (retrieval as RetrieveResult).answer_contract,
+    coverage: payload.coverage,
+    coveredWorkflowOwners: collectWorkflowOwners(
+      centers.map((entry) => entry.path),
+      firstRead.map((entry) => entry.path),
+      implementation?.likely_edit_files.map((entry) => entry.path) ?? [],
+      implementation?.likely_test_files.map((entry) => entry.path) ?? [],
+    ),
+    executionSlice: (retrieval as RetrieveResult).execution_slice,
+    graphPath,
+    missingPhases: missingPhasesFromPayload(pack as {
+      answer_contract?: { missing_phases?: readonly unknown[] }
+      execution_slice?: { phase_coverage?: { missing?: readonly unknown[] } }
+    }),
+    score: confidenceScore(payload.coverage, pack, implementation),
+  })
 
   return {
     ...payload,
@@ -197,7 +214,7 @@ export function buildExplainPackPayloadCore(
       ...payload.pack,
       workflow_centers: centers,
       recommended_first_read: firstRead,
-      confidence_score: score,
+      confidence_score: evidenceAssessment.score,
     },
   }
 }
@@ -686,6 +703,7 @@ function whyExplanation(
   coverage: ContextPackCoverage,
   score: number,
   implementation?: ImplementationPackGuidance,
+  confidenceReasons: readonly string[] = [],
 ): string[] {
   const requiredEntries = coverage.entries.filter((entry) => entry.required)
   const requiredCovered = requiredEntries.filter((entry) => entry.status === 'covered').length
@@ -705,6 +723,7 @@ function whyExplanation(
       ? ['No related tests were identified, so the brief keeps a manual validation caution visible.']
       : []),
     `Confidence ${score.toFixed(2)} from ${requiredCovered}/${requiredEntries.length || 0} required evidence classes and ${semanticCovered}/${semanticEntries.length || 0} required semantic categories covered.`,
+    ...confidenceReasons.map((reason) => `Confidence reason: ${reason}.`),
   ]
 
   return explanations
@@ -724,9 +743,11 @@ function buildPackSchemaV1<TPack extends PackPayload>(
   const firstRead = recommendedFirstRead(response.task, response.pack, response.implementation, retrieval)
   const contracts = publicContracts(response.implementation)
   const guidance = negativeGuidance(response.task, response.coverage, response.pack, response.implementation, retrieval)
-  const score = confidenceScore(response.coverage, response.pack, response.implementation)
-  const evidence = buildMadarResponseEvidence({
+  const evidenceAssessment = assessMadarResponseEvidence({
+    answerContract: retrieval?.answer_contract ?? ('answer_contract' in response.pack ? response.pack.answer_contract : undefined),
     coverage: response.coverage,
+    executionSlice: retrieval?.execution_slice ?? ('execution_slice' in response.pack ? response.pack.execution_slice : undefined),
+    graphPath: response.graph_path,
     missingPhases: missingPhasesFromPayload(response.pack as {
       answer_contract?: { missing_phases?: readonly unknown[] }
       execution_slice?: { phase_coverage?: { missing?: readonly unknown[] } }
@@ -737,8 +758,9 @@ function buildPackSchemaV1<TPack extends PackPayload>(
       response.implementation?.likely_edit_files.map((entry) => entry.path) ?? [],
       response.implementation?.likely_test_files.map((entry) => entry.path) ?? [],
     ),
-    score,
+    score: confidenceScore(response.coverage, response.pack, response.implementation),
   })
+  const { score, ...evidence } = evidenceAssessment
   const compatibilityFields: PackGuidanceCompatibilityFields = {
     workflow_centers: centers,
     recommended_first_read: firstRead,
@@ -767,6 +789,7 @@ function buildPackSchemaV1<TPack extends PackPayload>(
       response.coverage,
       score,
       response.implementation,
+      evidence.confidence_reasons,
     ),
   }
 }
@@ -1113,7 +1136,7 @@ export async function runContextPackCommand(
     ...baseResponse(options, initialPlan, plannerBudget, resolvedTask.task_kind),
     ...(
       resolvedTask.task_kind === 'explain'
-        ? buildExplainPackPayloadCore(dependencies.compactRetrieveResult(retrieval), retrieval, implementation)
+        ? buildExplainPackPayloadCore(dependencies.compactRetrieveResult(retrieval), retrieval, implementation, options.graphPath)
         : buildExplainPackPayload(dependencies.compactRetrieveResult(retrieval), retrieval, implementation)
     ),
     retrieval,

--- a/src/infrastructure/context-prompt-command.ts
+++ b/src/infrastructure/context-prompt-command.ts
@@ -9,7 +9,7 @@ const DEFAULT_PROMPT_BUDGET = 3_000
 export interface ContextPromptCommandDependencies {
   loadGraph: (graphPath: string) => KnowledgeGraph
   retrieveContext: (graph: KnowledgeGraph, options: { question: string; budget: number }) => RetrieveResult
-  buildMadarPromptPack: (input: { question: string; retrieval: RetrieveResult }) => ComparePromptPack
+  buildMadarPromptPack: (input: { graphPath?: string; question: string; retrieval: RetrieveResult }) => ComparePromptPack
 }
 
 const DEFAULT_DEPENDENCIES: ContextPromptCommandDependencies = {
@@ -68,6 +68,7 @@ export async function runContextPromptCommand(
     budget: DEFAULT_PROMPT_BUDGET,
   })
   const compiled = dependencies.buildMadarPromptPack({
+    graphPath: options.graphPath,
     question: options.prompt,
     retrieval,
   })

--- a/src/runtime/mcp-response-evidence.ts
+++ b/src/runtime/mcp-response-evidence.ts
@@ -1,4 +1,9 @@
-import type { ContextPackCoverage, ContextPackExecutionPhase } from '../contracts/context-pack.js'
+import type {
+  ContextPackCoverage,
+  ContextPackExecutionPhase,
+  ContextPackExecutionSlice,
+  ContextPackRuntimeGenerationAnswerContract,
+} from '../contracts/context-pack.js'
 
 export type MadarResponsePackConfidence = 'high' | 'medium' | 'low'
 export type MadarResponseCoverage = 'complete' | 'partial' | 'unknown'
@@ -9,11 +14,15 @@ export interface MadarResponseEvidence {
   coverage: MadarResponseCoverage
   missing_phases: ContextPackExecutionPhase[]
   covered_workflow_owners: string[]
+  confidence_reasons: string[]
   agent_directive: MadarResponseAgentDirective
 }
 
 const HIGH_CONFIDENCE_THRESHOLD = 0.85
 const MEDIUM_CONFIDENCE_THRESHOLD = 0.5
+const MEDIUM_CONFIDENCE_MAX = HIGH_CONFIDENCE_THRESHOLD - 0.01
+const LOW_CONFIDENCE_MAX = MEDIUM_CONFIDENCE_THRESHOLD - 0.01
+const GENERIC_SCOPE_SEGMENTS = new Set(['src', 'test', 'tests', 'docs', 'lib', 'libs', 'packages', 'apps'])
 
 function roundScore(value: number): number {
   return Math.round(Math.min(1, Math.max(0, value)) * 100) / 100
@@ -59,8 +68,9 @@ export function packConfidenceFromScore(score: number): MadarResponsePackConfide
 export function agentDirectiveForEvidence(
   packConfidence: MadarResponsePackConfidence,
   coverage: MadarResponseCoverage,
+  answerContained: boolean | undefined = undefined,
 ): MadarResponseAgentDirective {
-  if (coverage === 'complete' && packConfidence === 'high') {
+  if ((answerContained ?? true) && coverage === 'complete' && packConfidence === 'high') {
     return 'answer_from_pack'
   }
   if (coverage !== 'unknown' && packConfidence !== 'low') {
@@ -69,33 +79,245 @@ export function agentDirectiveForEvidence(
   return 'explore_with_caution'
 }
 
-export function buildMadarResponseEvidence(input: {
+export interface MadarResponseEvidenceAssessment extends MadarResponseEvidence {
+  score: number
+}
+
+function normalizeSourcePath(path: string): string {
+  return path.replaceAll('\\', '/').replace(/^\.?\//, '')
+}
+
+function confidenceCapForScore(confidence: MadarResponsePackConfidence): number {
+  switch (confidence) {
+    case 'high':
+      return 1
+    case 'medium':
+      return MEDIUM_CONFIDENCE_MAX
+    case 'low':
+      return LOW_CONFIDENCE_MAX
+  }
+}
+
+function moreRestrictiveConfidence(
+  current: MadarResponsePackConfidence,
+  next: MadarResponsePackConfidence,
+): MadarResponsePackConfidence {
+  const rank: Record<MadarResponsePackConfidence, number> = {
+    high: 2,
+    medium: 1,
+    low: 0,
+  }
+  return rank[next] < rank[current] ? next : current
+}
+
+function scopeQualityAssessment(
+  graphPath: string | undefined,
+  coveredWorkflowOwners: readonly string[],
+): {
+  confidenceCap: MadarResponsePackConfidence
+  reason: string
+} {
+  if (!graphPath) {
+    return {
+      confidenceCap: 'high',
+      reason: 'scope quality: graph scope was not provided, so scope alignment could not be checked',
+    }
+  }
+
+  const normalizedGraphPath = normalizeSourcePath(graphPath)
+  const candidateScopes = [...new Set(
+    coveredWorkflowOwners
+      .map(normalizeSourcePath)
+      .map((value) => value.split('/', 1)[0] ?? '')
+      .filter((value) => value.length > 0 && !GENERIC_SCOPE_SEGMENTS.has(value)),
+  )]
+  if (candidateScopes.length !== 1) {
+    return {
+      confidenceCap: 'high',
+      reason: 'scope quality: retrieved workflow owners do not point to one narrower subproject scope',
+    }
+  }
+
+  const expectedGraphPath = `${candidateScopes[0]}/out/graph.json`
+  if (normalizedGraphPath === expectedGraphPath || normalizedGraphPath.endsWith(`/${expectedGraphPath}`)) {
+    return {
+      confidenceCap: 'high',
+      reason: `scope quality: graph scope is aligned with the ${candidateScopes[0]} runtime evidence`,
+    }
+  }
+
+  return {
+    confidenceCap: 'medium',
+    reason: `scope quality: runtime evidence is concentrated under ${candidateScopes[0]}/ while the graph is rooted at ${normalizedGraphPath}`,
+  }
+}
+
+function workflowLocalityAssessment(
+  executionSlice: ContextPackExecutionSlice | undefined,
+): {
+  confidenceCap: MadarResponsePackConfidence
+  reason: string
+} {
+  if (!executionSlice) {
+    return {
+      confidenceCap: 'medium',
+      reason: 'workflow locality: no execution spine was captured for this answer',
+    }
+  }
+
+  if (executionSlice.steps.length >= 2) {
+    return {
+      confidenceCap: 'high',
+      reason: 'workflow locality: runtime evidence stays on one coherent workflow spine',
+    }
+  }
+
+  return {
+    confidenceCap: 'medium',
+    reason: 'workflow locality: runtime evidence is too shallow to prove one coherent workflow spine',
+  }
+}
+
+function phaseCompletenessAssessment(
+  missingPhases: readonly ContextPackExecutionPhase[],
+): {
+  confidenceCap: MadarResponsePackConfidence
+  reason: string
+} {
+  if (missingPhases.length === 0) {
+    return {
+      confidenceCap: 'high',
+      reason: 'phase completeness: critical runtime phases are present in the pack',
+    }
+  }
+
+  return {
+    confidenceCap: missingPhases.length >= 3 ? 'low' : 'medium',
+    reason: `phase completeness: missing ${missingPhases.join(', ')}`,
+  }
+}
+
+function answerContainednessAssessment(
+  executionSlice: ContextPackExecutionSlice | undefined,
+  answerContract: ContextPackRuntimeGenerationAnswerContract | undefined,
+  missingPhases: readonly ContextPackExecutionPhase[],
+): {
+  answerContained: boolean | undefined
+  confidenceCap: MadarResponsePackConfidence
+  reason: string
+} {
+  const runtimeGeneration =
+    answerContract?.answer_focus === 'runtime_generation'
+    || executionSlice !== undefined
+    || missingPhases.length > 0
+  if (!runtimeGeneration) {
+    return {
+      answerContained: undefined,
+      confidenceCap: 'high',
+      reason: 'answer containedness: no runtime-generation containment check was needed',
+    }
+  }
+
+  const confidence = answerContract?.confidence ?? executionSlice?.confidence
+  const contained =
+    executionSlice !== undefined
+    && missingPhases.length === 0
+    && executionSlice.status !== 'partial'
+    && confidence !== 'low'
+  if (contained) {
+    return {
+      answerContained: true,
+      confidenceCap: 'high',
+      reason: 'answer containedness: the pack contains a complete runtime answer without raw reads',
+    }
+  }
+
+  return {
+    answerContained: false,
+    confidenceCap: missingPhases.length >= 3 || confidence === 'low' ? 'low' : 'medium',
+    reason: 'answer containedness: the pack does not contain a complete runtime answer without raw reads',
+  }
+}
+
+export function assessMadarResponseEvidence(input: {
+  answerContract?: ContextPackRuntimeGenerationAnswerContract | undefined
   coverage?: ContextPackCoverage | undefined
-  missingPhases?: readonly ContextPackExecutionPhase[] | undefined
   coveredWorkflowOwners?: readonly string[] | undefined
+  executionSlice?: ContextPackExecutionSlice | undefined
+  graphPath?: string | undefined
+  missingPhases?: readonly ContextPackExecutionPhase[] | undefined
   score?: number | undefined
-}): MadarResponseEvidence {
+}): MadarResponseEvidenceAssessment {
   const coverage = coverageStatusFromCoverage(input.coverage)
-  const score = typeof input.score === 'number' && Number.isFinite(input.score)
+  const baseScore = typeof input.score === 'number' && Number.isFinite(input.score)
     ? input.score
     : input.coverage
       ? confidenceScoreFromCoverage(input.coverage)
       : 0.3
-  const packConfidence = packConfidenceFromScore(score)
   const coveredWorkflowOwners = [...new Set(
     (input.coveredWorkflowOwners ?? [])
       .map((value) => value.trim())
       .filter((value) => value.length > 0),
   )].slice(0, 5)
-  const missingPhases = [...new Set((input.missingPhases ?? []).filter((value) => typeof value === 'string'))]
+  const missingPhases = [...new Set((input.missingPhases ?? []).filter((value): value is ContextPackExecutionPhase => typeof value === 'string'))]
+  const runtimeGeneration =
+    input.answerContract?.answer_focus === 'runtime_generation'
+    || input.executionSlice !== undefined
+    || missingPhases.length > 0
+
+  let confidenceCap: MadarResponsePackConfidence = 'high'
+  const confidenceReasons: string[] = []
+  let answerContained: boolean | undefined
+
+  if (runtimeGeneration) {
+    const scopeQuality = scopeQualityAssessment(input.graphPath, coveredWorkflowOwners)
+    confidenceCap = moreRestrictiveConfidence(confidenceCap, scopeQuality.confidenceCap)
+    confidenceReasons.push(scopeQuality.reason)
+
+    const workflowLocality = workflowLocalityAssessment(input.executionSlice)
+    confidenceCap = moreRestrictiveConfidence(confidenceCap, workflowLocality.confidenceCap)
+    confidenceReasons.push(workflowLocality.reason)
+
+    const phaseCompleteness = phaseCompletenessAssessment(missingPhases)
+    confidenceCap = moreRestrictiveConfidence(confidenceCap, phaseCompleteness.confidenceCap)
+    confidenceReasons.push(phaseCompleteness.reason)
+
+    const answerContainedness = answerContainednessAssessment(input.executionSlice, input.answerContract, missingPhases)
+    answerContained = answerContainedness.answerContained
+    confidenceCap = moreRestrictiveConfidence(confidenceCap, answerContainedness.confidenceCap)
+    confidenceReasons.push(answerContainedness.reason)
+
+    const runtimeConfidence = input.answerContract?.confidence ?? input.executionSlice?.confidence
+    if (runtimeConfidence) {
+      confidenceCap = moreRestrictiveConfidence(confidenceCap, runtimeConfidence)
+    }
+  }
+
+  const effectiveScore = roundScore(Math.min(baseScore, confidenceCapForScore(confidenceCap)))
+  const packConfidence = packConfidenceFromScore(effectiveScore)
 
   return {
+    score: effectiveScore,
     pack_confidence: packConfidence,
     coverage,
     missing_phases: missingPhases,
     covered_workflow_owners: coveredWorkflowOwners,
-    agent_directive: agentDirectiveForEvidence(packConfidence, coverage),
+    confidence_reasons: confidenceReasons,
+    agent_directive: agentDirectiveForEvidence(packConfidence, coverage, answerContained),
   }
+}
+
+export function buildMadarResponseEvidence(input: {
+  answerContract?: ContextPackRuntimeGenerationAnswerContract | undefined
+  coverage?: ContextPackCoverage | undefined
+  missingPhases?: readonly ContextPackExecutionPhase[] | undefined
+  coveredWorkflowOwners?: readonly string[] | undefined
+  executionSlice?: ContextPackExecutionSlice | undefined
+  graphPath?: string | undefined
+  score?: number | undefined
+}): MadarResponseEvidence {
+  const { score: _score, ...evidence } = assessMadarResponseEvidence(input)
+  return evidence
 }
 
 export function collectWorkflowOwners(...groups: Array<readonly (string | null | undefined)[]>): string[] {

--- a/src/runtime/mcp-response-evidence.ts
+++ b/src/runtime/mcp-response-evidence.ts
@@ -23,6 +23,7 @@ const MEDIUM_CONFIDENCE_THRESHOLD = 0.5
 const MEDIUM_CONFIDENCE_MAX = HIGH_CONFIDENCE_THRESHOLD - 0.01
 const LOW_CONFIDENCE_MAX = MEDIUM_CONFIDENCE_THRESHOLD - 0.01
 const GENERIC_SCOPE_SEGMENTS = new Set(['src', 'test', 'tests', 'docs', 'lib', 'libs', 'packages', 'apps'])
+const GENERIC_SCOPE_WRAPPERS = new Set(['libs', 'packages', 'apps'])
 
 function roundScore(value: number): number {
   return Math.round(Math.min(1, Math.max(0, value)) * 100) / 100
@@ -128,8 +129,20 @@ function scopeQualityAssessment(
   const candidateScopes = [...new Set(
     coveredWorkflowOwners
       .map(normalizeSourcePath)
-      .map((value) => value.split('/', 1)[0] ?? '')
-      .filter((value) => value.length > 0 && !GENERIC_SCOPE_SEGMENTS.has(value)),
+      .map((value) => {
+        const segments = value
+          .split('/')
+          .filter((segment) => segment.length > 0)
+        if (segments.length === 0) {
+          return ''
+        }
+        const [firstSegment, secondSegment] = segments
+        if (segments.length > 1 && firstSegment && secondSegment && GENERIC_SCOPE_WRAPPERS.has(firstSegment.toLowerCase())) {
+          return secondSegment
+        }
+        return firstSegment ?? ''
+      })
+      .filter((value): value is string => value.length > 0 && !GENERIC_SCOPE_SEGMENTS.has(value.toLowerCase())),
   )]
   if (candidateScopes.length !== 1) {
     return {
@@ -289,7 +302,15 @@ export function assessMadarResponseEvidence(input: {
 
     const runtimeConfidence = input.answerContract?.confidence ?? input.executionSlice?.confidence
     if (runtimeConfidence) {
-      confidenceCap = moreRestrictiveConfidence(confidenceCap, runtimeConfidence)
+      const previousConfidenceCap = confidenceCap
+      const nextConfidenceCap = moreRestrictiveConfidence(confidenceCap, runtimeConfidence)
+      if (nextConfidenceCap !== previousConfidenceCap) {
+        const source = input.answerContract?.confidence ? 'answer contract' : 'execution slice'
+        confidenceReasons.push(
+          `runtime confidence: ${source} reported ${runtimeConfidence} confidence and lowered the cap from ${previousConfidenceCap} to ${nextConfidenceCap}`,
+        )
+      }
+      confidenceCap = nextConfidenceCap
     }
   }
 

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -330,7 +330,7 @@ function evidenceForRetrievePayload(
   payload: Partial<Pick<RetrieveResult, 'coverage' | 'answer_contract' | 'execution_slice'>> & {
     matched_nodes?: Array<{ source_file: string }>
   },
-  graphPath?: string,
+  graphPath: string,
 ) {
   return buildMadarResponseEvidence({
     answerContract: payload.answer_contract,
@@ -348,7 +348,7 @@ function evidenceForPathPayload(
     starter_files?: Array<{ path: string }>
     edit_steps?: Array<{ path: string }>
   },
-  graphPath?: string,
+  graphPath: string,
 ) {
   return buildMadarResponseEvidence({
     answerContract: payload.answer_contract,
@@ -965,6 +965,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           ...prResult,
           evidence: buildMadarResponseEvidence({
             coverage: prResult.review_bundle.coverage,
+            graphPath,
             coveredWorkflowOwners: collectWorkflowOwners(prResult.changed_files),
           }),
         })))
@@ -975,6 +976,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         missing_context: (prResult.review_bundle.coverage ?? emptyCoverage()).missing_required,
         evidence: buildMadarResponseEvidence({
           coverage: prResult.review_bundle.coverage,
+          graphPath,
           coveredWorkflowOwners: collectWorkflowOwners(prResult.changed_files),
         }),
       })))
@@ -1312,7 +1314,10 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           ...(implementation ? { implementation } : {}),
           ...metadata,
           evidence: buildMadarResponseEvidence({
+            answerContract: deltaResult.delta_pack.answer_contract,
             coverage: deltaResult.delta_pack.coverage,
+            executionSlice: deltaResult.delta_pack.execution_slice,
+            graphPath,
             missingPhases: missingPhasesFromPayload(deltaResult.delta_pack),
             coveredWorkflowOwners: collectWorkflowOwners(resolvedDeltaNodes.nodes.map((node) => node.source_file)),
           }),
@@ -1336,7 +1341,10 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         ...(implementation ? { implementation } : {}),
         ...metadata,
         evidence: buildMadarResponseEvidence({
+          answerContract: fullPack.answer_contract,
           coverage: fullPack.coverage,
+          executionSlice: fullPack.execution_slice,
+          graphPath,
           missingPhases: missingPhasesFromPayload(fullPack),
           coveredWorkflowOwners: collectWorkflowOwners(resolvedNodes.nodes.map((node) => node.source_file)),
         }),

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -330,9 +330,13 @@ function evidenceForRetrievePayload(
   payload: Partial<Pick<RetrieveResult, 'coverage' | 'answer_contract' | 'execution_slice'>> & {
     matched_nodes?: Array<{ source_file: string }>
   },
+  graphPath?: string,
 ) {
   return buildMadarResponseEvidence({
+    answerContract: payload.answer_contract,
     coverage: payload.coverage,
+    executionSlice: payload.execution_slice,
+    graphPath,
     missingPhases: missingPhasesFromPayload(payload),
     coveredWorkflowOwners: collectWorkflowOwners((payload.matched_nodes ?? []).map((node) => node.source_file)),
   })
@@ -344,9 +348,13 @@ function evidenceForPathPayload(
     starter_files?: Array<{ path: string }>
     edit_steps?: Array<{ path: string }>
   },
+  graphPath?: string,
 ) {
   return buildMadarResponseEvidence({
+    answerContract: payload.answer_contract,
     coverage: payload.coverage,
+    executionSlice: payload.execution_slice,
+    graphPath,
     missingPhases: missingPhasesFromPayload(payload),
     coveredWorkflowOwners: collectWorkflowOwners(
       (payload.relevant_files ?? []).map((entry) => entry.path),
@@ -783,7 +791,7 @@ function buildFocusedExpansionPayload(
     pack: compactRetrieveResult(retrieval),
     matched_focus: nodeCandidates.length,
     ...metadata,
-    evidence: evidenceForRetrievePayload(retrieval),
+    evidence: evidenceForRetrievePayload(retrieval, graphPath),
   }
 }
 
@@ -1052,7 +1060,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
             }
         return helpers.ok(id, helpers.textToolResult(JSON.stringify({
           ...payload,
-          evidence: evidenceForRetrievePayload(result),
+          evidence: evidenceForRetrievePayload(result, graphPath),
         })))
       })
     }
@@ -1449,7 +1457,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
               token_count: promptPack.token_count,
             },
         ...contextMetadata(retrieval),
-        evidence: evidenceForRetrievePayload(retrieval),
+        evidence: evidenceForRetrievePayload(retrieval, graphPath),
       })))
     }
     case 'context_session_reset': {
@@ -1489,7 +1497,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       })
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         ...result,
-        evidence: evidenceForPathPayload(result),
+        evidence: evidenceForPathPayload(result, graphPath),
       })))
     }
     case 'feature_map': {
@@ -1519,7 +1527,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       })
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         ...result,
-        evidence: evidenceForPathPayload(result),
+        evidence: evidenceForPathPayload(result, graphPath),
       })))
     }
     case 'risk_map': {
@@ -1549,7 +1557,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       })
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         ...result,
-        evidence: evidenceForPathPayload(result),
+        evidence: evidenceForPathPayload(result, graphPath),
       })))
     }
     case 'implementation_checklist': {
@@ -1579,7 +1587,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       })
       return helpers.ok(id, helpers.textToolResult(JSON.stringify({
         ...result,
-        evidence: evidenceForPathPayload(result),
+        evidence: evidenceForPathPayload(result, graphPath),
       })))
     }
     case 'time_travel_compare': {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
 import { build } from '../../src/pipeline/build.js'
-import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../../src/runtime/retrieve.js'
 
 const tempFixtureRoots: string[] = []
 
@@ -625,6 +625,424 @@ describe('context-pack-command', () => {
     })
     expect(payload.pack?.retrieval_strategy).toBe('slice-v1')
     expect(payload.pack?.execution_slice?.status).toBe('complete')
+  })
+
+  it('downgrades root non-SPI report-generation packs with weak scope quality and missing answer-containedness', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const retrieval = {
+      question: 'How idea report is being generated',
+      token_count: 260,
+      matched_nodes: [
+        {
+          node_id: 'controller_entry',
+          label: 'IdeaGenerationController.generateFromProblem',
+          source_file: 'backend/src/modules/ideas/interface/http/idea-generation.controller.ts',
+          line_number: 58,
+          file_type: 'code',
+          snippet: 'return this.pipelineTrigger.startPipeline(problem)',
+          match_score: 0.96,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+        {
+          node_id: 'trigger',
+          label: 'PipelineTriggerService.startPipeline',
+          source_file: 'backend/src/modules/pipeline/infrastructure/pipeline-trigger.service.ts',
+          line_number: 24,
+          file_type: 'code',
+          snippet: 'return this.queueRegistry.addJob(payload)',
+          match_score: 0.93,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+      ],
+      relationships: [],
+      community_context: [{ id: 0, label: 'Idea report runtime', node_count: 12 }],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [
+          { evidence_class: 'primary', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { evidence_class: 'supporting', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+        ],
+        semantic_entries: [
+          { category: 'implementation', label: 'implementation', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { category: 'structure', label: 'structure', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { category: 'tests', label: 'tests', required: false, available_nodes: 0, selected_nodes: 0, status: 'missing' },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 1,
+        selected_relationships: 1,
+      },
+      retrieval_gate: {
+        level: 4,
+        skipped_retrieval: false,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        intent: 'unknown',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation' as const,
+          target_domain_hint: 'backend_runtime' as const,
+        },
+      },
+      retrieval_strategy: 'slice-v1' as const,
+      execution_slice: {
+        status: 'partial' as const,
+        confidence: 'low' as const,
+        confidence_reasons: ['no_runtime_handoff'],
+        steps: [
+          {
+            node_id: 'controller_entry',
+            label: 'IdeaGenerationController.generateFromProblem',
+            source_file: 'backend/src/modules/ideas/interface/http/idea-generation.controller.ts',
+            line_number: 58,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'trigger',
+            label: 'PipelineTriggerService.startPipeline',
+            source_file: 'backend/src/modules/pipeline/infrastructure/pipeline-trigger.service.ts',
+            line_number: 24,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['planner', 'external_research_or_api', 'report_builder', 'scoring', 'quality_gate', 'renderer_or_synthesis', 'persistence'],
+          observed: ['controller', 'service'],
+          missing: ['planner', 'external_research_or_api', 'report_builder', 'scoring', 'quality_gate', 'renderer_or_synthesis', 'persistence'],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation' as const,
+        entrypoint_scope: 'setup_context' as const,
+        required_elements: ['main_pipeline_phases', 'missing_or_uncertain_phases'],
+        do_not_claim: ['full_runtime_certainty_when_slice_is_partial'],
+        observed_phases: ['controller', 'service'],
+        missing_phases: ['planner', 'external_research_or_api', 'report_builder', 'scoring', 'quality_gate', 'renderer_or_synthesis', 'persistence'],
+        confidence: 'low' as const,
+      },
+    } satisfies RetrieveResult
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'How idea report is being generated',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      retrievalStrategy: 'slice-v1',
+      format: 'json',
+    }, dependencies)
+
+    const payload = JSON.parse(output) as {
+      evidence?: {
+        pack_confidence?: string
+        agent_directive?: string
+        confidence_reasons?: string[]
+      }
+    }
+
+    expect(payload.evidence).toEqual(expect.objectContaining({
+      pack_confidence: expect.not.stringMatching(/^high$/),
+      agent_directive: expect.not.stringMatching(/^answer_from_pack$/),
+      confidence_reasons: expect.arrayContaining([
+        expect.stringContaining('scope'),
+        expect.stringContaining('answer'),
+        expect.stringContaining('phase'),
+      ]),
+    }))
+  })
+
+  it('flags root SPI report-generation packs when answer-containedness is still incomplete', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const retrieval = {
+      question: 'How idea report is being generated',
+      token_count: 260,
+      matched_nodes: [
+        {
+          node_id: 'spi_entry',
+          label: 'IdeaReportSpi.generate',
+          source_file: 'backend/src/spi/idea-report.spi.ts',
+          line_number: 12,
+          file_type: 'code',
+          snippet: 'export interface IdeaReportSpi { generate(): Promise<void> }',
+          match_score: 0.97,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+      ],
+      relationships: [],
+      community_context: [{ id: 0, label: 'Idea report runtime', node_count: 12 }],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [
+          { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'supporting', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+        ],
+        semantic_entries: [
+          { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'tests', label: 'tests', required: false, available_nodes: 0, selected_nodes: 0, status: 'missing' },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 1,
+        selected_relationships: 1,
+      },
+      retrieval_gate: {
+        level: 4,
+        skipped_retrieval: false,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        intent: 'unknown',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation' as const,
+          target_domain_hint: 'backend_runtime' as const,
+        },
+      },
+      retrieval_strategy: 'slice-v1' as const,
+      execution_slice: {
+        status: 'partial' as const,
+        confidence: 'medium' as const,
+        confidence_reasons: ['missing_phase:persistence'],
+        steps: [
+          {
+            node_id: 'spi_entry',
+            label: 'IdeaReportSpi.generate',
+            source_file: 'backend/src/spi/idea-report.spi.ts',
+            line_number: 12,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+          observed: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis'],
+          missing: ['persistence'],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation' as const,
+        entrypoint_scope: 'setup_context' as const,
+        required_elements: ['main_pipeline_phases', 'persistence_or_artifact_storage'],
+        do_not_claim: ['full_runtime_certainty_when_slice_is_partial'],
+        observed_phases: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis'],
+        missing_phases: ['persistence'],
+        confidence: 'medium' as const,
+      },
+    } satisfies RetrieveResult
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'How idea report is being generated',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      retrievalStrategy: 'slice-v1',
+      format: 'json',
+    }, dependencies)
+
+    const payload = JSON.parse(output) as {
+      evidence?: {
+        pack_confidence?: string
+        agent_directive?: string
+        confidence_reasons?: string[]
+      }
+    }
+
+    expect(payload.evidence).toEqual(expect.objectContaining({
+      pack_confidence: expect.not.stringMatching(/^high$/),
+      agent_directive: expect.not.stringMatching(/^answer_from_pack$/),
+      confidence_reasons: expect.arrayContaining([
+        expect.stringContaining('phase'),
+        expect.stringContaining('answer'),
+      ]),
+    }))
+  })
+
+  it('keeps backend SPI report-generation packs high confidence and answer_from_pack when the answer is contained', async () => {
+    const graph = buildRuntimeGenerationGraph()
+    const retrieval = {
+      question: 'How idea report is being generated',
+      token_count: 260,
+      matched_nodes: [
+        {
+          node_id: 'spi_entry',
+          label: 'IdeaReportSpi.generate',
+          source_file: 'src/spi/idea-report.spi.ts',
+          line_number: 12,
+          file_type: 'code',
+          snippet: 'export interface IdeaReportSpi { generate(): Promise<void> }',
+          match_score: 0.97,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+        {
+          node_id: 'worker_entry',
+          label: 'IdeaReportWorker.process',
+          source_file: 'src/ideas/report-worker.ts',
+          line_number: 84,
+          file_type: 'code',
+          snippet: 'return this.assembler.build(job)',
+          match_score: 0.9,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Idea report runtime',
+        },
+      ],
+      relationships: [],
+      community_context: [{ id: 0, label: 'Idea report runtime', node_count: 12 }],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+      claims: [],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'] as const,
+        semantic_required: ['implementation', 'structure'] as const,
+        semantic_optional: ['tests'] as const,
+        entries: [
+          { evidence_class: 'primary', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { evidence_class: 'supporting', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { evidence_class: 'structural', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+        ],
+        semantic_entries: [
+          { category: 'implementation', label: 'implementation', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { category: 'structure', label: 'structure', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+          { category: 'tests', label: 'tests', required: false, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 2,
+        selected_relationships: 2,
+      },
+      retrieval_gate: {
+        level: 4,
+        skipped_retrieval: false,
+        reason: 'runtime generation intent — behavior slice retrieval',
+        intent: 'unknown',
+        signals: {
+          has_pr_diff: false,
+          has_stack_trace: false,
+          mentioned_paths: [],
+          mentioned_symbols: [],
+          generation_intent: 'runtime_generation' as const,
+          target_domain_hint: 'backend_runtime' as const,
+        },
+      },
+      retrieval_strategy: 'slice-v1' as const,
+      execution_slice: {
+        status: 'complete' as const,
+        confidence: 'high' as const,
+        confidence_reasons: ['explicit_anchor', 'runtime_handoff_evidence', 'expected_phases_covered'],
+        steps: [
+          {
+            node_id: 'spi_entry',
+            label: 'IdeaReportSpi.generate',
+            source_file: 'src/spi/idea-report.spi.ts',
+            line_number: 12,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'worker_entry',
+            label: 'IdeaReportWorker.process',
+            source_file: 'src/ideas/report-worker.ts',
+            line_number: 84,
+            node_kind: 'method',
+          },
+        ],
+        primary_path: {
+          steps: [],
+          boundaries: [{ relation: 'enqueues_job' }],
+        },
+        phase_coverage: {
+          expected: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+          observed: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+          missing: [],
+        },
+      },
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation' as const,
+        entrypoint_scope: 'setup_context' as const,
+        required_elements: ['main_pipeline_phases', 'persistence_or_artifact_storage'],
+        do_not_claim: [],
+        observed_phases: ['planner', 'report_builder', 'scoring', 'renderer_or_synthesis', 'persistence'],
+        missing_phases: [],
+        confidence: 'high' as const,
+      },
+    } satisfies RetrieveResult
+    const dependencies: ContextPackCommandDependencies = {
+      loadGraph: vi.fn().mockReturnValue(graph),
+      retrieveContext: vi.fn().mockReturnValue(retrieval),
+      compactRetrieveResult,
+      analyzePrImpact: vi.fn(),
+      compactPrImpactResult: vi.fn(),
+      analyzeImpact: vi.fn(),
+      compactImpactResult: vi.fn(),
+    }
+
+    const output = await runContextPackCommand({
+      prompt: 'How idea report is being generated',
+      budget: 1800,
+      task: 'explain',
+      graphPath: 'backend/out/graph.json',
+      retrievalStrategy: 'slice-v1',
+      format: 'json',
+    }, dependencies)
+
+    const payload = JSON.parse(output) as {
+      evidence?: {
+        pack_confidence?: string
+        agent_directive?: string
+        confidence_reasons?: string[]
+      }
+    }
+
+    expect(payload.evidence).toEqual(expect.objectContaining({
+      pack_confidence: 'high',
+      agent_directive: 'answer_from_pack',
+      confidence_reasons: expect.arrayContaining([
+        expect.stringContaining('scope'),
+        expect.stringContaining('answer'),
+      ]),
+    }))
   })
 
   it('adds routing metadata only when --why is enabled', async () => {

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -761,6 +761,8 @@ describe('context-pack-command', () => {
       }
     }
 
+    expect(payload.evidence?.pack_confidence).toBeTypeOf('string')
+    expect(payload.evidence?.agent_directive).toBeTypeOf('string')
     expect(payload.evidence).toEqual(expect.objectContaining({
       pack_confidence: expect.not.stringMatching(/^high$/),
       agent_directive: expect.not.stringMatching(/^answer_from_pack$/),
@@ -887,6 +889,8 @@ describe('context-pack-command', () => {
       }
     }
 
+    expect(payload.evidence?.pack_confidence).toBeTypeOf('string')
+    expect(payload.evidence?.agent_directive).toBeTypeOf('string')
     expect(payload.evidence).toEqual(expect.objectContaining({
       pack_confidence: expect.not.stringMatching(/^high$/),
       agent_directive: expect.not.stringMatching(/^answer_from_pack$/),

--- a/tests/unit/mcp-response-evidence.test.ts
+++ b/tests/unit/mcp-response-evidence.test.ts
@@ -3,6 +3,131 @@ import { describe, expect, it } from 'vitest'
 import { buildMadarResponseEvidence } from '../../src/runtime/mcp-response-evidence.js'
 
 describe('mcp-response-evidence', () => {
+  it('uses the first non-generic path segment when checking scope quality', () => {
+    const evidence = buildMadarResponseEvidence({
+      graphPath: 'out/graph.json',
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'],
+        semantic_required: ['implementation', 'structure'],
+        semantic_optional: ['tests'],
+        entries: [
+          { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'supporting', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+        ],
+        semantic_entries: [
+          { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'tests', label: 'tests', required: false, available_nodes: 0, selected_nodes: 0, status: 'missing' },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 1,
+        selected_relationships: 1,
+      },
+      coveredWorkflowOwners: ['packages/spi/runtime.ts'],
+      executionSlice: {
+        status: 'partial',
+        confidence: 'high',
+        confidence_reasons: ['missing_phase:persistence'],
+        steps: [
+          {
+            node_id: 'runtime_entry',
+            label: 'RuntimeSpi.execute',
+            source_file: 'packages/spi/runtime.ts',
+            line_number: 10,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['controller', 'service', 'persistence'],
+          observed: ['controller', 'service'],
+          missing: ['persistence'],
+        },
+      },
+      answerContract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: [],
+        observed_phases: ['controller', 'service'],
+        missing_phases: ['persistence'],
+        confidence: 'high',
+      },
+    })
+
+    expect(evidence.confidence_reasons).toContain(
+      'scope quality: runtime evidence is concentrated under spi/ while the graph is rooted at out/graph.json',
+    )
+  })
+
+  it('adds a confidence reason when runtime confidence lowers the cap', () => {
+    const evidence = buildMadarResponseEvidence({
+      graphPath: 'backend/out/graph.json',
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'],
+        semantic_required: ['implementation', 'structure'],
+        semantic_optional: ['tests'],
+        entries: [
+          { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'supporting', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+        ],
+        semantic_entries: [
+          { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'tests', label: 'tests', required: false, available_nodes: 0, selected_nodes: 0, status: 'missing' },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 1,
+        selected_relationships: 1,
+      },
+      coveredWorkflowOwners: ['backend/src/spi/runtime.ts'],
+      executionSlice: {
+        status: 'complete',
+        confidence: 'medium',
+        confidence_reasons: ['runtime_handoff_evidence'],
+        steps: [
+          {
+            node_id: 'runtime_entry',
+            label: 'RuntimeSpi.execute',
+            source_file: 'backend/src/spi/runtime.ts',
+            line_number: 10,
+            node_kind: 'method',
+          },
+          {
+            node_id: 'runtime_store',
+            label: 'RuntimeStore.save',
+            source_file: 'backend/src/runtime/store.ts',
+            line_number: 30,
+            node_kind: 'method',
+          },
+        ],
+        phase_coverage: {
+          expected: ['controller', 'service', 'persistence'],
+          observed: ['controller', 'service', 'persistence'],
+          missing: [],
+        },
+      },
+      answerContract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: [],
+        observed_phases: ['controller', 'service', 'persistence'],
+        missing_phases: [],
+        confidence: 'medium',
+      },
+    })
+
+    expect(evidence.confidence_reasons).toContain(
+      'runtime confidence: answer contract reported medium confidence and lowered the cap from high to medium',
+    )
+  })
+
   it('does not mark runtime-generation answers as contained when no execution slice exists', () => {
     const evidence = buildMadarResponseEvidence({
       graphPath: 'backend/out/graph.json',

--- a/tests/unit/mcp-response-evidence.test.ts
+++ b/tests/unit/mcp-response-evidence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildMadarResponseEvidence } from '../../src/runtime/mcp-response-evidence.js'
+
+describe('mcp-response-evidence', () => {
+  it('does not mark runtime-generation answers as contained when no execution slice exists', () => {
+    const evidence = buildMadarResponseEvidence({
+      graphPath: 'backend/out/graph.json',
+      coverage: {
+        required_evidence: ['primary', 'supporting', 'structural'],
+        semantic_required: ['implementation', 'structure'],
+        semantic_optional: ['tests'],
+        entries: [
+          { evidence_class: 'primary', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'supporting', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { evidence_class: 'structural', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+        ],
+        semantic_entries: [
+          { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'structure', label: 'structure', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+          { category: 'tests', label: 'tests', required: false, available_nodes: 0, selected_nodes: 0, status: 'missing' },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 1,
+        selected_relationships: 1,
+      },
+      coveredWorkflowOwners: ['backend/src/spi/idea-report.spi.ts'],
+      answerContract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: [],
+        observed_phases: ['planner', 'report_builder', 'persistence'],
+        missing_phases: [],
+        confidence: 'high',
+      },
+    })
+
+    expect(evidence.agent_directive).toBe('verify_one_targeted_file')
+    expect(evidence.confidence_reasons).toContain(
+      'answer containedness: the pack does not contain a complete runtime answer without raw reads',
+    )
+  })
+})

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -44,6 +44,37 @@ function createGraphPath(): string {
   return graphPath
 }
 
+function createBackendRuntimeGraphPath(): string {
+  mkdirSync(scratchRoot, { recursive: true })
+  const root = join(scratchRoot, `madar-stdio-slice-backend-${randomUUID()}`)
+  mkdirSync(join(root, 'backend', 'src', 'spi'), { recursive: true })
+  mkdirSync(join(root, 'backend', 'src', 'runtime'), { recursive: true })
+  mkdirSync(join(root, 'out'), { recursive: true })
+  tempRoots.push(root)
+  const graphPath = join(root, 'out', 'graph.json')
+  writeFileSync(join(root, 'backend', 'src', 'auth-route.ts'), 'export const loginRoute = "POST /login"\n', 'utf8')
+  writeFileSync(join(root, 'backend', 'src', 'auth-controller.ts'), 'export class AuthController { login() {} }\n', 'utf8')
+  writeFileSync(join(root, 'backend', 'src', 'spi', 'auth-service.spi.ts'), 'export interface AuthServiceSpi { login(): Promise<void> }\n', 'utf8')
+  writeFileSync(join(root, 'backend', 'src', 'runtime', 'auth-service.ts'), 'export class AuthService { login() {} }\n', 'utf8')
+  writeFileSync(join(root, 'out', 'GRAPH_REPORT.md'), '# Graph report\n', 'utf8')
+  writeFileSync(graphPath, JSON.stringify({
+    root_path: root,
+    nodes: [
+      { id: 'auth_route', label: 'POST /login', source_file: join(root, 'backend', 'src', 'auth-route.ts'), source_location: 'L1', file_type: 'code', node_kind: 'route', framework: 'express', framework_role: 'express_route', community: 0 },
+      { id: 'auth_controller', label: 'AuthController.login', source_file: join(root, 'backend', 'src', 'auth-controller.ts'), source_location: 'L1', file_type: 'code', node_kind: 'method', framework: 'nestjs', framework_role: 'nest_controller', community: 0 },
+      { id: 'auth_spi', label: 'AuthServiceSpi.login', source_file: join(root, 'backend', 'src', 'spi', 'auth-service.spi.ts'), source_location: 'L1', file_type: 'code', node_kind: 'method', community: 0 },
+      { id: 'auth_service', label: 'AuthService.login', source_file: join(root, 'backend', 'src', 'runtime', 'auth-service.ts'), source_location: 'L1', file_type: 'code', node_kind: 'method', community: 0 },
+    ],
+    edges: [
+      { source: 'auth_route', target: 'auth_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: join(root, 'backend', 'src', 'auth-route.ts') },
+      { source: 'auth_controller', target: 'auth_spi', relation: 'calls', confidence: 'EXTRACTED', source_file: join(root, 'backend', 'src', 'auth-controller.ts') },
+      { source: 'auth_spi', target: 'auth_service', relation: 'implements', confidence: 'EXTRACTED', source_file: join(root, 'backend', 'src', 'spi', 'auth-service.spi.ts') },
+    ],
+    hyperedges: [],
+  }), 'utf8')
+  return graphPath
+}
+
 afterEach(() => {
   while (tempRoots.length > 0) {
     rmSync(tempRoots.pop()!, { recursive: true, force: true })
@@ -247,6 +278,30 @@ describe('stdio slice-v1 surface', () => {
     expect(contextPackText).toContain('"execution_slice"')
     expect(contextPackText).toContain('"confidence"')
     expect(contextPackText).toContain('"confidence_reasons"')
+  })
+
+  it('passes graphPath into verbose runtime-generation context_pack evidence', async () => {
+    const graphPath = createBackendRuntimeGraphPath()
+
+    const contextPackResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 40,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Trace how `AuthController.login` reaches persistence in the backend runtime pipeline',
+          budget: 1000,
+          task: 'explain',
+          retrieval_level: 4,
+          retrieval_strategy: 'slice-v1',
+          verbose: true,
+        },
+      },
+    }))
+
+    const contextPackText = ((contextPackResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? ''
+
+    expect(contextPackText).toContain('"scope quality: runtime evidence is concentrated under backend/')
   })
 
   it('rejects retrieval_strategy for review context packs instead of ignoring it', async () => {


### PR DESCRIPTION
## Summary
- make runtime-generation pack confidence account for scope quality, workflow locality, answer-containedness, and phase completeness
- add confidence reasons to pack evidence and require explicit answer-containedness before answer_from_pack
- thread graph-path context through prompt/evidence builders and cover the new gating with regressions

Closes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt generation now includes an explicit graph path for more targeted context.
  * Evidence assessment upgraded to produce richer confidence reasons and a computed confidence score.
  * Improved answer-containment detection to better guide agent directives.
  * Tools now attach graph-path-aware evidence for more accurate provenance.

* **Tests**
  * Added unit tests covering confidence reasons, containment behavior, and graph-path scoped evidence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->