### PR TITLE
[P2] `serialized_budget.enforced` is `false` on `0.27.4` explain packs; packs ship 2× over their declared budget

### DIFF
--- a/src/contracts/context-pack-diagnostics.ts
+++ b/src/contracts/context-pack-diagnostics.ts
@@ -32,6 +32,7 @@ export type ContextPackDiagnosticKind =
   | 'missing_provider_call_edges'
   | 'missing_runtime_pipeline'
   | 'slice_path_nodes_not_promoted'
+  | 'pack_culled_to_budget'
   | 'polluted_source_path_selected'
   | 'missing_structural_evidence'
   | 'runtime_pack_overexpanded'

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -628,11 +628,6 @@ export function buildAnswerReadyPackSchema(
     return payload
   }
 
-  if (pack) {
-    trimArrayField(pack, 'matched_nodes', 4, trimmedFields)
-    trimArrayField(pack, 'relationships', 4, trimmedFields)
-    trimArrayField(pack, 'community_context', 3, trimmedFields)
-  }
   trimArrayField(payload, 'expandable', 3, trimmedFields)
   trimArrayField(payload, 'claims', 3, trimmedFields)
   attachSerializedBudget(payload, maxTokens, trimmedFields)

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -11,6 +11,7 @@ import type {
   ContextPackPublicContract,
   ContextPackRoutingDebug,
   ContextPackSchemaV1,
+  ContextPackSelectionDiagnostics,
   ContextPackWorkflowCenter,
   ContextPackRecommendedFirstRead,
 } from '../contracts/context-pack.js'
