### PR TITLE
[Roadmap] Publish and validate MCP Registry metadata

### DIFF
--- a/.github/scripts/validate-mcp-registry.mjs
+++ b/.github/scripts/validate-mcp-registry.mjs
@@ -1,0 +1,225 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { strict as assert } from 'node:assert'
+
+import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
+
+const PACKAGE_JSON_PATH = resolve('package.json')
+const REGISTRY_MANIFEST_PATH = resolve('docs/mcp-registry/server.json')
+const REPOSITORY_ID = '1207912024'
+const REPOSITORY_URL = 'https://github.com/mohanagy/madar'
+const REGISTRY_NAME = 'io.github.mohanagy/madar'
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org'
+
+const registryManifestSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  required: ['$schema', 'name', 'description', 'repository', 'version', 'packages'],
+  properties: {
+    $schema: {
+      type: 'string',
+      format: 'uri',
+      pattern: '^https://static\\.modelcontextprotocol\\.io/schemas/.+/server\\.schema\\.json$',
+    },
+    name: {
+      type: 'string',
+      pattern: '^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$',
+    },
+    description: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 100,
+    },
+    title: {
+      type: 'string',
+      minLength: 1,
+    },
+    websiteUrl: {
+      type: 'string',
+      format: 'uri',
+    },
+    repository: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['id', 'source', 'url'],
+      properties: {
+        id: {
+          type: 'string',
+        },
+        source: {
+          const: 'github',
+        },
+        url: {
+          const: REPOSITORY_URL,
+        },
+      },
+    },
+    version: {
+      type: 'string',
+      minLength: 1,
+    },
+    packages: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['registryType', 'registryBaseUrl', 'identifier', 'version', 'runtimeHint', 'transport', 'packageArguments', 'environmentVariables'],
+        properties: {
+          registryType: {
+            const: 'npm',
+          },
+          registryBaseUrl: {
+            const: NPM_REGISTRY_URL,
+          },
+          identifier: {
+            type: 'string',
+            minLength: 1,
+          },
+          version: {
+            type: 'string',
+            minLength: 1,
+          },
+          runtimeHint: {
+            const: 'npx',
+          },
+          transport: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['type'],
+            properties: {
+              type: {
+                const: 'stdio',
+              },
+            },
+          },
+          packageArguments: {
+            type: 'array',
+            minItems: 3,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['type'],
+              properties: {
+                type: {
+                  const: 'positional',
+                },
+                value: {
+                  type: 'string',
+                },
+                valueHint: {
+                  type: 'string',
+                },
+                description: {
+                  type: 'string',
+                },
+                default: {
+                  type: 'string',
+                },
+                format: {
+                  type: 'string',
+                },
+                isRequired: {
+                  type: 'boolean',
+                },
+              },
+              oneOf: [
+                { required: ['value'] },
+                { required: ['valueHint'] },
+              ],
+            },
+          },
+          environmentVariables: {
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['name', 'description', 'default', 'choices'],
+              properties: {
+                name: {
+                  type: 'string',
+                },
+                description: {
+                  type: 'string',
+                },
+                default: {
+                  type: 'string',
+                },
+                choices: {
+                  type: 'array',
+                  minItems: 1,
+                  items: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    _meta: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        'io.modelcontextprotocol.registry/publisher-provided': {
+          type: 'object',
+          additionalProperties: true,
+        },
+      },
+    },
+  },
+}
+
+function loadJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function main() {
+  const packageManifest = loadJson(PACKAGE_JSON_PATH)
+  const registryManifest = loadJson(REGISTRY_MANIFEST_PATH)
+  const ajv = new Ajv({ allErrors: true, allowUnionTypes: true })
+  addFormats(ajv)
+
+  const validate = ajv.compile(registryManifestSchema)
+  const valid = validate(registryManifest)
+  if (!valid) {
+    console.error('MCP Registry metadata schema validation failed.')
+    console.error(JSON.stringify(validate.errors, null, 2))
+    process.exit(1)
+  }
+
+  assert.equal(registryManifest.name, REGISTRY_NAME, 'server.json name must use the verified GitHub namespace')
+  assert.equal(registryManifest.repository.id, REPOSITORY_ID, 'server.json repository.id must match the GitHub repository id')
+  assert.equal(registryManifest.version, packageManifest.version, 'server.json version must match package.json version')
+
+  const [npmPackage] = registryManifest.packages
+  assert.ok(npmPackage, 'server.json must define one npm package entry')
+  assert.equal(npmPackage.identifier, packageManifest.name, 'server.json package identifier must match package.json name')
+  assert.equal(npmPackage.version, packageManifest.version, 'server.json package version must match package.json version')
+
+  const packageArguments = npmPackage.packageArguments ?? []
+  assert.deepEqual(
+    packageArguments.map((entry) => entry.value ?? entry.valueHint ?? null),
+    ['serve', '--stdio', 'graph_path'],
+    'server.json package arguments must model `madar serve --stdio <graph_path>`',
+  )
+
+  const graphPathArgument = packageArguments.find((entry) => entry.valueHint === 'graph_path')
+  assert.ok(graphPathArgument, 'server.json must require a graph_path positional argument')
+  assert.equal(graphPathArgument.default, 'out/graph.json', 'graph_path should default to out/graph.json')
+  assert.equal(graphPathArgument.format, 'filepath', 'graph_path should be marked as a filepath input')
+  assert.equal(graphPathArgument.isRequired, true, 'graph_path should be required')
+
+  const toolProfile = (npmPackage.environmentVariables ?? []).find((entry) => entry.name === 'MADAR_TOOL_PROFILE')
+  assert.ok(toolProfile, 'server.json must describe the MADAR_TOOL_PROFILE environment variable')
+  assert.equal(toolProfile.default, 'core', 'MADAR_TOOL_PROFILE should default to core')
+  assert.deepEqual(toolProfile.choices, ['core', 'full'], 'MADAR_TOOL_PROFILE choices must match the supported MCP tool profiles')
+
+  console.log(`Validated ${REGISTRY_MANIFEST_PATH} against the pinned MCP Registry manifest rules.`)
+}
+
+main()

