### PR TITLE
Prepare 0.27.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.4] - 2026-05-29
+
+### Fixed
+
+- **Placeholder** — fill in before publishing.
+
 ## [0.27.3] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
-## [0.27.4] - 2026-05-29
-
-### Fixed
-
-- **Placeholder** — fill in before publishing.
-
 ## [0.27.3] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.4] - 2026-05-29
+
+### Fixed
+
+- **`runNativeAgentArmWithTimeout` no longer races ahead of a settling arm**: after aborting a timed-out arm the runner is given a 200 ms grace window to fully settle before the `timed_out` outcome is recorded, preventing a partially-completed result from being misclassified. Truly stuck arms that never respond to abort still resolve via the grace timeout.
+- **`assessNativeAgentPromptContract` returns `not_measured` for post-pack broad exploration**: broad exploration after a pack call can be justified by missing context or coverage gaps that the trace model does not capture, so marking it as `violated` caused false failures. The honest status is `not_measured`.
+- **`suggestBenchmarkGraphScope` handles absolute `source_file` paths**: source files from fixtures using absolute paths (e.g. `/tmp/.../backend/src/auth-route.ts`) now have their project root inferred and stripped before scope extraction, so the reported scope is `backend` instead of the first path segment.
+- **`candidateScopes` in MCP response evidence handles absolute and Windows paths**: scope detection now finds the segment immediately before a generic directory marker (`src`, `test`, `tests`, `lib`, etc.) rather than splitting on the first `/`, fixing incorrect scope attribution for long absolute paths and Windows-style paths.
+
 ## [0.27.3] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,13 +88,9 @@ Want a broader local-first walkthrough that also covers install, `prompt`, and a
 
 ---
 
-## What's new in 0.27.3
+## What's new in 0.27.4
 
-- `compare --baseline-mode native_agent` now stays honest when Madar was not actually invoked: degraded provider-only runs no longer print favorable reduction percentages or suite-summary wins.
-- Native-agent compare is more failure-tolerant: stalled baseline or Madar arms can time out, emit stderr heartbeat lines, and leave a `run-state.json` breadcrumb plus partial report artifacts instead of hanging forever.
-- `madar summary` runtime paths now stay closer to backend workflow spines instead of drifting toward helper-style endpoint chains.
-
-See the [`0.27.3` changelog entry](CHANGELOG.md#0273---2026-05-28) for the full release notes.
+See the [`0.27.4` changelog entry](CHANGELOG.md#0274---2026-05-29) for the full release notes.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -102,7 +98,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.3. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.4. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.3",
+    "version": "0.27.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.3",
+            "version": "0.27.4",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.3",
+    "version": "0.27.4",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Release 0.27.4

Bumps version `0.27.3` → `0.27.4` and documents the bug fixes shipped in this patch.

### Fixed
- `runNativeAgentArmWithTimeout`: 200ms grace window after abort so a settling arm isn't misclassified as timed_out
- `assessNativeAgentPromptContract`: post-pack broad exploration returns `not_measured` instead of `violated`
- `suggestBenchmarkGraphScope`: normalizes absolute `source_file` paths before scope extraction
- `candidateScopes` (MCP evidence): handles absolute and Windows paths by finding the segment before a generic directory marker

### Verification
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `CI=1 npm run test:run` — 162 files, 2323 tests passed
- [x] `npm pack --dry-run` — `lubab-madar-0.27.4.tgz` (620.5 kB, 350 files)