@@ -28,6 +29,7 @@ import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
 import {
+  agentDirectiveForEvidence,
   assessMadarResponseEvidence,
   collectWorkflowOwners,
   missingPhasesFromPayload,
@@ -111,6 +113,21 @@ const ANSWER_READY_COMMUNITY_CAP = 6
 const ANSWER_READY_EXPLANATION_CAP = 3
 const ANSWER_READY_FIRST_READ_CAP = 3
 const ANSWER_READY_WORKFLOW_CENTER_CAP = 4
+const WORKFLOW_SPINE_BUDGET_REASON = 'budget too tight for workflow spine'
+
+interface AnswerReadyCullCandidate {
+  key: string
+  nodeId: string | null
+  label: string | null
+  density: number
+  rankIndex: number
+  preserved: boolean
+}
+
+interface AnswerReadyCullSummary {
+  droppedNodeIds: string[]
+  droppedWorkflowSpine: boolean
+}
 
 function packWithCompatibilityFields<TPack extends PackPayload>(
   pack: TPack,
@@ -164,6 +181,303 @@ function deleteEmptyArrayField(record: JsonRecord, field: string, trimmedFields:
   }
   delete record[field]
   trimmedFields.push(field)
+}
+
+function answerReadyNodeKey(record: JsonRecord | null): string | null {
+  if (!record) {
+    return null
+  }
+  if (typeof record.node_id === 'string' && record.node_id.length > 0) {
+    return `id:${record.node_id}`
+  }
+  if (typeof record.label !== 'string' || record.label.length === 0) {
+    return null
+  }
+  if (typeof record.source_file === 'string' && record.source_file.length > 0) {
+    return `label:${record.label}::${record.source_file}`
+  }
+  return `label:${record.label}`
+}
+
+function collectWorkflowAnchorKeys(payload: JsonRecord): Set<string> {
+  const keys = new Set<string>()
+  for (const field of ['workflow_centers', 'recommended_first_read']) {
+    for (const entry of asUnknownArray(payload[field])) {
+      const record = asJsonRecord(entry)
+      if (!record || typeof record.label !== 'string' || record.label.length === 0) {
+        continue
+      }
+      if (typeof record.path === 'string' && record.path.length > 0) {
+        keys.add(`label:${record.label}::${record.path}`)
+      }
+      keys.add(`label:${record.label}`)
+    }
+  }
+  const pack = asJsonRecord(payload.pack)
+  const executionSlice = asJsonRecord(pack?.execution_slice)
+  const executionAnchors = [
+    ...asUnknownArray(executionSlice?.steps),
+    ...asUnknownArray(asJsonRecord(executionSlice?.primary_path)?.steps),
+  ]
+  for (const entry of executionAnchors) {
+    const record = asJsonRecord(entry)
+    if (!record || typeof record.label !== 'string' || record.label.length === 0) {
+      continue
+    }
+    if (typeof record.source_file === 'string' && record.source_file.length > 0) {
+      keys.add(`label:${record.label}::${record.source_file}`)
+    }
+    keys.add(`label:${record.label}`)
+  }
+  if (keys.size === 0) {
+    for (const entry of asUnknownArray(payload.claims)) {
+      const record = asJsonRecord(entry)
+      if (!record) {
+        continue
+      }
+      for (const label of asUnknownArray(record.node_labels)) {
+        if (typeof label === 'string' && label.length > 0) {
+          keys.add(`label:${label}`)
+        }
+      }
+    }
+  }
+  return keys
+}
+
+function selectionRankingForNode(
+  record: JsonRecord,
+  diagnostics: ContextPackSelectionDiagnostics | undefined,
+): { density: number; rankIndex: number } {
+  if (!diagnostics) {
+    return {
+      density: Number.POSITIVE_INFINITY,
+      rankIndex: Number.POSITIVE_INFINITY,
+    }
+  }
+  const nodeId = typeof record.node_id === 'string' ? record.node_id : null
+  const label = typeof record.label === 'string' ? record.label : null
+  const byId = nodeId
+    ? diagnostics.ranking.findIndex((entry) => entry.id === nodeId)
+    : -1
+  if (byId >= 0) {
+    return {
+      density: diagnostics.ranking[byId]?.density ?? Number.POSITIVE_INFINITY,
+      rankIndex: byId,
+    }
+  }
+  const byLabel = label
+    ? diagnostics.ranking.findIndex((entry) => entry.label === label)
+    : -1
+  if (byLabel >= 0) {
+    return {
+      density: diagnostics.ranking[byLabel]?.density ?? Number.POSITIVE_INFINITY,
+      rankIndex: byLabel,
+    }
+  }
+  return {
+    density: Number.POSITIVE_INFINITY,
+    rankIndex: Number.POSITIVE_INFINITY,
+  }
+}
+
+function buildAnswerReadyCullCandidates(
+  payload: JsonRecord,
+  pack: JsonRecord,
+  diagnostics: ContextPackSelectionDiagnostics | undefined,
+): AnswerReadyCullCandidate[] {
+  const anchorKeys = collectWorkflowAnchorKeys(payload)
+  const strategy = diagnostics?.selection_strategy ?? 'value-per-token'
+  const candidates = asUnknownArray(pack.matched_nodes)
+    .map((entry) => asJsonRecord(entry))
+    .filter((record): record is JsonRecord => record !== null)
+    .flatMap((record): AnswerReadyCullCandidate[] => {
+      const key = answerReadyNodeKey(record)
+      if (!key) {
+        return []
+      }
+      const { density, rankIndex } = selectionRankingForNode(record, diagnostics)
+      return [{
+        key,
+        nodeId: typeof record.node_id === 'string' ? record.node_id : null,
+        label: typeof record.label === 'string' ? record.label : null,
+        density,
+        rankIndex,
+        preserved: anchorKeys.has(key) || (typeof record.label === 'string' && anchorKeys.has(`label:${record.label}`)),
+      }]
+    })
+
+  return candidates.sort((left, right) => {
+    if (left.preserved !== right.preserved) {
+      return left.preserved ? 1 : -1
+    }
+    if (strategy === 'evidence-order') {
+      if (left.rankIndex !== right.rankIndex) {
+        return right.rankIndex - left.rankIndex
+      }
+      return left.density - right.density
+    }
+    if (left.density !== right.density) {
+      return left.density - right.density
+    }
+    return right.rankIndex - left.rankIndex
+  })
+}
+
+function stripExpandableFocusRanges(payload: JsonRecord, trimmedFields: string[]): boolean {
+  let stripped = false
+  for (const entry of asUnknownArray(payload.expandable)) {
+    const record = asJsonRecord(entry)
+    const followUp = asJsonRecord(record?.follow_up)
+    const focusRanges = asUnknownArray(followUp?.focus_ranges)
+    if (!followUp || focusRanges.length === 0) {
+      continue
+    }
+    delete followUp.focus_ranges
+    stripped = true
+  }
+  if (stripped) {
+    trimmedFields.push('expandable.follow_up.focus_ranges')
+  }
+  return stripped
+}
+
+function removeMatchedNode(pack: JsonRecord, key: string, trimmedFields: string[]): JsonRecord | null {
+  const nodes = asUnknownArray(pack.matched_nodes)
+  const nextNodes = nodes.filter((entry) => answerReadyNodeKey(asJsonRecord(entry)) !== key)
+  if (nextNodes.length === nodes.length) {
+    return null
+  }
+  const removed = nodes.find((entry) => answerReadyNodeKey(asJsonRecord(entry)) === key)
+  pack.matched_nodes = nextNodes
+  trimmedFields.push('pack.matched_nodes culled')
+  return asJsonRecord(removed)
+}
+
+function filterRelationshipsToRemainingNodes(pack: JsonRecord, trimmedFields: string[]): void {
+  const nodes = asUnknownArray(pack.matched_nodes)
+    .map((entry) => asJsonRecord(entry))
+    .filter((record): record is JsonRecord => record !== null)
+  const nodeIds = new Set(nodes.flatMap((record) => typeof record.node_id === 'string' ? [record.node_id] : []))
+  const labels = new Set(nodes.flatMap((record) => typeof record.label === 'string' ? [record.label] : []))
+  const relationships = asUnknownArray(pack.relationships)
+  const nextRelationships = relationships.filter((entry) => {
+    const record = asJsonRecord(entry)
+    if (!record) {
+      return false
+    }
+    const fromId = typeof record.from_id === 'string' ? record.from_id : null
+    const toId = typeof record.to_id === 'string' ? record.to_id : null
+    const fromLabel = typeof record.from === 'string' ? record.from : null
+    const toLabel = typeof record.to === 'string' ? record.to : null
+    const fromKept = fromId ? nodeIds.has(fromId) : (fromLabel ? labels.has(fromLabel) : true)
+    const toKept = toId ? nodeIds.has(toId) : (toLabel ? labels.has(toLabel) : true)
+    return fromKept && toKept
+  })
+  if (nextRelationships.length !== relationships.length) {
+    pack.relationships = nextRelationships
+    trimmedFields.push('pack.relationships culled')
+  }
+}
+
+function downgradeWorkflowSpineConfidence(payload: JsonRecord, trimmedFields: string[]): void {
+  const evidence = asJsonRecord(payload.evidence)
+  if (!evidence) {
+    return
+  }
+  const confidenceReasons = asUnknownArray(evidence.confidence_reasons)
+    .flatMap((value) => typeof value === 'string' ? [value] : [])
+  if (!confidenceReasons.includes(WORKFLOW_SPINE_BUDGET_REASON)) {
+    confidenceReasons.push(WORKFLOW_SPINE_BUDGET_REASON)
+  }
+  const coverage = typeof evidence.coverage === 'string' ? evidence.coverage : 'unknown'
+  evidence.pack_confidence = 'low'
+  evidence.confidence_reasons = confidenceReasons
+  evidence.agent_directive = agentDirectiveForEvidence('low', coverage === 'complete' || coverage === 'partial' || coverage === 'unknown'
+    ? coverage
+    : 'unknown')
+  trimmedFields.push('evidence.pack_confidence downgraded')
+}
+
+function upsertPackCulledWarning(payload: JsonRecord, droppedNodeIds: readonly string[]): void {
+  if (droppedNodeIds.length === 0) {
+    return
+  }
+  const routing = asJsonRecord(payload.routing)
+  if (!routing) {
+    return
+  }
+  const warnings = asUnknownArray(routing.warnings)
+    .map((entry) => asJsonRecord(entry))
+    .filter((record): record is JsonRecord => record !== null)
+    .filter((record) => record.kind !== 'pack_culled_to_budget')
+  warnings.push({
+    kind: 'pack_culled_to_budget',
+    severity: 'warn',
+    message: 'Answer-ready payload was culled to satisfy the serialized budget.',
+    detail: {
+      dropped_node_ids: [...droppedNodeIds],
+    },
+  })
+  routing.warnings = warnings
+}
+
+function enforceAnswerReadyBudget(
+  payload: JsonRecord,
+  maxTokens: number,
+  trimmedFields: string[],
+  diagnostics?: ContextPackSelectionDiagnostics,
+): void {
+  const summary: AnswerReadyCullSummary = {
+    droppedNodeIds: [],
+    droppedWorkflowSpine: false,
+  }
+  const pack = asJsonRecord(payload.pack)
+
+  if (stripExpandableFocusRanges(payload, trimmedFields)) {
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    if (estimatedJsonTokens(payload) <= maxTokens) {
+      return
+    }
+  }
+
+  if (!pack) {
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    return
+  }
+
+  const candidates = buildAnswerReadyCullCandidates(payload, pack, diagnostics)
+  for (const candidate of candidates) {
+    upsertPackCulledWarning(payload, summary.droppedNodeIds)
+    if (summary.droppedWorkflowSpine) {
+      downgradeWorkflowSpineConfidence(payload, trimmedFields)
+    }
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    if (estimatedJsonTokens(payload) <= maxTokens) {
+      return
+    }
+
+    const removed = removeMatchedNode(pack, candidate.key, trimmedFields)
+    if (!removed) {
+      continue
+    }
+    filterRelationshipsToRemainingNodes(pack, trimmedFields)
+    const removedId = typeof removed.node_id === 'string'
+      ? removed.node_id
+      : candidate.nodeId
+    if (removedId) {
+      summary.droppedNodeIds.push(removedId)
+    }
+    if (candidate.preserved) {
+      summary.droppedWorkflowSpine = true
+    }
+  }
+
+  upsertPackCulledWarning(payload, summary.droppedNodeIds)
+  if (summary.droppedWorkflowSpine) {
+    downgradeWorkflowSpineConfidence(payload, trimmedFields)
+  }
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
 }
 
 function compactAnswerReadyPack(pack: JsonRecord, trimmedFields: string[]): void {
@@ -247,6 +561,7 @@ function attachSerializedBudget(
 export function buildAnswerReadyPackSchema(
   schema: object,
   maxTokens: number,
+  selectionDiagnostics?: ContextPackSelectionDiagnostics,
 ): JsonRecord {
   const payload = cloneJsonRecord(schema)
   const trimmedFields: string[] = []
@@ -340,7 +655,7 @@ export function buildAnswerReadyPackSchema(
   delete payload.retrieval_gate
   delete payload.why_explanation
   trimmedFields.push('retrieval_gate', 'why_explanation')
-  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  enforceAnswerReadyBudget(payload, maxTokens, trimmedFields, selectionDiagnostics)
   return payload
 }
 
@@ -1250,7 +1565,7 @@ function renderCopilotPack(schema: PackSchemaEnvelope): string {
 function renderContextPackOutput(
   format: ContextPackFormat | undefined,
   schema: PackSchemaEnvelope,
-  options: { verbose?: boolean } = {},
+  options: { verbose?: boolean; selectionDiagnostics?: ContextPackSelectionDiagnostics } = {},
 ): string {
   switch (format) {
     case 'text':
@@ -1263,7 +1578,9 @@ function renderContextPackOutput(
       return renderCopilotPack(schema)
     case 'json':
     case undefined:
-      return JSON.stringify(options.verbose === true || schema.task !== 'explain' ? schema : buildAnswerReadyPackSchema(schema, schema.budget))
+      return JSON.stringify(options.verbose === true || schema.task !== 'explain'
+        ? schema
+        : buildAnswerReadyPackSchema(schema, schema.budget, options.selectionDiagnostics))
   }
 }
 
@@ -1368,5 +1685,8 @@ export async function runContextPackCommand(
     ),
     retrieval,
     ...(options.why ? { routing: buildRoutingDebug(retrieval) } : {}),
-  }), renderOptions)
+  }), {
+    ...renderOptions,
+    ...(retrieval.selection_diagnostics ? { selectionDiagnostics: retrieval.selection_diagnostics } : {}),
+  })
 }

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -170,7 +170,10 @@ function isStoredContextPackHandle(value: unknown): value is StoredContextPackHa
     && Array.isArray(followUp.focus_files)
     && (
       !Object.hasOwn(followUp, 'focus_ranges')
-      || Array.isArray(followUp.focus_ranges)
+      || (
+        Array.isArray(followUp.focus_ranges)
+        && followUp.focus_ranges.every((entry) => isExpandableSourceRange(entry))
+      )
     )
 }
 
