### PR TITLE
fix: surface runtime primary path nodes in answer-ready packs

### DIFF
--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -148,6 +148,42 @@ function asUnknownArray(value: unknown): unknown[] {
   return Array.isArray(value) ? value : []
 }
 
+function runtimePrimaryPathRecordKey(record: JsonRecord | null): string | null {
+  if (!record) {
+    return null
+  }
+  if (typeof record.node_id === 'string' && record.node_id.length > 0) {
+    return `id:${record.node_id}`
+  }
+  if (typeof record.label !== 'string' || record.label.length === 0) {
+    return null
+  }
+  const sourceFile = typeof record.source_file === 'string' ? record.source_file : ''
+  return `label:${record.label}::${sourceFile}`
+}
+
+function runtimePrimaryPathPreviewEntry(record: JsonRecord): JsonRecord | null {
+  if (typeof record.label !== 'string' || record.label.length === 0) {
+    return null
+  }
+  if (typeof record.source_file !== 'string' || record.source_file.length === 0) {
+    return null
+  }
+  return {
+    ...(typeof record.node_id === 'string' && record.node_id.length > 0 ? { node_id: record.node_id } : {}),
+    label: record.label,
+    source_file: record.source_file,
+    ...(typeof record.line_number === 'number'
+      ? {
+          line_range: {
+            start_line: record.line_number,
+            end_line: record.line_number,
+          },
+        }
+      : {}),
+  }
+}
+
 function trimArrayField(record: JsonRecord, field: string, cap: number, trimmedFields: string[]): void {
   const values = asUnknownArray(record[field])
   if (values.length <= cap) {
@@ -219,44 +255,39 @@ function preserveTrimmedRuntimePrimaryPathPreview(pack: JsonRecord, trimmedField
     return
   }
 
-  const primaryLabels = primarySteps.flatMap((step) => {
-    const record = asJsonRecord(step)
-    return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
-  })
-  if (primaryLabels.length === 0) {
+  const primaryStepRecords = primarySteps
+    .map((step) => asJsonRecord(step))
+    .filter((record): record is JsonRecord => record !== null)
+  if (primaryStepRecords.length === 0) {
     return
   }
 
-  const keptLabels = new Set(
+  const keptKeys = new Set(
     matchedNodes
       .slice(0, ANSWER_READY_MATCHED_NODE_CAP)
       .flatMap((node) => {
-        const record = asJsonRecord(node)
-        return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
+        const key = runtimePrimaryPathRecordKey(asJsonRecord(node))
+        return key ? [key] : []
       }),
   )
-  const matchedByLabel = new Map<string, JsonRecord>()
+  const matchedByKey = new Map<string, JsonRecord>()
   for (const node of matchedNodes) {
     const record = asJsonRecord(node)
-    if (!record || typeof record.label !== 'string' || record.label.length === 0 || matchedByLabel.has(record.label)) {
+    const key = runtimePrimaryPathRecordKey(record)
+    if (!record || !key || matchedByKey.has(key)) {
       continue
     }
-    matchedByLabel.set(record.label, record)
+    matchedByKey.set(key, record)
   }
 
-  const preview = primaryLabels
-    .filter((label) => !keptLabels.has(label))
-    .flatMap((label) => {
-      const node = matchedByLabel.get(label)
-      if (!node || typeof node.source_file !== 'string' || node.source_file.length === 0) {
-        return []
-      }
-      return [{
-        ...(typeof node.node_id === 'string' && node.node_id.length > 0 ? { node_id: node.node_id } : {}),
-        label,
-        source_file: node.source_file,
-      }]
-    })
+  const preview: JsonRecord[] = primaryStepRecords.flatMap((stepRecord): JsonRecord[] => {
+    const key = runtimePrimaryPathRecordKey(stepRecord)
+    if (!key || keptKeys.has(key)) {
+      return []
+    }
+    const entry = runtimePrimaryPathPreviewEntry(matchedByKey.get(key) ?? stepRecord)
+    return entry ? [entry] : []
+  })
 
   if (preview.length === 0) {
     return
@@ -295,53 +326,48 @@ function preserveFinalRuntimePrimaryPathPreview(
     return
   }
 
-  const primaryLabels = primarySteps.flatMap((step) => {
-    const record = asJsonRecord(step)
-    return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
-  })
-  if (primaryLabels.length === 0) {
+  const primaryStepRecords = primarySteps
+    .map((step) => asJsonRecord(step))
+    .filter((record): record is JsonRecord => record !== null)
+  if (primaryStepRecords.length === 0) {
     return
   }
 
-  const keptLabels = new Set(
+  const keptKeys = new Set(
     matchedNodes
       .slice(0, matchedNodeCap)
       .flatMap((node) => {
-        const record = asJsonRecord(node)
-        return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
+        const key = runtimePrimaryPathRecordKey(asJsonRecord(node))
+        return key ? [key] : []
       }),
   )
-  const existingPreviewLabels = new Set(
+  const existingPreviewKeys = new Set(
     asUnknownArray(payload.expandable).flatMap((entry) => {
       const record = asJsonRecord(entry)
       return asUnknownArray(record?.preview).flatMap((preview) => {
-        const previewRecord = asJsonRecord(preview)
-        return typeof previewRecord?.label === 'string' && previewRecord.label.length > 0 ? [previewRecord.label] : []
+        const key = runtimePrimaryPathRecordKey(asJsonRecord(preview))
+        return key ? [key] : []
       })
     }),
   )
-  const matchedByLabel = new Map<string, JsonRecord>()
+  const matchedByKey = new Map<string, JsonRecord>()
   for (const node of matchedNodes) {
     const record = asJsonRecord(node)
-    if (!record || typeof record.label !== 'string' || record.label.length === 0 || matchedByLabel.has(record.label)) {
+    const key = runtimePrimaryPathRecordKey(record)
+    if (!record || !key || matchedByKey.has(key)) {
       continue
     }
-    matchedByLabel.set(record.label, record)
+    matchedByKey.set(key, record)
   }
 
-  const preview = primaryLabels
-    .filter((label) => !keptLabels.has(label) && !existingPreviewLabels.has(label))
-    .flatMap((label) => {
-      const node = matchedByLabel.get(label)
-      if (!node || typeof node.source_file !== 'string' || node.source_file.length === 0) {
-        return []
-      }
-      return [{
-        ...(typeof node.node_id === 'string' && node.node_id.length > 0 ? { node_id: node.node_id } : {}),
-        label,
-        source_file: node.source_file,
-      }]
-    })
+  const preview: JsonRecord[] = primaryStepRecords.flatMap((stepRecord): JsonRecord[] => {
+    const key = runtimePrimaryPathRecordKey(stepRecord)
+    if (!key || keptKeys.has(key) || existingPreviewKeys.has(key)) {
+      return []
+    }
+    const entry = runtimePrimaryPathPreviewEntry(matchedByKey.get(key) ?? stepRecord)
+    return entry ? [entry] : []
+  })
 
   if (preview.length === 0) {
     return

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -204,9 +204,166 @@ function compactAnswerReadyPack(pack: JsonRecord, trimmedFields: string[]): void
     }
   }
 
+  preserveTrimmedRuntimePrimaryPathPreview(pack, trimmedFields)
   trimArrayField(pack, 'matched_nodes', ANSWER_READY_MATCHED_NODE_CAP, trimmedFields)
   trimArrayField(pack, 'relationships', ANSWER_READY_RELATIONSHIP_CAP, trimmedFields)
   trimArrayField(pack, 'community_context', ANSWER_READY_COMMUNITY_CAP, trimmedFields)
+}
+
+function preserveTrimmedRuntimePrimaryPathPreview(pack: JsonRecord, trimmedFields: string[]): void {
+  const executionSlice = asJsonRecord(pack.execution_slice)
+  const primaryPath = executionSlice ? asJsonRecord(executionSlice.primary_path) : null
+  const primarySteps = primaryPath ? asUnknownArray(primaryPath.steps) : []
+  const matchedNodes = asUnknownArray(pack.matched_nodes)
+  if (primarySteps.length === 0 || matchedNodes.length <= ANSWER_READY_MATCHED_NODE_CAP) {
+    return
+  }
+
+  const primaryLabels = primarySteps.flatMap((step) => {
+    const record = asJsonRecord(step)
+    return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
+  })
+  if (primaryLabels.length === 0) {
+    return
+  }
+
+  const keptLabels = new Set(
+    matchedNodes
+      .slice(0, ANSWER_READY_MATCHED_NODE_CAP)
+      .flatMap((node) => {
+        const record = asJsonRecord(node)
+        return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
+      }),
+  )
+  const matchedByLabel = new Map<string, JsonRecord>()
+  for (const node of matchedNodes) {
+    const record = asJsonRecord(node)
+    if (!record || typeof record.label !== 'string' || record.label.length === 0 || matchedByLabel.has(record.label)) {
+      continue
+    }
+    matchedByLabel.set(record.label, record)
+  }
+
+  const preview = primaryLabels
+    .filter((label) => !keptLabels.has(label))
+    .flatMap((label) => {
+      const node = matchedByLabel.get(label)
+      if (!node || typeof node.source_file !== 'string' || node.source_file.length === 0) {
+        return []
+      }
+      return [{
+        ...(typeof node.node_id === 'string' && node.node_id.length > 0 ? { node_id: node.node_id } : {}),
+        label,
+        source_file: node.source_file,
+      }]
+    })
+
+  if (preview.length === 0) {
+    return
+  }
+
+  const expandable = asUnknownArray(pack.expandable)
+  expandable.unshift({
+    kind: 'nodes',
+    handle_id: 'runtime-primary-path',
+    evidence_class: 'supporting',
+    count: preview.length,
+    preview: preview.slice(0, 3),
+    follow_up: {
+      kind: 'context_pack',
+      task_kind: 'explain',
+      evidence_class: 'supporting',
+      focus_files: [...new Set(preview.map((entry) => entry.source_file))],
+      focus_ranges: [],
+    },
+  })
+  pack.expandable = expandable
+  trimmedFields.push('pack.matched_nodes.primary_path_promoted_to_expandable')
+}
+
+function preserveFinalRuntimePrimaryPathPreview(
+  payload: JsonRecord,
+  pack: JsonRecord,
+  matchedNodeCap: number,
+  trimmedFields: string[],
+): void {
+  const executionSlice = asJsonRecord(pack.execution_slice)
+  const primaryPath = executionSlice ? asJsonRecord(executionSlice.primary_path) : null
+  const primarySteps = primaryPath ? asUnknownArray(primaryPath.steps) : []
+  const matchedNodes = asUnknownArray(pack.matched_nodes)
+  if (primarySteps.length === 0 || matchedNodes.length <= matchedNodeCap) {
+    return
+  }
+
+  const primaryLabels = primarySteps.flatMap((step) => {
+    const record = asJsonRecord(step)
+    return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
+  })
+  if (primaryLabels.length === 0) {
+    return
+  }
+
+  const keptLabels = new Set(
+    matchedNodes
+      .slice(0, matchedNodeCap)
+      .flatMap((node) => {
+        const record = asJsonRecord(node)
+        return typeof record?.label === 'string' && record.label.length > 0 ? [record.label] : []
+      }),
+  )
+  const existingPreviewLabels = new Set(
+    asUnknownArray(payload.expandable).flatMap((entry) => {
+      const record = asJsonRecord(entry)
+      return asUnknownArray(record?.preview).flatMap((preview) => {
+        const previewRecord = asJsonRecord(preview)
+        return typeof previewRecord?.label === 'string' && previewRecord.label.length > 0 ? [previewRecord.label] : []
+      })
+    }),
+  )
+  const matchedByLabel = new Map<string, JsonRecord>()
+  for (const node of matchedNodes) {
+    const record = asJsonRecord(node)
+    if (!record || typeof record.label !== 'string' || record.label.length === 0 || matchedByLabel.has(record.label)) {
+      continue
+    }
+    matchedByLabel.set(record.label, record)
+  }
+
+  const preview = primaryLabels
+    .filter((label) => !keptLabels.has(label) && !existingPreviewLabels.has(label))
+    .flatMap((label) => {
+      const node = matchedByLabel.get(label)
+      if (!node || typeof node.source_file !== 'string' || node.source_file.length === 0) {
+        return []
+      }
+      return [{
+        ...(typeof node.node_id === 'string' && node.node_id.length > 0 ? { node_id: node.node_id } : {}),
+        label,
+        source_file: node.source_file,
+      }]
+    })
+
+  if (preview.length === 0) {
+    return
+  }
+
+  const expandable = asUnknownArray(payload.expandable)
+  expandable.unshift({
+    kind: 'nodes',
+    handle_id: `runtime-primary-path-${matchedNodeCap}`,
+    evidence_class: 'supporting',
+    count: preview.length,
+    preview: preview.slice(0, 3),
+    follow_up: {
+      kind: 'context_pack',
+      task_kind: 'explain',
+      evidence_class: 'supporting',
+      focus_files: [...new Set(preview.map((entry) => entry.source_file))],
+      focus_ranges: [],
+    },
+  })
+  payload.expandable = expandable
+  trimmedFields.push(`pack.matched_nodes.primary_path_promoted_to_expandable_${matchedNodeCap}`)
 }
 
 function estimatedJsonTokens(payload: JsonRecord): number {
@@ -273,6 +430,13 @@ export function buildAnswerReadyPackSchema(
       trimmedFields.push('pack.confidence_score promoted')
     }
     compactAnswerReadyPack(pack, trimmedFields)
+    const packExpandable = asUnknownArray(pack.expandable)
+    const payloadExpandable = asUnknownArray(payload.expandable)
+    if (payloadExpandable.length === 0 && packExpandable.length > 0) {
+      payload.expandable = packExpandable
+      delete pack.expandable
+      trimmedFields.push('pack.expandable promoted')
+    }
   }
 
   trimArrayField(payload, 'workflow_centers', ANSWER_READY_WORKFLOW_CENTER_CAP, trimmedFields)
@@ -314,6 +478,7 @@ export function buildAnswerReadyPackSchema(
   }
 
   if (pack) {
+    preserveFinalRuntimePrimaryPathPreview(payload, pack, 4, trimmedFields)
     trimArrayField(pack, 'matched_nodes', 4, trimmedFields)
     trimArrayField(pack, 'relationships', 4, trimmedFields)
     trimArrayField(pack, 'community_context', 3, trimmedFields)

--- a/src/runtime/context-pack-diagnostics.ts
+++ b/src/runtime/context-pack-diagnostics.ts
@@ -473,11 +473,15 @@ function slicePathTargetsNotPromoted(
   )
   const anchorLabels = new Set(anchors.map((anchor) => anchor.label))
   const includedIds = new Set(
-    pack.nodes
-      .map((node) => node.node_id)
-      .filter((nodeId): nodeId is string => typeof nodeId === 'string' && nodeId.length > 0),
+    [
+      ...pack.nodes.map((node) => node.node_id),
+      ...pack.expandable.flatMap((entry) => entry.preview.map((preview) => preview.node_id)),
+    ].filter((nodeId): nodeId is string => typeof nodeId === 'string' && nodeId.length > 0),
   )
-  const includedLabels = new Set(pack.nodes.map((node) => node.label))
+  const includedLabels = new Set([
+    ...pack.nodes.map((node) => node.label),
+    ...pack.expandable.flatMap((entry) => entry.preview.map((preview) => preview.label)),
+  ])
   const omitted = new Map<string, { id?: string; label: string }>()
   const reachableIds = new Set(anchorIds)
   const reachableLabels = new Set(anchorLabels)

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -2003,6 +2003,59 @@ function augmentSliceCandidateIdsForDebug(
   return expanded
 }
 
+function runtimeGenerationSliceCandidatePromotionApplies(
+  retrievalGate: RetrievalGateDecision,
+  sliceMetadata: ContextPackSliceMetadata,
+): boolean {
+  return sliceMetadata.mode === 'explain'
+    && retrievalGate.intent === 'explain'
+    && retrievalGate.signals.generation_intent === 'runtime_generation'
+    && retrievalGate.signals.target_domain_hint === 'backend_runtime'
+}
+
+function augmentSliceCandidateIdsForRuntimeExplain(
+  graph: KnowledgeGraph,
+  orderedIds: readonly string[],
+  metadata: ContextPackSliceMetadata,
+  retrievalGate: RetrievalGateDecision,
+  question: string,
+): string[] {
+  if (!runtimeGenerationSliceCandidatePromotionApplies(retrievalGate, metadata)) {
+    return [...orderedIds]
+  }
+
+  const expanded = [...orderedIds]
+  const seen = new Set(expanded)
+  const nodeIdByLabel = new Map<string, string>()
+  for (const [nodeId, attributes] of graph.nodeEntries()) {
+    const label = String(attributes.label ?? nodeId)
+    if (!nodeIdByLabel.has(label)) {
+      nodeIdByLabel.set(label, nodeId)
+    }
+  }
+
+  const resolveNodeId = (nodeId: string | undefined, label: string): string | undefined => {
+    if (nodeId && graph.hasNode(nodeId)) {
+      return nodeId
+    }
+    return nodeIdByLabel.get(label)
+  }
+
+  const anchorIds = metadata.anchors
+    .map((anchor) => resolveNodeId(anchor.node_id, anchor.label))
+    .filter((nodeId): nodeId is string => typeof nodeId === 'string')
+  const executionScope = collectExecutionSliceScope(graph, metadata, anchorIds, question, resolveNodeId)
+
+  for (const nodeId of executionScope.orderedIds) {
+    if (!seen.has(nodeId)) {
+      seen.add(nodeId)
+      expanded.push(nodeId)
+    }
+  }
+
+  return expanded
+}
+
 function runtimeGenerationExecutionSliceApplies(
   taskContract: ContextPackTaskContract,
   retrievalGate: RetrievalGateDecision,
@@ -4428,7 +4481,14 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
 
     if (sliced) {
       const scoredById = new Map(scored.map((node) => [node.id, node]))
-      const orderedSliceIds = augmentSliceCandidateIdsForDebug(graph, sliced.ordered_ids, sliced.metadata)
+      const runtimeExpandedSliceIds = augmentSliceCandidateIdsForRuntimeExplain(
+        graph,
+        sliced.ordered_ids,
+        sliced.metadata,
+        retrievalGate,
+        options.question,
+      )
+      const orderedSliceIds = augmentSliceCandidateIdsForDebug(graph, runtimeExpandedSliceIds, sliced.metadata)
       const sliceCandidates = orderedSliceIds.map((nodeId, index) => (
         scoredById.get(nodeId) ?? scoredNodeFromGraph(graph, nodeId, Math.max(0.25, 2 - (index * 0.1)), classificationRootPath)
       ))

--- a/tests/unit/context-pack-diagnostics.test.ts
+++ b/tests/unit/context-pack-diagnostics.test.ts
@@ -554,6 +554,72 @@ describe('computeContextPackDiagnostics', () => {
     }))
   })
 
+  it('does not flag slice_path_nodes_not_promoted when the runtime path node is surfaced in expandable preview', () => {
+    const diag = computeContextPackDiagnostics(makePack({
+      nodes: [
+        makeNode({
+          node_id: 'route',
+          label: '.generateFromProblem()',
+          source_file: '/repo/src/idea-generation.controller.ts',
+          framework_role: 'nest_route',
+          node_kind: 'route',
+        }),
+      ],
+      relationships: [],
+      expandable: [{
+        kind: 'nodes',
+        handle_id: 'extra-runtime-path',
+        evidence_class: 'supporting',
+        count: 1,
+        preview: [{
+          node_id: 'persist',
+          label: 'saveStructuredReport()',
+          source_file: '/repo/src/idea-report-store.service.ts',
+        }],
+        follow_up: {
+          kind: 'context_pack',
+          task_kind: 'explain',
+          evidence_class: 'supporting',
+          focus_files: ['/repo/src/idea-report-store.service.ts'],
+          focus_ranges: [{
+            source_file: '/repo/src/idea-report-store.service.ts',
+            start_line: 1,
+            end_line: 40,
+          }],
+        },
+      }],
+      retrieval_gate: {
+        ...retrievalGate({
+          reason: 'pipeline prompt',
+        }),
+        signals: {
+          ...retrievalGate().signals,
+          mentioned_symbols: ['IdeaGenerationController.generateFromProblem'],
+        },
+      },
+      task_contract: taskContract({
+        prompt: 'Explain the production runtime path for IdeaGenerationController.generateFromProblem through the service and persistence pipeline.',
+      }),
+      slice: {
+        mode: 'explain',
+        anchors: [{ node_id: 'route', label: '.generateFromProblem()', reason: 'symbol mention' }],
+        directions: ['forward'],
+        selected_paths: [
+          {
+            from_id: 'route',
+            from: '.generateFromProblem()',
+            to_id: 'persist',
+            to: 'saveStructuredReport()',
+            relation: 'calls',
+            direction: 'forward',
+          },
+        ],
+      },
+    }))
+
+    expect(diag.warnings.map((entry) => entry.kind)).not.toContain('slice_path_nodes_not_promoted')
+  })
+
   it('does not borrow same-label call edges from a different node when the route node_id is known', () => {
     const diag = computeContextPackDiagnostics(makePack({
       nodes: [

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -207,6 +207,7 @@ describe('pack-quality fixtures (#298)', () => {
         typeof preview.label === 'string' && preview.label.length > 0 ? [preview.label] : [])),
     ])
 
+    expect(primaryLabels.length).toBeGreaterThan(0)
     expect([...surfacedLabels]).toEqual(expect.arrayContaining(primaryLabels))
   })
 
@@ -236,6 +237,7 @@ describe('pack-quality fixtures (#298)', () => {
         .flatMap((warning) => warning.detail?.labels ?? []),
     )
 
+    expect(workflowCenters.size).toBeGreaterThan(0)
     expect([...workflowCenters].filter((label) => omittedLabels.has(label))).toEqual([])
   })
 })

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -182,4 +182,60 @@ describe('pack-quality fixtures (#298)', () => {
     ]))
     expect(primaryLabels).not.toContain('saveStructuredReport()')
   })
+
+  it('surfaces runtime primary-path steps in matched nodes or expandable previews', async () => {
+    const result = await runPackQualityFixture('runtime-generation-explain-report-flow')
+    const payload = result.payload as typeof result.payload & {
+      expandable?: Array<{
+        preview?: Array<{ label?: string }>
+      }>
+      pack?: {
+        execution_slice?: {
+          primary_path?: {
+            steps?: Array<{ label?: string }>
+          }
+        }
+        matched_nodes?: Array<{ label?: string }>
+      }
+    }
+
+    const primaryLabels = (payload.pack?.execution_slice?.primary_path?.steps ?? [])
+      .flatMap((entry) => (typeof entry.label === 'string' && entry.label.length > 0 ? [entry.label] : []))
+    const surfacedLabels = new Set([
+      ...(payload.pack?.matched_nodes ?? []).flatMap((entry) => (typeof entry.label === 'string' && entry.label.length > 0 ? [entry.label] : [])),
+      ...(payload.expandable ?? []).flatMap((entry) => (entry.preview ?? []).flatMap((preview) =>
+        typeof preview.label === 'string' && preview.label.length > 0 ? [preview.label] : [])),
+    ])
+
+    expect([...surfacedLabels]).toEqual(expect.arrayContaining(primaryLabels))
+  })
+
+  it('does not report workflow centers as omitted slice-path warnings on the explain fixture', async () => {
+    const result = await runPackQualityFixture('runtime-generation-explain-report-flow')
+    const payload = result.payload as typeof result.payload & {
+      pack?: {
+        routing?: {
+          warnings?: Array<{
+            kind?: string
+            detail?: {
+              labels?: string[]
+            }
+          }>
+        }
+      }
+    }
+    const workflowCenterEntries = (payload.workflow_centers ?? []) as Array<{ path?: string; label?: string }>
+
+    const workflowCenters = new Set(
+      workflowCenterEntries.flatMap((entry) =>
+        typeof entry.label === 'string' && entry.label.length > 0 ? [entry.label] : []),
+    )
+    const omittedLabels = new Set(
+      (payload.pack?.routing?.warnings ?? [])
+        .filter((warning) => warning.kind === 'slice_path_nodes_not_promoted')
+        .flatMap((warning) => warning.detail?.labels ?? []),
+    )
+
+    expect([...workflowCenters].filter((label) => omittedLabels.has(label))).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary
- promote runtime-generation explain slice nodes into slice-v1 candidates so primary-path steps survive pack assembly
- treat expandable preview nodes as promoted in `slice_path_nodes_not_promoted` diagnostics
- preserve trimmed runtime primary-path steps in answer-ready output via expandable previews and add regressions

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced context pack organization with improved runtime path preview node management

* **Bug Fixes**
  * Improved diagnostic accuracy for detecting included information sources and nodes
  * Optimized candidate selection in explain flow for better relevance

* **Tests**
  * Added coverage for preview node promotion and diagnostic validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->