### PR TITLE
Fix SPI readiness detection

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1672,10 +1672,17 @@ function suggestBenchmarkGraphScope(graphPath: string, sourceFiles: readonly str
   return normalizedGraphPath.endsWith(`/${suggested}`) ? null : suggested
 }
 
-function retrievalHasSpiEvidence(retrieval: RetrieveResult): boolean {
-  return collectBenchmarkReadinessSourceFiles(retrieval).some((sourceFile) =>
-    /(^|\/)spi(\/|$)|\.spi\./.test(sourceFile),
-  )
+function graphPathHasSpiMode(graphPath: string): boolean {
+  if (!existsSync(graphPath)) {
+    return false
+  }
+
+  const parsed = JSON.parse(readFileSync(graphPath, 'utf8')) as unknown
+  if (parsed === null || typeof parsed !== 'object') {
+    return false
+  }
+
+  return (parsed as { spi_mode?: unknown }).spi_mode === true
 }
 
 function benchmarkReadinessSeverity(current: BenchmarkReadinessStatus, next: BenchmarkReadinessStatus): BenchmarkReadinessStatus {
@@ -1729,7 +1736,7 @@ export function assessBenchmarkReadinessFromRetrieveResult(input: {
     reasons.push('runtime slice confidence is medium')
   }
 
-  if (!retrievalHasSpiEvidence(retrieval)) {
+  if (!graphPathHasSpiMode(graphPath)) {
     status = benchmarkReadinessSeverity(status, suggestedGraphScope ? 'not_ready' : 'degraded')
     reasons.push(
       suggestedGraphScope

--- a/src/infrastructure/generate.ts
+++ b/src/infrastructure/generate.ts
@@ -438,6 +438,9 @@ export function generateGraph(rootPath = '.', options: GenerateGraphOptions = {}
   )
 
   graph.graph.root_path = resolvedRootPath
+  if (options.useSpi) {
+    graph.graph.spi_mode = true
+  }
 
   progress?.({ step: 'export', message: 'Writing outputs...' })
   writeFileSync(reportPath, `${report}\n`, 'utf8')

--- a/src/pipeline/export.ts
+++ b/src/pipeline/export.ts
@@ -391,6 +391,7 @@ export function toJson(
     schema_version: graph.graph.schema_version === 2 ? 2 : 1,
     directed: graph.isDirected(),
     ...(typeof graph.graph.root_path === 'string' && graph.graph.root_path.length > 0 ? { root_path: graph.graph.root_path } : {}),
+    ...(graph.graph.spi_mode === true ? { spi_mode: true } : {}),
     ...(typeof extractorVersion === 'number' ? { extractor_version: extractorVersion } : {}),
     nodes: graph.nodeEntries().map(([id, attributes]) => ({
       id,

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -4445,6 +4445,17 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
     }
   }
 
+  function writeReadinessGraphFixture(options: {
+    graphFixtureRoot: string
+    spiMode?: boolean
+  }): string {
+    const graph = makeGraph()
+    if (options.spiMode === true) {
+      graph.graph.spi_mode = true
+    }
+    return writeGraphFixture(graph, options.graphFixtureRoot)
+  }
+
   it('marks root non-SPI runtime-generation packs not ready and suggests a scoped backend graph', () => {
     const readiness = assessBenchmarkReadinessFromRetrieveResult({
       graphPath: '/repo/out/graph.json',
@@ -4489,9 +4500,77 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
     expect(readiness.suggested_graph_scope).toBe('backend/out/graph.json')
   })
 
-  it('marks root SPI runtime-generation packs degraded when downstream phases are still missing', () => {
+  it('treats SPI-mode graph metadata as SPI evidence for app-file runtime packs', () => {
+    const graphPath = writeReadinessGraphFixture({
+      graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'backend', 'out'),
+      spiMode: true,
+    })
+
     const readiness = assessBenchmarkReadinessFromRetrieveResult({
-      graphPath: '/repo/out/graph.json',
+      graphPath,
+      retrieval: makeRuntimeGenerationRetrieval({
+        matched_nodes: [
+          {
+            label: 'GenerateIdeaReportService.handle',
+            source_file: 'backend/src/modules/ideas/application/generate-idea-report.service.ts',
+            line_number: 42,
+            file_type: 'code',
+            snippet: null,
+            match_score: 12,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+      }),
+    })
+
+    expect(readiness).toEqual({
+      status: 'ready',
+      reasons: [],
+      suggested_graph_scope: null,
+    })
+  })
+
+  it('keeps non-SPI app-file runtime packs flagged as missing SPI evidence', () => {
+    const graphPath = writeReadinessGraphFixture({
+      graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'backend', 'out'),
+    })
+
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath,
+      retrieval: makeRuntimeGenerationRetrieval({
+        matched_nodes: [
+          {
+            label: 'GenerateIdeaReportService.handle',
+            source_file: 'backend/src/modules/ideas/application/generate-idea-report.service.ts',
+            line_number: 42,
+            file_type: 'code',
+            snippet: null,
+            match_score: 12,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+      }),
+    })
+
+    expect(readiness).toEqual({
+      status: 'degraded',
+      reasons: ['no SPI evidence found in the current pack'],
+      suggested_graph_scope: null,
+    })
+  })
+
+  it('marks root SPI runtime-generation packs degraded when downstream phases are still missing', () => {
+    const graphPath = writeReadinessGraphFixture({
+      graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'out'),
+      spiMode: true,
+    })
+
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath,
       retrieval: makeRuntimeGenerationRetrieval({
         matched_nodes: [
           {
@@ -4597,8 +4676,13 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
   })
 
   it('marks backend SPI runtime-generation packs ready when runtime spine evidence is covered', () => {
+    const graphPath = writeReadinessGraphFixture({
+      graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'backend', 'out'),
+      spiMode: true,
+    })
+
     const readiness = assessBenchmarkReadinessFromRetrieveResult({
-      graphPath: '/repo/backend/out/graph.json',
+      graphPath,
       retrieval: makeRuntimeGenerationRetrieval({
         matched_nodes: [
           {
@@ -4623,9 +4707,13 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
     })
   })
 
-  it('treats top-level spi paths as SPI evidence', () => {
+  it('does not treat top-level spi paths as SPI evidence without SPI graph metadata', () => {
+    const graphPath = writeReadinessGraphFixture({
+      graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'spi', 'out'),
+    })
+
     const readiness = assessBenchmarkReadinessFromRetrieveResult({
-      graphPath: '/repo/spi/out/graph.json',
+      graphPath,
       retrieval: makeRuntimeGenerationRetrieval({
         matched_nodes: [
           {
@@ -4644,8 +4732,8 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
     })
 
     expect(readiness).toEqual({
-      status: 'ready',
-      reasons: [],
+      status: 'degraded',
+      reasons: ['no SPI evidence found in the current pack'],
       suggested_graph_scope: null,
     })
   })

--- a/tests/unit/generate-spi-flag.test.ts
+++ b/tests/unit/generate-spi-flag.test.ts
@@ -52,10 +52,14 @@ describe('generateGraph useSpi:true (v0.18)', () => {
     ].join('\n') + '\n')
 
     const result = generateGraph(sandbox, { useSpi: true, noHtml: true })
+    const parsed = JSON.parse(readFileSync(result.graphPath, 'utf8')) as {
+      spi_mode?: unknown
+    }
 
     // Standard graph.json should exist with code nodes for foo + bar.
     expect(existsSync(result.graphPath)).toBe(true)
     expect(result.nodeCount).toBeGreaterThan(0)
+    expect(parsed.spi_mode).toBe(true)
 
     // Notes should reference the SPI pipeline.
     const hasSpiNote = result.notes.some((note) => note.toLowerCase().includes('spi'))
@@ -134,9 +138,13 @@ describe('generateGraph useSpi:true (v0.18)', () => {
     writeFile(sandbox, 'src/foo.ts', 'export function foo(): number { return 1 }\n')
 
     const result = generateGraph(sandbox, { noHtml: true })
+    const parsed = JSON.parse(readFileSync(result.graphPath, 'utf8')) as {
+      spi_mode?: unknown
+    }
 
     // No SPI notes in the legacy path.
     const hasSpiNote = result.notes.some((note) => note.toLowerCase().includes('spi'))
     expect(hasSpiNote).toBe(false)
+    expect(parsed.spi_mode).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- persist an explicit `spi_mode` flag in exported SPI graphs
- make compare benchmark readiness read SPI status from graph metadata instead of source-file path strings
- add regressions for SPI-mode app-file graphs and generate-time graph header export

Closes #404

## Verification
- npm run test:run -- tests/unit/compare.test.ts tests/unit/generate-spi-flag.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved SPI evidence detection: Benchmark readiness assessments now use direct graph metadata flags to determine SPI support status, replacing the previous file-path-based detection method. This enhances accuracy and reliability of readiness evaluations, providing more consistent and dependable assessment results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->