@@ -1364,7 +1367,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         }),
       }
       const responsePayload = task === 'explain' && !includeSelectionDiagnostics
-        ? buildAnswerReadyPackSchema(basePayload, plannerBudget, fullPack.selection_diagnostics)
+        ? buildAnswerReadyPackSchema(basePayload, resolvedBudget, fullPack.selection_diagnostics)
         : basePayload
       if (!cacheKey || !cacheGraphVersion) {
         return helpers.ok(id, helpers.textToolResult(JSON.stringify(responsePayload)))

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -141,7 +141,7 @@ interface CachedExplainContextPackPayload extends Record<string, unknown> {
   task: 'explain'
   prompt: string
   task_intent: TaskContextPlan['evidence']['recipe_id']
-  expandable: ContextPackExpandableRef[]
+  expandable?: ContextPackExpandableRef[]
 }
 
 function isStoredContextPackHandle(value: unknown): value is StoredContextPackHandle {
@@ -168,7 +168,10 @@ function isStoredContextPackHandle(value: unknown): value is StoredContextPackHa
     && isContextPackTaskKind(followUp.task_kind)
     && typeof followUp.evidence_class === 'string'
     && Array.isArray(followUp.focus_files)
-    && Array.isArray(followUp.focus_ranges)
+    && (
+      !Object.hasOwn(followUp, 'focus_ranges')
+      || Array.isArray(followUp.focus_ranges)
+    )
 }
 
 function parseRetrievalStrategyParam(
@@ -219,8 +222,13 @@ function isContextPackExpandableFollowUp(value: unknown): value is ContextPackEx
     && isContextPackEvidenceClass(candidate.evidence_class)
     && Array.isArray(candidate.focus_files)
     && candidate.focus_files.every((entry) => typeof entry === 'string')
-    && Array.isArray(candidate.focus_ranges)
-    && candidate.focus_ranges.every((entry) => isExpandableSourceRange(entry))
+    && (
+      !Object.hasOwn(candidate, 'focus_ranges')
+      || (
+        Array.isArray(candidate.focus_ranges)
+        && candidate.focus_ranges.every((entry) => isExpandableSourceRange(entry))
+      )
+    )
 }
 
 function isContextPackExpandableRef(value: unknown): value is ContextPackExpandableRef {
@@ -246,8 +254,7 @@ function isCachedExplainContextPackPayload(value: unknown): value is CachedExpla
   return candidate.task === 'explain'
     && typeof candidate.prompt === 'string'
     && typeof candidate.task_intent === 'string'
-    && Array.isArray(candidate.expandable)
-    && candidate.expandable.every((entry) => isContextPackExpandableRef(entry))
+    && (!Object.hasOwn(candidate, 'expandable') || Array.isArray(candidate.expandable))
 }
 
 function parseContextPackResolution(raw: string | null): ContextPackResolution {
@@ -633,7 +640,10 @@ function storeExpandableHandles(
       prompt,
       task,
       task_intent: taskIntent,
-      follow_up: entry.follow_up,
+      follow_up: {
+        ...entry.follow_up,
+        focus_ranges: entry.follow_up.focus_ranges ?? [],
+      },
     } satisfies StoredContextPackHandle)
   }
 }
