### PR TITLE
Fix PR 409 review follow-up

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1677,12 +1677,16 @@ function graphPathHasSpiMode(graphPath: string): boolean {
     return false
   }
 
-  const parsed = JSON.parse(readFileSync(graphPath, 'utf8')) as unknown
-  if (parsed === null || typeof parsed !== 'object') {
+  try {
+    const parsed = JSON.parse(readFileSync(graphPath, 'utf8')) as unknown
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return false
+    }
+
+    return (parsed as { spi_mode?: unknown }).spi_mode === true
+  } catch {
     return false
   }
-
-  return (parsed as { spi_mode?: unknown }).spi_mode === true
 }
 
 function benchmarkReadinessSeverity(current: BenchmarkReadinessStatus, next: BenchmarkReadinessStatus): BenchmarkReadinessStatus {

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -4563,6 +4563,38 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
     })
   })
 
+  it('fails closed when SPI graph metadata cannot be parsed', () => {
+    const graphFixtureRoot = join(PROJECT_FIXTURE_ROOT, 'backend', 'out')
+    mkdirSync(graphFixtureRoot, { recursive: true })
+    const graphPath = join(graphFixtureRoot, 'graph.json')
+    writeFileSync(graphPath, '{not-valid-json', 'utf8')
+
+    const readiness = assessBenchmarkReadinessFromRetrieveResult({
+      graphPath,
+      retrieval: makeRuntimeGenerationRetrieval({
+        matched_nodes: [
+          {
+            label: 'GenerateIdeaReportService.handle',
+            source_file: 'backend/src/modules/ideas/application/generate-idea-report.service.ts',
+            line_number: 42,
+            file_type: 'code',
+            snippet: null,
+            match_score: 12,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+      }),
+    })
+
+    expect(readiness).toEqual({
+      status: 'degraded',
+      reasons: ['no SPI evidence found in the current pack'],
+      suggested_graph_scope: null,
+    })
+  })
+
   it('marks root SPI runtime-generation packs degraded when downstream phases are still missing', () => {
     const graphPath = writeReadinessGraphFixture({
       graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'out'),

--- a/tests/unit/generate-spi-flag.test.ts
+++ b/tests/unit/generate-spi-flag.test.ts
@@ -147,4 +147,20 @@ describe('generateGraph useSpi:true (v0.18)', () => {
     expect(hasSpiNote).toBe(false)
     expect(parsed.spi_mode).toBeUndefined()
   })
+
+  it('clears stale spi_mode on a non-SPI update after an SPI build', () => {
+    writeFile(sandbox, 'src/foo.ts', 'export function foo(): number { return 1 }\n')
+
+    const spiResult = generateGraph(sandbox, { useSpi: true, noHtml: true })
+    const spiGraph = JSON.parse(readFileSync(spiResult.graphPath, 'utf8')) as {
+      spi_mode?: unknown
+    }
+    expect(spiGraph.spi_mode).toBe(true)
+
+    const updated = generateGraph(sandbox, { update: true, noHtml: true })
+    const updatedGraph = JSON.parse(readFileSync(updated.graphPath, 'utf8')) as {
+      spi_mode?: unknown
+    }
+    expect(updatedGraph.spi_mode).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- make SPI readiness detection fail closed when `graph.json` cannot be parsed
- add a regression for invalid SPI metadata parsing in compare readiness
- add a non-repro regression proving non-SPI `--update` runs do not keep stale `spi_mode` on current main

## Context
- follow-up to merged PR #409 after verifying the unresolved CodeRabbit threads
- the invalid-JSON comment was valid and is fixed here
- the stale `spi_mode` comment does not reproduce on current main and is locked with a passing regression

## Verification
- npm run test:run -- tests/unit/compare.test.ts tests/unit/generate-spi-flag.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for SPI configuration files; invalid or malformed JSON now triggers graceful service degradation with appropriate status indicators instead of throwing exceptions.
  * Improved SPI mode detection logic to properly handle edge cases with non-standard JSON values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->