--- a/.github/scripts/validate-mcp-registry.mjs
+++ b/.github/scripts/validate-mcp-registry.mjs
@@ -63,6 +63,7 @@ const registryManifestSchema = {
     packages: {
       type: 'array',
       minItems: 1,
+      maxItems: 1,
       items: {
         type: 'object',
         additionalProperties: false,
@@ -196,8 +197,8 @@ function main() {
   assert.equal(registryManifest.repository.id, REPOSITORY_ID, 'server.json repository.id must match the GitHub repository id')
   assert.equal(registryManifest.version, packageManifest.version, 'server.json version must match package.json version')
 
+  assert.equal(registryManifest.packages.length, 1, 'server.json must define exactly one npm package entry')
   const [npmPackage] = registryManifest.packages
-  assert.ok(npmPackage, 'server.json must define one npm package entry')
   assert.equal(npmPackage.identifier, packageManifest.name, 'server.json package identifier must match package.json name')
   assert.equal(npmPackage.version, packageManifest.version, 'server.json package version must match package.json version')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate MCP Registry metadata
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22'
+        run: npm run registry:validate
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ Codex is intentionally context-pack-first: run `madar generate .`, install with 
 
 For practical multi-agent workflows across Claude Code, Codex, Copilot, Cursor, and Gemini, see the [agent orchestration guide](docs/integrations/agent-orchestration.md).
 
+### MCP Registry metadata
+
+The checked-in public registry manifest lives at [`docs/mcp-registry/server.json`](docs/mcp-registry/server.json). Validate it locally with `npm run registry:validate`.
+
+The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry still points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json` (or let `madar <agent> install` write that wiring for you).
+
+Private registry usage stays out of scope for the public Madar listing because the official MCP Registry only accepts public package sources. Keep private or self-hosted registry workflows separate from this metadata file.
+
 ---
 
 ## MCP tools

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.mohanagy/madar",
+    "description": "Local MCP context packs for AI coding agents.",
+    "title": "Madar",
+    "websiteUrl": "https://github.com/mohanagy/madar",
+    "repository": {
+        "id": "1207912024",
+        "source": "github",
+        "url": "https://github.com/mohanagy/madar"
+    },
+    "version": "0.27.4",
+    "packages": [
+        {
+            "registryType": "npm",
+            "registryBaseUrl": "https://registry.npmjs.org",
+            "identifier": "@lubab/madar",
+            "version": "0.27.4",
+            "runtimeHint": "npx",
+            "transport": {
+                "type": "stdio"
+            },
+            "packageArguments": [
+                {
+                    "type": "positional",
+                    "value": "serve"
+                },
+                {
+                    "type": "positional",
+                    "value": "--stdio"
+                },
+                {
+                    "type": "positional",
+                    "valueHint": "graph_path",
+                    "description": "Path to out/graph.json. Run `madar generate .` first so the local MCP server has a graph artifact to serve.",
+                    "default": "out/graph.json",
+                    "format": "filepath",
+                    "isRequired": true
+                }
+            ],
+            "environmentVariables": [
+                {
+                    "name": "MADAR_TOOL_PROFILE",
+                    "description": "Optional MCP tool surface. Madar installs default to the lean core profile.",
+                    "default": "core",
+                    "choices": [
+                        "core",
+                        "full"
+                    ]
+                }
+            ]
+        }
+    ],
+    "_meta": {
+        "io.modelcontextprotocol.registry/publisher-provided": {
+            "notes": "Public npm package plus local graph artifact install flow.",
+            "source": "docs/mcp-registry/server.json"
+        }
+    }
+}

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ Use this checklist when preparing a new `madar` release. It is intentionally man
 1. Update the package version with `npm version <patch|minor|major>`.
 2. Review `package.json` and `package-lock.json` to confirm the new version is correct.
 3. Update `CHANGELOG.md` with the user-visible changes in the release.
-4. Make sure any linked docs, examples, or install flows reflect the new behavior.
+4. Make sure any linked docs, examples, install flows, and `docs/mcp-registry/server.json` reflect the new behavior.
 5. Any new public claim requires a reproducible artifact under `docs/benchmarks/suite/` and a matching update to `docs/claims-and-evidence.md` before the README or release notes can say it publicly.
 
 ## 2. Run the required verification commands
@@ -16,13 +16,14 @@ From the repository root:
 
 ```bash
 npm install
+npm run registry:validate
 npm run typecheck
 npm run build
 npm run test:run
 npm pack --dry-run
 ```
 
-If the change touches packaging or installer behavior, keep the `npm pack --dry-run` output with the release notes or pull request for easy review.
+If the change touches packaging, installer behavior, or public MCP Registry metadata, keep the `npm pack --dry-run` output with the release notes or pull request for easy review.
 
 ## 3. Run manual CLI smoke checks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
             "devDependencies": {
                 "@types/node": "^25.6.0",
                 "@vitest/coverage-v8": "^4.1.5",
+                "ajv": "^8.20.0",
+                "ajv-formats": "^3.0.1",
                 "vite": "^8.0.11",
                 "vitest": "^4.1.5"
             },
@@ -635,6 +637,41 @@
             "version": "0.3.1",
             "license": "MIT"
         },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -740,6 +777,30 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -848,6 +909,13 @@
         },
         "node_modules/js-tokens": {
             "version": "10.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
         },
@@ -1251,6 +1319,16 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/rolldown": {

--- a/package.json
+++ b/package.json
@@ -61,11 +61,14 @@
         "prepack": "npm run clean && npm run build",
         "pack:dry-run": "npm pack --dry-run",
         "publish:public": "npm publish --access public",
-        "publish:dry-run": "npm publish --dry-run"
+        "publish:dry-run": "npm publish --dry-run",
+        "registry:validate": "node .github/scripts/validate-mcp-registry.mjs"
     },
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "vite": "^8.0.11",
         "vitest": "^4.1.5"
     },

--- a/tests/unit/mcp-registry-metadata.test.ts
+++ b/tests/unit/mcp-registry-metadata.test.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+interface PackageManifest {
+  name?: string
+  scripts?: Record<string, string>
+  version?: string
+}
+
+interface RegistryEnvironmentVariable {
+  name?: string
+  default?: string
+  choices?: string[]
+}
+
+interface RegistryPackageArgument {
+  type?: string
+  value?: string
+  valueHint?: string
+  default?: string
+  description?: string
+  format?: string
+  isRequired?: boolean
+}
+
+interface RegistryPackage {
+  registryType?: string
+  registryBaseUrl?: string
+  identifier?: string
+  version?: string
+  runtimeHint?: string
+  transport?: {
+    type?: string
+  }
+  packageArguments?: RegistryPackageArgument[]
+  environmentVariables?: RegistryEnvironmentVariable[]
+}
+
+interface RegistryManifest {
+  $schema?: string
+  name?: string
+  description?: string
+  repository?: {
+    id?: string
+    source?: string
+    url?: string
+  }
+  version?: string
+  packages?: RegistryPackage[]
+}
+
+function loadPackageManifest(): PackageManifest {
+  return JSON.parse(readFileSync(resolve('package.json'), 'utf8')) as PackageManifest
+}
+
+function loadRegistryManifest(): RegistryManifest {
+  return JSON.parse(readFileSync(resolve('docs/mcp-registry/server.json'), 'utf8')) as RegistryManifest
+}
+
+describe('MCP Registry metadata', () => {
+  it('keeps the checked-in server.json aligned with the published Madar npm package and install flow', () => {
+    expect(existsSync(resolve('docs/mcp-registry/server.json'))).toBe(true)
+
+    const packageManifest = loadPackageManifest()
+    const registryManifest = loadRegistryManifest()
+    const npmPackage = registryManifest.packages?.[0]
+    const graphPathArgument = npmPackage?.packageArguments?.find((entry) => entry.valueHint === 'graph_path')
+    const toolProfile = npmPackage?.environmentVariables?.find((entry) => entry.name === 'MADAR_TOOL_PROFILE')
+
+    expect(registryManifest.$schema).toContain('static.modelcontextprotocol.io/schemas/')
+    expect(registryManifest.name).toBe('io.github.mohanagy/madar')
+    expect(registryManifest.description?.toLowerCase()).toContain('local')
+    expect(registryManifest.repository).toEqual({
+      id: '1207912024',
+      source: 'github',
+      url: 'https://github.com/mohanagy/madar',
+    })
+    expect(registryManifest.version).toBe(packageManifest.version)
+    expect(npmPackage).toMatchObject({
+      registryType: 'npm',
+      registryBaseUrl: 'https://registry.npmjs.org',
+      identifier: packageManifest.name,
+      version: packageManifest.version,
+      runtimeHint: 'npx',
+      transport: { type: 'stdio' },
+    })
+    expect(npmPackage?.packageArguments?.map((entry) => entry.value)).toEqual([
+      'serve',
+      '--stdio',
+      undefined,
+    ])
+    expect(graphPathArgument).toMatchObject({
+      type: 'positional',
+      valueHint: 'graph_path',
+      default: 'out/graph.json',
+      format: 'filepath',
+      isRequired: true,
+    })
+    expect(graphPathArgument?.description?.toLowerCase()).toContain('madar generate')
+    expect(toolProfile).toMatchObject({
+      name: 'MADAR_TOOL_PROFILE',
+      default: 'core',
+    })
+    expect(toolProfile?.choices).toEqual(expect.arrayContaining(['core', 'full']))
+  })
+
+  it('exposes a repeatable local validation command for the checked-in registry metadata', () => {
+    const packageManifest = loadPackageManifest()
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+    expect(packageManifest.scripts?.['registry:validate']).toBeDefined()
+
+    expect(() =>
+      execFileSync(npmCommand, ['run', 'registry:validate'], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }),
+    ).not.toThrow()
+  })
+
+  it('documents the public-registry decision, validation command, and local-first trust boundary', () => {
+    const readme = readFileSync(resolve('README.md'), 'utf8')
+    const releaseDoc = readFileSync(resolve('docs/release.md'), 'utf8')
+
+    expect(readme).toContain('docs/mcp-registry/server.json')
+    expect(readme).toContain('npm run registry:validate')
+    expect(readme).toContain('The official MCP Registry hosts metadata, not Madar code or your local graph artifact.')
+    expect(readme).toContain('Private registry usage stays out of scope for the public Madar listing')
+    expect(releaseDoc).toContain('npm run registry:validate')
+  })
+})

--- a/tests/unit/mcp-registry-metadata.test.ts
+++ b/tests/unit/mcp-registry-metadata.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -109,17 +110,48 @@ describe('MCP Registry metadata', () => {
 
   it('exposes a repeatable local validation command for the checked-in registry metadata', () => {
     const packageManifest = loadPackageManifest()
-    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 
-    expect(packageManifest.scripts?.['registry:validate']).toBeDefined()
+    expect(packageManifest.scripts?.['registry:validate']).toBe('node .github/scripts/validate-mcp-registry.mjs')
 
     expect(() =>
-      execFileSync(npmCommand, ['run', 'registry:validate'], {
+      execFileSync(process.execPath, [resolve('.github/scripts/validate-mcp-registry.mjs')], {
         cwd: process.cwd(),
         encoding: 'utf8',
         stdio: 'pipe',
       }),
     ).not.toThrow()
+  })
+
+  it('rejects duplicate package entries in the registry manifest validator', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'madar-registry-'))
+    const packageManifest = loadPackageManifest()
+    const registryManifest = loadRegistryManifest()
+
+    mkdirSync(join(tempRoot, 'docs', 'mcp-registry'), { recursive: true })
+    writeFileSync(join(tempRoot, 'package.json'), JSON.stringify(packageManifest, null, 2))
+    writeFileSync(
+      join(tempRoot, 'docs', 'mcp-registry', 'server.json'),
+      JSON.stringify(
+        {
+          ...registryManifest,
+          packages: [...(registryManifest.packages ?? []), ...(registryManifest.packages ?? [])],
+        },
+        null,
+        2,
+      ),
+    )
+
+    try {
+      expect(() =>
+        execFileSync(process.execPath, [resolve('.github/scripts/validate-mcp-registry.mjs')], {
+          cwd: tempRoot,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow()
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
   })
 
   it('documents the public-registry decision, validation command, and local-first trust boundary', () => {


### PR DESCRIPTION
## Summary
- add a checked-in MCP Registry `server.json` for the public `@lubab/madar` npm package
- add a repeatable `npm run registry:validate` command and run it in CI
- document the public-registry decision and the local-first trust boundary in README and release docs

Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public MCP registry entry and local stdio server metadata; included a validator to check registry metadata consistency.

* **Chores**
  * Integrated registry validation into CI and added npm script to run validation.

* **Documentation**
  * Updated README and release checklist with registry metadata location, validation instructions, and public-vs-local guidance.

* **Tests**
  * Added tests to enforce registry metadata matches package and to exercise the validator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->