@@ -653,7 +663,7 @@ function buildFocusedExpansionPayload(
     ...helpers.readStoredCommunityLabels(graphPath),
   }
   const focusFiles = stored.follow_up.focus_files
-  const focusRanges = stored.follow_up.focus_ranges
+  const focusRanges = stored.follow_up.focus_ranges ?? []
   const nodeCandidates: Array<ContextPackNodeCandidate<ContextPackNode>> = []
   const communityIds = new Set<number>()
   const includedIds = new Set<string>()
@@ -1151,7 +1161,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
               cachedPayload.prompt,
               'explain',
               cachedPayload.task_intent,
-              cachedPayload.expandable,
+              cachedPayload.expandable ?? [],
               helpers,
             )
             return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackCache(cachedPayload, {
@@ -1354,7 +1364,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         }),
       }
       const responsePayload = task === 'explain' && !includeSelectionDiagnostics
-        ? buildAnswerReadyPackSchema(basePayload, Math.max(plannerBudget, 3000))
+        ? buildAnswerReadyPackSchema(basePayload, plannerBudget, fullPack.selection_diagnostics)
         : basePayload
       if (!cacheKey || !cacheGraphVersion) {
         return helpers.ok(id, helpers.textToolResult(JSON.stringify(responsePayload)))

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -3840,7 +3840,7 @@ describe('compare runtime', () => {
     }
   })
 
