### PR TITLE
feat: add local proof report command

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -47,7 +47,7 @@ madar doctor out/graph.json
 madar status out/graph.json
 ```
 
-For Claude, Cursor, Gemini, and Copilot, `doctor` checks graph freshness plus the install wiring, and `status` gives you the compact readiness summary plus the next recommended commands. Codex, Aider, and OpenCode still install correctly, but these verification commands do not report them yet, so use the install output itself as confirmation for those targets.
+For Claude, Cursor, Gemini, and Copilot, `doctor` checks graph freshness plus the install wiring, and `status` gives you the compact readiness summary plus the next recommended commands. `doctor`/`status` also report Codex, Aider, and OpenCode when their AGENTS/hook/plugin/MCP signals are present; if any of those drift, the agent is marked `partial` with a reinstall suggestion.
 
 ## 5. Start with a bounded summary
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,6 +8,7 @@ import { BenchmarkReadinessError, NativeAgentInstallRequiredError, runCompareCom
 import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
 import { runContextPromptCommand } from '../infrastructure/context-prompt-command.js'
 import { runDoctorCommand, runStatusCommand } from '../infrastructure/doctor.js'
+import { runProofReportCommand, type ProofReportResult } from '../infrastructure/proof-report.js'
 import { runReviewCompareCommand } from '../infrastructure/review-compare.js'
 import { compareRefs } from '../infrastructure/time-travel.js'
 import { federate } from '../pipeline/federate.js'
@@ -57,6 +58,7 @@ import {
   parseInstallArgs,
   parsePathArgs,
   parsePlatformActionArgs,
+  parseProofReportArgs,
   parsePromptArgs,
   parseQueryArgs,
   parseReviewCompareArgs,
@@ -65,6 +67,7 @@ import {
   parseServeArgs,
   parseTimeTravelArgs,
   type PackCliOptions,
+  type ProofReportCliOptions,
   type PromptCliOptions,
   parseWatchArgs,
   type CompareCliOptions,
@@ -120,6 +123,10 @@ export interface ContextPromptCommandContext {
   io: CliIO
 }
 
+export interface ProofReportCommandContext {
+  options: ProofReportCliOptions
+}
+
 export interface CliDependencies {
   loadGraph: typeof loadGraph
   queryGraph: typeof queryGraph
@@ -133,6 +140,7 @@ export interface CliDependencies {
   runTimeTravel: (context: TimeTravelCommandContext) => Promise<string | void> | string | void
   runContextPack: (context: ContextPackCommandContext) => Promise<string | void> | string | void
   runContextPrompt: (context: ContextPromptCommandContext) => Promise<string | void> | string | void
+  runProofReport: (options: ProofReportCliOptions) => ProofReportResult
   runDoctor: (graphPath: string) => string
   runStatus: (graphPath: string) => string
   runGraphSummary?: (graphPath: string) => Promise<GraphSummary> | GraphSummary
@@ -236,6 +244,7 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   runContextPrompt: async ({ options }) => {
     return await runContextPromptCommand(options)
   },
+  runProofReport: (options) => runProofReportCommand(options),
   runDoctor: (graphPath) => runDoctorCommand({ graphPath }),
   runStatus: (graphPath) => runStatusCommand({ graphPath }),
   runGraphSummary: (graphPath) => buildGraphSummary(loadGraph(graphPath)),
@@ -442,6 +451,10 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --graph <path>      path to graph.json to validate (default out/graph.json)',
     '  status [graph.json]   compact readiness summary with next commands',
     '    --graph <path>      path to graph.json to validate (default out/graph.json)',
+    '  proof-report [graph.json]  generate a local markdown proof report from graph, pack, and compare evidence',
+    '    --output-dir DIR      proof report output directory (default out/proof-report)',
+    '    --compare-dir DIR     compare receipt directory (default out/compare)',
+    '    --pack PATH           optional saved context-pack JSON for pack-quality evidence',
     '  install [--platform P] install the platform skill or local madar config',
     '    platforms            claude|windows|gemini|cursor|codex|opencode|aider|claw|droid|trae|trae-cn|copilot',
     '    If you update madar, re-run your platform install command to refresh local agent rules:',
@@ -678,6 +691,13 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
     if (command === 'status') {
       const options = parseDoctorArgs(args, 'status')
       io.log(dependencies.runStatus(options.graphPath))
+      return 0
+    }
+
+    if (command === 'proof-report') {
+      const options = parseProofReportArgs(args)
+      const result = dependencies.runProofReport(options)
+      io.log(`Saved to ${result.outputPath}`)
       return 0
     }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, resolve } from 'node:path'
+import { dirname, isAbsolute, resolve } from 'node:path'
 
 import type { ContextPackFormat, ContextPackRetrievalStrategy, ContextPackTaskKind } from '../contracts/context-pack.js'
 import { validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
@@ -182,6 +182,13 @@ export interface DoctorCliOptions {
 
 export interface SummaryCliOptions {
   graphPath: string
+}
+
+export interface ProofReportCliOptions {
+  graphPath: string
+  outputDir: string
+  compareDir: string
+  packPath: string | null
 }
 
 export interface HookCliOptions {
@@ -1842,6 +1849,75 @@ export function parseSummaryArgs(args: string[]): SummaryCliOptions {
   }
 
   return { graphPath }
+}
+
+export function parseProofReportArgs(args: string[]): ProofReportCliOptions {
+  const usage = 'Usage: madar proof-report [graph.json] [--output-dir DIR] [--compare-dir DIR] [--pack PATH]'
+  let graphPath = 'out/graph.json'
+  let outputDir: string | null = null
+  let compareDir: string | null = null
+  let packPath: string | null = null
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (argument === '--output-dir') {
+      outputDir = validateGraphOutputPath(requireOptionValue('--output-dir', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--output-dir=')) {
+      const [, value] = argument.split('=', 2)
+      outputDir = validateGraphOutputPath(requireOptionValue('--output-dir', value))
+      continue
+    }
+
+    if (argument === '--compare-dir') {
+      compareDir = validateGraphOutputPath(requireOptionValue('--compare-dir', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--compare-dir=')) {
+      const [, value] = argument.split('=', 2)
+      compareDir = validateGraphOutputPath(requireOptionValue('--compare-dir', value))
+      continue
+    }
+
+    if (argument === '--pack') {
+      packPath = validateGraphOutputPath(requireOptionValue('--pack', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--pack=')) {
+      const [, value] = argument.split('=', 2)
+      packPath = validateGraphOutputPath(requireOptionValue('--pack', value))
+      continue
+    }
+
+    if (argument.startsWith('--')) {
+      throw new UsageError(`error: unknown option for proof-report: ${argument}`)
+    }
+
+    if (graphPath !== 'out/graph.json') {
+      throw new UsageError(usage)
+    }
+
+    graphPath = argument
+  }
+
+  const graphBase = dirname(resolve(graphPath))
+  return {
+    graphPath,
+    outputDir: outputDir ?? resolve(graphBase, 'proof-report'),
+    compareDir: compareDir ?? resolve(graphBase, 'compare'),
+    packPath,
+  }
 }
 
 export function parseHookArgs(args: string[]): HookCliOptions {

--- a/src/infrastructure/proof-report.ts
+++ b/src/infrastructure/proof-report.ts
@@ -1,0 +1,406 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+import { buildGraphSummary } from '../runtime/graph-summary.js'
+import { computeContextPackDiagnostics } from '../runtime/context-pack-diagnostics.js'
+import { loadGraph } from '../runtime/serve.js'
+import { validateGraphOutputPath } from '../shared/security.js'
+
+import type { CompiledContextPack, ContextPackCoverage, ContextPackNode, ContextPackTaskKind } from '../contracts/context-pack.js'
+import type { ContextPackDiagnostics } from '../contracts/context-pack-diagnostics.js'
+import type { TaskIntentKind } from '../contracts/task-intent.js'
+
+interface ProofReportCompareSummary {
+  question: string
+  reductionRatio: number | null
+  effectiveReductionRatio: number | null
+  totalReductionRatio: number | null
+  baselineStatus: string
+  madarStatus: string
+  winner: string | null
+}
+
+interface ProofReportOptions {
+  graphPath: string
+  outputDir?: string
+  compareDir?: string
+  packPath?: string | null
+}
+
+export interface ProofReportResult {
+  outputPath: string
+  report: string
+}
+
+function readJsonFile(path: string): unknown {
+  const raw = readFileSync(path, 'utf8')
+  try {
+    return JSON.parse(raw) as unknown
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid JSON at ${path}: ${message}`)
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? value as T[] : []
+}
+
+function asTaskKind(value: unknown): ContextPackTaskKind | null {
+  return value === 'explain' || value === 'implement' || value === 'review' || value === 'impact'
+    ? value
+    : null
+}
+
+function asCoverage(value: unknown): ContextPackCoverage | null {
+  const record = asRecord(value)
+  if (!record) {
+    return null
+  }
+
+  const requiredEvidence = asArray<string>(record.required_evidence)
+  const semanticRequired = asArray<string>(record.semantic_required)
+  const semanticOptional = asArray<string>(record.semantic_optional)
+  const entries = asArray(record.entries)
+  const semanticEntries = asArray(record.semantic_entries)
+  const missingRequired = asArray<string>(record.missing_required)
+  const missingSemantic = asArray<string>(record.missing_semantic)
+  const availableRelationships = typeof record.available_relationships === 'number' ? record.available_relationships : 0
+  const selectedRelationships = typeof record.selected_relationships === 'number' ? record.selected_relationships : 0
+
+  return {
+    required_evidence: requiredEvidence as ContextPackCoverage['required_evidence'],
+    semantic_required: semanticRequired as ContextPackCoverage['semantic_required'],
+    semantic_optional: semanticOptional as ContextPackCoverage['semantic_optional'],
+    entries: entries as ContextPackCoverage['entries'],
+    semantic_entries: semanticEntries as ContextPackCoverage['semantic_entries'],
+    missing_required: missingRequired as ContextPackCoverage['missing_required'],
+    missing_semantic: missingSemantic as ContextPackCoverage['missing_semantic'],
+    available_relationships: availableRelationships,
+    selected_relationships: selectedRelationships,
+  }
+}
+
+function asDiagnostics(value: unknown): ContextPackDiagnostics | null {
+  const record = asRecord(value)
+  if (!record) {
+    return null
+  }
+  if (
+    typeof record.quality_score !== 'number' ||
+    !Array.isArray(record.warnings) ||
+    !asRecord(record.signals)
+  ) {
+    return null
+  }
+  return record as unknown as ContextPackDiagnostics
+}
+
+function compiledPackFromSchema(
+  schema: Record<string, unknown>,
+  pack: Record<string, unknown>,
+): CompiledContextPack | null {
+  const taskKind = asTaskKind(schema.task)
+  const coverage = asCoverage(schema.coverage)
+  if (!taskKind || !coverage) {
+    return null
+  }
+
+  const nodes = asArray<ContextPackNode>(pack.matched_nodes ?? pack.nodes)
+  const relationships = asArray<CompiledContextPack['relationships'][number]>(pack.relationships)
+  const communityContext = asArray<CompiledContextPack['community_context'][number]>(pack.community_context)
+  const graphSignalsRecord = asRecord(pack.graph_signals)
+  const graphSignals = graphSignalsRecord
+    ? {
+      god_nodes: asArray<string>(graphSignalsRecord.god_nodes),
+      bridge_nodes: asArray<string>(graphSignalsRecord.bridge_nodes),
+    }
+    : { god_nodes: [], bridge_nodes: [] }
+  const taskIntent = typeof schema.task_intent === 'string' ? schema.task_intent as TaskIntentKind : null
+  const prompt = typeof schema.prompt === 'string' ? schema.prompt : null
+  const taskContract: CompiledContextPack['task_contract'] = {
+    version: 1,
+    task_kind: taskKind,
+    evidence_recipe_id: (taskIntent ?? taskKind) as TaskIntentKind,
+    budget: typeof schema.budget === 'number' ? schema.budget : 0,
+    required_evidence: coverage.required_evidence,
+    preferred_evidence: [],
+    semantic_required: coverage.semantic_required,
+    semantic_optional: coverage.semantic_optional,
+    ...(taskIntent ? { task_intent: taskIntent } : {}),
+    ...(prompt ? { prompt } : {}),
+  }
+
+  const compiledPack: CompiledContextPack = {
+    task_contract: taskContract,
+    token_count: typeof pack.token_count === 'number' ? pack.token_count : 0,
+    nodes,
+    relationships,
+    community_context: communityContext,
+    claims: asArray(schema.claims) as CompiledContextPack['claims'],
+    expandable: asArray(schema.expandable) as CompiledContextPack['expandable'],
+    coverage,
+    graph_signals: graphSignals,
+  }
+  if (typeof pack.shared_file_type === 'string') {
+    compiledPack.shared_file_type = pack.shared_file_type
+  }
+  if (pack.selection_diagnostics !== undefined) {
+    compiledPack.selection_diagnostics = pack.selection_diagnostics as NonNullable<CompiledContextPack['selection_diagnostics']>
+  }
+  if (typeof pack.retrieval_strategy === 'string') {
+    compiledPack.retrieval_strategy = pack.retrieval_strategy as NonNullable<CompiledContextPack['retrieval_strategy']>
+  }
+  if (pack.slice !== undefined) {
+    compiledPack.slice = pack.slice as NonNullable<CompiledContextPack['slice']>
+  }
+  if (pack.execution_slice !== undefined) {
+    compiledPack.execution_slice = pack.execution_slice as NonNullable<CompiledContextPack['execution_slice']>
+  }
+  if (pack.answer_contract !== undefined) {
+    compiledPack.answer_contract = pack.answer_contract as NonNullable<CompiledContextPack['answer_contract']>
+  }
+  if (pack.answer_ready !== undefined) {
+    compiledPack.answer_ready = pack.answer_ready as NonNullable<CompiledContextPack['answer_ready']>
+  }
+  if (pack.retrieval_gate !== undefined) {
+    compiledPack.retrieval_gate = pack.retrieval_gate as NonNullable<CompiledContextPack['retrieval_gate']>
+  }
+  return compiledPack
+}
+
+function relativeOutputBase(graphPath: string): string {
+  return dirname(resolve(graphPath))
+}
+
+function graphCommandSuffix(graphPath: string): string {
+  return resolve(graphPath) === resolve('out/graph.json') ? '' : ` --graph ${graphPath}`
+}
+
+function findFilesByName(rootDir: string, fileName: string): string[] {
+  if (!existsSync(rootDir)) {
+    return []
+  }
+
+  const entries = readdirSync(rootDir, { withFileTypes: true })
+  const matches: string[] = []
+  for (const entry of entries) {
+    const entryPath = join(rootDir, entry.name)
+    if (entry.isDirectory()) {
+      matches.push(...findFilesByName(entryPath, fileName))
+      continue
+    }
+    if (entry.isFile() && entry.name === fileName) {
+      matches.push(entryPath)
+    }
+  }
+  return matches.sort((left, right) => left.localeCompare(right))
+}
+
+function readCompareSummaries(compareDir: string, graphBase: string): ProofReportCompareSummary[] {
+  const safeCompareDir = validateGraphOutputPath(compareDir, graphBase)
+  return findFilesByName(safeCompareDir, 'report.share-safe.json').map((reportPath) => {
+    const parsed = readJsonFile(reportPath) as Record<string, unknown>
+    const status = parsed.status && typeof parsed.status === 'object' && !Array.isArray(parsed.status)
+      ? parsed.status as Record<string, unknown>
+      : {}
+    const providerProof = parsed.provider_proof && typeof parsed.provider_proof === 'object' && !Array.isArray(parsed.provider_proof)
+      ? parsed.provider_proof as Record<string, unknown>
+      : {}
+    return {
+      question: typeof parsed.question === 'string' ? parsed.question : '(unknown question)',
+      reductionRatio: typeof parsed.reduction_ratio === 'number' ? parsed.reduction_ratio : null,
+      effectiveReductionRatio: typeof parsed.effective_reduction_ratio === 'number' ? parsed.effective_reduction_ratio : null,
+      totalReductionRatio: typeof parsed.total_reduction_ratio === 'number' ? parsed.total_reduction_ratio : null,
+      baselineStatus: typeof status.baseline === 'string' ? status.baseline : 'unknown',
+      madarStatus: typeof status.madar === 'string' ? status.madar : 'unknown',
+      winner: typeof providerProof.winner === 'string' ? providerProof.winner : null,
+    }
+  })
+}
+
+function readPackDiagnostics(packPath: string | null | undefined, graphBase: string): ContextPackDiagnostics | null {
+  if (!packPath) {
+    return null
+  }
+  const safePackPath = validateGraphOutputPath(packPath, graphBase)
+  if (!existsSync(safePackPath)) {
+    return null
+  }
+  if (!statSync(safePackPath).isFile()) {
+    throw new Error(`Pack report path is not a file: ${safePackPath}`)
+  }
+  const parsed = asRecord(readJsonFile(safePackPath))
+  if (!parsed) {
+    return null
+  }
+  const pack = asRecord(parsed.pack)
+  if (!pack) {
+    return null
+  }
+
+  const diagnostics = asDiagnostics(pack.diagnostics)
+  if (diagnostics) {
+    return diagnostics
+  }
+
+  const compiledPack = compiledPackFromSchema(parsed, pack)
+  return compiledPack ? computeContextPackDiagnostics(compiledPack) : null
+}
+
+function formatRatio(label: string, value: number | null): string {
+  if (value === null) {
+    return `${label}: unavailable`
+  }
+  return `${label}: ${value.toFixed(2)}x`
+}
+
+function formatGraphQualitySection(graphPath: string): string[] {
+  const summary = buildGraphSummary(loadGraph(graphPath))
+  const lines = [
+    '## Graph quality',
+    '',
+    `- Nodes: ${summary.node_count}`,
+    `- Edges: ${summary.edge_count}`,
+    `- Files: ${summary.file_count}`,
+    `- Communities: ${summary.community_count}`,
+  ]
+  if (summary.frameworks.length > 0) {
+    lines.push(`- Frameworks: ${summary.frameworks.join(', ')}`)
+  }
+  return lines
+}
+
+function formatWorkflowSection(graphPath: string): string[] {
+  const summary = buildGraphSummary(loadGraph(graphPath))
+  const lines = ['## Top workflows', '']
+  if (summary.runtime_paths.length > 0) {
+    for (const path of summary.runtime_paths.slice(0, 5)) {
+      lines.push(`- ${path.from} -> ${path.to} (${path.hops} hops)`)
+    }
+    return lines
+  }
+  if (summary.entrypoints.length > 0) {
+    for (const entry of summary.entrypoints.slice(0, 5)) {
+      lines.push(`- ${entry.label} (${entry.source_file})`)
+    }
+    return lines
+  }
+  for (const module of summary.top_modules.slice(0, 5)) {
+    lines.push(`- ${module.label} (degree ${module.degree})`)
+  }
+  return lines
+}
+
+function formatPackSection(
+  diagnostics: ContextPackDiagnostics | null,
+  graphPath: string,
+  nextCommands: string[],
+  limitations: string[],
+): string[] {
+  const lines = ['## Pack quality', '']
+  if (!diagnostics) {
+    lines.push('- No local context-pack diagnostics were provided.')
+    limitations.push('Pack quality has not been measured locally yet.')
+    nextCommands.push(`madar pack "<question>" --task explain${graphCommandSuffix(graphPath)} > out/proof-inputs/context-pack.json`)
+    return lines
+  }
+
+  lines.push(`- Quality score: ${diagnostics.quality_score.toFixed(2)}`)
+  lines.push(`- Claims: ${diagnostics.signals.claim_count}`)
+  lines.push(`- Snippet coverage: ${(diagnostics.signals.snippet_coverage * 100).toFixed(0)}%`)
+  lines.push(`- Budget utilization: ${(diagnostics.signals.budget_utilization * 100).toFixed(0)}%`)
+  if (diagnostics.warnings.length === 0) {
+    lines.push('- Warnings: none')
+    return lines
+  }
+
+  lines.push('- Warnings:')
+  for (const warning of diagnostics.warnings) {
+    lines.push(`  - ${warning.message}`)
+    limitations.push(warning.message)
+  }
+  return lines
+}
+
+function formatCompareSection(
+  compareSummaries: readonly ProofReportCompareSummary[],
+  graphPath: string,
+  nextCommands: string[],
+  limitations: string[],
+): string[] {
+  const lines = ['## Compare results', '']
+  if (compareSummaries.length === 0) {
+    lines.push('- No local compare receipts were found.')
+    limitations.push('Compare evidence is missing for this repository snapshot.')
+    nextCommands.push(`madar compare "<question>" --exec "<runner template>" --yes${graphCommandSuffix(graphPath)}`)
+    return lines
+  }
+
+  for (const summary of compareSummaries) {
+    lines.push(`### ${summary.question}`)
+    lines.push(`- Baseline status: ${summary.baselineStatus}`)
+    lines.push(`- Madar status: ${summary.madarStatus}`)
+    lines.push(`- ${formatRatio('Reduction ratio', summary.reductionRatio)}`)
+    lines.push(`- ${formatRatio('Effective reduction ratio', summary.effectiveReductionRatio)}`)
+    lines.push(`- ${formatRatio('Total reduction ratio', summary.totalReductionRatio)}`)
+    if (summary.winner) {
+      lines.push(`- Winner: ${summary.winner}`)
+    }
+    lines.push('')
+    if (summary.baselineStatus !== 'completed' || summary.madarStatus !== 'completed') {
+      limitations.push(`Compare run for "${summary.question}" is incomplete.`)
+    }
+  }
+  return lines
+}
+
+function uniqueOrdered(values: readonly string[]): string[] {
+  return [...new Set(values)]
+}
+
+export function runProofReportCommand(options: ProofReportOptions): ProofReportResult {
+  const graphBase = relativeOutputBase(options.graphPath)
+  const outputDir = validateGraphOutputPath(options.outputDir ?? join(graphBase, 'proof-report'), graphBase)
+  const compareDir = options.compareDir ?? join(graphBase, 'compare')
+  const compareSummaries = readCompareSummaries(compareDir, graphBase)
+  const diagnostics = readPackDiagnostics(options.packPath ?? null, graphBase)
+  const limitations: string[] = []
+  const nextCommands: string[] = []
+  const defaultCommands = [
+    resolve(options.graphPath) === resolve('out/graph.json') ? 'madar summary out/graph.json' : `madar summary ${options.graphPath}`,
+    resolve(options.graphPath) === resolve('out/graph.json') ? 'madar doctor out/graph.json' : `madar doctor ${options.graphPath}`,
+  ]
+
+  const report = [
+    '# Local Proof Report',
+    '',
+    ...formatGraphQualitySection(options.graphPath),
+    '',
+    ...formatWorkflowSection(options.graphPath),
+    '',
+    ...formatPackSection(diagnostics, options.graphPath, nextCommands, limitations),
+    '',
+    ...formatCompareSection(compareSummaries, options.graphPath, nextCommands, limitations),
+    '',
+    '## Limitations',
+    '',
+    ...uniqueOrdered(limitations).map((line) => `- ${line}`),
+    '',
+    '## Next commands',
+    '',
+    ...uniqueOrdered([...nextCommands, ...defaultCommands]).map((line) => `- \`${line}\``),
+    '',
+  ].join('\n')
+
+  mkdirSync(outputDir, { recursive: true })
+  const outputPath = join(outputDir, 'proof-report.md')
+  writeFileSync(outputPath, report, 'utf8')
+  return { outputPath, report }
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { type CliDependencies, executeCli, formatHelp } from '../../src/cli/main.js'
 import {
@@ -16,6 +16,7 @@ import {
   parseInstallArgs,
   parsePathArgs,
   parsePlatformActionArgs,
+  parseProofReportArgs,
   parsePromptArgs,
   parseQueryArgs,
   parseReviewCompareArgs,
@@ -137,6 +138,10 @@ function createDependencies(): CliTestDependencies {
     runTimeTravel: async () => 'time-travel command is not implemented yet',
     runContextPack: async () => 'context pack command is not implemented yet',
     runContextPrompt: async () => 'context prompt command is not implemented yet',
+    runProofReport: (options) => ({
+      outputPath: `${options.outputDir}/proof-report.md`,
+      report: '# Local Proof Report\n',
+    }),
     runDoctor: (graphPath) => `doctor check for ${graphPath}`,
     runStatus: (graphPath) => `status check for ${graphPath}`,
     confirm: async () => true,
@@ -961,6 +966,37 @@ describe('cli parser', () => {
     expect(() => parseDoctorArgs(['--wat'], 'status')).toThrow('error: unknown option for status: --wat')
   })
 
+  it('parses proof-report args with defaults and overrides', () => {
+    expect(parseProofReportArgs([])).toEqual({
+      graphPath: 'out/graph.json',
+      outputDir: resolve('out/proof-report'),
+      compareDir: resolve('out/compare'),
+      packPath: null,
+    })
+    expect(parseProofReportArgs(['out/custom/graph.json'])).toEqual({
+      graphPath: 'out/custom/graph.json',
+      outputDir: resolve('out/custom/proof-report'),
+      compareDir: resolve('out/custom/compare'),
+      packPath: null,
+    })
+    expect(parseProofReportArgs([
+      'custom.json',
+      '--output-dir',
+      'out/proof/custom',
+      '--compare-dir',
+      'out/compare/custom',
+      '--pack',
+      'out/proof-inputs/context-pack.json',
+    ])).toEqual({
+      graphPath: 'custom.json',
+      outputDir: resolve('out/proof/custom'),
+      compareDir: resolve('out/compare/custom'),
+      packPath: resolve('out/proof-inputs/context-pack.json'),
+    })
+    expect(() => parseProofReportArgs(['custom.json', 'second.json'])).toThrow('Usage: madar proof-report [graph.json] [--output-dir DIR] [--compare-dir DIR] [--pack PATH]')
+    expect(() => parseProofReportArgs(['--wat'])).toThrow('error: unknown option for proof-report: --wat')
+  })
+
   it('parses hook args', () => {
     expect(parseHookArgs(['install'])).toEqual({ action: 'install' })
     expect(parseHookArgs(['uninstall'])).toEqual({ action: 'uninstall' })
@@ -1130,6 +1166,10 @@ describe('cli main', () => {
     expect(help).toContain('doctor [graph.json]')
     expect(help).toContain('status [graph.json]')
     expect(help).toContain('check graph freshness, agent config, and MCP wiring')
+    expect(help).toContain('proof-report [graph.json]')
+    expect(help).toContain('generate a local markdown proof report from graph, pack, and compare evidence')
+    expect(help).toContain('    --output-dir DIR      proof report output directory (default out/proof-report)')
+    expect(help).toContain('    --pack PATH           optional saved context-pack JSON for pack-quality evidence')
     expect(help).toContain('question coverage')
     expect(help).toContain('hook <action>')
     expect(help).toContain('install [--platform P]')
@@ -1212,9 +1252,86 @@ describe('cli main', () => {
       limit: 5,
       why: true,
     })
+
     expect(compareRequest.io).toBe(io)
     await expect(compareRequest.confirm('Proceed?')).resolves.toBe(true)
     expect(confirmCalls).toBe(1)
+  })
+
+  it('routes proof-report through the injected dependency after parsing args', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      runProofReport?: (options: {
+        graphPath: string
+        outputDir: string
+        compareDir: string
+        packPath: string | null
+      }) => { outputPath: string; report: string }
+    }
+    let capturedOptions: unknown
+
+    dependencies.runProofReport = (options) => {
+      capturedOptions = options
+      return {
+        outputPath: resolve('out/proof-report/custom', 'proof-report.md'),
+        report: '# Local Proof Report\n',
+      }
+    }
+
+    const exitCode = await executeCli(
+      [
+        'proof-report',
+        'custom.json',
+        '--output-dir',
+        'out/proof-report/custom',
+        '--pack',
+        'out/proof-inputs/context-pack.json',
+      ],
+      io,
+      dependencies,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(errors).toEqual([])
+    expect(logs).toEqual([`Saved to ${resolve('out/proof-report/custom', 'proof-report.md')}`])
+    expect(capturedOptions).toEqual({
+      graphPath: 'custom.json',
+      outputDir: resolve('out/proof-report/custom'),
+      compareDir: resolve('compare'),
+      packPath: resolve('out/proof-inputs/context-pack.json'),
+    })
+  })
+
+  it('derives proof-report default directories from a custom graph path', async () => {
+    const { io, logs } = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      runProofReport?: (options: {
+        graphPath: string
+        outputDir: string
+        compareDir: string
+        packPath: string | null
+      }) => { outputPath: string; report: string }
+    }
+    let capturedOptions: unknown
+
+    dependencies.runProofReport = (options) => {
+      capturedOptions = options
+      return {
+        outputPath: join(options.outputDir, 'proof-report.md'),
+        report: '# Local Proof Report\n',
+      }
+    }
+
+    const exitCode = await executeCli(['proof-report', 'out/custom/graph.json'], io, dependencies)
+
+    expect(exitCode).toBe(0)
+    expect(logs).toEqual([`Saved to ${resolve('out/custom/proof-report', 'proof-report.md')}`])
+    expect(capturedOptions).toEqual({
+      graphPath: 'out/custom/graph.json',
+      outputDir: resolve('out/custom/proof-report'),
+      compareDir: resolve('out/custom/compare'),
+      packPath: null,
+    })
   })
 
   it('routes bench:suite through the injected dependency after parsing args', async () => {

--- a/tests/unit/getting-started-docs.test.ts
+++ b/tests/unit/getting-started-docs.test.ts
@@ -31,6 +31,7 @@ describe('getting started tutorial', () => {
     expect(tutorial).toContain('madar claude install')
     expect(tutorial).toContain('madar doctor out/graph.json')
     expect(tutorial).toContain('madar status out/graph.json')
+    expect(tutorial).toContain('`doctor`/`status` also report Codex, Aider, and OpenCode when their AGENTS/hook/plugin/MCP signals are present')
     expect(tutorial).toContain('madar pack "how does password reset request enqueue the reset email"')
     expect(tutorial).toContain('madar generate . --no-html')
     expect(tutorial).toContain('madar generate . --spi --no-html')

--- a/tests/unit/proof-report.test.ts
+++ b/tests/unit/proof-report.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
+import { toJson } from '../../src/pipeline/export.js'
+
+const tempRoots: string[] = []
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop()
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+})
+
+function withTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'madar-proof-report-'))
+  tempRoots.push(root)
+  return root
+}
+
+function buildProofGraph(): KnowledgeGraph {
+  const graph = new KnowledgeGraph()
+  graph.addNode('route', {
+    label: 'POST /login',
+    source_file: 'src/auth/routes.ts',
+    source_location: 'L10',
+    node_kind: 'route',
+    file_type: 'code',
+    framework: 'express',
+    framework_role: 'express_route',
+    community: 0,
+  })
+  graph.addNode('controller', {
+    label: 'AuthController.login',
+    source_file: 'src/auth/controller.ts',
+    source_location: 'L20',
+    node_kind: 'method',
+    file_type: 'code',
+    framework: 'nestjs',
+    framework_role: 'nest_controller',
+    community: 0,
+  })
+  graph.addNode('service', {
+    label: 'AuthService.login',
+    source_file: 'src/auth/service.ts',
+    source_location: 'L30',
+    node_kind: 'method',
+    file_type: 'code',
+    community: 0,
+  })
+  graph.addNode('worker', {
+    label: 'SessionWorker.persist',
+    source_file: 'src/session/worker.ts',
+    source_location: 'L40',
+    node_kind: 'method',
+    file_type: 'code',
+    framework_role: 'worker',
+    community: 1,
+  })
+  graph.addEdge('route', 'controller', {
+    relation: 'controller_route',
+    confidence: 'EXTRACTED',
+    source_file: 'src/auth/routes.ts',
+  })
+  graph.addEdge('controller', 'service', {
+    relation: 'calls',
+    confidence: 'EXTRACTED',
+    source_file: 'src/auth/controller.ts',
+  })
+  graph.addEdge('service', 'worker', {
+    relation: 'enqueues_job',
+    confidence: 'EXTRACTED',
+    source_file: 'src/auth/service.ts',
+  })
+  return graph
+}
+
+function writeGraphFixture(root: string, outDir = 'out'): string {
+  const graphDir = join(root, outDir)
+  mkdirSync(graphDir, { recursive: true })
+  const graphPath = join(graphDir, 'graph.json')
+  toJson(buildProofGraph(), { 0: ['route', 'controller', 'service'], 1: ['worker'] }, graphPath)
+  return graphPath
+}
+
+function writeCompareFixture(root: string): string {
+  const compareDir = join(root, 'out', 'compare', 'login-flow')
+  mkdirSync(compareDir, { recursive: true })
+  writeFileSync(
+    join(compareDir, 'report.share-safe.json'),
+    JSON.stringify({
+      question: 'How does login reach persistence?',
+      baseline_mode: 'bounded',
+      reduction_ratio: 3.7,
+      effective_reduction_ratio: 4.2,
+      total_reduction_ratio: 2.9,
+      status: {
+        baseline: 'completed',
+        madar: 'completed',
+      },
+      failure_reason: {
+        baseline: null,
+        madar: null,
+      },
+      provider_proof: {
+        winner: 'madar',
+      },
+    }, null, 2),
+    'utf8',
+  )
+  return join(root, 'out', 'compare')
+}
+
+function writePackFixture(root: string): string {
+  const packPath = join(root, 'out', 'proof-inputs', 'context-pack.json')
+  mkdirSync(dirname(packPath), { recursive: true })
+  writeFileSync(
+    packPath,
+    JSON.stringify({
+      schema_version: 1,
+      task: 'explain',
+      task_intent: 'explain',
+      prompt: 'Trace login persistence flow',
+      budget: 1000,
+      graph_path: 'out/graph.json',
+      claims: [
+        {
+          evidence_class: 'primary',
+          text: 'AuthService.login writes session data through SessionWorker.persist.',
+          node_labels: ['AuthService.login', 'SessionWorker.persist'],
+        },
+      ],
+      expandable: [],
+      coverage: {
+        required_evidence: ['primary'],
+        semantic_required: ['implementation'],
+        semantic_optional: [],
+        entries: [
+          {
+            evidence_class: 'primary',
+            required: true,
+            available_nodes: 3,
+            selected_nodes: 3,
+            status: 'covered',
+          },
+        ],
+        semantic_entries: [
+          {
+            category: 'implementation',
+            label: 'Implementation',
+            required: true,
+            available_nodes: 3,
+            selected_nodes: 3,
+            status: 'covered',
+          },
+        ],
+        missing_required: [],
+        missing_semantic: [],
+        available_relationships: 2,
+        selected_relationships: 2,
+      },
+      pack: {
+        token_count: 400,
+        matched_nodes: [
+          {
+            label: 'POST /login',
+            source_file: 'src/http/routes.ts',
+            line_number: 10,
+            snippet: 'router.post("/login", controller.login)',
+            match_score: 0.98,
+            source_domain: 'production',
+          },
+          {
+            label: 'AuthService.login',
+            source_file: 'src/auth/service.ts',
+            line_number: 42,
+            snippet: null,
+            match_score: 0.91,
+            source_domain: 'production',
+          },
+          {
+            label: 'SessionWorker.persist',
+            source_file: 'src/session/worker.ts',
+            line_number: 88,
+            snippet: null,
+            match_score: 0.84,
+            source_domain: 'production',
+          },
+        ],
+        relationships: [
+          {
+            from: 'POST /login',
+            to: 'AuthService.login',
+            relation: 'calls',
+          },
+          {
+            from: 'AuthService.login',
+            to: 'SessionWorker.persist',
+            relation: 'calls',
+          },
+        ],
+        community_context: [],
+        graph_signals: {
+          god_nodes: [],
+          bridge_nodes: ['AuthService.login'],
+        },
+      },
+    }, null, 2),
+    'utf8',
+  )
+  return packPath
+}
+
+describe('proof report', () => {
+  it('writes a local markdown proof report from graph, pack, and compare evidence', async () => {
+    const root = withTempRoot()
+    const graphPath = writeGraphFixture(root)
+    const compareDir = writeCompareFixture(root)
+    const packPath = writePackFixture(root)
+    const outputDir = join(root, 'out', 'proof-report')
+
+    const proofReportModule = await import('../../src/infrastructure/proof-report.js') as {
+      runProofReportCommand: (options: {
+        graphPath: string
+        outputDir: string
+        compareDir: string
+        packPath: string | null
+      }) => { outputPath: string; report: string }
+    }
+
+    const result = proofReportModule.runProofReportCommand({
+      graphPath,
+      outputDir,
+      compareDir,
+      packPath,
+    })
+
+    expect(result.outputPath).toBe(join(outputDir, 'proof-report.md'))
+    expect(readFileSync(result.outputPath, 'utf8')).toBe(result.report)
+    expect(result.report).toContain('# Local Proof Report')
+    expect(result.report).toContain('## Graph quality')
+    expect(result.report).toContain('## Top workflows')
+    expect(result.report).toContain('## Pack quality')
+    expect(result.report).toContain('## Compare results')
+    expect(result.report).toContain('## Limitations')
+    expect(result.report).toContain('## Next commands')
+    expect(result.report).toContain('- Nodes: 4')
+    expect(result.report).toContain('- Edges: 3')
+    expect(result.report).toContain('POST /login')
+    expect(result.report).toContain('SessionWorker.persist')
+    expect(result.report).toContain('How does login reach persistence?')
+    expect(result.report).toContain('Reduction ratio: 3.70x')
+    expect(result.report).toContain('Quality score:')
+    expect(result.report).toContain('Claims: 1')
+    expect(result.report).toContain('Snippet coverage: 33%')
+    expect(result.report).toContain('67% of nodes lack a source snippet')
+  })
+
+  it('spells out missing local evidence with limitations and next commands', async () => {
+    const root = withTempRoot()
+    const graphPath = writeGraphFixture(root)
+    const outputDir = join(root, 'out', 'proof-report')
+
+    const proofReportModule = await import('../../src/infrastructure/proof-report.js') as {
+      runProofReportCommand: (options: {
+        graphPath: string
+        outputDir: string
+        compareDir: string
+        packPath: string | null
+      }) => { outputPath: string; report: string }
+    }
+
+    const result = proofReportModule.runProofReportCommand({
+      graphPath,
+      outputDir,
+      compareDir: join(root, 'out', 'compare'),
+      packPath: null,
+    })
+
+    expect(result.report).toContain('No local context-pack diagnostics were provided.')
+    expect(result.report).toContain('No local compare receipts were found.')
+    expect(result.report).toContain('Pack quality has not been measured locally yet.')
+    expect(result.report).toContain('Compare evidence is missing for this repository snapshot.')
+    expect(result.report).toContain(`madar pack "<question>" --task explain --graph ${graphPath} > out/proof-inputs/context-pack.json`)
+    expect(result.report).toContain(`madar compare "<question>" --exec "<runner template>" --yes --graph ${graphPath}`)
+    expect(result.report).toContain(`madar summary ${graphPath}`)
+    expect(result.report).toContain(`madar doctor ${graphPath}`)
+  })
+
+  it('treats a missing saved pack path as absent evidence instead of failing', async () => {
+    const root = withTempRoot()
+    const graphPath = writeGraphFixture(root)
+    const outputDir = join(root, 'out', 'proof-report')
+
+    const proofReportModule = await import('../../src/infrastructure/proof-report.js') as {
+      runProofReportCommand: (options: {
+        graphPath: string
+        outputDir: string
+        compareDir: string
+        packPath: string | null
+      }) => { outputPath: string; report: string }
+    }
+
+    const result = proofReportModule.runProofReportCommand({
+      graphPath,
+      outputDir,
+      compareDir: join(root, 'out', 'compare'),
+      packPath: join(root, 'out', 'proof-inputs', 'missing-context-pack.json'),
+    })
+
+    expect(result.outputPath).toBe(join(outputDir, 'proof-report.md'))
+    expect(result.report).toContain('No local context-pack diagnostics were provided.')
+  })
+
+  it('threads a custom graph path into next commands', async () => {
+    const root = withTempRoot()
+    const graphPath = writeGraphFixture(root, join('out', 'custom'))
+    const outputDir = join(root, 'out', 'custom', 'proof-report')
+
+    const proofReportModule = await import('../../src/infrastructure/proof-report.js') as {
+      runProofReportCommand: (options: {
+        graphPath: string
+        outputDir: string
+        compareDir: string
+        packPath: string | null
+      }) => { outputPath: string; report: string }
+    }
+
+    const result = proofReportModule.runProofReportCommand({
+      graphPath,
+      outputDir,
+      compareDir: join(root, 'out', 'custom', 'compare'),
+      packPath: null,
+    })
+
+    expect(result.report).toContain(`madar pack "<question>" --task explain --graph ${graphPath} > out/proof-inputs/context-pack.json`)
+    expect(result.report).toContain(`madar compare "<question>" --exec "<runner template>" --yes --graph ${graphPath}`)
+    expect(result.report).toContain(`madar summary ${graphPath}`)
+    expect(result.report).toContain(`madar doctor ${graphPath}`)
+  })
+})


### PR DESCRIPTION
## Summary
- add `madar proof-report [graph.json]` plus parser/main wiring for local proof reports
- derive pack diagnostics from the real saved context-pack schema and degrade cleanly when pack or compare evidence is missing
- add regressions for parser defaults, CLI routing, missing evidence fallback, and custom graph-path guidance

## Verification
- `npm run test:run -- tests/unit/cli.test.ts tests/unit/proof-report.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run`

## Known repo baseline issue
- `CI=1 npm run test:run` still fails on plain `next` at `tests/unit/benchmark-quality.test.ts`
- failure: `Gold label "cluster" (normalized: "cluster") not found in graph for question: "how does louvain clustering work"`
- reproduced after stashing this diff and checking out detached `next` in the same worktree

Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `madar proof-report` CLI command to generate local markdown proof reports with optional `--output-dir`, `--compare-dir`, and `--pack` flags.

* **Documentation**
  * Revised "Getting Started" tutorial with streamlined 10-minute first-run path using sample workspace.
  * Updated tutorial steps to include new commands: `madar summary`, `madar pack`, `madar prompt`, and `madar compare`.
  * Expanded troubleshooting section with additional diagnostic guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->