### PR TITLE
[Roadmap] Publish implementation-task outcome evidence

### DIFF
--- a/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/baseline-answer.txt
+++ b/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/baseline-answer.txt
@@ -1,0 +1,1 @@
+updated config

--- a/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/madar-answer.txt
+++ b/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/madar-answer.txt
@@ -1,0 +1,1 @@
+updated session manager

--- a/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/native_agent-prompt.txt
+++ b/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/native_agent-prompt.txt
@@ -1,0 +1,18 @@
+Follow the Madar implementation-pack contract exactly.
+Implement the requested change using the Madar implementation pack.
+Call context_pack first for implementation tasks before editing files or broad raw repo search.
+Inspect likely_edit_files, likely_test_files, validation_commands, cautions, and risk boundaries before making any changes.
+Prefer the likely_edit_files set first; editing outside the likely_edit_files or likely_test_files set requires an explicit reason.
+Run the listed validation_commands before concluding.
+If Madar is unavailable, continue from raw repo evidence and say so explicitly.
+
+Implementation guidance:
+- Summary: Start with src/session.ts, then validate the highest-risk shared boundaries before finishing.
+- Likely edit files: src/session.ts
+- Likely test files: tests/session.test.ts
+- Validation commands: npm run typecheck ; npm run build ; npm run test
+- Risk boundaries: SessionManager
+
+Question: Implement sliding session expiration in SessionManager
+
+Answer:

