### PR TITLE
feat: add share-safe handoff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Want the opt-in semantic retrieval / rerank path too? Install the optional local
 npm install @huggingface/transformers
 ```
 
-`madar prompt` stays local and only compiles a prompt payload. By contrast, compare and benchmark flows can spend paid model tokens when you swap the local smoke-check runner for a real model CLI or hosted model configuration.
+`madar prompt` stays local and only compiles a prompt payload. `madar handoff` is the share-safe remote/background-agent artifact when you need to pass a bounded brief to a cloud or async worker without shipping the richer local pack verbatim. `madar pack` stays the richer local/full-context surface. By contrast, compare and benchmark flows can spend paid model tokens when you swap the local smoke-check runner for a real model CLI or hosted model configuration.
 
 **Install commands:**
 
@@ -93,6 +93,7 @@ madar opencode install    # OpenCode
 madar summary                             # bounded JSON overview before pack/prompt
 madar pack "how does auth work?" --task explain --format text   # human-readable execution brief
 madar pack "add auth telemetry" --task implement --format json  # Pack Schema v1 for automation
+madar handoff "add auth telemetry" --task implement --consumer copilot   # share-safe remote/background-agent artifact
 madar prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
 ```
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { runBenchmarkSuite } from '../infrastructure/benchmark/suite.js'
 import { evaluateRetrievalQuality, formatQualityReport } from '../infrastructure/benchmark/quality.js'
 import { BenchmarkReadinessError, NativeAgentInstallRequiredError, runCompareCommand } from '../infrastructure/compare.js'
 import { runContextPackCommand } from '../infrastructure/context-pack-command.js'
+import { runHandoffCommand } from '../infrastructure/handoff-command.js'
 import { runContextPromptCommand } from '../infrastructure/context-prompt-command.js'
 import { runDoctorCommand, runStatusCommand } from '../infrastructure/doctor.js'
 import { runReviewCompareCommand } from '../infrastructure/review-compare.js'
