### PR TITLE
Release 0.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.5] - 2026-05-29
+
+### Fixed
+
+- **Answer-ready explain packs now keep promoted runtime-path workflow centers**: explain pack assembly preserves nodes that are simultaneously part of the runtime primary path and promoted into `workflow_centers`, so scope-matched runs no longer emit `slice_path_nodes_not_promoted` for evidence already kept in the pack. Closes #399.
+- **Explain serialization now enforces the declared budget**: answer-ready `madar pack`, MCP `context_pack`, and stdio explain responses now trim lower-value evidence until the serialized payload fits the requested budget, set `serialized_budget.enforced: true` when trimming occurs, and reject malformed stored follow-up handles instead of expanding them silently. Closes #400.
+
 ## [0.27.4] - 2026-05-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.4",
+    "version": "0.27.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.4",
+            "version": "0.27.5",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.4",
+    "version": "0.27.5",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump @lubab/madar to 0.27.5
- document the fixes shipped since 0.27.4
- carry the verified release changelog, package metadata, and lockfile

## Verification
- npm install
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- node dist/src/cli/bin.js --version
- node dist/src/cli/bin.js generate .
- node dist/src/cli/bin.js claude install
- node dist/src/cli/bin.js claude uninstall
- node dist/src/cli/bin.js codex install
- node dist/src/cli/bin.js codex uninstall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where explanation pack assembly incorrectly removed certain nodes from results, improving data consistency
* Fixed explain serialization to properly enforce the requested budget limit by trimming lower-value evidence items and rejecting malformed stored follow-up handles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->