### PR TITLE
chore: release 0.27.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.6] - 2026-05-29
+
+### Changed
+
+- **The legacy `madar add <url>` surface is removed from the public CLI**: Madar now stays explicitly local-codebase-only at the command surface, while `save-result` remains available for exporting query results and older ingest-produced artifacts still preserve their legacy `builtin:ingest:*` provenance when they are read back.
+
 ## [0.27.5] - 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ Want a broader local-first walkthrough that also covers install, `prompt`, and a
 
 ---
 
-## What's new in 0.27.4
+## What's new in 0.27.6
 
-See the [`0.27.4` changelog entry](CHANGELOG.md#0274---2026-05-29) for the full release notes.
+See the [`0.27.6` changelog entry](CHANGELOG.md#0276---2026-05-29) for the full release notes.
+
+This patch removes the legacy `madar add <url>` ingest surface, keeps `save-result` available for exporting query results, and preserves backward-compatible legacy ingest provenance for older saved artifacts.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -98,7 +100,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.4. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.6. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.5",
+    "version": "0.27.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.5",
+            "version": "0.27.6",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.5",
+    "version": "0.27.6",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump the package metadata and lockfile to 0.27.6
- add the 0.27.6 changelog entry for the local-only ingest-boundary change
- refresh the README release section to point at 0.27.6

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.27.6

* **Breaking Changes**
  * Removed legacy CLI command for remote URL ingestion; tool now operates on local codebase only.

* **Documentation**
  * Updated release notes documenting CLI surface changes and backward compatibility for legacy artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohanagy/madar/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->