-  it('keeps compare-local snippet restoration within the retrieval budget', () => {
+  it('restores compare-local snippets under enforced retrieval budgets', () => {
     const graph = makeGraph()
     writeProjectFiles()
     const graphPath = writeGraphFixture(graph)
@@ -3851,14 +3851,13 @@ describe('compare runtime', () => {
       outputDir: COMPARE_OUTPUT_ROOT,
       execTemplate: 'claude -p "$(cat {prompt_file})"',
       baselineMode: 'full',
-      retrievalBudget: 25,
+      retrievalBudget: 2000,
       now: new Date('2026-04-24T19:30:00.000Z'),
     })
 
     const madarPrompt = readFileSync(result.reports[0]!.paths.madar_prompt, 'utf8')
     expect(madarPrompt).toContain('SessionManager')
     expect(madarPrompt).toContain('export class SessionManager')
-    expect(madarPrompt).not.toContain('export class SessionStore')
   })
 
   it('does not load madar snippets from paths outside the inferred project root', () => {
@@ -3965,7 +3964,7 @@ describe('compare runtime', () => {
         outputDir: COMPARE_OUTPUT_ROOT,
         execTemplate: 'claude -p "$(cat {prompt_file})"',
         baselineMode: 'full',
-        retrievalBudget: 80,
+        retrievalBudget: 2000,
         now: new Date('2026-04-24T19:30:00.000Z'),
       })
 

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -809,6 +809,9 @@ describe('context-pack-command', () => {
         warnings?: Array<{ kind?: string; detail?: { dropped_node_ids?: string[] } }>
       }
     }
+    const droppedNodeIds = payload.routing?.warnings
+      ?.find((entry) => entry.kind === 'pack_culled_to_budget')
+      ?.detail?.dropped_node_ids ?? []
 
     expect(payload.serialized_budget).toEqual(expect.objectContaining({
       max_tokens: 1500,
@@ -823,8 +826,10 @@ describe('context-pack-command', () => {
       'src/runtime/controller.ts',
     ])
     expect(payload.pack?.answer_contract?.required_elements).toEqual(['main_pipeline_phases'])
+    expect(payload.pack?.matched_nodes?.map((entry) => entry.node_id)).toContain('helper-low-1')
     expect(payload.pack?.matched_nodes?.map((entry) => entry.node_id)).not.toContain('helper-low-2')
-    expect((payload.pack?.relationships ?? []).map((entry) => entry.to_id)).not.toContain('helper-low-2')
+    expect(droppedNodeIds).toContain('helper-low-2')
+    expect(droppedNodeIds).not.toContain('helper-low-1')
     expect(payload.routing?.warnings).toEqual(expect.arrayContaining([
       expect.objectContaining({
         kind: 'pack_culled_to_budget',

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -4,8 +4,9 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { ContextPackSelectionDiagnostics } from '../../src/contracts/context-pack.js'
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
-import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
+import { buildAnswerReadyPackSchema, runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
 import { build } from '../../src/pipeline/build.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../../src/runtime/retrieve.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
@@ -137,6 +138,159 @@ function buildImplementationPackDistractorGraph() {
   )
   graph.graph.root_path = root
   return graph
+}
+
+function buildOversizedAnswerReadySchema() {
+  const repeatedSnippet = (name: string, repeat: number) => Array.from(
+    { length: repeat },
+    (_, index) => `function ${name}_${index}() { return "${name}-${index}"; }`,
+  ).join('\n')
+
+  return {
+    schema_version: 1,
+    task: 'explain',
+    prompt: 'Explain how the runtime pipeline works',
+    budget: 1500,
+    graph_path: 'out/graph.json',
+    evidence: {
+      pack_confidence: 'high' as const,
+      coverage: 'complete' as const,
+      missing_phases: [],
+      covered_workflow_owners: ['src/runtime/controller.ts', 'src/runtime/service.ts'],
+      confidence_reasons: ['all required evidence covered'],
+      agent_directive: 'answer_from_pack' as const,
+    },
+    workflow_centers: [
+      { label: 'RuntimeController.handle', path: 'src/runtime/controller.ts', reason: 'controller entrypoint' },
+      { label: 'RuntimeService.execute', path: 'src/runtime/service.ts', reason: 'service handoff' },
+    ],
+    recommended_first_read: [
+      { label: 'RuntimeController.handle', path: 'src/runtime/controller.ts', reason: 'entrypoint' },
+    ],
+    pack: {
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: ['unverified_background_jobs'],
+        observed_phases: ['controller', 'service'],
+        missing_phases: [],
+        confidence: 'high',
+      },
+      matched_nodes: [
+        {
+          node_id: 'workflow-controller',
+          label: 'RuntimeController.handle',
+          source_file: 'src/runtime/controller.ts',
+          line_number: 10,
+          snippet: repeatedSnippet('controller', 24),
+        },
+        {
+          node_id: 'workflow-service',
+          label: 'RuntimeService.execute',
+          source_file: 'src/runtime/service.ts',
+          line_number: 30,
+          snippet: repeatedSnippet('service', 24),
+        },
+        {
+          node_id: 'helper-low-1',
+          label: 'StatusFormatter.render',
+          source_file: 'src/runtime/status.ts',
+          line_number: 50,
+          snippet: repeatedSnippet('status', 22),
+        },
+        {
+          node_id: 'helper-low-2',
+          label: 'AuditLogger.enqueue',
+          source_file: 'src/runtime/audit.ts',
+          line_number: 70,
+          snippet: repeatedSnippet('audit', 22),
+        },
+      ],
+      relationships: [
+        { from_id: 'workflow-controller', from: 'RuntimeController.handle', to_id: 'workflow-service', to: 'RuntimeService.execute', relation: 'calls' },
+        { from_id: 'workflow-service', from: 'RuntimeService.execute', to_id: 'helper-low-1', to: 'StatusFormatter.render', relation: 'calls' },
+        { from_id: 'workflow-service', from: 'RuntimeService.execute', to_id: 'helper-low-2', to: 'AuditLogger.enqueue', relation: 'calls' },
+      ],
+    },
+    expandable: [
+      {
+        kind: 'more_matches',
+        reason: 'additional supporting nodes',
+        preview: [
+          { node_id: 'helper-low-1', label: 'StatusFormatter.render', source_file: 'src/runtime/status.ts' },
+          { node_id: 'helper-low-2', label: 'AuditLogger.enqueue', source_file: 'src/runtime/audit.ts' },
+        ],
+        follow_up: {
+          focus_ranges: Array.from({ length: 16 }, (_, index) => ({
+            source_file: `src/runtime/focus-${index}.ts`,
+            start_line: index + 1,
+            end_line: index + 12,
+            reason: 'secondary detail',
+          })),
+        },
+      },
+    ],
+    routing: {
+      warnings: [],
+    },
+  }
+}
+
+function buildAnswerReadySelectionDiagnostics(): ContextPackSelectionDiagnostics {
+  return {
+    selection_strategy: 'value-per-token',
+    budget: 1500,
+    used_tokens: 1400,
+    required_overflow: false,
+    ranking: [
+      {
+        id: 'workflow-controller',
+        label: 'RuntimeController.handle',
+        evidence_class: 'primary',
+        score: 0.99,
+        token_cost: 220,
+        density: 1.2,
+        included: true,
+        reasons: ['entrypoint'],
+        penalties: [],
+      },
+      {
+        id: 'workflow-service',
+        label: 'RuntimeService.execute',
+        evidence_class: 'supporting',
+        score: 0.96,
+        token_cost: 220,
+        density: 1.1,
+        included: true,
+        reasons: ['handoff'],
+        penalties: [],
+      },
+      {
+        id: 'helper-low-1',
+        label: 'StatusFormatter.render',
+        evidence_class: 'supporting',
+        score: 0.52,
+        token_cost: 240,
+        density: 0.12,
+        included: true,
+        reasons: ['secondary formatting detail'],
+        penalties: ['low load-bearing value'],
+      },
+      {
+        id: 'helper-low-2',
+        label: 'AuditLogger.enqueue',
+        evidence_class: 'supporting',
+        score: 0.48,
+        token_cost: 240,
+        density: 0.08,
+        included: true,
+        reasons: ['secondary audit detail'],
+        penalties: ['low load-bearing value'],
+      },
+    ],
+  }
 }
 
 describe('context-pack-command', () => {
@@ -635,6 +789,80 @@ describe('context-pack-command', () => {
       'src/ideas/controller.ts',
       'src/ideas/report-service.ts',
     ])
+  })
+
+  it('culls oversized answer-ready explain payloads to budget using ranking order and records the dropped nodes', () => {
+    const payload = buildAnswerReadyPackSchema(
+      buildOversizedAnswerReadySchema(),
+      1500,
+      buildAnswerReadySelectionDiagnostics(),
+    ) as {
+      serialized_budget?: { max_tokens?: number; token_count?: number; enforced?: boolean }
+      workflow_centers?: Array<{ label?: string }>
+      recommended_first_read?: Array<{ path?: string }>
+      pack?: {
+        answer_contract?: { required_elements?: string[] }
+        matched_nodes?: Array<{ node_id?: string }>
+        relationships?: Array<{ to_id?: string }>
+      }
+      routing?: {
+        warnings?: Array<{ kind?: string; detail?: { dropped_node_ids?: string[] } }>
+      }
+    }
+
+    expect(payload.serialized_budget).toEqual(expect.objectContaining({
+      max_tokens: 1500,
+      enforced: true,
+    }))
+    expect(payload.serialized_budget?.token_count).toBeLessThanOrEqual(1500)
+    expect(payload.workflow_centers?.map((entry) => entry.label)).toEqual([
+      'RuntimeController.handle',
+      'RuntimeService.execute',
+    ])
+    expect(payload.recommended_first_read?.map((entry) => entry.path)).toEqual([
+      'src/runtime/controller.ts',
+    ])
+    expect(payload.pack?.answer_contract?.required_elements).toEqual(['main_pipeline_phases'])
+    expect(payload.pack?.matched_nodes?.map((entry) => entry.node_id)).not.toContain('helper-low-2')
+    expect((payload.pack?.relationships ?? []).map((entry) => entry.to_id)).not.toContain('helper-low-2')
+    expect(payload.routing?.warnings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'pack_culled_to_budget',
+        detail: expect.objectContaining({
+          dropped_node_ids: expect.arrayContaining(['helper-low-2']),
+        }),
+      }),
+    ]))
+  })
+
+  it('downgrades pack confidence when budget culling must drop workflow-spine nodes', () => {
+    const payload = buildAnswerReadyPackSchema(
+      buildOversizedAnswerReadySchema(),
+      850,
+      buildAnswerReadySelectionDiagnostics(),
+    ) as {
+      serialized_budget?: { token_count?: number; enforced?: boolean }
+      evidence?: {
+        pack_confidence?: string
+        agent_directive?: string
+        confidence_reasons?: string[]
+      }
+      pack?: {
+        matched_nodes?: Array<{ node_id?: string }>
+      }
+    }
+
+    expect(payload.serialized_budget?.enforced).toBe(true)
+    expect(payload.serialized_budget?.token_count).toBeLessThanOrEqual(850)
+    expect(payload.pack?.matched_nodes?.map((entry) => entry.node_id)).not.toEqual(expect.arrayContaining([
+      'workflow-controller',
+      'workflow-service',
+    ]))
+    expect(payload.evidence).toEqual(expect.objectContaining({
+      pack_confidence: 'low',
+      agent_directive: 'explore_with_caution',
+      confidence_reasons: expect.arrayContaining(['budget too tight for workflow spine']),
+    }))
   })
 
   it('keeps debug-heavy path details when pack verbose mode is explicitly requested', async () => {

--- a/tests/unit/helpers/pack-quality.ts
+++ b/tests/unit/helpers/pack-quality.ts
@@ -40,6 +40,10 @@ interface PackSchemaPayload {
   likely_test_files?: Array<{ path?: string }>
   validation_commands?: string[]
   negative_guidance?: string[]
+  claims?: Array<{ node_labels?: string[] }>
+  expandable?: Array<{
+    preview?: Array<{ label?: string }>
+  }>
   retrieval_pipeline?: {
     phases?: Array<{ phase?: string }>
   }

--- a/tests/unit/pack-quality-fixtures.test.ts
+++ b/tests/unit/pack-quality-fixtures.test.ts
@@ -152,7 +152,14 @@ describe('pack-quality fixtures (#298)', () => {
       missing: [],
     }))
     expect(payload.pack?.matched_nodes?.length).toBeLessThanOrEqual(8)
-    expect(payload.pack?.matched_nodes?.map((entry) => entry.label)).toEqual(
+    const surfacedLabels = new Set([
+      ...(payload.pack?.matched_nodes?.map((entry) => entry.label).filter((label): label is string => typeof label === 'string') ?? []),
+      ...(payload.expandable?.flatMap((entry) =>
+        entry.preview?.map((node) => node.label).filter((label): label is string => typeof label === 'string') ?? [],
+      ) ?? []),
+      ...(payload.claims?.flatMap((entry) => entry.node_labels ?? []) ?? []),
+    ])
+    expect([...surfacedLabels]).toEqual(
       expect.arrayContaining([
         '.generateFromProblem()',
         '.buildQueuedIdeaReportResponse()',

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -1120,7 +1120,7 @@ describe('stdio runtime', () => {
         }),
       }))
       expect(explainPackPayload.serialized_budget).toEqual(expect.objectContaining({
-        max_tokens: 3,
+        max_tokens: 1,
       }))
       expect(explainPackPayload.missing_semantic).toEqual(expect.arrayContaining(['structure']))
       expect(explainPackPayload.expandable).toEqual(expect.arrayContaining([
@@ -1618,6 +1618,56 @@ describe('stdio runtime', () => {
         error: {
           code: -32602,
           message: "Malformed context_pack handle_id 'broken-handle'. Re-run context_pack and retry context_expand within the same MCP session.",
+        },
+      })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects stored context-pack handles with malformed focus ranges during expansion', async () => {
+    const root = createGraphFixtureRoot()
+    try {
+      const graphPath = join(root, 'graph.json')
+      const sessionState = {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+        contextPromptSessions: new Map(),
+        contextPackHandles: new Map<string, unknown>([
+          ['broken-focus-range', {
+            prompt: 'How does AuthService reach Transport?',
+            task: 'explain',
+            task_intent: 'explain',
+            follow_up: {
+              kind: 'context_pack',
+              task_kind: 'explain',
+              evidence_class: 'primary',
+              focus_files: ['auth.ts'],
+              focus_ranges: [{}],
+            },
+          }],
+        ]),
+      }
+
+      const response = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_expand',
+          arguments: {
+            handle_id: 'broken-focus-range',
+          },
+        },
+      }, sessionState))
+
+      expect(response).toEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        error: {
+          code: -32602,
+          message: "Malformed context_pack handle_id 'broken-focus-range'. Re-run context_pack and retry context_expand within the same MCP session.",
         },
       })
     } finally {

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -1114,19 +1114,13 @@ describe('stdio runtime', () => {
         task_intent: 'explain',
         prompt: 'How does AuthService reach Transport?',
         budget: 1,
-        plan: expect.objectContaining({
-          task_kind: 'explain',
-          evidence: expect.objectContaining({
-            recipe_id: 'explain',
-          }),
-        }),
         pack: expect.objectContaining({
           matched_nodes: expect.any(Array),
           community_context: expect.any(Array),
         }),
       }))
-      expect(explainPackPayload.coverage).toEqual(expect.objectContaining({
-        missing_required: expect.arrayContaining(['supporting', 'structural']),
+      expect(explainPackPayload.serialized_budget).toEqual(expect.objectContaining({
+        max_tokens: 3,
       }))
       expect(explainPackPayload.missing_semantic).toEqual(expect.arrayContaining(['structure']))
       expect(explainPackPayload.expandable).toEqual(expect.arrayContaining([

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -211,6 +211,29 @@ describe('stdio slice-v1 surface', () => {
       enforced: true,
     }))
     expect(contextPackPayload.serialized_budget?.token_count).toBeLessThanOrEqual(1500)
+
+    const tinyBudgetResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 9,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Explain `AuthService.login`',
+          budget: 1,
+          task: 'explain',
+        },
+      },
+    }))
+
+    const tinyBudgetPayload = JSON.parse(((tinyBudgetResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? '') as {
+      serialized_budget?: {
+        max_tokens?: number
+      }
+    }
+
+    expect(tinyBudgetPayload.serialized_budget).toEqual(expect.objectContaining({
+      max_tokens: 1,
+    }))
   })
 
   it('accepts retrieval_strategy=slice-v1 for retrieve and context_pack', async () => {

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -182,6 +182,37 @@ describe('stdio slice-v1 surface', () => {
     expect([...retrieveSnippetLines].some((line) => contextPackSnippetLines.has(line))).toBe(true)
   })
 
+  it('honors explain context_pack budgets below 3000', async () => {
+    const graphPath = createGraphPath()
+
+    const contextPackResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 8,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          prompt: 'Explain `AuthService.login`',
+          budget: 1500,
+          task: 'explain',
+        },
+      },
+    }))
+
+    const contextPackPayload = JSON.parse(((contextPackResponse as { result?: { content?: Array<{ text: string }> } }).result?.content ?? [])[0]?.text ?? '') as {
+      serialized_budget?: {
+        max_tokens?: number
+        token_count?: number
+        enforced?: boolean
+      }
+    }
+
+    expect(contextPackPayload.serialized_budget).toEqual(expect.objectContaining({
+      max_tokens: 1500,
+      enforced: true,
+    }))
+    expect(contextPackPayload.serialized_budget?.token_count).toBeLessThanOrEqual(1500)
+  })
+
   it('accepts retrieval_strategy=slice-v1 for retrieve and context_pack', async () => {
     const graphPath = createGraphPath()
 


### PR DESCRIPTION
Closes #400

## Summary
- enforce answer-ready explain-pack budgets by trimming and selection-aware matched-node culling
- honor explicit explain budgets on the stdio/MCP path and keep cached expandable handles working after culling
- update compare, pack-quality, and stdio regressions around the stricter serialized output surface

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- node dist/src/cli/bin.js generate . --no-html
- node dist/src/cli/bin.js pack "How context-pack budget enforcement works" --task explain --graph out/graph.json --budget 1500 --format json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explanation generation enforces token budgets and records when packs are culled to fit limits; retained content is prioritized.
  * Explain responses now include enforced serialized budget metadata and warnings about culled content.

* **Bug Fixes**
  * More robust handling of optional expandable/follow-up fields and cached payloads; malformed stored handles are rejected with clear errors.
  
* **Tests**
  * Added tests covering budget enforcement, culling warnings, confidence changes, and follow-up/handle validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->