### PR TITLE
Boost prompt identifier retrieval

### DIFF
--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -835,6 +835,7 @@ interface SeedScoreBreakdown {
   labelExactScore: number
   labelTokenScore: number
   sourcePathScore: number
+  promptIdentifierScore: number
   communityScore: number
   total: number
 }
@@ -973,6 +974,11 @@ interface SymbolReference {
   methodName?: string
 }
 
+interface PromptIdentifierSignal {
+  normalized: string
+  tokenCount: number
+}
+
 function activeFrameworksForProfile(profile: FrameworkQuestionProfile): ReadonlySet<string> {
   const frameworks = new Set<string>()
   if (profile.express) frameworks.add('express')
@@ -1003,6 +1009,15 @@ function normalizeSeedText(value: string): string {
 
 function normalizeIdentifier(value: string): string {
   return normalizeSeedText(value.replace(/\(\)$/, ''))
+}
+
+function normalizedPromptIdentifier(value: string): string {
+  return tokenizeLabel(
+    value
+      .replace(/^[`'"]+|[`'"]+$/g, '')
+      .replace(/\(\)$/, '')
+      .replace(/\.[A-Za-z0-9]{1,6}$/, ''),
+  ).join('')
 }
 
 function compareStableText(left: string, right: string): number {
@@ -1053,6 +1068,111 @@ function labelSymbolParts(label: string): { className?: string; methodName?: str
     ...(methodOnlyMatch?.[1] ? { methodName: methodOnlyMatch[1] } : {}),
     normalized,
   }
+}
+
+function explicitPromptIdentifierSet(
+  mentionedSymbolRefs: readonly SymbolReference[],
+  mentionedPaths: readonly string[],
+): ReadonlySet<string> {
+  const explicit = new Set<string>()
+
+  for (const reference of mentionedSymbolRefs) {
+    for (const value of [reference.raw, reference.bareName, reference.className, reference.methodName]) {
+      if (typeof value !== 'string' || value.trim().length === 0) {
+        continue
+      }
+      const normalized = normalizedPromptIdentifier(value)
+      if (normalized.length > 0) {
+        explicit.add(normalized)
+      }
+    }
+  }
+
+  for (const path of mentionedPaths) {
+    const normalizedPath = normalizedPromptIdentifier(path)
+    if (normalizedPath.length > 0) {
+      explicit.add(normalizedPath)
+    }
+    const normalizedBase = normalizedPromptIdentifier(basename(path))
+    if (normalizedBase.length > 0) {
+      explicit.add(normalizedBase)
+    }
+  }
+
+  return explicit
+}
+
+function extractPromptIdentifierSignals(
+  question: string,
+  mentionedSymbolRefs: readonly SymbolReference[],
+  mentionedPaths: readonly string[],
+): PromptIdentifierSignal[] {
+  const explicit = explicitPromptIdentifierSet(mentionedSymbolRefs, mentionedPaths)
+  const seen = new Set<string>()
+  const signals: PromptIdentifierSignal[] = []
+  const candidates = question.match(/[A-Za-z0-9_./-]+/g) ?? []
+
+  for (const candidate of candidates) {
+    if (!/[A-Za-z]/.test(candidate)) {
+      continue
+    }
+    if (!(/[_./-]/.test(candidate) || /[a-z][A-Z]/.test(candidate) || /[A-Z][a-z]+[A-Z]/.test(candidate))) {
+      continue
+    }
+
+    const tokens = tokenizeLabel(candidate)
+    if (tokens.length < 2) {
+      continue
+    }
+
+    const normalized = normalizedPromptIdentifier(candidate)
+    if (normalized.length < 6 || explicit.has(normalized) || seen.has(normalized)) {
+      continue
+    }
+
+    seen.add(normalized)
+    signals.push({
+      normalized,
+      tokenCount: tokens.length,
+    })
+  }
+
+  return signals
+}
+
+function promptIdentifierMatchScore(
+  label: string,
+  sourceFile: string,
+  identifiers: readonly PromptIdentifierSignal[],
+): number {
+  if (identifiers.length === 0) {
+    return 0
+  }
+
+  const normalizedLabel = normalizeIdentifier(label)
+  const normalizedSource = normalizeSeedText(sourceFile)
+  let best = 0
+
+  for (const identifier of identifiers) {
+    const labelContains = normalizedLabel.includes(identifier.normalized)
+    const sourceContains = normalizedSource.includes(identifier.normalized)
+    if (!labelContains && !sourceContains) {
+      continue
+    }
+
+    const specificityBonus = Math.min(0.35, Math.max(0, identifier.tokenCount - 2) * 0.15)
+    let score = labelContains ? 1.1 : 0.8
+    if (sourceContains) {
+      score += labelContains ? 0.35 : 0.25
+    }
+    if (normalizedLabel === identifier.normalized) {
+      score += 0.2
+    }
+
+    best = Math.max(best, Math.min(1.75, score + specificityBonus))
+  }
+
+  return best
 }
 
 /**
@@ -1204,7 +1324,7 @@ function evidenceTierForSeedScore(score: SeedScoreBreakdown): 0 | 1 | 2 {
   if (score.labelExactScore > 0 || score.labelTokenScore > 0) {
     return 2
   }
-  if (score.sourcePathScore > 0 || score.communityScore > 0) {
+  if (score.sourcePathScore > 0 || score.promptIdentifierScore > 0 || score.communityScore > 0) {
     return 1
   }
   return 0
@@ -1394,6 +1514,7 @@ function scoreSeedCandidate(
   label: string,
   sourceFile: string,
   communityLabel: string | null,
+  promptIdentifiers: readonly PromptIdentifierSignal[],
   tokenWeights: ReadonlyMap<string, number>,
   averageLabelLength: number,
   options: { fileNodeLike: boolean; fileOrientedQuestion: boolean },
@@ -1402,6 +1523,7 @@ function scoreSeedCandidate(
   const fileNodePenaltyApplies = options.fileNodeLike && !options.fileOrientedQuestion && labelExactScore === 0
   const labelTokenScore = fileNodePenaltyApplies ? 0 : scoreNode(questionTokens, tokenizeLabel(label), tokenWeights, averageLabelLength)
   const sourcePathScore = fileNodePenaltyApplies ? 0 : scoreNode(questionTokens, tokenizeLabel(sourceFile), tokenWeights) * 0.25
+  const promptIdentifierScore = fileNodePenaltyApplies ? 0 : promptIdentifierMatchScore(label, sourceFile, promptIdentifiers)
   const communityScore = fileNodePenaltyApplies
     ? 0
     : communityLabel
@@ -1412,8 +1534,9 @@ function scoreSeedCandidate(
     labelExactScore,
     labelTokenScore,
     sourcePathScore,
+    promptIdentifierScore,
     communityScore,
-    total: labelExactScore + labelTokenScore + sourcePathScore + communityScore,
+    total: labelExactScore + labelTokenScore + sourcePathScore + promptIdentifierScore + communityScore,
   }
 }
 
@@ -4011,6 +4134,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
   }
   const mentionedSymbolRefs = retrievalGate.signals.mentioned_symbols.map(parseSymbolReference)
   const mentionedPaths = retrievalGate.signals.mentioned_paths
+  const promptIdentifiers = extractPromptIdentifierSignals(question, mentionedSymbolRefs, mentionedPaths)
   const excludedDomains = retrievalGate.signals.excluded_domains ?? []
   const excludedTerms = retrievalGate.signals.excluded_terms ?? []
   const excludedPathHints = retrievalGate.signals.excluded_path_hints ?? []
@@ -4046,6 +4170,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       label,
       sourceFile,
       community !== null ? (communityLabels[community] ?? null) : null,
+      promptIdentifiers,
       tokenWeights,
       averageLabelLength,
       { fileNodeLike, fileOrientedQuestion },
@@ -4149,10 +4274,11 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
   const fusedSeedScores = reciprocalRankFuse([
     rankedSeedCandidateIds(graph, filteredSeedCandidates, (candidate) => candidate.seedScore.labelExactScore),
     rankedSeedCandidateIds(graph, filteredSeedCandidates, (candidate) => candidate.seedScore.labelTokenScore),
+    rankedSeedCandidateIds(graph, filteredSeedCandidates, (candidate) => candidate.seedScore.promptIdentifierScore),
     rankedSeedCandidateIds(graph, filteredSeedCandidates, (candidate) => candidate.seedScore.sourcePathScore),
     rankedSeedCandidateIds(graph, filteredSeedCandidates, (candidate) => candidate.seedScore.communityScore),
   ], {
-    weights: [2, 1.5, 0.5, 0.25],
+    weights: [2, 1.5, 0.5, 0.25, 0.25],
   })
   const scored: ScoredNode[] = filteredSeedCandidates.map((candidate) => ({
     id: candidate.id,

--- a/tests/unit/retrieve-prompt-symbol-boost.test.ts
+++ b/tests/unit/retrieve-prompt-symbol-boost.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { compactRetrieveResult, retrieveContext } from '../../src/runtime/retrieve.js'
+
+function buildPromptCompetitionGraph(): KnowledgeGraph {
+  const graph = new KnowledgeGraph()
+
+  graph.addNode('service', {
+    label: 'CheckoutFlowService',
+    source_file: '/src/checkout/CheckoutFlowService.ts',
+    line_number: 1,
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+
+  graph.addNode('persist', {
+    label: 'PersistOrderCenter',
+    source_file: '/src/checkout/PersistOrderCenter.ts',
+    line_number: 10,
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+
+  graph.addNode('audit_helper', {
+    label: 'ComposeEnvelopePayload',
+    source_file: '/src/checkout/helpers/audit-envelope-helper.ts',
+    line_number: 20,
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+
+  graph.addNode('generic_helper', {
+    label: 'CheckoutEnvelopeHelper',
+    source_file: '/src/checkout/helpers/CheckoutEnvelopeHelper.ts',
+    line_number: 30,
+    node_kind: 'function',
+    file_type: 'code',
+    community: 0,
+  })
+
+  graph.addEdge('service', 'persist', { relation: 'calls' })
+  graph.addEdge('service', 'audit_helper', { relation: 'calls' })
+  graph.addEdge('service', 'generic_helper', { relation: 'calls' })
+
+  return graph
+}
+
+function buildPromptDivergenceGraph(): KnowledgeGraph {
+  const graph = new KnowledgeGraph()
+
+  for (const [id, label, sourceFile, line] of [
+    ['entry', 'CheckoutFlowController', '/src/checkout/CheckoutFlowController.ts', 0],
+    ['service', 'CheckoutFlowService', '/src/checkout/CheckoutFlowService.ts', 1],
+    ['persist', 'PersistOrderCenter', '/src/checkout/PersistOrderCenter.ts', 10],
+    ['audit_helper', 'ComposeEnvelopePayload', '/src/checkout/helpers/audit-envelope-helper.ts', 20],
+    ['receipt_helper', 'ComposeEnvelopePayload', '/src/checkout/helpers/receipt-envelope-helper.ts', 30],
+    ['summary_helper', 'PrepareCheckoutSummary', '/src/checkout/helpers/PrepareCheckoutSummary.ts', 40],
+    ['ledger_helper', 'WriteCheckoutLedger', '/src/checkout/helpers/WriteCheckoutLedger.ts', 50],
+    ['metrics_helper', 'EmitCheckoutMetrics', '/src/checkout/helpers/EmitCheckoutMetrics.ts', 60],
+  ] as const) {
+    graph.addNode(id, {
+      label,
+      source_file: sourceFile,
+      line_number: line,
+      node_kind: 'function',
+      file_type: 'code',
+      community: 0,
+    })
+  }
+
+  for (const [source, target] of [
+    ['entry', 'service'],
+    ['service', 'persist'],
+    ['service', 'audit_helper'],
+    ['service', 'receipt_helper'],
+    ['service', 'summary_helper'],
+    ['service', 'ledger_helper'],
+    ['service', 'metrics_helper'],
+    ['audit_helper', 'persist'],
+    ['receipt_helper', 'persist'],
+  ] as const) {
+    graph.addEdge(source, target, { relation: 'calls' })
+  }
+
+  return graph
+}
+
+function compactedSourceFiles(question: string): string[] {
+  const result = retrieveContext(buildPromptDivergenceGraph(), {
+    question,
+    budget: 80,
+    fileType: 'code',
+  })
+
+  return compactRetrieveResult(result).matched_nodes.map((node) => node.source_file)
+}
+
+describe('retrieve prompt-symbol boost', () => {
+  it('promotes a plain prompt identifier over a stronger generic checkout helper', () => {
+    const result = retrieveContext(buildPromptCompetitionGraph(), {
+      question: 'Explain the checkout flow around auditEnvelopeHelper',
+      budget: 120,
+      fileType: 'code',
+    })
+
+    const sourceFiles = result.matched_nodes.map((node) => node.source_file)
+    expect(sourceFiles).toContain('/src/checkout/helpers/audit-envelope-helper.ts')
+    expect(sourceFiles).toContain('/src/checkout/helpers/CheckoutEnvelopeHelper.ts')
+    expect(sourceFiles.indexOf('/src/checkout/helpers/audit-envelope-helper.ts')).toBeLessThan(
+      sourceFiles.indexOf('/src/checkout/helpers/CheckoutEnvelopeHelper.ts'),
+    )
+  })
+
+  it('changes compact packs for different plain prompt identifiers without dropping the workflow spine', () => {
+    const auditPack = compactedSourceFiles('Explain the checkout flow around auditEnvelopeHelper')
+    const receiptPack = compactedSourceFiles('Explain the checkout flow around receiptEnvelopeHelper')
+
+    expect(auditPack).not.toEqual(receiptPack)
+
+    expect(auditPack).toContain('/src/checkout/helpers/audit-envelope-helper.ts')
+    expect(receiptPack).toContain('/src/checkout/helpers/receipt-envelope-helper.ts')
+
+    for (const pack of [auditPack, receiptPack]) {
+      expect(pack).toContain('/src/checkout/CheckoutFlowService.ts')
+      expect(pack).toContain('/src/checkout/PersistOrderCenter.ts')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add a bounded prompt-identifier retrieval signal for plain identifier-shaped prompt terms
- feed that signal into seed ranking without touching frameworkBoost
- cover helper promotion and compact-pack divergence with focused regressions

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved retrieval results through enhanced ranking logic that considers identifiers mentioned in queries, helping surface the most relevant information more consistently.

* **Tests**
  * Added test coverage validating identifier-based retrieval improvements, ensuring proper prioritization across various query scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->