@@ -49,6 +50,7 @@ import {
   type BenchmarkCliOptions,
   parseCompareArgs,
   parseDoctorArgs,
+  parseHandoffArgs,
   parsePackArgs,
   parseDiffArgs,
   parseExplainArgs,
@@ -64,6 +66,7 @@ import {
   parseSummaryArgs,
   parseServeArgs,
   parseTimeTravelArgs,
+  type HandoffCliOptions,
   type PackCliOptions,
   type PromptCliOptions,
   parseWatchArgs,
@@ -115,6 +118,11 @@ export interface ContextPackCommandContext {
   io: CliIO
 }
 
+export interface HandoffCommandContext {
+  options: HandoffCliOptions
+  io: CliIO
+}
+
 export interface ContextPromptCommandContext {
   options: PromptCliOptions
   io: CliIO
@@ -132,6 +140,7 @@ export interface CliDependencies {
   runReviewCompare: (context: ReviewCompareCommandContext) => Promise<string | void> | string | void
   runTimeTravel: (context: TimeTravelCommandContext) => Promise<string | void> | string | void
   runContextPack: (context: ContextPackCommandContext) => Promise<string | void> | string | void
+  runHandoff: (context: HandoffCommandContext) => Promise<string | void> | string | void
   runContextPrompt: (context: ContextPromptCommandContext) => Promise<string | void> | string | void
   runDoctor: (graphPath: string) => string
   runStatus: (graphPath: string) => string
@@ -232,6 +241,9 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
   },
   runContextPack: async ({ options }) => {
     return await runContextPackCommand(options)
+  },
+  runHandoff: async ({ options }) => {
+    return await runHandoffCommand(options)
   },
   runContextPrompt: async ({ options }) => {
     return await runContextPromptCommand(options)
@@ -374,6 +386,12 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --graph <path>       path to graph.json (default out/graph.json)',
     '    --format MODE       json|text|markdown|claude|copilot (default json)',
     '    --why               include retrieval-routing debug metadata in the pack output',
+    '  handoff "<prompt>"    emit a portable remote-agent handoff artifact',
+    '    --budget N            cap handoff assembly at N tokens (default 3000)',
+    '    --task KIND          explain|implement|review|impact (default explain)',
+    '    --graph <path>       path to graph.json (default out/graph.json)',
+    '    --consumer NAME      generic|codex|cursor|copilot (default generic)',
+    '    --allow-snippets     include raw snippets and mark the artifact non-share-safe',
     '  prompt "<prompt>"     compile a provider-ready prompt payload',
     '    --provider NAME      claude|gemini',
     '    --graph <path>       path to graph.json (default out/graph.json)',
@@ -691,6 +709,15 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
     if (command === 'pack') {
       const options = parsePackArgs(args)
       const output = await dependencies.runContextPack({ options, io })
+      if (output !== undefined) {
+        io.log(output)
+      }
+      return 0
+    }
+
+    if (command === 'handoff') {
+      const options = parseHandoffArgs(args)
+      const output = await dependencies.runHandoff({ options, io })
       if (output !== undefined) {
         io.log(output)
       }

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -39,6 +39,15 @@ export interface PackCliOptions {
   retrievalStrategy?: ContextPackRetrievalStrategy
 }
 
+export interface HandoffCliOptions {
+  prompt: string
+  budget: number
+  task: ContextPackTaskKind
+  graphPath: string
+  consumer: 'generic' | 'codex' | 'cursor' | 'copilot'
+  allowSnippets?: boolean
+}
+
 export type PromptCliProvider = 'claude' | 'gemini'
 
 export interface PromptCliOptions {
@@ -344,6 +353,10 @@ function parseValidatedGraphPath(flag: string, value: string | undefined): strin
   return validateGraphPath(requireOptionValue(flag, value))
 }
 
+function parseGraphPathArgument(flag: string, value: string | undefined): string {
+  return validateCliText(flag, requireOptionValue(flag, value))
+}
+
 export function parseQueryArgs(args: string[]): QueryCliOptions {
   const question = args[0]?.trim()
   if (!question) {
@@ -564,6 +577,97 @@ export function parsePackArgs(args: string[]): PackCliOptions {
   }
 }
 
+export function parseHandoffArgs(args: string[]): HandoffCliOptions {
+  const usage = 'Usage: madar handoff "<prompt>" [--budget N] [--task KIND] [--graph path] [--consumer generic|codex|cursor|copilot] [--allow-snippets]'
+  const prompt = args[0]?.trim()
+  if (!prompt) {
+    throw new UsageError(usage)
+  }
+
+  let budget = 3000
+  let task: ContextPackTaskKind = 'explain'
+  let graphPath = 'out/graph.json'
+  let consumer: HandoffCliOptions['consumer'] = 'generic'
+  let allowSnippets = false
+
+  const normalizedPrompt = validateCliQuestionText('prompt', prompt)
+
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument) {
+      continue
+    }
+
+    if (!argument.startsWith('--')) {
+      throw new UsageError(usage)
+    }
+
+    if (argument === '--budget') {
+      budget = parseBudget(requireOptionValue('--budget', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--budget=')) {
+      const [, value] = argument.split('=', 2)
+      budget = parseBudget(requireOptionValue('--budget', value))
+      continue
+    }
+
+    if (argument === '--task') {
+      task = parseContextPackTask(requireOptionValue('--task', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--task=')) {
+      const [, value] = argument.split('=', 2)
+      task = parseContextPackTask(requireOptionValue('--task', value))
+      continue
+    }
+
+    if (argument === '--graph') {
+      graphPath = parseGraphPathArgument('--graph', args[index + 1])
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--graph=')) {
+      const [, value] = argument.split('=', 2)
+      graphPath = parseGraphPathArgument('--graph', value)
+      continue
+    }
+
+    if (argument === '--consumer') {
+      consumer = parseHandoffConsumer(requireOptionValue('--consumer', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--consumer=')) {
+      const [, value] = argument.split('=', 2)
+      consumer = parseHandoffConsumer(requireOptionValue('--consumer', value))
+      continue
+    }
+
+    if (argument === '--allow-snippets') {
+      allowSnippets = true
+      continue
+    }
+
+    throw new UsageError(`error: unknown option for handoff: ${argument}`)
+  }
+
+  return {
+    prompt: normalizedPrompt,
+    budget,
+    task,
+    graphPath,
+    consumer,
+    ...(allowSnippets ? { allowSnippets: true } : {}),
+  }
+}
+
 function parseContextPackFormat(value: string): PackCliOptions['format'] {
   const normalized = value.trim().toLowerCase()
   if (
@@ -576,6 +680,14 @@ function parseContextPackFormat(value: string): PackCliOptions['format'] {
     return normalized as PackCliOptions['format']
   }
   throw new UsageError('error: --format must be one of json, text, markdown, claude, copilot')
+}
+
+function parseHandoffConsumer(value: string): HandoffCliOptions['consumer'] {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'generic' || normalized === 'codex' || normalized === 'cursor' || normalized === 'copilot') {
+    return normalized as HandoffCliOptions['consumer']
+  }
+  throw new UsageError('error: --consumer must be one of generic, codex, cursor, copilot')
 }
 
 function parseRetrievalLevel(value: string): PackCliOptions['retrievalLevel'] {

--- a/src/contracts/handoff.ts
+++ b/src/contracts/handoff.ts
@@ -1,0 +1,12 @@
+import type { ContextPackSchemaV1 } from './context-pack.js'
+
+export type HandoffConsumer = 'generic' | 'codex' | 'cursor' | 'copilot'
+
+export type HandoffSnippetPolicy = 'omit' | 'include'
+
+export interface HandoffArtifactSchemaV1<TPack = unknown> extends Omit<ContextPackSchemaV1<TPack>, 'plan'> {
+  artifact_kind: 'madar_handoff'
+  consumer: HandoffConsumer
+  share_safe: boolean
+  snippet_policy: HandoffSnippetPolicy
+}

--- a/src/infrastructure/handoff-command.ts
+++ b/src/infrastructure/handoff-command.ts
@@ -1,0 +1,226 @@
+import { dirname, resolve } from 'node:path'
+
+import type { HandoffCliOptions } from '../cli/parser.js'
+import type { ContextPackSchemaV1 } from '../contracts/context-pack.js'
+import type { HandoffArtifactSchemaV1, HandoffConsumer } from '../contracts/handoff.js'
+import type { KnowledgeGraph } from '../contracts/graph.js'
+import {
+  runContextPackCommand,
+  type ContextPackCommandDependencies,
+} from './context-pack-command.js'
+import {
+  sanitizeShareSafeText,
+  toShareSafeArtifactPath,
+  type ShareSafePathRoots,
+} from '../shared/share-safe-artifacts.js'
+import { loadGraph } from '../runtime/serve.js'
+
+export interface HandoffArtifactBuildOptions {
+  consumer: HandoffConsumer
+  artifactRoot: string
+  projectRoot: string
+  allowSnippets?: boolean
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
+
+const PATH_KEYS = new Set([
+  'graph_path',
+  'path',
+  'source_file',
+  'target_file',
+])
+
+const PATH_ARRAY_KEYS = new Set([
+  'affected_files',
+  'changed_files',
+  'covered_workflow_owners',
+  'excluded_path_hints',
+  'focus_files',
+  'mentioned_paths',
+  'path_hints',
+  'supporting_paths',
+  'test_paths',
+])
+
+const TEXT_KEYS = new Set([
+  'boundary_reason',
+  'prompt',
+  'question',
+  'reason',
+  'representation_reason',
+  'summary',
+  'text',
+  'why',
+])
+
+const TEXT_ARRAY_KEYS = new Set([
+  'confidence_reasons',
+  'negative_guidance',
+  'validation_commands',
+  'why_explanation',
+])
+
+const SECRET_ENV_ASSIGNMENT_PATTERN = /\b([A-Z][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD))=(?:"[^"]*"|'[^']*'|[^\s"'`]+)/g
+const AUTH_HEADER_PATTERN = /\b(Authorization:\s*(?:Bearer|Basic)\s+)[^\s"'`]+/gi
+const SECRET_QUERY_PARAM_PATTERN = /([?&](?:access_token|api[_-]?key|auth|key|password|refresh_token|secret|token)=)[^&#\s]+/gi
+const URL_USERINFO_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)([^\/\s@]+)@/gi
+
+function redactHandoffSecrets(text: string): string {
+  return text
+    .replace(SECRET_ENV_ASSIGNMENT_PATTERN, '$1=<redacted>')
+    .replace(AUTH_HEADER_PATTERN, '$1<redacted>')
+    .replace(URL_USERINFO_PATTERN, '$1<redacted>@')
+    .replace(SECRET_QUERY_PARAM_PATTERN, '$1<redacted>')
+}
+
+function sanitizeHandoffText(text: string, roots: ShareSafePathRoots): string {
+  return redactHandoffSecrets(sanitizeShareSafeText(text, roots))
+}
+
+function sanitizeStringValue(key: string, value: string, roots: ShareSafePathRoots): string {
+  if (PATH_KEYS.has(key)) {
+    return toShareSafeArtifactPath(value, roots)
+  }
+  if (TEXT_KEYS.has(key) || TEXT_ARRAY_KEYS.has(key)) {
+    return sanitizeHandoffText(value, roots)
+  }
+  return value
+}
+
+function sanitizeJsonValue(
+  value: JsonValue,
+  roots: ShareSafePathRoots,
+  options: { allowSnippets: boolean; parentKey?: string } = { allowSnippets: false },
+): JsonValue {
+  if (typeof value === 'string') {
+    if (options.parentKey && PATH_ARRAY_KEYS.has(options.parentKey)) {
+      return toShareSafeArtifactPath(value, roots)
+    }
+    if (options.parentKey && TEXT_ARRAY_KEYS.has(options.parentKey)) {
+      return sanitizeHandoffText(value, roots)
+    }
+    return options.parentKey ? sanitizeStringValue(options.parentKey, value, roots) : value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeJsonValue(entry, roots, options))
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+
+  const sanitizedEntries: Array<[string, JsonValue]> = []
+  for (const [key, entry] of Object.entries(value)) {
+    if (!options.allowSnippets && key === 'snippet') {
+      continue
+    }
+    sanitizedEntries.push([
+      key,
+      sanitizeJsonValue(entry as JsonValue, roots, {
+        allowSnippets: options.allowSnippets,
+        parentKey: key,
+      }),
+    ])
+  }
+  return Object.fromEntries(sanitizedEntries)
+}
+
+function asJsonValue<TPack>(value: TPack): JsonValue {
+  return JSON.parse(JSON.stringify(value)) as JsonValue
+}
+
+function sanitizeObjectValue<T extends object>(
+  value: T,
+  roots: ShareSafePathRoots,
+  options: { allowSnippets: boolean },
+): T {
+  const sanitized = sanitizeJsonValue(asJsonValue(value), roots, options)
+  if (sanitized === null || Array.isArray(sanitized) || typeof sanitized !== 'object') {
+    throw new Error('Expected sanitized handoff payload to remain an object')
+  }
+  return sanitized as T
+}
+
+function buildShareSafeRoots(options: Pick<HandoffArtifactBuildOptions, 'artifactRoot' | 'projectRoot'>): ShareSafePathRoots {
+  return {
+    artifactRoot: resolve(options.artifactRoot),
+    projectRoot: resolve(options.projectRoot),
+  }
+}
+
+export function buildHandoffArtifactV1<TPack>(
+  schema: ContextPackSchemaV1<TPack>,
+  options: HandoffArtifactBuildOptions,
+): HandoffArtifactSchemaV1<TPack> {
+  const { plan: _plan, ...rest } = schema
+  const roots = buildShareSafeRoots(options)
+  const sanitized = sanitizeObjectValue(rest, roots, {
+    allowSnippets: options.allowSnippets === true,
+  })
+
+  return {
+    artifact_kind: 'madar_handoff',
+    consumer: options.consumer,
+    share_safe: options.allowSnippets !== true,
+    snippet_policy: options.allowSnippets === true ? 'include' : 'omit',
+    ...sanitized,
+  }
+}
+
+export interface HandoffCommandDependencies extends Partial<ContextPackCommandDependencies> {
+  loadGraph?: (graphPath: string) => KnowledgeGraph
+  runContextPackCommand?: (options: {
+    prompt: string
+    budget: number
+    task: HandoffCliOptions['task']
+    graphPath: string
+    format: 'json'
+    verbose: true
+  }) => Promise<string>
+}
+
+function hasContextPackDependencyOverrides(
+  dependencies: HandoffCommandDependencies,
+): dependencies is ContextPackCommandDependencies & HandoffCommandDependencies {
+  return typeof dependencies.loadGraph === 'function'
+    && typeof dependencies.retrieveContext === 'function'
+    && typeof dependencies.compactRetrieveResult === 'function'
+    && typeof dependencies.analyzePrImpact === 'function'
+    && typeof dependencies.compactPrImpactResult === 'function'
+    && typeof dependencies.analyzeImpact === 'function'
+    && typeof dependencies.compactImpactResult === 'function'
+}
+
+export async function runHandoffCommand(
+  options: HandoffCliOptions,
+  dependencies: HandoffCommandDependencies = {},
+): Promise<string> {
+  const loadGraphDependency = dependencies.loadGraph ?? loadGraph
+  const graph = loadGraphDependency(options.graphPath)
+  const packOptions = {
+    prompt: options.prompt,
+    budget: options.budget,
+    task: options.task,
+    graphPath: options.graphPath,
+    format: 'json',
+    verbose: true,
+  } as const
+  const contextPackPayload = dependencies.runContextPackCommand
+    ? await dependencies.runContextPackCommand(packOptions)
+    : hasContextPackDependencyOverrides(dependencies)
+      ? await runContextPackCommand(packOptions, dependencies)
+      : await runContextPackCommand(packOptions)
+
+  const schema = JSON.parse(contextPackPayload) as ContextPackSchemaV1<unknown>
+  const artifact = buildHandoffArtifactV1(schema, {
+    consumer: options.consumer,
+    artifactRoot: dirname(resolve(options.graphPath)),
+    projectRoot: typeof graph.graph.root_path === 'string' && graph.graph.root_path.trim().length > 0
+      ? graph.graph.root_path
+      : process.cwd(),
+    ...(options.allowSnippets === true ? { allowSnippets: true } : {}),
+  })
+  return JSON.stringify(artifact)
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -8,6 +8,7 @@ import {
   parseBenchmarkArgs,
   parseCompareArgs,
   parseDoctorArgs,
+  parseHandoffArgs,
   parsePackArgs,
   parseDiffArgs,
   parseExplainArgs,
@@ -136,6 +137,7 @@ function createDependencies(): CliTestDependencies {
     runReviewCompare: async () => 'review compare command is not implemented yet',
     runTimeTravel: async () => 'time-travel command is not implemented yet',
     runContextPack: async () => 'context pack command is not implemented yet',
+    runHandoff: async () => 'handoff command is not implemented yet',
     runContextPrompt: async () => 'context prompt command is not implemented yet',
     runDoctor: (graphPath) => `doctor check for ${graphPath}`,
     runStatus: (graphPath) => `status check for ${graphPath}`,
@@ -328,6 +330,40 @@ describe('cli parser', () => {
     expect(() => parsePackArgs(['how does auth work', '--task', 'summarize'])).toThrow('error: --task must be one of explain, implement, review, impact')
     expect(() => parsePackArgs(['how does auth work', '--format', 'yaml'])).toThrow('error: --format must be one of json, text, markdown, claude, copilot')
     expect(() => parsePackArgs(['how does auth work', '--wat'])).toThrow('error: unknown option for pack: --wat')
+  })
+
+  it('parses handoff args with defaults and overrides', () => {
+    expect(parseHandoffArgs(['ship remote auth debug brief'])).toEqual({
+      prompt: 'ship remote auth debug brief',
+      budget: 3000,
+      task: 'explain',
+      graphPath: 'out/graph.json',
+      consumer: 'generic',
+    })
+
+    expect(parseHandoffArgs([
+      'implement session handoff',
+      '--budget', '1800',
+      '--task', 'implement',
+      '--graph', 'out/custom.json',
+      '--consumer', 'copilot',
+      '--allow-snippets',
+    ])).toEqual({
+      prompt: 'implement session handoff',
+      budget: 1800,
+      task: 'implement',
+      graphPath: 'out/custom.json',
+      consumer: 'copilot',
+      allowSnippets: true,
+    })
+  })
+
+  it('rejects invalid handoff args', () => {
+    expect(() => parseHandoffArgs([])).toThrow('Usage: madar handoff')
+    expect(() => parseHandoffArgs(['task', '--budget', '0'])).toThrow('error: --budget must be a positive integer')
+    expect(() => parseHandoffArgs(['task', '--task', 'summarize'])).toThrow('error: --task must be one of explain, implement, review, impact')
+    expect(() => parseHandoffArgs(['task', '--consumer', 'claude'])).toThrow('error: --consumer must be one of generic, codex, cursor, copilot')
+    expect(() => parseHandoffArgs(['task', '--wat'])).toThrow('error: unknown option for handoff: --wat')
   })
 
   it('parses prompt args with defaults and overrides', () => {
@@ -1595,6 +1631,30 @@ describe('cli main', () => {
       io,
     })
     expect(logs).toEqual(['{"task":"explain"}'])
+    expect(errors).toEqual([])
+  })
+
+  it('routes handoff through the injected dependency after parsing args', async () => {
+    const { io, logs, errors } = createIo()
+    const runHandoff = vi.fn<NonNullable<CliDependencies['runHandoff']>>().mockResolvedValue('{"share_safe":true}')
+    const dependencies: CliDependencies = {
+      ...createDependencies(),
+      runHandoff,
+    }
+
+    await expect(executeCli(['handoff', 'remote auth incident brief', '--budget', '1200', '--consumer', 'cursor'], io, dependencies)).resolves.toBe(0)
+
+    expect(runHandoff).toHaveBeenCalledWith({
+      options: {
+        prompt: 'remote auth incident brief',
+        budget: 1200,
+        task: 'explain',
+        graphPath: 'out/graph.json',
+        consumer: 'cursor',
+      },
+      io,
+    })
+    expect(logs).toEqual(['{"share_safe":true}'])
     expect(errors).toEqual([])
   })
 

--- a/tests/unit/handoff-command.test.ts
+++ b/tests/unit/handoff-command.test.ts
@@ -1,0 +1,357 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type {
+  ContextPackCommunityContext,
+  ContextPackCoverage,
+  ContextPackNode,
+  ContextPackRelationship,
+  ContextPackSchemaV1,
+} from '../../src/contracts/context-pack.js'
+import { build } from '../../src/pipeline/build.js'
+import { buildHandoffArtifactV1, runHandoffCommand } from '../../src/infrastructure/handoff-command.js'
+import type { MadarResponseEvidence } from '../../src/runtime/mcp-response-evidence.js'
+
+interface TestPack {
+  matched_nodes: ContextPackNode[]
+  relationships: ContextPackRelationship[]
+  community_context: ContextPackCommunityContext[]
+}
+
+const tempRoots: string[] = []
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop()
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+})
+
+function emptyCoverage(): ContextPackCoverage {
+  return {
+    required_evidence: [],
+    semantic_required: [],
+    semantic_optional: [],
+    entries: [],
+    semantic_entries: [],
+    missing_required: [],
+    missing_semantic: [],
+    available_relationships: 0,
+    selected_relationships: 0,
+  }
+}
+
+function sampleEvidence(root: string): MadarResponseEvidence {
+  return {
+    pack_confidence: 'high',
+    coverage: 'complete',
+    missing_phases: [],
+    covered_workflow_owners: ['src/auth/service.ts'],
+    confidence_reasons: [`scope quality: runtime evidence is concentrated under src/auth/ while the graph is rooted at ${join(root, 'out', 'graph.json')}`],
+    agent_directive: 'answer_from_pack',
+  }
+}
+
+function createPackSchema(root: string): ContextPackSchemaV1<TestPack> {
+  return {
+    schema_version: 1,
+    task: 'implement',
+    task_intent: 'implement',
+    prompt: 'Implement login session handoff',
+    budget: 1800,
+    graph_path: join(root, 'out', 'graph.json'),
+    plan: {
+      version: 1,
+      task_kind: 'implement',
+      prompt: 'Implement login session handoff',
+      total_budget: 1800,
+      scope: {
+        seed_mode: 'focused',
+        focus_paths: [join(root, 'src', 'auth', 'service.ts')],
+        changed_paths: [],
+      },
+      evidence: {
+        recipe_id: 'implement',
+        required: ['primary', 'supporting'],
+        preferred: ['structural'],
+        semantic_required: ['implementation', 'tests'],
+        semantic_optional: ['contracts'],
+      },
+      steps: [
+        {
+          id: 'seed',
+          kind: 'retrieve',
+          title: 'Find the session entrypoint',
+          budget: 600,
+          evidence: ['primary'],
+          scope_mode: 'focused',
+          scope_paths: [join(root, 'src', 'auth', 'service.ts')],
+        },
+      ],
+    },
+    workflow_centers: [
+      {
+        label: 'Auth flow',
+        path: join(root, 'src', 'auth', 'service.ts'),
+        reason: 'Login orchestration starts here.',
+      },
+    ],
+    recommended_first_read: [
+      {
+        path: join(root, 'src', 'auth', 'service.ts'),
+        label: 'AuthService.login',
+        reason: `Read ${join(root, 'src', 'auth', 'service.ts')} first to follow the login path.`,
+      },
+    ],
+    likely_edit_files: [
+      {
+        path: join(root, 'src', 'auth', 'service.ts'),
+        score: 0.97,
+        reason: `Session creation currently happens in ${join(root, 'src', 'auth', 'service.ts')}.`,
+        matched_symbols: ['AuthService.login'],
+      },
+    ],
+    likely_test_files: [
+      {
+        path: join(root, 'tests', 'auth.service.test.ts'),
+        score: 0.81,
+        reason: 'Regression coverage already exists here.',
+        matched_symbols: ['AuthService login'],
+      },
+    ],
+    public_contracts: [
+      {
+        label: 'LoginRequest',
+        source_file: join(root, 'src', 'contracts', 'auth.ts'),
+        line_number: 12,
+        kind: 'contract',
+        why: `The request contract lives in ${join(root, 'src', 'contracts', 'auth.ts')}.`,
+      },
+    ],
+    retrieval_pipeline: {
+      phases: [
+        { phase: 'seed', summary: 'Anchor the auth entrypoint and tests.' },
+      ],
+    },
+    risk_boundaries: [
+      {
+        label: 'Session persistence',
+        severity: 'high',
+        reason: `Writes fan out into ${join(root, 'src', 'session', 'store.ts')}.`,
+        affected_files: [
+          join(root, 'src', 'session', 'store.ts'),
+          '/tmp/external/private.ts',
+        ],
+        affected_communities: ['auth-runtime'],
+      },
+    ],
+    validation_commands: [
+      'OPENAI_API_KEY=super-secret npm run test:run -- tests/unit/auth.service.test.ts',
+      'OPENAI_API_KEY="super-secret" npm run build',
+      'curl -H "Authorization: Bearer abc123" https://user:pass@example.com/login?token=abc123',
+    ],
+    negative_guidance: [
+      `Do not edit generated files under ${join(root, 'dist')}.`,
+    ],
+    confidence_score: 0.92,
+    why_explanation: [
+      `Start in ${join(root, 'src', 'auth', 'service.ts')} because the planner and workflow center agree on it.`,
+    ],
+    pack: {
+      matched_nodes: [
+        {
+          label: 'AuthService.login',
+          source_file: join(root, 'src', 'auth', 'service.ts'),
+          line_number: 33,
+          snippet: 'const sessionToken = await issueSessionToken(user)',
+          evidence_class: 'primary',
+          file_type: 'code',
+        },
+        {
+          label: 'ExternalSecretReader',
+          source_file: '/opt/private/secret-reader.ts',
+          line_number: 7,
+          snippet: 'const leaked = readFileSync("/opt/private/token.txt", "utf8")',
+          evidence_class: 'supporting',
+          file_type: 'code',
+        },
+      ],
+      relationships: [
+        {
+          from: 'AuthService.login',
+          to: 'SessionStore.createSession',
+          relation: 'calls',
+        },
+      ],
+      community_context: [
+        {
+          id: 1,
+          label: 'Auth runtime',
+          node_count: 6,
+        },
+      ],
+    },
+    evidence: sampleEvidence(root),
+    claims: [
+      {
+        evidence_class: 'primary',
+        text: `The login path starts in ${join(root, 'src', 'auth', 'service.ts')}.`,
+        node_labels: ['AuthService.login'],
+      },
+    ],
+    expandable: [
+      {
+        kind: 'nodes',
+        handle_id: 'auth-flow',
+        evidence_class: 'primary',
+        count: 1,
+        preview: [
+          {
+            label: 'AuthService.login',
+            source_file: join(root, 'src', 'auth', 'service.ts'),
+          },
+        ],
+        follow_up: {
+          kind: 'context_pack',
+          task_kind: 'implement',
+          evidence_class: 'primary',
+          focus_files: [join(root, 'src', 'auth', 'service.ts')],
+          focus_ranges: [
+            {
+              source_file: join(root, 'src', 'auth', 'service.ts'),
+              start_line: 30,
+              end_line: 48,
+            },
+          ],
+        },
+      },
+    ],
+    coverage: emptyCoverage(),
+    missing_context: [],
+    missing_semantic: [],
+    retrieval_gate: {
+      level: 4,
+      skipped_retrieval: false,
+      reason: 'manual override',
+      intent: 'implement',
+      signals: {
+        has_pr_diff: false,
+        has_stack_trace: false,
+        mentioned_paths: [join(root, 'src', 'auth', 'service.ts')],
+        mentioned_symbols: ['AuthService.login'],
+        excluded_path_hints: [join(root, 'tests', 'auth.service.test.ts')],
+      },
+    },
+  }
+}
+
+describe('handoff-command', () => {
+  it('builds a share-safe handoff artifact by default without raw plan state or snippets', () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-handoff-'))
+    tempRoots.push(root)
+    const artifact = buildHandoffArtifactV1(createPackSchema(root), {
+      consumer: 'copilot',
+      artifactRoot: join(root, 'out'),
+      projectRoot: root,
+    })
+
+    expect(artifact).toMatchObject({
+      schema_version: 1,
+      artifact_kind: 'madar_handoff',
+      consumer: 'copilot',
+      share_safe: true,
+      snippet_policy: 'omit',
+      task: 'implement',
+      task_intent: 'implement',
+      prompt: 'Implement login session handoff',
+      graph_path: '<artifact-root>/graph.json',
+      workflow_centers: [
+        expect.objectContaining({
+          path: '<project-root>/src/auth/service.ts',
+        }),
+      ],
+      recommended_first_read: [
+        expect.objectContaining({
+          path: '<project-root>/src/auth/service.ts',
+        }),
+      ],
+      likely_edit_files: [
+        expect.objectContaining({
+          path: '<project-root>/src/auth/service.ts',
+        }),
+      ],
+      likely_test_files: [
+        expect.objectContaining({
+          path: '<project-root>/tests/auth.service.test.ts',
+        }),
+      ],
+      public_contracts: [
+        expect.objectContaining({
+          source_file: '<project-root>/src/contracts/auth.ts',
+        }),
+      ],
+      risk_boundaries: [
+        expect.objectContaining({
+          affected_files: ['<project-root>/src/session/store.ts', 'private.ts'],
+        }),
+      ],
+    })
+
+    expect(artifact).not.toHaveProperty('plan')
+    expect(artifact.pack.matched_nodes[0]).not.toHaveProperty('snippet')
+    expect(JSON.stringify(artifact)).not.toContain(root)
+    expect(JSON.stringify(artifact)).not.toContain('/opt/private/secret-reader.ts')
+    expect(JSON.stringify(artifact)).not.toContain('super-secret')
+    expect(JSON.stringify(artifact)).not.toContain('abc123')
+    expect(JSON.stringify(artifact)).not.toContain('user:pass')
+  })
+
+  it('marks snippet-inclusive handoffs as non-share-safe while still sanitizing paths', () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-handoff-'))
+    tempRoots.push(root)
+    const artifact = buildHandoffArtifactV1(createPackSchema(root), {
+      consumer: 'generic',
+      allowSnippets: true,
+      artifactRoot: join(root, 'out'),
+      projectRoot: root,
+    })
+
+    expect(artifact.share_safe).toBe(false)
+    expect(artifact.snippet_policy).toBe('include')
+    expect(artifact.pack.matched_nodes[0]?.snippet).toBe('const sessionToken = await issueSessionToken(user)')
+    expect(artifact.pack.matched_nodes[0]?.source_file).toBe('<project-root>/src/auth/service.ts')
+    expect(artifact.pack.matched_nodes[1]?.source_file).toBe('secret-reader.ts')
+  })
+
+  it('normalizes relative graph paths when building a handoff from the command entrypoint', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-handoff-'))
+    tempRoots.push(root)
+    const schema = {
+      ...createPackSchema(root),
+      graph_path: 'out/graph.json',
+    } satisfies ContextPackSchemaV1<TestPack>
+    const graph = build([], { directed: true })
+    graph.graph.root_path = root
+
+    const output = await runHandoffCommand({
+      prompt: schema.prompt,
+      budget: schema.budget,
+      task: schema.task,
+      graphPath: 'out/graph.json',
+      consumer: 'cursor',
+    }, {
+      loadGraph: () => graph,
+      runContextPackCommand: async () => JSON.stringify(schema),
+    })
+
+    expect(JSON.parse(output)).toEqual(expect.objectContaining({
+      consumer: 'cursor',
+      graph_path: '<artifact-root>/graph.json',
+    }))
+  })
+})

--- a/tests/unit/install-docs.test.ts
+++ b/tests/unit/install-docs.test.ts
@@ -28,6 +28,15 @@ describe('install documentation', () => {
     expect(readme).toContain('mark the agent as `partial` and suggest the matching reinstall command')
   })
 
+  it('documents handoff as the share-safe remote-agent artifact distinct from local pack and prompt flows', () => {
+    const readme = readFileSync(resolve('README.md'), 'utf8')
+
+    expect(readme).toContain('madar handoff "add auth telemetry" --task implement --consumer copilot')
+    expect(readme).toContain('share-safe remote/background-agent artifact')
+    expect(readme).toContain('`madar pack` stays the richer local/full-context surface')
+    expect(readme).toContain('`madar prompt` stays local')
+  })
+
   it('documents the strict MCP install profile for claude, cursor, copilot, and gemini', () => {
     const readme = readFileSync(resolve('README.md'), 'utf8')
 


### PR DESCRIPTION
## Summary
- add a new `madar handoff` CLI surface with a distinct versioned artifact contract for remote/background agents
- build share-safe handoff artifacts by default by omitting raw planner state, stripping snippets, sanitizing path-bearing fields, and scrubbing secret-bearing command text
- document the new handoff flow in the README and cover the parser, serializer, and docs behavior with focused tests

## Test Plan
- [x] npm run typecheck
- [x] npm run build
- [x] CI=1 npm run test:run

Closes #435


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `madar handoff` command for generating share-safe artifacts optimized for remote agents and background execution
  * Supports `--consumer` flag to target specific AI assistant platforms (generic, copilot, cursor, codex)
  * Added `--allow-snippets` flag to control snippet inclusion in artifacts

* **Documentation**
  * Updated README with examples and clarifications distinguishing `madar handoff` from existing local commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->