--- a/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/report.json
+++ b/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/report.json
@@ -1,0 +1,458 @@
+{
+  "baseline_mode": "native_agent",
+  "task": "implement",
+  "question": "Implement sliding session expiration in SessionManager",
+  "graph_path": "../../../../../../../../private/var/folders/n1/l0_t90js31d0yyhbxfvgfgzr0000gn/T/madar-implement-receipt-czm3Gy/out/graph.json",
+  "isolation": false,
+  "environment": {
+    "claude_code_version": "2.1.157",
+    "host_os": "darwin-arm64",
+    "node_version": "v22.22.3",
+    "mcp_servers_active": [
+      "madar"
+    ],
+    "mcp_server_count": 1,
+    "skills_loaded": [
+      "agent-email-inbox",
+      "agent-memory-systems",
+      "ai-regression-testing",
+      "android-clean-architecture",
+      "api-design",
+      "backend-patterns",
+      "best-practices",
+      "brainstorming",
+      "code-reviewer",
+      "coding-standards",
+      "compose-multiplatform-patterns",
+      "configure-ecc",
+      "context7-auto-research",
+      "continuous-learning",
+      "continuous-learning-v2",
+      "cpp-coding-standards",
+      "cpp-testing",
+      "design-md",
+      "django-patterns",
+      "django-tdd",
+      "django-verification",
+      "e2e-testing",
+      "email-best-practices",
+      "enhance-prompt",
+      "eval-harness",
+      "figma-implement-design",
+      "find-skills",
+      "frontend-design",
+      "frontend-patterns",
+      "frontend-slides",
+      "frontend-to-backend-requirements",
+      "golang-patterns",
+      "golang-testing",
+      "iterative-retrieval",
+      "java-coding-standards",
+      "kotlin-coroutines-flows",
+      "kotlin-exposed-patterns",
+      "kotlin-ktor-patterns",
+      "kotlin-patterns",
+      "kotlin-testing",
+      "laravel-patterns",
+      "laravel-tdd",
+      "learned",
+      "mcp-server-patterns",
+      "mermaid-diagrams",
+      "microsoft-foundry",
+      "mobile-design",
+      "nodejs-best-practices",
+      "perl-patterns",
+      "perl-testing",
+      "plankton-code-quality",
+      "project-guidelines-example",
+      "python-patterns",
+      "python-testing",
+      "react-best-practices",
+      "react-email",
+      "react-ui-patterns",
+      "remotion",
+      "resend",
+      "resend-cli",
+      "rust-patterns",
+      "rust-testing",
+      "senior-architect",
+      "senior-backend",
+      "senior-frontend",
+      "senior-fullstack",
+      "shadcn-ui",
+      "skill-development",
+      "skill-stocktake",
+      "software-architecture",
+      "springboot-patterns",
+      "springboot-tdd",
+      "springboot-verification",
+      "stitch-design",
+      "stitch-loop",
+      "strategic-compact",
+      "subagent-driven-development",
+      "tailwind-patterns",
+      "taste-design",
+      "tdd-workflow",
+      "ui-design-system",
+      "using-superpowers",
+      "ux-researcher-designer",
+      "verification-before-completion",
+      "verification-loop",
+      "writing-plans"
+    ],
+    "skills_loaded_count": 86,
+    "plugins_active": [],
+    "user_claude_md_hash": "sha256:576e6cc125d7e1f236eb7b4ffa414d0b31a36562374a22202b646af08242cff2",
+    "project_claude_md_hash": "sha256:f756cedc14b026ff7879bccec92865638324e29e05860c83d7858375465d0940",
+    "parent_claude_md_hashes": [],
+    "hooks_active": {
+      "user_prompt_submit": [
+        "project:command:*"
+      ],
+      "pre_tool_use": [],
+      "post_tool_use": []
+    }
+  },
+  "environment_contamination": {
+    "skills_activated_during_run": [],
+    "skills_conflicting_with_madar_rules": [],
+    "calls_to_other_mcps": {},
+    "subagent_dispatches_detected": 0,
+    "skill_alignment_score": 1
+  },
+  "exec_command": {
+    "command": null,
+    "placeholders": [],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 14,
+      "cache_creation_input_tokens": 40648,
+      "cache_read_input_tokens": 574528,
+      "output_tokens": 3152
+    },
+    "total_input_tokens_anthropic_exact": 615190,
+    "uncached_input_tokens_anthropic_exact": 40662,
+    "cached_input_tokens_anthropic_exact": 574528,
+    "total_cost_usd": 0.62,
+    "num_turns": 9,
+    "duration_ms": 96368,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-419-graph-schema-versioning/out/implementation-receipt-artifacts/2026-05-31T12-00-00/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 13,
+      "cache_creation_input_tokens": 92833,
+      "cache_read_input_tokens": 140662,
+      "output_tokens": 1893
+    },
+    "total_input_tokens_anthropic_exact": 233508,
+    "uncached_input_tokens_anthropic_exact": 92846,
+    "cached_input_tokens_anthropic_exact": 140662,
+    "total_cost_usd": 0.7,
+    "num_turns": 3,
+    "duration_ms": 34744,
+    "result_path": "/Users/mohammednaji/Desktop/projects/works/madar/.worktrees/issue-419-graph-schema-versioning/out/implementation-receipt-artifacts/2026-05-31T12-00-00/madar-answer.txt"
+  },
+  "install_verified": true,
+  "measurement_validity": "degraded",
+  "trace_status": "missing_verbose_trace",
+  "madar_mcp_call_count": 0,
+  "reductions": null,
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-31T12:00:00.000Z",
+  "completed_at": "2026-05-31T12:00:00.000Z",
+  "paths": {
+    "output_dir": "out/implementation-receipt-artifacts/2026-05-31T12-00-00",
+    "report": "out/implementation-receipt-artifacts/2026-05-31T12-00-00/report.json",
+    "share_safe_report": "out/implementation-receipt-artifacts/2026-05-31T12-00-00/report.share-safe.json",
+    "baseline_answer": "out/implementation-receipt-artifacts/2026-05-31T12-00-00/baseline-answer.txt",
+    "madar_answer": "out/implementation-receipt-artifacts/2026-05-31T12-00-00/madar-answer.txt",
+    "prompt_file": "out/implementation-receipt-artifacts/2026-05-31T12-00-00/native_agent-prompt.txt"
+  },
+  "implementation_guidance": {
+    "summary": "Start with src/session.ts, then validate the highest-risk shared boundaries before finishing.",
+    "retrieval_pipeline": {
+      "phases": [
+        {
+          "phase": "seed",
+          "summary": "Seed search matched 1 production retrieval node."
+        },
+        {
+          "phase": "expand",
+          "summary": "Graph expansion added 0 promoted workflow candidates from structural neighbors."
+        },
+        {
+          "phase": "promote",
+          "summary": "Workflow-center promotion ranked 1 owning file for the brief."
+        },
+        {
+          "phase": "attach",
+          "summary": "Attachment linked 1 test file and 0 contract/public surface files."
+        },
+        {
+          "phase": "refine",
+          "summary": "Refinement kept 1 edit file, 1 test file, and 0 supporting patterns."
+        },
+        {
+          "phase": "render",
+          "summary": "Pack Schema v1 renders the refined implementation guidance for downstream agents."
+        }
+      ]
+    },
+    "workflow_centers": [
+      {
+        "label": "SessionManager",
+        "path": "src/session.ts",
+        "score": 2.04,
+        "reasons": [
+          "Direct task evidence anchors this file in the implementation brief."
+        ],
+        "matched_symbols": [
+          "SessionManager"
+        ],
+        "reason": "Seed search matched this symbol directly from the task prompt. Workflow-center promotion preferred this file as the owning workflow surface. Direct task evidence anchors this file in the implementation brief.",
+        "phases": [
+          "seed",
+          "promote"
+        ]
+      }
+    ],
+    "likely_edit_files": [
+      {
+        "path": "src/session.ts",
+        "score": 2.47,
+        "reason": "Seed search matched this symbol directly from the task prompt. Workflow-center promotion preferred this file as the owning workflow surface. Direct task evidence anchors this file in the implementation brief.",
+        "why": "Seed search matched this symbol directly from the task prompt. Workflow-center promotion preferred this file as the owning workflow surface. Direct task evidence anchors this file in the implementation brief.",
+        "matched_symbols": [
+          "SessionManager"
+        ],
+        "phases": [
+          "seed",
+          "promote",
+          "attach",
+          "refine"
+        ]
+      }
+    ],
+    "likely_test_files": [
+      {
+        "path": "tests/session.test.ts",
+        "score": 2.4,
+        "reason": "Naming overlaps with src/session.ts.",
+        "why": "Naming overlaps with src/session.ts.",
+        "matched_symbols": [
+          "SessionManager test",
+          "SessionManager"
+        ],
+        "phases": [
+          "attach",
+          "refine"
+        ]
+      }
+    ],
+    "contracts_and_public_surfaces": [],
+    "existing_patterns": [],
+    "risk_boundaries": [
+      {
+        "label": "SessionManager",
+        "severity": "high",
+        "reason": "SessionManager propagates into 1 file across 1 community. Includes god node hotspot exposure.",
+        "affected_files": [
+          "tests/session.test.ts"
+        ],
+        "affected_communities": [
+          "Community 1"
+        ]
+      }
+    ],
+    "validation_commands": [
+      "npm run typecheck",
+      "npm run build",
+      "npm run test"
+    ],
+    "acceptance_criteria_summary": [
+      "Implement the requested change: Implement sliding session expiration in SessionManager.",
+      "Update the likely edit surface starting with src/session.ts.",
+      "Keep related tests aligned, including tests/session.test.ts.",
+      "Avoid regressions around SessionManager."
+    ],
+    "cautions": [
+      "Missing required context: supporting, structural.",
+      "Missing semantic coverage: structure.",
+      "High-risk shared boundary: SessionManager affects 1 files."
+    ]
+  },
+  "benchmark_readiness": {
+    "status": "ready",
+    "reasons": [],
+    "suggested_graph_scope": null
+  },
+  "prompt_contract": {
+    "status": "not_measured",
+    "evidence": [
+      "Claude --verbose trace unavailable."
+    ]
+  },
+  "claim_assessment": {
+    "routing_efficiency": {
+      "status": "not_measured",
+      "evidence": [
+        "Madar MCP attribution is missing."
+      ]
+    },
+    "token_reduction": {
+      "status": "not_measured",
+      "evidence": [
+        "Madar MCP attribution is missing."
+      ]
+    }
+  },
+  "benchmark_outcome": {
+    "outcome": "not_measured",
+    "checks": {
+      "routing_tool_latency": "not_measured",
+      "token": "not_measured",
+      "fresh_token": "not_measured",
+      "cost": "not_measured",
+      "turns": "not_measured"
+    },
+    "evidence": [
+      "Madar MCP attribution is missing."
+    ]
+  },
+  "implement_outcome": {
+    "baseline": {
+      "files_touched": [
+        "src/config.ts"
+      ],
+      "wrong_file_edits": [
+        "src/config.ts"
+      ],
+      "validation": {
+        "status": "failed",
+        "commands": [
+          {
+            "command": "npm run typecheck",
+            "status": "failed",
+            "exit_code": 1,
+            "stdout": "\n> typecheck\n> node scripts/check-session.mjs\n\n",
+            "stderr": "missing sliding expiration implementation\n"
+          },
+          {
+            "command": "npm run build",
+            "status": "failed",
+            "exit_code": 1,
+            "stdout": "\n> build\n> node scripts/check-session.mjs\n\n",
+            "stderr": "missing sliding expiration implementation\n"
+          },
+          {
+            "command": "npm run test",
+            "status": "failed",
+            "exit_code": 1,
+            "stdout": "\n> test\n> node scripts/check-session.mjs\n\n",
+            "stderr": "missing sliding expiration implementation\n"
+          }
+        ]
+      },
+      "reviewer_visible_correctness": {
+        "status": "failed",
+        "checks": [
+          {
+            "path": "src/session.ts",
+            "passed": false,
+            "missing_required_snippets": [
+              "slidingExpirationMs"
+            ],
+            "forbidden_snippets_present": []
+          },
+          {
+            "path": "src/config.ts",
+            "passed": false,
+            "missing_required_snippets": [],
+            "forbidden_snippets_present": [
+              "slidingExpirationMs"
+            ]
+          }
+        ]
+      }
+    },
+    "madar": {
+      "files_touched": [
+        "src/session.ts"
+      ],
+      "wrong_file_edits": [],
+      "validation": {
+        "status": "passed",
+        "commands": [
+          {
+            "command": "npm run typecheck",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": "\n> typecheck\n> node scripts/check-session.mjs\n\nvalidation ok\n",
+            "stderr": null
+          },
+          {
+            "command": "npm run build",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": "\n> build\n> node scripts/check-session.mjs\n\nvalidation ok\n",
+            "stderr": null
+          },
+          {
+            "command": "npm run test",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": "\n> test\n> node scripts/check-session.mjs\n\nvalidation ok\n",
+            "stderr": null
+          }
+        ]
+      },
+      "reviewer_visible_correctness": {
+        "status": "passed",
+        "checks": [
+          {
+            "path": "src/session.ts",
+            "passed": true,
+            "missing_required_snippets": [],
+            "forbidden_snippets_present": []
+          },
+          {
+            "path": "src/config.ts",
+            "passed": true,
+            "missing_required_snippets": [],
+            "forbidden_snippets_present": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/report.share-safe.json
+++ b/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/report.share-safe.json
@@ -1,0 +1,458 @@
+{
+  "baseline_mode": "native_agent",
+  "task": "implement",
+  "question": "Implement sliding session expiration in SessionManager",
+  "graph_path": "<project-root>/out/graph.json",
+  "isolation": false,
+  "environment": {
+    "claude_code_version": "2.1.157",
+    "host_os": "darwin-arm64",
+    "node_version": "v22.22.3",
+    "mcp_servers_active": [
+      "madar"
+    ],
+    "mcp_server_count": 1,
+    "skills_loaded": [
+      "agent-email-inbox",
+      "agent-memory-systems",
+      "ai-regression-testing",
+      "android-clean-architecture",
+      "api-design",
+      "backend-patterns",
+      "best-practices",
+      "brainstorming",
+      "code-reviewer",
+      "coding-standards",
+      "compose-multiplatform-patterns",
+      "configure-ecc",
+      "context7-auto-research",
+      "continuous-learning",
+      "continuous-learning-v2",
+      "cpp-coding-standards",
+      "cpp-testing",
+      "design-md",
+      "django-patterns",
+      "django-tdd",
+      "django-verification",
+      "e2e-testing",
+      "email-best-practices",
+      "enhance-prompt",
+      "eval-harness",
+      "figma-implement-design",
+      "find-skills",
+      "frontend-design",
+      "frontend-patterns",
+      "frontend-slides",
+      "frontend-to-backend-requirements",
+      "golang-patterns",
+      "golang-testing",
+      "iterative-retrieval",
+      "java-coding-standards",
+      "kotlin-coroutines-flows",
+      "kotlin-exposed-patterns",
+      "kotlin-ktor-patterns",
+      "kotlin-patterns",
+      "kotlin-testing",
+      "laravel-patterns",
+      "laravel-tdd",
+      "learned",
+      "mcp-server-patterns",
+      "mermaid-diagrams",
+      "microsoft-foundry",
+      "mobile-design",
+      "nodejs-best-practices",
+      "perl-patterns",
+      "perl-testing",
+      "plankton-code-quality",
+      "project-guidelines-example",
+      "python-patterns",
+      "python-testing",
+      "react-best-practices",
+      "react-email",
+      "react-ui-patterns",
+      "remotion",
+      "resend",
+      "resend-cli",
+      "rust-patterns",
+      "rust-testing",
+      "senior-architect",
+      "senior-backend",
+      "senior-frontend",
+      "senior-fullstack",
+      "shadcn-ui",
+      "skill-development",
+      "skill-stocktake",
+      "software-architecture",
+      "springboot-patterns",
+      "springboot-tdd",
+      "springboot-verification",
+      "stitch-design",
+      "stitch-loop",
+      "strategic-compact",
+      "subagent-driven-development",
+      "tailwind-patterns",
+      "taste-design",
+      "tdd-workflow",
+      "ui-design-system",
+      "using-superpowers",
+      "ux-researcher-designer",
+      "verification-before-completion",
+      "verification-loop",
+      "writing-plans"
+    ],
+    "skills_loaded_count": 86,
+    "plugins_active": [],
+    "user_claude_md_hash": "sha256:576e6cc125d7e1f236eb7b4ffa414d0b31a36562374a22202b646af08242cff2",
+    "project_claude_md_hash": "sha256:f756cedc14b026ff7879bccec92865638324e29e05860c83d7858375465d0940",
+    "parent_claude_md_hashes": [],
+    "hooks_active": {
+      "user_prompt_submit": [
+        "project:command:*"
+      ],
+      "pre_tool_use": [],
+      "post_tool_use": []
+    }
+  },
+  "environment_contamination": {
+    "skills_activated_during_run": [],
+    "skills_conflicting_with_madar_rules": [],
+    "calls_to_other_mcps": {},
+    "subagent_dispatches_detected": 0,
+    "skill_alignment_score": 1
+  },
+  "exec_command": {
+    "command": null,
+    "placeholders": [],
+    "redacted": true
+  },
+  "baseline": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 14,
+      "cache_creation_input_tokens": 40648,
+      "cache_read_input_tokens": 574528,
+      "output_tokens": 3152
+    },
+    "total_input_tokens_anthropic_exact": 615190,
+    "uncached_input_tokens_anthropic_exact": 40662,
+    "cached_input_tokens_anthropic_exact": 574528,
+    "total_cost_usd": 0.62,
+    "num_turns": 9,
+    "duration_ms": 96368,
+    "result_path": "<artifact-root>/baseline-answer.txt"
+  },
+  "madar": {
+    "kind": "succeeded",
+    "model": null,
+    "usage": {
+      "input_tokens": 13,
+      "cache_creation_input_tokens": 92833,
+      "cache_read_input_tokens": 140662,
+      "output_tokens": 1893
+    },
+    "total_input_tokens_anthropic_exact": 233508,
+    "uncached_input_tokens_anthropic_exact": 92846,
+    "cached_input_tokens_anthropic_exact": 140662,
+    "total_cost_usd": 0.7,
+    "num_turns": 3,
+    "duration_ms": 34744,
+    "result_path": "<artifact-root>/madar-answer.txt"
+  },
+  "install_verified": true,
+  "measurement_validity": "degraded",
+  "trace_status": "missing_verbose_trace",
+  "madar_mcp_call_count": 0,
+  "reductions": null,
+  "token_regression": true,
+  "token_regression_reasons": [
+    "uncached_input_tokens",
+    "cache_creation_input_tokens"
+  ],
+  "prompt_token_source": {
+    "baseline": "anthropic_provider_reported",
+    "madar": "anthropic_provider_reported"
+  },
+  "provider_proof": {
+    "baseline": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "madar": {
+      "provider": "anthropic",
+      "input_tokens_source": "anthropic_provider_reported",
+      "effective_tokens_source": "anthropic_provider_reported",
+      "total_tokens_source": "anthropic_provider_reported"
+    },
+    "reduction_basis": "provider_reported"
+  },
+  "started_at": "2026-05-31T12:00:00.000Z",
+  "completed_at": "2026-05-31T12:00:00.000Z",
+  "paths": {
+    "output_dir": "<artifact-root>",
+    "report": "<artifact-root>/report.json",
+    "share_safe_report": "<artifact-root>/report.share-safe.json",
+    "baseline_answer": "<artifact-root>/baseline-answer.txt",
+    "madar_answer": "<artifact-root>/madar-answer.txt",
+    "prompt_file": "<artifact-root>/native_agent-prompt.txt"
+  },
+  "implementation_guidance": {
+    "summary": "Start with src/session.ts, then validate the highest-risk shared boundaries before finishing.",
+    "retrieval_pipeline": {
+      "phases": [
+        {
+          "phase": "seed",
+          "summary": "Seed search matched 1 production retrieval node."
+        },
+        {
+          "phase": "expand",
+          "summary": "Graph expansion added 0 promoted workflow candidates from structural neighbors."
+        },
+        {
+          "phase": "promote",
+          "summary": "Workflow-center promotion ranked 1 owning file for the brief."
+        },
+        {
+          "phase": "attach",
+          "summary": "Attachment linked 1 test file and 0 contract/public surface files."
+        },
+        {
+          "phase": "refine",
+          "summary": "Refinement kept 1 edit file, 1 test file, and 0 supporting patterns."
+        },
+        {
+          "phase": "render",
+          "summary": "Pack Schema v1 renders the refined implementation guidance for downstream agents."
+        }
+      ]
+    },
+    "workflow_centers": [
+      {
+        "label": "SessionManager",
+        "path": "src/session.ts",
+        "score": 2.04,
+        "reasons": [
+          "Direct task evidence anchors this file in the implementation brief."
+        ],
+        "matched_symbols": [
+          "SessionManager"
+        ],
+        "reason": "Seed search matched this symbol directly from the task prompt. Workflow-center promotion preferred this file as the owning workflow surface. Direct task evidence anchors this file in the implementation brief.",
+        "phases": [
+          "seed",
+          "promote"
+        ]
+      }
+    ],
+    "likely_edit_files": [
+      {
+        "path": "src/session.ts",
+        "score": 2.47,
+        "reason": "Seed search matched this symbol directly from the task prompt. Workflow-center promotion preferred this file as the owning workflow surface. Direct task evidence anchors this file in the implementation brief.",
+        "why": "Seed search matched this symbol directly from the task prompt. Workflow-center promotion preferred this file as the owning workflow surface. Direct task evidence anchors this file in the implementation brief.",
+        "matched_symbols": [
+          "SessionManager"
+        ],
+        "phases": [
+          "seed",
+          "promote",
+          "attach",
+          "refine"
+        ]
+      }
+    ],
+    "likely_test_files": [
+      {
+        "path": "tests/session.test.ts",
+        "score": 2.4,
+        "reason": "Naming overlaps with src/session.ts.",
+        "why": "Naming overlaps with src/session.ts.",
+        "matched_symbols": [
+          "SessionManager test",
+          "SessionManager"
+        ],
+        "phases": [
+          "attach",
+          "refine"
+        ]
+      }
+    ],
+    "contracts_and_public_surfaces": [],
+    "existing_patterns": [],
+    "risk_boundaries": [
+      {
+        "label": "SessionManager",
+        "severity": "high",
+        "reason": "SessionManager propagates into 1 file across 1 community. Includes god node hotspot exposure.",
+        "affected_files": [
+          "tests/session.test.ts"
+        ],
+        "affected_communities": [
+          "Community 1"
+        ]
+      }
+    ],
+    "validation_commands": [
+      "npm run typecheck",
+      "npm run build",
+      "npm run test"
+    ],
+    "acceptance_criteria_summary": [
+      "Implement the requested change: Implement sliding session expiration in SessionManager.",
+      "Update the likely edit surface starting with src/session.ts.",
+      "Keep related tests aligned, including tests/session.test.ts.",
+      "Avoid regressions around SessionManager."
+    ],
+    "cautions": [
+      "Missing required context: supporting, structural.",
+      "Missing semantic coverage: structure.",
+      "High-risk shared boundary: SessionManager affects 1 files."
+    ]
+  },
+  "benchmark_readiness": {
+    "status": "ready",
+    "reasons": [],
+    "suggested_graph_scope": null
+  },
+  "prompt_contract": {
+    "status": "not_measured",
+    "evidence": [
+      "Claude --verbose trace unavailable."
+    ]
+  },
+  "claim_assessment": {
+    "routing_efficiency": {
+      "status": "not_measured",
+      "evidence": [
+        "Madar MCP attribution is missing."
+      ]
+    },
+    "token_reduction": {
+      "status": "not_measured",
+      "evidence": [
+        "Madar MCP attribution is missing."
+      ]
+    }
+  },
+  "benchmark_outcome": {
+    "outcome": "not_measured",
+    "checks": {
+      "routing_tool_latency": "not_measured",
+      "token": "not_measured",
+      "fresh_token": "not_measured",
+      "cost": "not_measured",
+      "turns": "not_measured"
+    },
+    "evidence": [
+      "Madar MCP attribution is missing."
+    ]
+  },
+  "implement_outcome": {
+    "baseline": {
+      "files_touched": [
+        "src/config.ts"
+      ],
+      "wrong_file_edits": [
+        "src/config.ts"
+      ],
+      "validation": {
+        "status": "failed",
+        "commands": [
+          {
+            "command": "npm run typecheck",
+            "status": "failed",
+            "exit_code": 1,
+            "stdout": "\n> typecheck\n> node scripts/check-session.mjs\n\n",
+            "stderr": "missing sliding expiration implementation\n"
+          },
+          {
+            "command": "npm run build",
+            "status": "failed",
+            "exit_code": 1,
+            "stdout": "\n> build\n> node scripts/check-session.mjs\n\n",
+            "stderr": "missing sliding expiration implementation\n"
+          },
+          {
+            "command": "npm run test",
+            "status": "failed",
+            "exit_code": 1,
+            "stdout": "\n> test\n> node scripts/check-session.mjs\n\n",
+            "stderr": "missing sliding expiration implementation\n"
+          }
+        ]
+      },
+      "reviewer_visible_correctness": {
+        "status": "failed",
+        "checks": [
+          {
+            "path": "src/session.ts",
+            "passed": false,
+            "missing_required_snippets": [
+              "slidingExpirationMs"
+            ],
+            "forbidden_snippets_present": []
+          },
+          {
+            "path": "src/config.ts",
+            "passed": false,
+            "missing_required_snippets": [],
+            "forbidden_snippets_present": [
+              "slidingExpirationMs"
+            ]
+          }
+        ]
+      }
+    },
+    "madar": {
+      "files_touched": [
+        "src/session.ts"
+      ],
+      "wrong_file_edits": [],
+      "validation": {
+        "status": "passed",
+        "commands": [
+          {
+            "command": "npm run typecheck",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": "\n> typecheck\n> node scripts/check-session.mjs\n\nvalidation ok\n",
+            "stderr": null
+          },
+          {
+            "command": "npm run build",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": "\n> build\n> node scripts/check-session.mjs\n\nvalidation ok\n",
+            "stderr": null
+          },
+          {
+            "command": "npm run test",
+            "status": "passed",
+            "exit_code": 0,
+            "stdout": "\n> test\n> node scripts/check-session.mjs\n\nvalidation ok\n",
+            "stderr": null
+          }
+        ]
+      },
+      "reviewer_visible_correctness": {
+        "status": "passed",
+        "checks": [
+          {
+            "path": "src/session.ts",
+            "passed": true,
+            "missing_required_snippets": [],
+            "forbidden_snippets_present": []
+          },
+          {
+            "path": "src/config.ts",
+            "passed": true,
+            "missing_required_snippets": [],
+            "forbidden_snippets_present": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/run-state.json
+++ b/docs/benchmarks/2026-05-31-implement-outcome/2026-05-31T12-00-00/run-state.json
@@ -1,0 +1,13 @@
+{
+  "phase": "madar_done",
+  "arm": "madar",
+  "updated_at": "2026-05-31T12:00:00.000Z",
+  "baseline": {
+    "kind": "succeeded",
+    "duration_ms": 96368
+  },
+  "madar": {
+    "kind": "succeeded",
+    "duration_ms": 34744
+  }
+}

--- a/docs/benchmarks/2026-05-31-implement-outcome/README.md
+++ b/docs/benchmarks/2026-05-31-implement-outcome/README.md
@@ -1,0 +1,16 @@
+# 2026-05-31 implementation outcome receipt
+
+This folder records one deterministic `madar compare --task implement --baseline-mode native_agent` receipt for a bounded fixture task: **"Implement sliding session expiration in SessionManager."**
+
+## What this receipt shows
+
+- **Baseline arm:** edited `src/config.ts`, touched the wrong file, failed validation, and failed the reviewer-visible correctness checks.
+- **Madar arm:** edited `src/session.ts`, touched the intended file, passed validation, and passed the reviewer-visible correctness checks.
+- **Scope:** this is a single isolated fixture cell. It proves the implementation-task scoring path exists and produces reviewable artifacts. It does **not** justify a generalized public claim that Madar improves implementation outcomes across repos.
+
+## Artifacts
+
+- [`2026-05-31T12-00-00/report.share-safe.json`](2026-05-31T12-00-00/report.share-safe.json) — public receipt with task, prompt/runtime metadata, files touched, validation, and reviewer-visible correctness.
+- [`2026-05-31T12-00-00/baseline-answer.txt`](2026-05-31T12-00-00/baseline-answer.txt) — baseline native-agent result text.
+- [`2026-05-31T12-00-00/madar-answer.txt`](2026-05-31T12-00-00/madar-answer.txt) — Madar native-agent result text.
+- [`2026-05-31T12-00-00/native_agent-prompt.txt`](2026-05-31T12-00-00/native_agent-prompt.txt) — generated compare prompt artifact for the receipt run.

--- a/docs/claims-and-evidence.md
+++ b/docs/claims-and-evidence.md
@@ -17,13 +17,14 @@ This file is the public map between what Madar says and what the repo can actual
 | Claim | Current status | Next evidence |
 | --- | --- | --- |
 | Public benchmark claims should hold up as per-repo receipts instead of a single headline number. | The repo ships the methodology, manifests, isolation assets, and `madar bench:suite` runner under [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md), but the populated matrix is still small. | Add more measured rows under `docs/benchmarks/suite/results/` and keep each row tied to its repo/task cell. |
+| Madar can be scored on bounded implementation-task correctness signals. | A deterministic implementation-task receipt now exists under [`docs/benchmarks/2026-05-31-implement-outcome/`](docs/benchmarks/2026-05-31-implement-outcome/README.md). It records files touched, wrong-file edits, validation commands, and reviewer-visible correctness on an isolated fixture harness without turning that one row into a generalized product claim. | Add more implementation rows across distinct repos/tasks, then promote only the metrics that stay stable across cells. |
 | Install-guided bounded retrieval should hold across more repos and prompts. | Evidence is mixed today; the FounderCommandCenter contrast note shows a case where the pack acted as extra context instead of a stop condition. | Keep publishing counterexamples and positive receipts side-by-side, starting with [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](docs/benchmarks/2026-05-25-founder-command-center-auth-flow/README.md) and future suite rows. |
 
 ## Not yet measured
 
 | Claim | Why it is not public copy today |
 | --- | --- |
-| Madar improves implement-task outcomes or wrong-file edit accuracy. | We do not yet have an implementation-task benchmark cell that measures edit correctness or implementation success. Track that under [#332](https://github.com/mohanagy/madar/issues/332). |
+| Madar improves implementation outcomes across repos or consistently avoids wrong-file edits. | We now have one deterministic implementation-task receipt, but we do not yet have cross-repo implementation-task evidence strong enough for a generalized public win claim. Track that under [#332](https://github.com/mohanagy/madar/issues/332). |
 | Lower-confidence packs behave as well as the demonstrated high-confidence release cell. | The `0.27.0` public receipt is one strong, install-verified explain cell; medium/low-confidence prompts still need their own measured rows. |
 | A universal turns / latency / exploration win across repos. | Public receipts are repo- and prompt-specific, so they do not justify a single-number cross-repo headline. |
 | The agent always stops exploring after one pack. | Madar shapes the first pass, but it does not control the runtime or guarantee tool behavior. |
@@ -37,6 +38,7 @@ This file is the public map between what Madar says and what the repo can actual
 ## Related evidence
 
 - [`docs/benchmarks/regression/0.27.0-next.4-govalidate-explain/`](docs/benchmarks/regression/0.27.0-next.4-govalidate-explain/) — the verified `0.27.0` release cell cited in `README.md` and `CHANGELOG.md`.
+- [`docs/benchmarks/2026-05-31-implement-outcome/`](docs/benchmarks/2026-05-31-implement-outcome/README.md) — deterministic implementation-task receipt with isolated workspaces, validation, and reviewer-visible correctness checks.
 - [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](docs/benchmarks/2026-05-25-founder-command-center-auth-flow/README.md) — mixed exploration evidence, including the FounderCommandCenter contrast note.
 - [`docs/benchmarks/govalidate-suite/`](docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates.
 - [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -417,6 +417,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}',
     '    --questions PATH      load questions from a JSON file instead of a positional question',
     '    --output-dir DIR      compare output directory (default out/compare)',
+    '    --task TASK           explain | implement (default explain; implement currently requires --baseline-mode native_agent)',
     '    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
     '      For Claude MCP attribution in native_agent mode, include --verbose with --output-format json',
     '    --per-arm-timeout S   per-arm timeout seconds for native_agent runs (default 600)',

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -105,6 +105,7 @@ export interface CompareCliOptions {
   execTemplate: string
   questionsPath: string | null
   outputDir: string
+  task: 'explain' | 'implement'
   baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent'
   perArmTimeoutSeconds: number
   heartbeatIntervalMs: number
@@ -192,7 +193,7 @@ export interface InstallCliOptions {
   platform: InstallPlatform
 }
 
-const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'
+const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'
 
 export interface PlatformActionCliOptions {
   action: 'install' | 'uninstall'
@@ -312,6 +313,14 @@ function parseContextPackTask(value: string): ContextPackTaskKind {
     return normalized
   }
   throw new UsageError('error: --task must be one of explain, implement, review, impact')
+}
+
+function parseCompareTask(value: string): 'explain' | 'implement' {
+  const task = parseContextPackTask(value)
+  if (task === 'explain' || task === 'implement') {
+    return task
+  }
+  throw new UsageError('error: compare --task must be one of explain, implement')
 }
 
 function parsePromptProvider(value: string): PromptCliProvider {
@@ -1089,6 +1098,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   let execTemplate = ''
   let questionsPath: string | null = null
   let outputDir = 'out/compare'
+  let task: 'explain' | 'implement' = 'explain'
   let baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent' = 'full'
   let perArmTimeoutSeconds = 600
   let heartbeatIntervalMs = 30000
@@ -1162,6 +1172,18 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
     if (argument.startsWith('--output-dir=')) {
       const [, value] = argument.split('=', 2)
       outputDir = requireOptionValue('--output-dir', value)
+      continue
+    }
+
+    if (argument === '--task') {
+      task = parseCompareTask(requireOptionValue('--task', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--task=')) {
+      const [, value] = argument.split('=', 2)
+      task = parseCompareTask(requireOptionValue('--task', value))
       continue
     }
 
@@ -1261,6 +1283,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
     execTemplate,
     questionsPath,
     outputDir,
+    task,
     baselineMode,
     perArmTimeoutSeconds,
     heartbeatIntervalMs,

--- a/src/infrastructure/benchmark/suite.ts
+++ b/src/infrastructure/benchmark/suite.ts
@@ -8,6 +8,7 @@ import {
   type NativeAgentCompareReport,
   type NativeAgentCompareResult,
 } from '../compare.js'
+import { copyWorkspaceForBenchmark } from '../../shared/workspace-copy.js'
 import {
   benchmarkIsolationEnabled,
   captureBenchmarkEnvironment,
@@ -283,22 +284,8 @@ function portablePath(path: string): string {
   return relative(process.cwd(), path) || '.'
 }
 
-function filterWorkspaceCopy(sourceRoot: string, sourcePath: string): boolean {
-  const relativePath = relative(sourceRoot, sourcePath)
-  return (
-    relativePath !== 'out'
-    && !relativePath.startsWith(`out${sep}`)
-    && relativePath !== '.git'
-    && !relativePath.startsWith(`.git${sep}`)
-  )
-}
-
 function copyWorkspace(sourceRoot: string, targetRoot: string): void {
-  mkdirSync(dirname(targetRoot), { recursive: true })
-  cpSync(sourceRoot, targetRoot, {
-    recursive: true,
-    filter: (sourcePath) => filterWorkspaceCopy(sourceRoot, sourcePath),
-  })
+  copyWorkspaceForBenchmark(sourceRoot, targetRoot)
 }
 
 function shellQuote(value: string): string {

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1,8 +1,9 @@
 import { spawn } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
-import type { ContextPackExecutionPhase, ContextPackRoutingDebug } from '../contracts/context-pack.js'
+import type { ContextPackExecutionPhase, ContextPackRoutingDebug, ContextPackTaskKind, ImplementationPackGuidance } from '../contracts/context-pack.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
@@ -20,6 +21,7 @@ import {
   type BenchmarkEnvironmentContamination,
 } from './benchmark/environment.js'
 import { parsePromptRunnerJsonRecord, parsePromptRunnerOutput, type PromptRunnerUsage } from './prompt-runner.js'
+import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
 import { classifyRetrievalLevel } from '../runtime/retrieval-gate.js'
 import { compactRetrieveResult, retrieveContext, tokenizeLabel, type CompactRetrieveResult, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
@@ -27,6 +29,7 @@ import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtim
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
 import { sanitizeShareSafeText, toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
+import { copyWorkspaceForBenchmark } from '../shared/workspace-copy.js'
 
 export type CompareBaselineMode = 'full' | 'bounded' | 'pack_only' | 'native_agent'
 export type CompareRunMode = 'baseline' | 'madar'
@@ -227,6 +230,7 @@ export interface GenerateCompareArtifactsInput {
   questionsPath?: string | null
   outputDir: string
   execTemplate: string
+  task?: 'explain' | 'implement'
   baselineMode: CompareBaselineMode
   perArmTimeoutSeconds?: number
   heartbeatIntervalMs?: number
@@ -1607,7 +1611,17 @@ function createCompareRetrievalGraph(
   return { graph: retrievalGraph, originalSourceFiles }
 }
 
-function retrieveCompareContext(graph: KnowledgeGraph, question: string, budget: number, projectRoot: string): RetrieveResult {
+function compareTaskKind(input: Pick<GenerateCompareArtifactsInput, 'task'>): 'explain' | 'implement' {
+  return input.task === 'implement' ? 'implement' : 'explain'
+}
+
+function retrieveCompareContext(
+  graph: KnowledgeGraph,
+  question: string,
+  budget: number,
+  projectRoot: string,
+  taskKind: ContextPackTaskKind = 'explain',
+): RetrieveResult {
   const { graph: retrievalGraph, originalSourceFiles } = createCompareRetrievalGraph(graph, projectRoot)
   const originalCwd = process.cwd()
   try {
@@ -1616,6 +1630,7 @@ function retrieveCompareContext(graph: KnowledgeGraph, question: string, budget:
     const retrieval = retrieveContext(retrievalGraph, {
       question,
       budget: Math.max(budget, 200),
+      taskKind,
       ...(gate.signals.generation_intent === 'runtime_generation' ? { retrievalStrategy: 'slice-v1' as const } : {}),
     })
     for (const matchedNode of retrieval.matched_nodes) {
@@ -1893,7 +1908,43 @@ export function buildMadarPromptPack(input: BuildMadarPromptPackInput): CompareP
   }
 }
 
-export function buildNativeAgentPrompt(question: string): string {
+function formatImplementationPromptGuidance(guidance: ImplementationPackGuidance): string[] {
+  return [
+    `- Summary: ${guidance.summary}`,
+    `- Likely edit files: ${guidance.likely_edit_files.map((entry) => entry.path).join(', ') || 'none identified'}`,
+    `- Likely test files: ${guidance.likely_test_files.map((entry) => entry.path).join(', ') || 'none identified'}`,
+    `- Validation commands: ${guidance.validation_commands.join(' ; ') || 'none identified'}`,
+    `- Risk boundaries: ${guidance.risk_boundaries.map((entry) => entry.label).join(', ') || 'none identified'}`,
+  ]
+}
+
+export function buildNativeAgentPrompt(
+  question: string,
+  options: {
+    task?: 'explain' | 'implement'
+    implementation?: ImplementationPackGuidance
+  } = {},
+): string {
+  if (options.task === 'implement' && options.implementation) {
+    return [
+      'Follow the Madar implementation-pack contract exactly.',
+      'Implement the requested change using the Madar implementation pack.',
+      'Call context_pack first for implementation tasks before editing files or broad raw repo search.',
+      'Inspect likely_edit_files, likely_test_files, validation_commands, cautions, and risk boundaries before making any changes.',
+      'Prefer the likely_edit_files set first; editing outside the likely_edit_files or likely_test_files set requires an explicit reason.',
+      'Run the listed validation_commands before concluding.',
+      'If Madar is unavailable, continue from raw repo evidence and say so explicitly.',
+      '',
+      'Implementation guidance:',
+      ...formatImplementationPromptGuidance(options.implementation),
+      '',
+      `Question: ${question}`,
+      '',
+      'Answer:',
+      '',
+    ].join('\n')
+  }
+
   return [
     'Follow the Madar pack contract exactly.',
     'Call context_pack first for explain or runtime questions before any raw file or broad repo search.',
@@ -2371,6 +2422,9 @@ export async function runCompareCommand(
   input: GenerateCompareArtifactsInput,
   dependencies: ExecuteCompareRunsDependencies = {},
 ): Promise<string> {
+  if (compareTaskKind(input) === 'implement' && input.baselineMode !== 'native_agent') {
+    throw new Error('[madar compare] implement task currently requires --baseline-mode native_agent')
+  }
   if (input.baselineMode === 'native_agent') {
     const nativeResult = await executeNativeAgentCompare(input, dependencies)
     const failed = nativeResult.reports.filter((report) => isNativeAgentRunFailure(report.baseline) || isNativeAgentRunFailure(report.madar)).length
@@ -2494,8 +2548,49 @@ export interface NativeAgentToolCallCounts {
   madar: NativeAgentToolCallCountsEntry
 }
 
+export type ImplementValidationStatus = 'passed' | 'failed' | 'setup_error' | 'not_run'
+export type ReviewerVisibleStatus = 'passed' | 'failed' | 'not_scored'
+
+export interface ImplementValidationCommandResult {
+  command: string
+  status: Exclude<ImplementValidationStatus, 'not_run'>
+  exit_code: number | null
+  stdout: string | null
+  stderr: string | null
+}
+
+export interface ImplementValidationResult {
+  status: ImplementValidationStatus
+  commands: ImplementValidationCommandResult[]
+}
+
+export interface ReviewerVisibleCheckResult {
+  path: string
+  passed: boolean
+  missing_required_snippets: string[]
+  forbidden_snippets_present: string[]
+}
+
+export interface ReviewerVisibleCorrectnessResult {
+  status: ReviewerVisibleStatus
+  checks: ReviewerVisibleCheckResult[]
+}
+
+export interface ImplementOutcomeArmResult {
+  files_touched: string[]
+  wrong_file_edits: string[]
+  validation: ImplementValidationResult
+  reviewer_visible_correctness: ReviewerVisibleCorrectnessResult
+}
+
+export interface ImplementOutcomeReport {
+  baseline: ImplementOutcomeArmResult
+  madar: ImplementOutcomeArmResult
+}
+
 export interface NativeAgentCompareReport {
   baseline_mode: 'native_agent'
+  task: 'explain' | 'implement'
   question: string
   graph_path: string
   isolation: boolean
@@ -2521,6 +2616,8 @@ export interface NativeAgentCompareReport {
   token_regression: boolean
   token_regression_reasons: NativeAgentTokenRegressionMetric[]
   benchmark_readiness?: BenchmarkReadiness
+  implementation_guidance?: ImplementationPackGuidance
+  implement_outcome?: ImplementOutcomeReport
   prompt_contract?: NativeAgentPromptContractAssessment
   claim_assessment?: NativeAgentClaimAssessment
   benchmark_outcome?: NativeAgentBenchmarkOutcome
@@ -2592,6 +2689,7 @@ export interface NativeAgentRunnerInput {
   promptFile: string
   outputFile: string
   command: string
+  cwd?: string
   signal?: AbortSignal
 }
 
@@ -2664,6 +2762,231 @@ function hasSectionMarker(filePath: string, marker = MADAR_SECTION_MARKER): bool
     return false
   }
   return readFileSync(filePath, 'utf8').includes(marker)
+}
+
+interface ImplementationReviewerVisibleGate {
+  checks: Array<{
+    path: string
+    must_contain: string[]
+    must_not_contain: string[]
+  }>
+}
+
+interface ImplementationWorkspace {
+  tempRoot: string
+  workspaceRoot: string
+  graphPath: string
+}
+
+function loadImplementationReviewerVisibleGates(questionsPath?: string | null): Map<string, ImplementationReviewerVisibleGate> {
+  if (!questionsPath) {
+    return new Map()
+  }
+  const gatesPath = join(dirname(questionsPath), 'implementation-gates.json')
+  const parsed = readJsonObject(gatesPath)
+  if (!parsed) {
+    return new Map()
+  }
+
+  const gates = new Map<string, ImplementationReviewerVisibleGate>()
+  for (const [question, value] of Object.entries(parsed)) {
+    if (!isRecord(value) || !Array.isArray(value.checks)) {
+      continue
+    }
+    const checks = value.checks
+      .filter((entry): entry is Record<string, unknown> => isRecord(entry))
+      .map((entry) => ({
+        path: typeof entry.path === 'string' ? entry.path : '',
+        must_contain: Array.isArray(entry.must_contain) ? entry.must_contain.filter((item): item is string => typeof item === 'string') : [],
+        must_not_contain: Array.isArray(entry.must_not_contain) ? entry.must_not_contain.filter((item): item is string => typeof item === 'string') : [],
+      }))
+      .filter((entry) => entry.path.length > 0)
+    if (checks.length > 0) {
+      gates.set(question, { checks })
+    }
+  }
+  return gates
+}
+
+function shouldTrackWorkspacePath(rootPath: string, candidatePath: string): boolean {
+  const relativePath = relative(rootPath, candidatePath).replaceAll('\\', '/')
+  if (relativePath.length === 0) {
+    return true
+  }
+  const [topLevel = ''] = relativePath.split('/', 1)
+  return !['.git', 'out', 'node_modules', 'coverage', 'dist', 'build'].includes(topLevel)
+}
+
+function snapshotWorkspaceFiles(rootPath: string): Map<string, number> {
+  const snapshot = new Map<string, number>()
+  const pending = [rootPath]
+  while (pending.length > 0) {
+    const currentPath = pending.pop()
+    if (!currentPath) {
+      continue
+    }
+    if (!shouldTrackWorkspacePath(rootPath, currentPath)) {
+      continue
+    }
+    const stats = statSync(currentPath)
+    if (stats.isDirectory()) {
+      for (const child of readdirSync(currentPath)) {
+        pending.push(join(currentPath, child))
+      }
+      continue
+    }
+    if (!stats.isFile()) {
+      continue
+    }
+    const relativePath = relative(rootPath, currentPath).replaceAll(sep, '/')
+    snapshot.set(relativePath, sidecarAwareFileFingerprint(currentPath, stats.mtimeMs))
+  }
+  return snapshot
+}
+
+function diffWorkspaceSnapshots(before: Map<string, number>, after: Map<string, number>): string[] {
+  const changed = new Set<string>()
+  for (const [relativePath, fingerprint] of before.entries()) {
+    if (after.get(relativePath) !== fingerprint) {
+      changed.add(relativePath)
+    }
+  }
+  for (const [relativePath, fingerprint] of after.entries()) {
+    if (before.get(relativePath) !== fingerprint) {
+      changed.add(relativePath)
+    }
+  }
+  return [...changed].sort()
+}
+
+function prepareImplementationWorkspace(projectRoot: string, graphPath: string): ImplementationWorkspace {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'madar-compare-arm-'))
+  const workspaceRoot = join(tempRoot, 'workspace')
+  copyWorkspaceForBenchmark(projectRoot, workspaceRoot, { sharedTopLevelEntries: ['node_modules'] })
+  const relativeGraphPath = relative(projectRoot, graphPath)
+  const workspaceGraphPath = join(workspaceRoot, relativeGraphPath)
+  mkdirSync(dirname(workspaceGraphPath), { recursive: true })
+  writeFileSync(workspaceGraphPath, readFileSync(graphPath, 'utf8'), 'utf8')
+  return {
+    tempRoot,
+    workspaceRoot,
+    graphPath: workspaceGraphPath,
+  }
+}
+
+function cleanupImplementationWorkspace(workspace: ImplementationWorkspace | null | undefined): void {
+  if (!workspace) {
+    return
+  }
+  rmSync(workspace.tempRoot, { recursive: true, force: true })
+}
+
+function classifyValidationFailure(stdout: string, stderr: string): 'failed' | 'setup_error' {
+  return /cannot find module|command not found|enoent|missing script/i.test(`${stdout}\n${stderr}`) ? 'setup_error' : 'failed'
+}
+
+async function runShellCommand(command: string, options: { cwd?: string; signal?: AbortSignal } = {}): Promise<{
+  exitCode: number
+  stdout: string
+  stderr: string
+}> {
+  return await new Promise((resolveExecution, rejectExecution) => {
+    const shellCommand =
+      process.platform === 'win32'
+        ? { file: 'powershell.exe', args: ['-NoProfile', '-Command', command] }
+        : { file: '/bin/sh', args: ['-lc', command] }
+    const child = spawn(shellCommand.file, shellCommand.args, {
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+    })
+    let stdout = ''
+    let stderr = ''
+
+    const handleAbort = () => {
+      child.kill()
+    }
+    if (options.signal) {
+      if (options.signal.aborted) {
+        handleAbort()
+      } else {
+        options.signal.addEventListener('abort', handleAbort, { once: true })
+      }
+    }
+
+    child.stdout?.on('data', (chunk: string | Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk: string | Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on('error', (error) => {
+      rejectExecution(error)
+    })
+    child.on('close', (code) => {
+      resolveExecution({
+        exitCode: code ?? 1,
+        stdout,
+        stderr,
+      })
+    })
+  })
+}
+
+async function runImplementationValidationCommands(
+  commands: readonly string[],
+  workspaceRoot: string,
+): Promise<ImplementValidationResult> {
+  if (commands.length === 0) {
+    return { status: 'not_run', commands: [] }
+  }
+
+  const results: ImplementValidationCommandResult[] = []
+  for (const command of commands) {
+    const execution = await runShellCommand(command, { cwd: workspaceRoot })
+    results.push({
+      command,
+      status: execution.exitCode === 0 ? 'passed' : classifyValidationFailure(execution.stdout, execution.stderr),
+      exit_code: execution.exitCode,
+      stdout: execution.stdout.length > 0 ? execution.stdout : null,
+      stderr: execution.stderr.length > 0 ? execution.stderr : null,
+    })
+  }
+
+  if (results.every((entry) => entry.status === 'passed')) {
+    return { status: 'passed', commands: results }
+  }
+  if (results.some((entry) => entry.status === 'failed')) {
+    return { status: 'failed', commands: results }
+  }
+  return { status: 'setup_error', commands: results }
+}
+
+function evaluateReviewerVisibleCorrectness(
+  workspaceRoot: string,
+  gate: ImplementationReviewerVisibleGate | undefined,
+): ReviewerVisibleCorrectnessResult {
+  if (!gate) {
+    return { status: 'not_scored', checks: [] }
+  }
+
+  const checks = gate.checks.map((check) => {
+    const absolutePath = join(workspaceRoot, check.path)
+    const content = existsSync(absolutePath) ? readFileSync(absolutePath, 'utf8') : ''
+    const missingRequiredSnippets = check.must_contain.filter((snippet) => !content.includes(snippet))
+    const forbiddenSnippetsPresent = check.must_not_contain.filter((snippet) => content.includes(snippet))
+    return {
+      path: check.path,
+      passed: missingRequiredSnippets.length === 0 && forbiddenSnippetsPresent.length === 0,
+      missing_required_snippets: missingRequiredSnippets,
+      forbidden_snippets_present: forbiddenSnippetsPresent,
+    }
+  })
+
+  return {
+    status: checks.every((check) => check.passed) ? 'passed' : 'failed',
+    checks,
+  }
 }
 
 function findHookEntry(
@@ -2992,56 +3315,14 @@ function restoreMadarArtifacts(records: readonly SnapshotRecord[]): void {
 
 async function defaultNativeAgentRunner(input: NativeAgentRunnerInput): Promise<NativeAgentRunnerResult> {
   const startedAt = Date.now()
-
-  return await new Promise<NativeAgentRunnerResult>((resolveExecution, rejectExecution) => {
-    const command =
-      process.platform === 'win32'
-        ? { file: 'powershell.exe', args: ['-NoProfile', '-Command', input.command] }
-        : { file: '/bin/sh', args: ['-lc', input.command] }
-    const child = spawn(command.file, command.args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
-    let stdout = ''
-    let stderr = ''
-    let settled = false
-
-    const cleanupAbortListener = () => {
-      input.signal?.removeEventListener('abort', handleAbort)
-    }
-
-    const handleAbort = () => {
-      child.kill()
-    }
-
-    if (input.signal) {
-      if (input.signal.aborted) {
-        handleAbort()
-      } else {
-        input.signal.addEventListener('abort', handleAbort, { once: true })
-      }
-    }
-
-    child.stdout?.on('data', (chunk: string | Buffer) => {
-      stdout += chunk.toString()
-    })
-    child.stderr?.on('data', (chunk: string | Buffer) => {
-      stderr += chunk.toString()
-    })
-    child.on('error', (error) => {
-      if (settled) {
-        return
-      }
-      settled = true
-      cleanupAbortListener()
-      rejectExecution(error)
-    })
-    child.on('close', (code) => {
-      if (settled) {
-        return
-      }
-      settled = true
-      cleanupAbortListener()
-      resolveExecution({ exitCode: code ?? 1, stdout, stderr, elapsedMs: Date.now() - startedAt })
-    })
+  const execution = await runShellCommand(input.command, {
+    ...(input.cwd ? { cwd: input.cwd } : {}),
+    ...(input.signal ? { signal: input.signal } : {}),
   })
+  return {
+    ...execution,
+    elapsedMs: Date.now() - startedAt,
+  }
 }
 
 function perArmTimeoutMs(seconds: number | undefined): number {
@@ -3679,13 +3960,15 @@ export async function executeNativeAgentCompare(
   const timeoutMs = perArmTimeoutMs(input.perArmTimeoutSeconds)
   const heartbeatIntervalMs = compareHeartbeatIntervalMs(input.heartbeatIntervalMs)
   const retrievalBudget = input.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET
+  const task = compareTaskKind(input)
   const timestamp = now()
   const outputRoot = createCompareOutputRoot(outputDir, timestamp)
   const runner = dependencies.runner ?? defaultNativeAgentRunner
   const assessBenchmarkReadiness = dependencies.assessBenchmarkReadiness
-  const graph = assessBenchmarkReadiness ? null : loadGraph(graphPath)
+  const graph = loadGraph(graphPath)
   const reports: NativeAgentCompareReport[] = []
   const answerQualityGates = loadNativeAgentAnswerQualityGates(input.questionsPath)
+  const reviewerVisibleGates = task === 'implement' ? loadImplementationReviewerVisibleGates(input.questionsPath) : new Map()
   const environment = await captureBenchmarkEnvironment({ projectRoot })
   const isolation = benchmarkIsolationEnabled()
   const installCheck = inspectClaudeNativeAgentInstall(projectRoot)
@@ -3696,9 +3979,20 @@ export async function executeNativeAgentCompare(
   const preparedQuestions = questions.map((question, index) => {
     const questionDir = questions.length === 1 ? outputRoot : join(outputRoot, `question-${String(index + 1).padStart(3, '0')}`)
     mkdirSync(questionDir, { recursive: true })
+    const retrieval = retrieveCompareContext(graph, question, retrievalBudget, projectRoot, task)
+    const implementationGuidance =
+      task === 'implement'
+        ? buildImplementationPackGuidance(graph, retrieval, {
+            budget: retrievalBudget,
+            taskIntent: 'implement',
+          })
+        : undefined
 
     const promptFile = join(questionDir, 'native_agent-prompt.txt')
-    writeFileSync(promptFile, buildNativeAgentPrompt(question), 'utf8')
+    writeFileSync(promptFile, buildNativeAgentPrompt(question, {
+      task,
+      ...(implementationGuidance ? { implementation: implementationGuidance } : {}),
+    }), 'utf8')
     const baselineAnswerPath = answerFilePath(questionDir, 'baseline')
     const madarAnswerPath = answerFilePath(questionDir, 'madar')
     const reportPath = join(questionDir, 'report.json')
@@ -3707,6 +4001,7 @@ export async function executeNativeAgentCompare(
 
     const reportShell: NativeAgentCompareReport = {
       baseline_mode: 'native_agent',
+      task,
       question,
       graph_path: graphPath,
       isolation,
@@ -3752,16 +4047,19 @@ export async function executeNativeAgentCompare(
         prompt_file: promptFile,
       },
     }
+    if (implementationGuidance) {
+      reportShell.implementation_guidance = implementationGuidance
+    }
     if (assessBenchmarkReadiness) {
       reportShell.benchmark_readiness = assessBenchmarkReadiness({
         graphPath,
         projectRoot,
         question,
       })
-    } else if (graph) {
+    } else {
       reportShell.benchmark_readiness = assessBenchmarkReadinessFromRetrieveResult({
         graphPath,
-        retrieval: retrieveCompareContext(graph, question, retrievalBudget, projectRoot),
+        retrieval,
       })
     }
     if (reportShell.benchmark_readiness) {
@@ -3776,6 +4074,8 @@ export async function executeNativeAgentCompare(
       shareSafeReportPath,
       runStatePath,
       reportShell,
+      implementationGuidance,
+      reviewerVisibleGate: reviewerVisibleGates.get(question),
     }
   })
 
@@ -3798,21 +4098,30 @@ export async function executeNativeAgentCompare(
       madarAnswerPath,
       runStatePath,
       reportShell,
+      implementationGuidance,
+      reviewerVisibleGate,
     } = entry
-
-    writeNativeAgentRunState(runStatePath, {
-      phase: 'baseline_pending',
-      arm: 'baseline',
-      updated_at: now().toISOString(),
-    })
-
-    // Step 1: snapshot madar artifacts and run baseline.
-    const stamp = timestamp.toISOString().replace(/[^0-9]/g, '').slice(0, 14)
-    let snapshot: SnapshotRecord[] = []
-    let baselineCrashed: unknown = null
-    let baselineToolCallCounts: NativeAgentToolCallCountsEntry | null = null
+    const baselineWorkspace = task === 'implement' ? prepareImplementationWorkspace(projectRoot, graphPath) : null
+    const madarWorkspace = task === 'implement' ? prepareImplementationWorkspace(projectRoot, graphPath) : null
+    let baselineTouchedFiles: string[] = []
+    let madarTouchedFiles: string[] = []
+    let baselineWorkspaceSnapshot = baselineWorkspace ? snapshotWorkspaceFiles(baselineWorkspace.workspaceRoot) : null
+    let madarWorkspaceSnapshot = madarWorkspace ? snapshotWorkspaceFiles(madarWorkspace.workspaceRoot) : null
     try {
-      snapshot = snapshotMadarArtifacts(projectRoot, stamp)
+
+      writeNativeAgentRunState(runStatePath, {
+        phase: 'baseline_pending',
+        arm: 'baseline',
+        updated_at: now().toISOString(),
+      })
+
+      // Step 1: snapshot madar artifacts and run baseline.
+      const stamp = timestamp.toISOString().replace(/[^0-9]/g, '').slice(0, 14)
+      let snapshot: SnapshotRecord[] = []
+      let baselineCrashed: unknown = null
+      let baselineToolCallCounts: NativeAgentToolCallCountsEntry | null = null
+      try {
+        snapshot = snapshotMadarArtifacts(baselineWorkspace?.workspaceRoot ?? projectRoot, stamp)
       const baselineCommand = expandCompareExecTemplate(input.execTemplate, {
         promptFile,
         question,
@@ -3824,7 +4133,14 @@ export async function executeNativeAgentCompare(
       try {
         const baselineExecution = await runNativeAgentArmWithTimeout(
           runner,
-          { mode: 'baseline', question, promptFile, outputFile: baselineAnswerPath, command: baselineCommand },
+          {
+            mode: 'baseline',
+            question,
+            promptFile,
+            outputFile: baselineAnswerPath,
+            command: baselineCommand,
+            ...(baselineWorkspace ? { cwd: baselineWorkspace.workspaceRoot } : {}),
+          },
           timeoutMs,
           heartbeatIntervalMs,
           writeStderr,
@@ -3903,9 +4219,16 @@ export async function executeNativeAgentCompare(
                 ...runStateDetails({ baseline: reportShell.baseline }),
         })
       }
-    } finally {
-      restoreMadarArtifacts(snapshot)
-    }
+      } finally {
+        restoreMadarArtifacts(snapshot)
+        if (baselineWorkspace && baselineWorkspaceSnapshot) {
+          baselineTouchedFiles = diffWorkspaceSnapshots(
+            baselineWorkspaceSnapshot,
+            snapshotWorkspaceFiles(baselineWorkspace.workspaceRoot),
+          )
+          baselineWorkspaceSnapshot = null
+        }
+      }
 
     if (baselineCrashed !== null) {
       // Persist a partial report before re-throwing so users can inspect it.
@@ -3923,30 +4246,37 @@ export async function executeNativeAgentCompare(
       continue
     }
 
-    // Step 2: run madar (artifacts are restored, MCP server is in place).
-    writeNativeAgentRunState(runStatePath, {
+      // Step 2: run madar (artifacts are restored, MCP server is in place).
+      writeNativeAgentRunState(runStatePath, {
       phase: 'madar_pending',
       arm: 'madar',
       updated_at: now().toISOString(),
       ...runStateDetails({ baseline: reportShell.baseline }),
-    })
-    const madarCommand = expandCompareExecTemplate(input.execTemplate, {
+      })
+      const madarCommand = expandCompareExecTemplate(input.execTemplate, {
       promptFile,
       question,
       mode: 'madar',
       outputFile: madarAnswerPath,
-    })
-    let madarRun: NativeAgentRunnerResult | null = null
-    let madarToolCallCounts: NativeAgentToolCallCountsEntry | null = null
-    try {
-      const madarExecution = await runNativeAgentArmWithTimeout(
+      })
+      let madarRun: NativeAgentRunnerResult | null = null
+      let madarToolCallCounts: NativeAgentToolCallCountsEntry | null = null
+      try {
+        const madarExecution = await runNativeAgentArmWithTimeout(
         runner,
-        { mode: 'madar', question, promptFile, outputFile: madarAnswerPath, command: madarCommand },
+        {
+          mode: 'madar',
+          question,
+          promptFile,
+          outputFile: madarAnswerPath,
+          command: madarCommand,
+          ...(madarWorkspace ? { cwd: madarWorkspace.workspaceRoot } : {}),
+        },
         timeoutMs,
         heartbeatIntervalMs,
         writeStderr,
-      )
-      if (madarExecution.kind === 'timed_out') {
+        )
+        if (madarExecution.kind === 'timed_out') {
         reportShell.madar = {
           kind: 'runner_error',
           evidence: `Timed out after ${timeoutMs}ms`,
@@ -3962,19 +4292,26 @@ export async function executeNativeAgentCompare(
           ...runStateDetails({ baseline: reportShell.baseline, madar: reportShell.madar }),
         })
         writeStderr(`[madar compare] madar arm timed out after ${timeoutMs}ms\n`)
-      } else {
-        madarRun = madarExecution.result
-      }
-    } catch (error) {
+        } else {
+          madarRun = madarExecution.result
+        }
+      } catch (error) {
       reportShell.madar = {
         kind: 'runner_error',
         evidence: error instanceof Error ? error.message : String(error),
         exit_code: null,
         stderr: null,
       }
-      ensureCompareAnswerFile(madarAnswerPath, '')
-    }
-    if (madarRun !== null) {
+        ensureCompareAnswerFile(madarAnswerPath, '')
+      }
+      if (madarWorkspace && madarWorkspaceSnapshot) {
+        madarTouchedFiles = diffWorkspaceSnapshots(
+          madarWorkspaceSnapshot,
+          snapshotWorkspaceFiles(madarWorkspace.workspaceRoot),
+        )
+        madarWorkspaceSnapshot = null
+      }
+      if (madarRun !== null) {
       madarToolCallCounts = extractNativeAgentToolCallCounts(madarRun.stdout)
       reportShell.environment_contamination = extractEnvironmentContamination(madarRun.stdout)
       const rawMadarTrace = extractMadarTrace(madarRun.stdout)
@@ -4107,10 +4444,51 @@ export async function executeNativeAgentCompare(
     if (answerQuality !== undefined) {
       reportShell.answer_quality = answerQuality
     }
+    if (task === 'implement' && implementationGuidance && baselineWorkspace && madarWorkspace) {
+      const allowedEditPaths = new Set([
+        ...implementationGuidance.likely_edit_files.map((entry) => entry.path),
+        ...implementationGuidance.likely_test_files.map((entry) => entry.path),
+      ])
+      const baselineValidation =
+        reportShell.baseline.kind === 'runner_error'
+          ? { status: 'not_run' as const, commands: [] }
+          : await runImplementationValidationCommands(implementationGuidance.validation_commands, baselineWorkspace.workspaceRoot)
+      const madarValidation =
+        reportShell.madar.kind === 'runner_error'
+          ? { status: 'not_run' as const, commands: [] }
+          : await runImplementationValidationCommands(implementationGuidance.validation_commands, madarWorkspace.workspaceRoot)
+      const baselineReviewerVisible =
+        reportShell.baseline.kind === 'runner_error'
+          ? { status: 'not_scored' as const, checks: [] }
+          : evaluateReviewerVisibleCorrectness(baselineWorkspace.workspaceRoot, reviewerVisibleGate)
+      const madarReviewerVisible =
+        reportShell.madar.kind === 'runner_error'
+          ? { status: 'not_scored' as const, checks: [] }
+          : evaluateReviewerVisibleCorrectness(madarWorkspace.workspaceRoot, reviewerVisibleGate)
 
-    reportShell.completed_at = now().toISOString()
-    writeNativeAgentReport(reportShell)
-    reports.push(reportShell)
+      reportShell.implement_outcome = {
+        baseline: {
+          files_touched: baselineTouchedFiles,
+          wrong_file_edits: baselineTouchedFiles.filter((path) => !allowedEditPaths.has(path)),
+          validation: baselineValidation,
+          reviewer_visible_correctness: baselineReviewerVisible,
+        },
+        madar: {
+          files_touched: madarTouchedFiles,
+          wrong_file_edits: madarTouchedFiles.filter((path) => !allowedEditPaths.has(path)),
+          validation: madarValidation,
+          reviewer_visible_correctness: madarReviewerVisible,
+        },
+      }
+    }
+
+      reportShell.completed_at = now().toISOString()
+      writeNativeAgentReport(reportShell)
+      reports.push(reportShell)
+    } finally {
+      cleanupImplementationWorkspace(baselineWorkspace)
+      cleanupImplementationWorkspace(madarWorkspace)
+    }
   }
 
   const answerQualitySummary = summarizeNativeAgentAnswerQuality(reports)
@@ -4254,6 +4632,15 @@ function formatNativeAgentMadarTraceOutcomeSummary(reports: NativeAgentCompareRe
   return outcomeParts.length > 0 ? `Madar trace outcomes: ${outcomeParts.join(', ')}` : null
 }
 
+function formatImplementOutcomeStatus(outcome: ImplementOutcomeArmResult): string {
+  return [
+    `${formatCount(outcome.files_touched.length, 'file touched', 'files touched')}`,
+    `${formatCount(outcome.wrong_file_edits.length, 'wrong-file edit', 'wrong-file edits')}`,
+    `validation ${outcome.validation.status}`,
+    `reviewer-visible ${outcome.reviewer_visible_correctness.status}`,
+  ].join(' · ')
+}
+
 export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult): string {
   const lines: string[] = [
     `[madar compare] completed ${result.reports.length} native_agent question(s)`,
@@ -4356,6 +4743,11 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       if (tokenRegressionWarning) {
         lines.push(`    ${tokenRegressionWarning}`)
       }
+      if (report.implement_outcome) {
+        lines.push(
+          `    implement outcome: baseline ${formatImplementOutcomeStatus(report.implement_outcome.baseline)} · madar ${formatImplementOutcomeStatus(report.implement_outcome.madar)}`,
+        )
+      }
       if (report.madar_trace) {
         lines.push(`    madar_trace: ${report.madar_trace.exploration_outcome} · ${report.madar_trace.exploration_summary}`)
       }
@@ -4400,6 +4792,11 @@ export function formatNativeAgentCompareSummary(result: NativeAgentCompareResult
       ]
       lines.push(
         `    answer quality: baseline ${report.answer_quality.baseline.passed ? 'PASS' : `FAIL (${baselineFindings.join(', ')})`} · madar ${report.answer_quality.madar.passed ? 'PASS' : `FAIL (${madarFindings.join(', ')})`}${report.answer_quality.manual_review_notes.length > 0 ? ` · manual review: ${formatCount(report.answer_quality.manual_review_notes.length, 'note', 'notes')}` : ''}`,
+      )
+    }
+    if (report.implement_outcome) {
+      lines.push(
+        `    implement outcome: baseline ${formatImplementOutcomeStatus(report.implement_outcome.baseline)} · madar ${formatImplementOutcomeStatus(report.implement_outcome.madar)}`,
       )
     }
     if (report.madar_trace) {

--- a/src/shared/workspace-copy.ts
+++ b/src/shared/workspace-copy.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from 'node:fs'
+import { cpSync, existsSync, lstatSync, mkdirSync, rmSync, symlinkSync } from 'node:fs'
 import { dirname, join, relative, sep } from 'node:path'
 
 export interface CopyWorkspaceOptions {
@@ -40,6 +40,7 @@ function linkSharedTopLevelEntries(
     }
     const targetEntryPath = join(targetRoot, entry)
     mkdirSync(dirname(targetEntryPath), { recursive: true })
+    rmSync(targetEntryPath, { recursive: true, force: true })
     symlinkSync(sourceEntryPath, targetEntryPath, symlinkKindForEntry(sourceEntryPath))
   }
 }

--- a/src/shared/workspace-copy.ts
+++ b/src/shared/workspace-copy.ts
@@ -5,6 +5,8 @@ export interface CopyWorkspaceOptions {
   sharedTopLevelEntries?: readonly string[]
 }
 
+const FILTERED_TOP_LEVEL_ENTRIES = ['out', '.git'] as const
+
 function filterWorkspaceCopy(sourceRoot: string, sourcePath: string, sharedTopLevelEntries: ReadonlySet<string>): boolean {
   const relativePath = relative(sourceRoot, sourcePath)
   if (sharedTopLevelEntries.size > 0) {
@@ -45,6 +47,12 @@ function linkSharedTopLevelEntries(
   }
 }
 
+function removeFilteredTopLevelEntries(targetRoot: string): void {
+  for (const entry of FILTERED_TOP_LEVEL_ENTRIES) {
+    rmSync(join(targetRoot, entry), { recursive: true, force: true })
+  }
+}
+
 export function copyWorkspaceForBenchmark(sourceRoot: string, targetRoot: string, options: CopyWorkspaceOptions = {}): void {
   const sharedTopLevelEntries = options.sharedTopLevelEntries ?? []
   const sharedTopLevelEntrySet = new Set(sharedTopLevelEntries)
@@ -53,5 +61,6 @@ export function copyWorkspaceForBenchmark(sourceRoot: string, targetRoot: string
     recursive: true,
     filter: (sourcePath) => filterWorkspaceCopy(sourceRoot, sourcePath, sharedTopLevelEntrySet),
   })
+  removeFilteredTopLevelEntries(targetRoot)
   linkSharedTopLevelEntries(sourceRoot, targetRoot, sharedTopLevelEntries)
 }

--- a/src/shared/workspace-copy.ts
+++ b/src/shared/workspace-copy.ts
@@ -1,0 +1,56 @@
+import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+
+export interface CopyWorkspaceOptions {
+  sharedTopLevelEntries?: readonly string[]
+}
+
+function filterWorkspaceCopy(sourceRoot: string, sourcePath: string, sharedTopLevelEntries: ReadonlySet<string>): boolean {
+  const relativePath = relative(sourceRoot, sourcePath)
+  if (sharedTopLevelEntries.size > 0) {
+    const [topLevel = ''] = relativePath.split(sep, 1)
+    if (sharedTopLevelEntries.has(topLevel)) {
+      return false
+    }
+  }
+  return (
+    relativePath !== 'out'
+    && !relativePath.startsWith(`out${sep}`)
+    && relativePath !== '.git'
+    && !relativePath.startsWith(`.git${sep}`)
+  )
+}
+
+function symlinkKindForEntry(entryPath: string): 'file' | 'dir' | 'junction' {
+  if (lstatSync(entryPath).isDirectory()) {
+    return process.platform === 'win32' ? 'junction' : 'dir'
+  }
+  return 'file'
+}
+
+function linkSharedTopLevelEntries(
+  sourceRoot: string,
+  targetRoot: string,
+  sharedTopLevelEntries: readonly string[],
+): void {
+  for (const entry of sharedTopLevelEntries) {
+    const sourceEntryPath = join(sourceRoot, entry)
+    if (!existsSync(sourceEntryPath)) {
+      continue
+    }
+    const targetEntryPath = join(targetRoot, entry)
+    mkdirSync(dirname(targetEntryPath), { recursive: true })
+    symlinkSync(sourceEntryPath, targetEntryPath, symlinkKindForEntry(sourceEntryPath))
+  }
+}
+
+export function copyWorkspaceForBenchmark(sourceRoot: string, targetRoot: string, options: CopyWorkspaceOptions = {}): void {
+  const sharedTopLevelEntries = options.sharedTopLevelEntries ?? []
+  const sharedTopLevelEntrySet = new Set(sharedTopLevelEntries)
+  mkdirSync(dirname(targetRoot), { recursive: true })
+  cpSync(sourceRoot, targetRoot, {
+    recursive: true,
+    filter: (sourcePath) => filterWorkspaceCopy(sourceRoot, sourcePath, sharedTopLevelEntrySet),
+  })
+  linkSharedTopLevelEntries(sourceRoot, targetRoot, sharedTopLevelEntries)
+}

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -129,6 +129,7 @@ function makeCompareResult(input: {
 
   const report: NativeAgentCompareReport = {
     baseline_mode: 'native_agent',
+    task: 'explain',
     question: input.question,
     graph_path: input.graphPath,
     isolation: input.isolation ?? false,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -548,6 +548,7 @@ describe('cli parser', () => {
       execTemplate: 'claude -p "$(cat {prompt_file})"',
       questionsPath: null,
       outputDir: resolve('out/compare'),
+      task: 'explain',
       baselineMode: 'full',
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
@@ -564,6 +565,7 @@ describe('cli parser', () => {
       execTemplate: 'gemini -p "$(cat {prompt_file})"',
       questionsPath: 'benchmark-questions.json',
       outputDir: resolve('out/compare'),
+      task: 'explain',
       baselineMode: 'full',
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
@@ -604,6 +606,7 @@ describe('cli parser', () => {
       execTemplate: 'claude -p "$(cat {prompt_file})"',
       questionsPath: null,
       outputDir: resolve('out/compare/custom'),
+      task: 'explain',
       baselineMode: 'bounded',
       perArmTimeoutSeconds: 900,
       heartbeatIntervalMs: 15000,
@@ -630,6 +633,7 @@ describe('cli parser', () => {
       execTemplate: 'claude -p "$(cat {prompt_file})"',
       questionsPath: null,
       outputDir: resolve('out/compare'),
+      task: 'explain',
       baselineMode: 'pack_only',
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
@@ -638,6 +642,35 @@ describe('cli parser', () => {
       allowNoInstall: false,
       yes: false,
       limit: null,
+    })
+  })
+
+  it('parses compare args with an explicit task kind', () => {
+    expect(
+      parseCompareArgs([
+        'implement session sliding expiration',
+        '--exec',
+        'claude -p "$(cat {prompt_file})"',
+        '--baseline-mode',
+        'native_agent',
+        '--task',
+        'implement',
+      ]),
+    ).toEqual({
+      question: 'implement session sliding expiration',
+      graphPath: 'out/graph.json',
+      execTemplate: 'claude -p "$(cat {prompt_file})"',
+      questionsPath: null,
+      outputDir: resolve('out/compare'),
+      baselineMode: 'native_agent',
+      perArmTimeoutSeconds: 600,
+      heartbeatIntervalMs: 30000,
+      strictMadarFirst: false,
+      strictBenchmarkReadiness: false,
+      allowNoInstall: false,
+      yes: false,
+      limit: null,
+      task: 'implement',
     })
   })
 
@@ -655,6 +688,7 @@ describe('cli parser', () => {
       execTemplate: 'claude -p "$(cat {prompt_file})"',
       questionsPath: null,
       outputDir: resolve('out/compare'),
+      task: 'explain',
       baselineMode: 'full',
       perArmTimeoutSeconds: 600,
       heartbeatIntervalMs: 30000,
@@ -680,6 +714,7 @@ describe('cli parser', () => {
     execTemplate: 'claude -p "$(cat {prompt_file})"',
     questionsPath: null,
     outputDir: resolve('out/compare'),
+    task: 'explain',
     baselineMode: 'full',
     perArmTimeoutSeconds: 600,
     heartbeatIntervalMs: 30000,
@@ -1111,6 +1146,7 @@ describe('cli main', () => {
     expect(help).toContain('    --exec TEMPLATE       required command template; supports {prompt_file}, {question}, {mode}, and {output_file}')
     expect(help).toContain('    --questions PATH      load questions from a JSON file instead of a positional question')
     expect(help).toContain('    --output-dir DIR      compare output directory (default out/compare)')
+    expect(help).toContain('    --task TASK           explain | implement (default explain; implement currently requires --baseline-mode native_agent)')
     expect(help).toContain('    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)')
     expect(help).toContain('      For Claude MCP attribution in native_agent mode, include --verbose with --output-format json')
     expect(help).toContain('    --per-arm-timeout S   per-arm timeout seconds for native_agent runs (default 600)')
@@ -1202,6 +1238,7 @@ describe('cli main', () => {
       execTemplate: 'gemini -p "$(cat {prompt_file})"',
       questionsPath: 'benchmark-questions.json',
       outputDir: resolve('out/compare/custom'),
+      task: 'explain',
       baselineMode: 'bounded',
       perArmTimeoutSeconds: 900,
       heartbeatIntervalMs: 15000,
@@ -1489,7 +1526,7 @@ describe('cli main', () => {
 
     expect(exitCode).toBe(2)
     expect(logs).toEqual([])
-    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'])
+    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'])
   })
 
   it('prefers the explicit compare command over an implicit generate path match', async () => {

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
+import { KnowledgeGraph } from '../../src/contracts/graph.js'
 import {
   executeNativeAgentCompare,
   formatNativeAgentCompareSummary,
@@ -14,6 +15,7 @@ import {
   type NativeAgentRunner,
 } from '../../src/infrastructure/compare.js'
 import { claudeInstall } from '../../src/infrastructure/install.js'
+import { toJson } from '../../src/pipeline/export.js'
 
 const FIXTURE_PARENT = resolve('out', 'test-runtime', 'native-agent')
 const COMPARE_OUTPUT_PARENT = resolve('out', 'compare', 'test-runtime-native-agent')
@@ -48,6 +50,147 @@ function makeFixtureProject(options: { installState?: 'managed' | 'valid' | 'mis
     writeClaudeInstallArtifacts(projectDir)
   }
   return { projectDir, graphPath, outputDir }
+}
+
+function makeImplementationFixtureProject(): {
+  projectDir: string
+  graphPath: string
+  outputDir: string
+  questionsPath: string
+} {
+  const { projectDir, outputDir } = makeFixtureProject()
+  mkdirSync(join(projectDir, 'src'), { recursive: true })
+  mkdirSync(join(projectDir, 'tests'), { recursive: true })
+  mkdirSync(join(projectDir, 'scripts'), { recursive: true })
+  mkdirSync(join(projectDir, 'benchmarks', 'implement'), { recursive: true })
+
+  writeFileSync(
+    join(projectDir, 'src', 'session.ts'),
+    [
+      'export class SessionManager {',
+      '  createSession(userId: string) {',
+      '    return `session:${userId}`',
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  writeFileSync(
+    join(projectDir, 'src', 'config.ts'),
+    [
+      'export const config = {',
+      '  sessionTtlSeconds: 86400,',
+      '}',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  writeFileSync(
+    join(projectDir, 'tests', 'session.test.ts'),
+    [
+      'import { SessionManager } from "../src/session"',
+      '',
+      'export function assertSessionManager() {',
+      '  return new SessionManager()',
+      '}',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  writeFileSync(
+    join(projectDir, 'scripts', 'check-session.mjs'),
+    [
+      "import { readFileSync } from 'node:fs'",
+      "import { join } from 'node:path'",
+      '',
+      "const sessionSource = readFileSync(join(process.cwd(), 'src', 'session.ts'), 'utf8')",
+      "if (!sessionSource.includes('slidingExpirationMs')) {",
+      "  console.error('missing sliding expiration implementation')",
+      '  process.exit(1)',
+      '}',
+      '',
+      "console.log('validation ok')",
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  writeFileSync(
+    join(projectDir, 'package.json'),
+    JSON.stringify({
+      name: 'implement-fixture',
+      private: true,
+      type: 'module',
+      scripts: {
+        typecheck: 'node scripts/check-session.mjs',
+        build: 'node scripts/check-session.mjs',
+        test: 'node scripts/check-session.mjs',
+      },
+    }, null, 2),
+    'utf8',
+  )
+
+  const question = 'Implement sliding session expiration in SessionManager'
+  const questionsPath = join(projectDir, 'benchmarks', 'implement', 'questions.json')
+  writeFileSync(questionsPath, JSON.stringify([{ question }], null, 2), 'utf8')
+  writeFileSync(
+    join(projectDir, 'benchmarks', 'implement', 'implementation-gates.json'),
+    JSON.stringify({
+      [question]: {
+        checks: [
+          {
+            path: 'src/session.ts',
+            must_contain: ['slidingExpirationMs'],
+          },
+          {
+            path: 'src/config.ts',
+            must_not_contain: ['slidingExpirationMs'],
+          },
+        ],
+      },
+    }, null, 2),
+    'utf8',
+  )
+
+  const graph = new KnowledgeGraph()
+  graph.graph.root_path = projectDir
+  graph.addNode('session_manager', {
+    label: 'SessionManager',
+    source_file: 'src/session.ts',
+    source_location: 'L1',
+    line_number: 1,
+    node_kind: 'class',
+    file_type: 'code',
+    community: 0,
+  })
+  graph.addNode('config', {
+    label: 'config',
+    source_file: 'src/config.ts',
+    source_location: 'L1',
+    line_number: 1,
+    node_kind: 'constant',
+    file_type: 'code',
+    community: 0,
+  })
+  graph.addNode('session_test', {
+    label: 'SessionManager test',
+    source_file: 'tests/session.test.ts',
+    source_location: 'L1',
+    line_number: 1,
+    node_kind: 'function',
+    file_type: 'code',
+    community: 1,
+  })
+  graph.addEdge('session_test', 'session_manager', {
+    relation: 'tests',
+    confidence: 'EXTRACTED',
+    source_file: 'tests/session.test.ts',
+  })
+
+  const graphPath = join(projectDir, 'out', 'graph.json')
+  toJson(graph, { 0: ['session_manager', 'config'], 1: ['session_test'] }, graphPath)
+
+  return { projectDir, graphPath, outputDir, questionsPath }
 }
 
 const BASELINE_USAGE_PAYLOAD = {
@@ -677,6 +820,7 @@ function buildSummaryResult(overrides: {
     reports: [
       {
         baseline_mode: 'native_agent',
+        task: 'explain',
         question: overrides.question,
         graph_path: '/tmp/project/out/graph.json',
         isolation: false,
@@ -854,6 +998,132 @@ describe('executeNativeAgentCompare', () => {
       expect(prompt).toContain('Allow at most one focused Madar follow-up before raw search')
       expect(prompt).toContain('Broad raw search requires an explicit missing-context reason')
       expect(prompt).toContain('Question: What is the cluster module?')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('records implement-task outcome scoring with isolated per-arm workspaces', async () => {
+    const { projectDir, graphPath, outputDir, questionsPath } = makeImplementationFixtureProject()
+    try {
+      const runner: NativeAgentRunner = async (input) => {
+        const workspaceRoot = input.cwd ?? projectDir
+        if (input.mode === 'baseline') {
+          writeFileSync(
+            join(workspaceRoot, 'src', 'config.ts'),
+            [
+              'export const config = {',
+              '  sessionTtlSeconds: 86400,',
+              '  slidingExpirationMs: 30000,',
+              '}',
+              '',
+            ].join('\n'),
+            'utf8',
+          )
+        } else {
+          writeFileSync(
+            join(workspaceRoot, 'src', 'session.ts'),
+            [
+              'export class SessionManager {',
+              '  readonly slidingExpirationMs = 30000',
+              '',
+              '  createSession(userId: string) {',
+              '    return `session:${userId}`',
+              '  }',
+              '}',
+              '',
+            ].join('\n'),
+            'utf8',
+          )
+        }
+
+        return {
+          exitCode: 0,
+          stdout: `${JSON.stringify({
+            ...(input.mode === 'baseline' ? BASELINE_USAGE_PAYLOAD : MADAR_USAGE_PAYLOAD),
+            result: input.mode === 'baseline' ? 'updated config' : 'updated session manager',
+          })}\n`,
+          stderr: '',
+          elapsedMs: input.mode === 'baseline' ? 11 : 7,
+        }
+      }
+
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          questionsPath,
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+          task: 'implement',
+        },
+        {
+          runner,
+          now: () => new Date('2026-05-31T12:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.task).toBe('implement')
+      expect(report.implementation_guidance?.likely_edit_files.map((entry) => entry.path)).toContain('src/session.ts')
+      expect(report.implementation_guidance?.validation_commands).toContain('npm run typecheck')
+      expect(report.implement_outcome).toEqual({
+        baseline: expect.objectContaining({
+          files_touched: ['src/config.ts'],
+          wrong_file_edits: ['src/config.ts'],
+          validation: expect.objectContaining({
+            status: 'failed',
+          }),
+          reviewer_visible_correctness: expect.objectContaining({
+            status: 'failed',
+          }),
+        }),
+        madar: expect.objectContaining({
+          files_touched: ['src/session.ts'],
+          wrong_file_edits: [],
+          validation: expect.objectContaining({
+            status: 'passed',
+          }),
+          reviewer_visible_correctness: expect.objectContaining({
+            status: 'passed',
+          }),
+        }),
+      })
+
+      const prompt = readFileSync(report.paths.prompt_file, 'utf8')
+      expect(prompt).toContain('Implement the requested change using the Madar implementation pack.')
+      expect(prompt).toContain('src/session.ts')
+      expect(prompt).toContain('npm run typecheck')
+
+      const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
+      const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
+      expect(savedReport).toEqual(expect.objectContaining({
+        task: 'implement',
+        implement_outcome: expect.objectContaining({
+          baseline: expect.objectContaining({
+            wrong_file_edits: ['src/config.ts'],
+          }),
+          madar: expect.objectContaining({
+            wrong_file_edits: [],
+          }),
+        }),
+      }))
+      expect(shareSafeReport).toEqual(expect.objectContaining({
+        task: 'implement',
+        implement_outcome: expect.objectContaining({
+          madar: expect.objectContaining({
+            files_touched: ['src/session.ts'],
+          }),
+        }),
+      }))
+
+      expect(readFileSync(join(projectDir, 'src', 'session.ts'), 'utf8')).not.toContain('slidingExpirationMs')
+      expect(readFileSync(join(projectDir, 'src', 'config.ts'), 'utf8')).not.toContain('slidingExpirationMs')
+
+      const summary = formatNativeAgentCompareSummary(result)
+      expect(summary).toContain('implement outcome:')
+      expect(summary).toContain('wrong-file edits')
+      expect(summary).toContain('reviewer-visible')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -2940,6 +2940,24 @@ describe('compare runtime', () => {
     expect(readFileSync(join(COMPARE_OUTPUT_ROOT, outputTimestamp, 'madar-answer.txt'), 'utf8')).toBe('madar answer\n')
   })
 
+  it('rejects implement compare tasks outside native_agent mode', async () => {
+    const graph = makeGraph()
+    writeProjectFiles()
+    const graphPath = writeGraphFixture(graph)
+
+    await expect(
+      runCompareCommand({
+        graphPath,
+        question: 'implement session sliding expiration',
+        outputDir: COMPARE_OUTPUT_ROOT,
+        execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+        baselineMode: 'full',
+        task: 'implement',
+        now: new Date('2026-04-24T19:30:00.000Z'),
+      }),
+    ).rejects.toThrow('implement task currently requires --baseline-mode native_agent')
+  })
+
   it('adds deterministic answer-quality results to native_agent suite summaries when sibling quality gates exist', async () => {
     const graph = makeGraph()
     writeProjectFiles()

--- a/tests/unit/why-madar-doc.test.ts
+++ b/tests/unit/why-madar-doc.test.ts
@@ -195,6 +195,15 @@ describe('public marketing copy honesty', () => {
         expect(content).toContain('docs/benchmarks/suite/')
         expect(lower).toContain('foundercommandcenter')
       })
+
+      it('links the dated implementation receipt while keeping generalized implementation-win claims conservative', () => {
+        expect(content).toContain('docs/benchmarks/2026-05-31-implement-outcome/')
+        expect(lower).toContain('deterministic implementation-task receipt')
+        expect(lower).toContain('files touched')
+        expect(lower).toContain('wrong-file edits')
+        expect(lower).toContain('reviewer-visible')
+        expect(lower).toContain('we do not yet have cross-repo implementation-task evidence')
+      })
     })
   })
 

--- a/tests/unit/workspace-copy.test.ts
+++ b/tests/unit/workspace-copy.test.ts
@@ -24,6 +24,7 @@ describe('copyWorkspaceForBenchmark', () => {
     mkdirSync(join(sourceRoot, 'out'), { recursive: true })
     mkdirSync(join(sourceRoot, '.git'), { recursive: true })
     mkdirSync(join(sourceRoot, 'node_modules', 'example'), { recursive: true })
+    mkdirSync(join(targetRoot, 'node_modules'), { recursive: true })
 
     writeFileSync(join(sourceRoot, 'src', 'session.ts'), 'export const ok = true\n', 'utf8')
     writeFileSync(join(sourceRoot, 'out', 'graph.json'), '{"skip":true}\n', 'utf8')

--- a/tests/unit/workspace-copy.test.ts
+++ b/tests/unit/workspace-copy.test.ts
@@ -1,0 +1,44 @@
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { copyWorkspaceForBenchmark } from '../../src/shared/workspace-copy.js'
+
+describe('copyWorkspaceForBenchmark', () => {
+  const tempRoots: string[] = []
+
+  afterEach(() => {
+    for (const tempRoot of tempRoots.splice(0)) {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('reuses shared top-level dependency trees without copying out or .git', () => {
+    const sourceRoot = mkdtempSync(join(tmpdir(), 'workspace-copy-source-'))
+    const targetRoot = join(mkdtempSync(join(tmpdir(), 'workspace-copy-target-')), 'workspace')
+    tempRoots.push(sourceRoot, dirname(targetRoot))
+
+    mkdirSync(join(sourceRoot, 'src'), { recursive: true })
+    mkdirSync(join(sourceRoot, 'out'), { recursive: true })
+    mkdirSync(join(sourceRoot, '.git'), { recursive: true })
+    mkdirSync(join(sourceRoot, 'node_modules', 'example'), { recursive: true })
+
+    writeFileSync(join(sourceRoot, 'src', 'session.ts'), 'export const ok = true\n', 'utf8')
+    writeFileSync(join(sourceRoot, 'out', 'graph.json'), '{"skip":true}\n', 'utf8')
+    writeFileSync(join(sourceRoot, '.git', 'config'), '[core]\n', 'utf8')
+    writeFileSync(join(sourceRoot, 'node_modules', 'example', 'index.js'), 'module.exports = true\n', 'utf8')
+
+    copyWorkspaceForBenchmark(sourceRoot, targetRoot, { sharedTopLevelEntries: ['node_modules'] })
+
+    expect(readFileSync(join(targetRoot, 'src', 'session.ts'), 'utf8')).toContain('ok = true')
+    expect(existsSync(join(targetRoot, 'out'))).toBe(false)
+    expect(existsSync(join(targetRoot, '.git'))).toBe(false)
+
+    const linkedNodeModules = join(targetRoot, 'node_modules')
+    expect(lstatSync(linkedNodeModules).isSymbolicLink()).toBe(true)
+    expect(realpathSync(linkedNodeModules)).toBe(realpathSync(join(sourceRoot, 'node_modules')))
+    expect(readFileSync(join(linkedNodeModules, 'example', 'index.js'), 'utf8')).toContain('module.exports = true')
+  })
+})

--- a/tests/unit/workspace-copy.test.ts
+++ b/tests/unit/workspace-copy.test.ts
@@ -25,6 +25,8 @@ describe('copyWorkspaceForBenchmark', () => {
     mkdirSync(join(sourceRoot, '.git'), { recursive: true })
     mkdirSync(join(sourceRoot, 'node_modules', 'example'), { recursive: true })
     mkdirSync(join(targetRoot, 'node_modules'), { recursive: true })
+    mkdirSync(join(targetRoot, 'out'), { recursive: true })
+    mkdirSync(join(targetRoot, '.git'), { recursive: true })
 
     writeFileSync(join(sourceRoot, 'src', 'session.ts'), 'export const ok = true\n', 'utf8')
     writeFileSync(join(sourceRoot, 'out', 'graph.json'), '{"skip":true}\n', 'utf8')


### PR DESCRIPTION
## Summary
- add `madar compare --task implement` with native-agent implementation outcome scoring, isolated workspaces, validation checks, and reviewer-visible correctness gates
- publish a dated implementation-task receipt under `docs/benchmarks/2026-05-31-implement-outcome/` and update `docs/claims-and-evidence.md` conservatively
- extract shared workspace copy logic and reuse top-level `node_modules` in compare workspaces to avoid duplicating heavy dependency trees

## Verification
- `npm run test:run -- tests/unit/cli.test.ts tests/unit/compare.test.ts tests/unit/compare-native-agent.test.ts tests/unit/why-madar-doc.test.ts`
- `npm run test:run -- tests/unit/workspace-copy.test.ts tests/unit/benchmark-suite.test.ts tests/unit/compare.test.ts tests/unit/compare-native-agent.test.ts tests/unit/why-madar-doc.test.ts`
- `npm run typecheck`
- `npm run build`
- `CI=1 npm run test:run`

Closes #419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --task explain|implement CLI option (implement requires native-agent mode).
  * Implementation-outcome benchmarking: per-arm workspace isolation, artifact snapshotting, validation commands, reviewer-visible correctness checks, and reporting of files touched.
  * Workspace copy for benchmarks with filtered copying and optional shared top-level symlinks.

* **Documentation**
  * Added deterministic benchmark receipts and updated claims-and-evidence to reference them.

* **Tests**
  * New unit tests for implement-task flows, validation gates, workspace isolation, and workspace-copy symlink behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->