### PR TITLE
feat: add pack governance receipts

### DIFF
--- a/docs/agent-governance.md
+++ b/docs/agent-governance.md
@@ -1,0 +1,43 @@
+# Agent governance receipts
+
+Madar now emits a **source-safe governance receipt** on JSON pack surfaces:
+
+- CLI `madar pack --format json`
+- MCP `context_pack`
+
+The receipt is meant for audit and governance review flows where teams need to verify **how** Madar prepared context for an agent without exposing the prompt, answer text, source snippets, or file paths.
+
+## What the receipt includes
+
+Each receipt is versioned (`version: 1`) and records:
+
+- graph freshness (`graph_version`, modified time)
+- request metadata (`task`, `task_intent`, `budget`, retrieval strategy, resolution when present)
+- agent directive summary (`pack_confidence`, `coverage`, `agent_directive`, `missing_phases`)
+- follow-up expansion summary (handle count, evidence classes, expansion task kinds, preview/focus counts)
+- MCP call metadata for `context_pack` (`cache_eligible`, `cache_status`, and a hashed `delta_session_hash` when delta mode is used)
+
+## Privacy boundary
+
+The governance receipt is explicitly **source-safe**. It does **not** include:
+
+- the original prompt
+- generated answer text
+- source snippets
+- file paths or focus-file lists
+- `confidence_reasons`
+- `covered_workflow_owners`
+- expandable preview `source_file` values
+
+This keeps the receipt compatible with review workflows that need operational evidence without leaking repository structure or code content.
+
+## Operational guidance
+
+Use the receipt to answer questions like:
+
+- Was the graph fresh when the pack was produced?
+- Did the agent have enough coverage to answer from the pack?
+- Was the MCP response served from cache or recomputed?
+- Did the pack offer follow-up expansion handles, and roughly how much extra context was available?
+
+For deeper source review, use the main pack payload itself. The governance receipt is a bounded audit summary, not a replacement for the full context pack.

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -436,6 +436,66 @@ export interface CompiledContextPack<
   retrieval_gate?: RetrievalGateDecision
 }
 
+export type ContextPackGovernanceSurface = 'cli_pack' | 'mcp_context_pack'
+export type ContextPackGovernanceResolution = 'detail' | 'summary' | 'mixed' | 'signature' | 'sketch'
+export type ContextPackGovernanceCacheStatus = 'hit' | 'miss' | 'bypass'
+
+export interface ContextPackGovernancePrivacyBoundary {
+  source_safe: true
+  includes_prompt: false
+  includes_source_content: false
+  includes_answer_content: false
+  includes_file_paths: false
+}
+
+export interface ContextPackGovernanceGraphFreshness {
+  graph_version: string
+  graph_modified_ms: number
+  graph_modified_at: string
+}
+
+export interface ContextPackGovernanceRequest {
+  task: ContextPackTaskKind
+  task_intent: TaskIntentKind
+  budget: number
+  retrieval_strategy?: ContextPackRetrievalStrategy
+  resolution?: ContextPackGovernanceResolution
+}
+
+export interface ContextPackGovernanceDirectiveSummary {
+  pack_confidence: 'high' | 'medium' | 'low'
+  coverage: 'complete' | 'partial' | 'unknown'
+  agent_directive: 'answer_from_pack' | 'verify_one_targeted_file' | 'explore_with_caution'
+  missing_phases: ContextPackExecutionPhase[]
+}
+
+export interface ContextPackGovernanceFollowUpSummary {
+  expandable_handle_count: number
+  expandable_evidence_classes: ContextPackEvidenceClass[]
+  expansion_task_kinds: ContextPackTaskKind[]
+  preview_item_count: number
+  focus_file_count: number
+  focus_range_count: number
+}
+
+export interface ContextPackGovernanceMcpCall {
+  tool_name: 'context_pack'
+  cache_eligible: boolean
+  cache_status: ContextPackGovernanceCacheStatus
+  delta_session_hash?: string
+}
+
+export interface ContextPackGovernanceReceipt {
+  version: 1
+  surface: ContextPackGovernanceSurface
+  privacy_boundary: ContextPackGovernancePrivacyBoundary
+  graph_freshness: ContextPackGovernanceGraphFreshness
+  request: ContextPackGovernanceRequest
+  directive: ContextPackGovernanceDirectiveSummary
+  follow_up: ContextPackGovernanceFollowUpSummary
+  mcp_call?: ContextPackGovernanceMcpCall
+}
+
 export interface ContextPackSchemaV1<TPack = unknown> {
   schema_version: 1
   task: ContextPackTaskKind
@@ -457,6 +517,7 @@ export interface ContextPackSchemaV1<TPack = unknown> {
   why_explanation: string[]
   pack: TPack
   evidence: MadarResponseEvidence
+  governance: ContextPackGovernanceReceipt
   claims: ContextPackClaim[]
   expandable: ContextPackExpandableRef[]
   coverage: ContextPackCoverage

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -517,7 +517,7 @@ export interface ContextPackSchemaV1<TPack = unknown> {
   why_explanation: string[]
   pack: TPack
   evidence: MadarResponseEvidence
-  governance: ContextPackGovernanceReceipt
+  governance?: ContextPackGovernanceReceipt
   claims: ContextPackClaim[]
   expandable: ContextPackExpandableRef[]
   coverage: ContextPackCoverage

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -297,10 +297,6 @@ function compactAnswerReadyGovernance(payload: JsonRecord, trimmedFields: string
 
   const request = asJsonRecord(governance.request)
   if (request) {
-    if (surface === 'cli_pack' && typeof request.task_intent === 'string') {
-      delete request.task_intent
-      trimmedFields.push('governance.request.task_intent')
-    }
     if (typeof request.budget === 'number') {
       delete request.budget
       trimmedFields.push('governance.request.budget')
@@ -309,16 +305,16 @@ function compactAnswerReadyGovernance(payload: JsonRecord, trimmedFields: string
         trimmedFields.push('governance.request.resolution')
       }
     }
-    if (surface === 'cli_pack' && typeof request.retrieval_strategy === 'string') {
-      delete request.retrieval_strategy
-      trimmedFields.push('governance.request.retrieval_strategy')
-    }
   }
 
   const directive = asJsonRecord(governance.directive)
   if (directive && asUnknownArray(directive.missing_phases).length === 0) {
     delete directive.missing_phases
     trimmedFields.push('governance.directive.missing_phases')
+  }
+  if (surface === 'cli_pack' && directive && typeof directive.coverage === 'string') {
+    delete directive.coverage
+    trimmedFields.push('governance.directive.coverage')
   }
 
   const followUp = asJsonRecord(governance.follow_up)
@@ -659,6 +655,22 @@ export function buildAnswerReadyPackSchema(
     'validation_commands',
   ]) {
     deleteEmptyArrayField(payload, field, trimmedFields)
+  }
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
+  const evidence = asJsonRecord(payload.evidence)
+  if (evidence) {
+    if (Array.isArray(evidence.covered_workflow_owners)) {
+      delete evidence.covered_workflow_owners
+      trimmedFields.push('evidence.covered_workflow_owners')
+    }
+    if (Array.isArray(evidence.confidence_reasons)) {
+      delete evidence.confidence_reasons
+      trimmedFields.push('evidence.confidence_reasons')
+    }
   }
   attachSerializedBudget(payload, maxTokens, trimmedFields)
   if (estimatedJsonTokens(payload) <= maxTokens) {

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -115,22 +115,6 @@ const ANSWER_READY_COMMUNITY_CAP = 6
 const ANSWER_READY_EXPLANATION_CAP = 3
 const ANSWER_READY_FIRST_READ_CAP = 3
 const ANSWER_READY_WORKFLOW_CENTER_CAP = 4
-const WORKFLOW_SPINE_BUDGET_REASON = 'budget too tight for workflow spine'
-
-interface AnswerReadyCullCandidate {
-  key: string
-  nodeId: string | null
-  label: string | null
-  density: number
-  rankIndex: number
-  preserved: boolean
-}
-
-interface AnswerReadyCullSummary {
-  droppedNodeIds: string[]
-  droppedWorkflowSpine: boolean
-}
-
 function packWithCompatibilityFields<TPack extends PackPayload>(
   pack: TPack,
   fields: PackGuidanceCompatibilityFields,
@@ -221,147 +205,6 @@ function deleteEmptyArrayField(record: JsonRecord, field: string, trimmedFields:
   trimmedFields.push(field)
 }
 
-function answerReadyNodeKey(record: JsonRecord | null): string | null {
-  if (!record) {
-    return null
-  }
-  if (typeof record.node_id === 'string' && record.node_id.length > 0) {
-    return `id:${record.node_id}`
-  }
-  if (typeof record.label !== 'string' || record.label.length === 0) {
-    return null
-  }
-  if (typeof record.source_file === 'string' && record.source_file.length > 0) {
-    return `label:${record.label}::${record.source_file}`
-  }
-  return `label:${record.label}`
-}
-
-function collectWorkflowAnchorKeys(payload: JsonRecord): Set<string> {
-  const keys = new Set<string>()
-  for (const field of ['workflow_centers', 'recommended_first_read']) {
-    for (const entry of asUnknownArray(payload[field])) {
-      const record = asJsonRecord(entry)
-      if (!record || typeof record.label !== 'string' || record.label.length === 0) {
-        continue
-      }
-      if (typeof record.path === 'string' && record.path.length > 0) {
-        keys.add(`label:${record.label}::${record.path}`)
-      }
-      keys.add(`label:${record.label}`)
-    }
-  }
-  const pack = asJsonRecord(payload.pack)
-  const executionSlice = asJsonRecord(pack?.execution_slice)
-  const executionAnchors = [
-    ...asUnknownArray(executionSlice?.steps),
-    ...asUnknownArray(asJsonRecord(executionSlice?.primary_path)?.steps),
-  ]
-  for (const entry of executionAnchors) {
-    const record = asJsonRecord(entry)
-    if (!record || typeof record.label !== 'string' || record.label.length === 0) {
-      continue
-    }
-    if (typeof record.source_file === 'string' && record.source_file.length > 0) {
-      keys.add(`label:${record.label}::${record.source_file}`)
-    }
-    keys.add(`label:${record.label}`)
-  }
-  if (keys.size === 0) {
-    for (const entry of asUnknownArray(payload.claims)) {
-      const record = asJsonRecord(entry)
-      if (!record) {
-        continue
-      }
-      for (const label of asUnknownArray(record.node_labels)) {
-        if (typeof label === 'string' && label.length > 0) {
-          keys.add(`label:${label}`)
-        }
-      }
-    }
-  }
-  return keys
-}
-
-function selectionRankingForNode(
-  record: JsonRecord,
-  diagnostics: ContextPackSelectionDiagnostics | undefined,
-): { density: number; rankIndex: number } {
-  if (!diagnostics) {
-    return {
-      density: Number.POSITIVE_INFINITY,
-      rankIndex: Number.POSITIVE_INFINITY,
-    }
-  }
-  const nodeId = typeof record.node_id === 'string' ? record.node_id : null
-  const label = typeof record.label === 'string' ? record.label : null
-  const byId = nodeId
-    ? diagnostics.ranking.findIndex((entry) => entry.id === nodeId)
-    : -1
-  if (byId >= 0) {
-    return {
-      density: diagnostics.ranking[byId]?.density ?? Number.POSITIVE_INFINITY,
-      rankIndex: byId,
-    }
-  }
-  const byLabel = label
-    ? diagnostics.ranking.findIndex((entry) => entry.label === label)
-    : -1
-  if (byLabel >= 0) {
-    return {
-      density: diagnostics.ranking[byLabel]?.density ?? Number.POSITIVE_INFINITY,
-      rankIndex: byLabel,
-    }
-  }
-  return {
-    density: Number.POSITIVE_INFINITY,
-    rankIndex: Number.POSITIVE_INFINITY,
-  }
-}
-
-function buildAnswerReadyCullCandidates(
-  payload: JsonRecord,
-  pack: JsonRecord,
-  diagnostics: ContextPackSelectionDiagnostics | undefined,
-): AnswerReadyCullCandidate[] {
-  const anchorKeys = collectWorkflowAnchorKeys(payload)
-  const strategy = diagnostics?.selection_strategy ?? 'value-per-token'
-  const candidates = asUnknownArray(pack.matched_nodes)
-    .map((entry) => asJsonRecord(entry))
-    .filter((record): record is JsonRecord => record !== null)
-    .flatMap((record): AnswerReadyCullCandidate[] => {
-      const key = answerReadyNodeKey(record)
-      if (!key) {
-        return []
-      }
-      const { density, rankIndex } = selectionRankingForNode(record, diagnostics)
-      return [{
-        key,
-        nodeId: typeof record.node_id === 'string' ? record.node_id : null,
-        label: typeof record.label === 'string' ? record.label : null,
-        density,
-        rankIndex,
-        preserved: anchorKeys.has(key) || (typeof record.label === 'string' && anchorKeys.has(`label:${record.label}`)),
-      }]
-    })
-
-  return candidates.sort((left, right) => {
-    if (left.preserved !== right.preserved) {
-      return left.preserved ? 1 : -1
-    }
-    if (strategy === 'evidence-order') {
-      if (left.rankIndex !== right.rankIndex) {
-        return right.rankIndex - left.rankIndex
-      }
-      return left.density - right.density
-    }
-    if (left.density !== right.density) {
-      return left.density - right.density
-    }
-    return right.rankIndex - left.rankIndex
-  })
-}
-
 function stripExpandableFocusRanges(payload: JsonRecord, trimmedFields: string[]): boolean {
   let stripped = false
   for (const entry of asUnknownArray(payload.expandable)) {
@@ -378,147 +221,6 @@ function stripExpandableFocusRanges(payload: JsonRecord, trimmedFields: string[]
     trimmedFields.push('expandable.follow_up.focus_ranges')
   }
   return stripped
-}
-
-function removeMatchedNode(pack: JsonRecord, key: string, trimmedFields: string[]): JsonRecord | null {
-  const nodes = asUnknownArray(pack.matched_nodes)
-  const nextNodes = nodes.filter((entry) => answerReadyNodeKey(asJsonRecord(entry)) !== key)
-  if (nextNodes.length === nodes.length) {
-    return null
-  }
-  const removed = nodes.find((entry) => answerReadyNodeKey(asJsonRecord(entry)) === key)
-  pack.matched_nodes = nextNodes
-  trimmedFields.push('pack.matched_nodes culled')
-  return asJsonRecord(removed)
-}
-
-function filterRelationshipsToRemainingNodes(pack: JsonRecord, trimmedFields: string[]): void {
-  const nodes = asUnknownArray(pack.matched_nodes)
-    .map((entry) => asJsonRecord(entry))
-    .filter((record): record is JsonRecord => record !== null)
-  const nodeIds = new Set(nodes.flatMap((record) => typeof record.node_id === 'string' ? [record.node_id] : []))
-  const labels = new Set(nodes.flatMap((record) => typeof record.label === 'string' ? [record.label] : []))
-  const relationships = asUnknownArray(pack.relationships)
-  const nextRelationships = relationships.filter((entry) => {
-    const record = asJsonRecord(entry)
-    if (!record) {
-      return false
-    }
-    const fromId = typeof record.from_id === 'string' ? record.from_id : null
-    const toId = typeof record.to_id === 'string' ? record.to_id : null
-    const fromLabel = typeof record.from === 'string' ? record.from : null
-    const toLabel = typeof record.to === 'string' ? record.to : null
-    const fromKept = fromId ? nodeIds.has(fromId) : (fromLabel ? labels.has(fromLabel) : true)
-    const toKept = toId ? nodeIds.has(toId) : (toLabel ? labels.has(toLabel) : true)
-    return fromKept && toKept
-  })
-  if (nextRelationships.length !== relationships.length) {
-    pack.relationships = nextRelationships
-    trimmedFields.push('pack.relationships culled')
-  }
-}
-
-function downgradeWorkflowSpineConfidence(payload: JsonRecord, trimmedFields: string[]): void {
-  const evidence = asJsonRecord(payload.evidence)
-  if (!evidence) {
-    return
-  }
-  const confidenceReasons = asUnknownArray(evidence.confidence_reasons)
-    .flatMap((value) => typeof value === 'string' ? [value] : [])
-  if (!confidenceReasons.includes(WORKFLOW_SPINE_BUDGET_REASON)) {
-    confidenceReasons.push(WORKFLOW_SPINE_BUDGET_REASON)
-  }
-  const coverage = typeof evidence.coverage === 'string' ? evidence.coverage : 'unknown'
-  evidence.pack_confidence = 'low'
-  evidence.confidence_reasons = confidenceReasons
-  evidence.agent_directive = agentDirectiveForEvidence(
-    'low',
-    coverage === 'complete' || coverage === 'partial' || coverage === 'unknown'
-      ? coverage
-      : 'unknown',
-  )
-  trimmedFields.push('evidence.pack_confidence downgraded')
-}
-
-function upsertPackCulledWarning(payload: JsonRecord, droppedNodeIds: readonly string[]): void {
-  if (droppedNodeIds.length === 0) {
-    return
-  }
-  const routing = asJsonRecord(payload.routing)
-  if (!routing) {
-    return
-  }
-  const warnings = asUnknownArray(routing.warnings)
-    .map((entry) => asJsonRecord(entry))
-    .filter((record): record is JsonRecord => record !== null)
-    .filter((record) => record.kind !== 'pack_culled_to_budget')
-  warnings.push({
-    kind: 'pack_culled_to_budget',
-    severity: 'warn',
-    message: 'Answer-ready payload was culled to satisfy the serialized budget.',
-    detail: {
-      dropped_node_ids: [...droppedNodeIds],
-    },
-  })
-  routing.warnings = warnings
-}
-
-function enforceAnswerReadyBudget(
-  payload: JsonRecord,
-  maxTokens: number,
-  trimmedFields: string[],
-  diagnostics?: ContextPackSelectionDiagnostics,
-): void {
-  const summary: AnswerReadyCullSummary = {
-    droppedNodeIds: [],
-    droppedWorkflowSpine: false,
-  }
-  const pack = asJsonRecord(payload.pack)
-
-  if (stripExpandableFocusRanges(payload, trimmedFields)) {
-    attachSerializedBudget(payload, maxTokens, trimmedFields)
-    if (estimatedJsonTokens(payload) <= maxTokens) {
-      return
-    }
-  }
-
-  if (!pack) {
-    attachSerializedBudget(payload, maxTokens, trimmedFields)
-    return
-  }
-
-  const candidates = buildAnswerReadyCullCandidates(payload, pack, diagnostics)
-  for (const candidate of candidates) {
-    upsertPackCulledWarning(payload, summary.droppedNodeIds)
-    if (summary.droppedWorkflowSpine) {
-      downgradeWorkflowSpineConfidence(payload, trimmedFields)
-    }
-    attachSerializedBudget(payload, maxTokens, trimmedFields)
-    if (estimatedJsonTokens(payload) <= maxTokens) {
-      return
-    }
-
-    const removed = removeMatchedNode(pack, candidate.key, trimmedFields)
-    if (!removed) {
-      continue
-    }
-    filterRelationshipsToRemainingNodes(pack, trimmedFields)
-    const removedId = typeof removed.node_id === 'string'
-      ? removed.node_id
-      : candidate.nodeId
-    if (removedId) {
-      summary.droppedNodeIds.push(removedId)
-    }
-    if (candidate.preserved) {
-      summary.droppedWorkflowSpine = true
-    }
-  }
-
-  upsertPackCulledWarning(payload, summary.droppedNodeIds)
-  if (summary.droppedWorkflowSpine) {
-    downgradeWorkflowSpineConfidence(payload, trimmedFields)
-  }
-  attachSerializedBudget(payload, maxTokens, trimmedFields)
 }
 
 function compactAnswerReadyPack(pack: JsonRecord, trimmedFields: string[]): void {
@@ -595,16 +297,21 @@ function compactAnswerReadyGovernance(payload: JsonRecord, trimmedFields: string
 
   const request = asJsonRecord(governance.request)
   if (request) {
-    if (surface === 'cli_pack') {
-      delete governance.request
-      trimmedFields.push('governance.request')
-    } else if (typeof request.budget === 'number') {
+    if (surface === 'cli_pack' && typeof request.task_intent === 'string') {
+      delete request.task_intent
+      trimmedFields.push('governance.request.task_intent')
+    }
+    if (typeof request.budget === 'number') {
       delete request.budget
       trimmedFields.push('governance.request.budget')
       if (request.resolution === 'detail') {
         delete request.resolution
         trimmedFields.push('governance.request.resolution')
       }
+    }
+    if (surface === 'cli_pack' && typeof request.retrieval_strategy === 'string') {
+      delete request.retrieval_strategy
+      trimmedFields.push('governance.request.retrieval_strategy')
     }
   }
 
@@ -629,6 +336,28 @@ function compactAnswerReadyGovernance(payload: JsonRecord, trimmedFields: string
           trimmedFields.push(`governance.follow_up.${field}`)
         }
       }
+    }
+  }
+
+  if (surface === 'cli_pack') {
+    const privacyBoundary = asJsonRecord(governance.privacy_boundary)
+    if (privacyBoundary) {
+      for (const field of ['includes_prompt', 'includes_source_content', 'includes_answer_content', 'includes_file_paths']) {
+        if (typeof privacyBoundary[field] === 'boolean') {
+          delete privacyBoundary[field]
+          trimmedFields.push(`governance.privacy_boundary.${field}`)
+        }
+      }
+    }
+
+    const graphFreshness = asJsonRecord(governance.graph_freshness)
+    if (graphFreshness && typeof graphFreshness.graph_modified_ms === 'number') {
+      delete graphFreshness.graph_modified_ms
+      trimmedFields.push('governance.graph_freshness.graph_modified_ms')
+    }
+    if (graphFreshness && typeof graphFreshness.graph_modified_at === 'string') {
+      delete graphFreshness.graph_modified_at
+      trimmedFields.push('governance.graph_freshness.graph_modified_at')
     }
   }
 }
@@ -659,10 +388,6 @@ function trimGovernanceBeforeNodeCulling(payload: JsonRecord, maxTokens: number,
       trimmedFields.push('governance.directive.pack_confidence', 'governance.directive.coverage')
     })
   }
-  attempts.push(() => {
-    delete payload.governance
-    trimmedFields.push('governance')
-  })
 
   let trimmed = false
   for (const attempt of attempts) {
@@ -912,9 +637,21 @@ export function buildAnswerReadyPackSchema(
     return payload
   }
 
+  delete payload.prompt
+  delete payload.graph_path
+  delete payload.task_intent
+  trimmedFields.push('prompt', 'graph_path', 'task_intent')
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
+  if (estimatedJsonTokens(payload) <= maxTokens) {
+    return payload
+  }
+
   for (const field of [
     'claims',
     'expandable',
+    'missing_context',
+    'missing_semantic',
+    'negative_guidance',
     'likely_edit_files',
     'likely_test_files',
     'public_contracts',

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -11,6 +11,7 @@ import type {
   ContextPackPublicContract,
   ContextPackRoutingDebug,
   ContextPackSchemaV1,
+  ContextPackSelectionDiagnostics,
   ContextPackWorkflowCenter,
   ContextPackRecommendedFirstRead,
 } from '../contracts/context-pack.js'
@@ -28,11 +29,14 @@ import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
 import {
+  agentDirectiveForEvidence,
   assessMadarResponseEvidence,
   collectWorkflowOwners,
   missingPhasesFromPayload,
   type MadarResponseEvidence,
 } from '../runtime/mcp-response-evidence.js'
+import { buildContextPackGovernanceReceipt } from '../runtime/context-pack-governance.js'
+import { graphFreshnessMetadata } from '../runtime/freshness.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 
@@ -111,6 +115,21 @@ const ANSWER_READY_COMMUNITY_CAP = 6
 const ANSWER_READY_EXPLANATION_CAP = 3
 const ANSWER_READY_FIRST_READ_CAP = 3
 const ANSWER_READY_WORKFLOW_CENTER_CAP = 4
+const WORKFLOW_SPINE_BUDGET_REASON = 'budget too tight for workflow spine'
+
+interface AnswerReadyCullCandidate {
+  key: string
+  nodeId: string | null
+  label: string | null
+  density: number
+  rankIndex: number
+  preserved: boolean
+}
+
+interface AnswerReadyCullSummary {
+  droppedNodeIds: string[]
+  droppedWorkflowSpine: boolean
+}
 
 function packWithCompatibilityFields<TPack extends PackPayload>(
   pack: TPack,
@@ -148,6 +167,42 @@ function asUnknownArray(value: unknown): unknown[] {
   return Array.isArray(value) ? value : []
 }
 
+function runtimePrimaryPathRecordKey(record: JsonRecord | null): string | null {
+  if (!record) {
+    return null
+  }
+  if (typeof record.node_id === 'string' && record.node_id.length > 0) {
+    return `id:${record.node_id}`
+  }
+  if (typeof record.label !== 'string' || record.label.length === 0) {
+    return null
+  }
+  const sourceFile = typeof record.source_file === 'string' ? record.source_file : ''
+  return `label:${record.label}::${sourceFile}`
+}
+
+function runtimePrimaryPathPreviewEntry(record: JsonRecord): JsonRecord | null {
+  if (typeof record.label !== 'string' || record.label.length === 0) {
+    return null
+  }
+  if (typeof record.source_file !== 'string' || record.source_file.length === 0) {
+    return null
+  }
+  return {
+    ...(typeof record.node_id === 'string' && record.node_id.length > 0 ? { node_id: record.node_id } : {}),
+    label: record.label,
+    source_file: record.source_file,
+    ...(typeof record.line_number === 'number'
+      ? {
+          line_range: {
+            start_line: record.line_number,
+            end_line: record.line_number,
+          },
+        }
+      : {}),
+  }
+}
+
 function trimArrayField(record: JsonRecord, field: string, cap: number, trimmedFields: string[]): void {
   const values = asUnknownArray(record[field])
   if (values.length <= cap) {
@@ -164,6 +219,306 @@ function deleteEmptyArrayField(record: JsonRecord, field: string, trimmedFields:
   }
   delete record[field]
   trimmedFields.push(field)
+}
+
+function answerReadyNodeKey(record: JsonRecord | null): string | null {
+  if (!record) {
+    return null
+  }
+  if (typeof record.node_id === 'string' && record.node_id.length > 0) {
+    return `id:${record.node_id}`
+  }
+  if (typeof record.label !== 'string' || record.label.length === 0) {
+    return null
+  }
+  if (typeof record.source_file === 'string' && record.source_file.length > 0) {
+    return `label:${record.label}::${record.source_file}`
+  }
+  return `label:${record.label}`
+}
+
+function collectWorkflowAnchorKeys(payload: JsonRecord): Set<string> {
+  const keys = new Set<string>()
+  for (const field of ['workflow_centers', 'recommended_first_read']) {
+    for (const entry of asUnknownArray(payload[field])) {
+      const record = asJsonRecord(entry)
+      if (!record || typeof record.label !== 'string' || record.label.length === 0) {
+        continue
+      }
+      if (typeof record.path === 'string' && record.path.length > 0) {
+        keys.add(`label:${record.label}::${record.path}`)
+      }
+      keys.add(`label:${record.label}`)
+    }
+  }
+  const pack = asJsonRecord(payload.pack)
+  const executionSlice = asJsonRecord(pack?.execution_slice)
+  const executionAnchors = [
+    ...asUnknownArray(executionSlice?.steps),
+    ...asUnknownArray(asJsonRecord(executionSlice?.primary_path)?.steps),
+  ]
+  for (const entry of executionAnchors) {
+    const record = asJsonRecord(entry)
+    if (!record || typeof record.label !== 'string' || record.label.length === 0) {
+      continue
+    }
+    if (typeof record.source_file === 'string' && record.source_file.length > 0) {
+      keys.add(`label:${record.label}::${record.source_file}`)
+    }
+    keys.add(`label:${record.label}`)
+  }
+  if (keys.size === 0) {
+    for (const entry of asUnknownArray(payload.claims)) {
+      const record = asJsonRecord(entry)
+      if (!record) {
+        continue
+      }
+      for (const label of asUnknownArray(record.node_labels)) {
+        if (typeof label === 'string' && label.length > 0) {
+          keys.add(`label:${label}`)
+        }
+      }
+    }
+  }
+  return keys
+}
+
+function selectionRankingForNode(
+  record: JsonRecord,
+  diagnostics: ContextPackSelectionDiagnostics | undefined,
+): { density: number; rankIndex: number } {
+  if (!diagnostics) {
+    return {
+      density: Number.POSITIVE_INFINITY,
+      rankIndex: Number.POSITIVE_INFINITY,
+    }
+  }
+  const nodeId = typeof record.node_id === 'string' ? record.node_id : null
+  const label = typeof record.label === 'string' ? record.label : null
+  const byId = nodeId
+    ? diagnostics.ranking.findIndex((entry) => entry.id === nodeId)
+    : -1
+  if (byId >= 0) {
+    return {
+      density: diagnostics.ranking[byId]?.density ?? Number.POSITIVE_INFINITY,
+      rankIndex: byId,
+    }
+  }
+  const byLabel = label
+    ? diagnostics.ranking.findIndex((entry) => entry.label === label)
+    : -1
+  if (byLabel >= 0) {
+    return {
+      density: diagnostics.ranking[byLabel]?.density ?? Number.POSITIVE_INFINITY,
+      rankIndex: byLabel,
+    }
+  }
+  return {
+    density: Number.POSITIVE_INFINITY,
+    rankIndex: Number.POSITIVE_INFINITY,
+  }
+}
+
+function buildAnswerReadyCullCandidates(
+  payload: JsonRecord,
+  pack: JsonRecord,
+  diagnostics: ContextPackSelectionDiagnostics | undefined,
+): AnswerReadyCullCandidate[] {
+  const anchorKeys = collectWorkflowAnchorKeys(payload)
+  const strategy = diagnostics?.selection_strategy ?? 'value-per-token'
+  const candidates = asUnknownArray(pack.matched_nodes)
+    .map((entry) => asJsonRecord(entry))
+    .filter((record): record is JsonRecord => record !== null)
+    .flatMap((record): AnswerReadyCullCandidate[] => {
+      const key = answerReadyNodeKey(record)
+      if (!key) {
+        return []
+      }
+      const { density, rankIndex } = selectionRankingForNode(record, diagnostics)
+      return [{
+        key,
+        nodeId: typeof record.node_id === 'string' ? record.node_id : null,
+        label: typeof record.label === 'string' ? record.label : null,
+        density,
+        rankIndex,
+        preserved: anchorKeys.has(key) || (typeof record.label === 'string' && anchorKeys.has(`label:${record.label}`)),
+      }]
+    })
+
+  return candidates.sort((left, right) => {
+    if (left.preserved !== right.preserved) {
+      return left.preserved ? 1 : -1
+    }
+    if (strategy === 'evidence-order') {
+      if (left.rankIndex !== right.rankIndex) {
+        return right.rankIndex - left.rankIndex
+      }
+      return left.density - right.density
+    }
+    if (left.density !== right.density) {
+      return left.density - right.density
+    }
+    return right.rankIndex - left.rankIndex
+  })
+}
+
+function stripExpandableFocusRanges(payload: JsonRecord, trimmedFields: string[]): boolean {
+  let stripped = false
+  for (const entry of asUnknownArray(payload.expandable)) {
+    const record = asJsonRecord(entry)
+    const followUp = asJsonRecord(record?.follow_up)
+    const focusRanges = asUnknownArray(followUp?.focus_ranges)
+    if (!followUp || focusRanges.length === 0) {
+      continue
+    }
+    delete followUp.focus_ranges
+    stripped = true
+  }
+  if (stripped) {
+    trimmedFields.push('expandable.follow_up.focus_ranges')
+  }
+  return stripped
+}
+
+function removeMatchedNode(pack: JsonRecord, key: string, trimmedFields: string[]): JsonRecord | null {
+  const nodes = asUnknownArray(pack.matched_nodes)
+  const nextNodes = nodes.filter((entry) => answerReadyNodeKey(asJsonRecord(entry)) !== key)
+  if (nextNodes.length === nodes.length) {
+    return null
+  }
+  const removed = nodes.find((entry) => answerReadyNodeKey(asJsonRecord(entry)) === key)
+  pack.matched_nodes = nextNodes
+  trimmedFields.push('pack.matched_nodes culled')
+  return asJsonRecord(removed)
+}
+
+function filterRelationshipsToRemainingNodes(pack: JsonRecord, trimmedFields: string[]): void {
+  const nodes = asUnknownArray(pack.matched_nodes)
+    .map((entry) => asJsonRecord(entry))
+    .filter((record): record is JsonRecord => record !== null)
+  const nodeIds = new Set(nodes.flatMap((record) => typeof record.node_id === 'string' ? [record.node_id] : []))
+  const labels = new Set(nodes.flatMap((record) => typeof record.label === 'string' ? [record.label] : []))
+  const relationships = asUnknownArray(pack.relationships)
+  const nextRelationships = relationships.filter((entry) => {
+    const record = asJsonRecord(entry)
+    if (!record) {
+      return false
+    }
+    const fromId = typeof record.from_id === 'string' ? record.from_id : null
+    const toId = typeof record.to_id === 'string' ? record.to_id : null
+    const fromLabel = typeof record.from === 'string' ? record.from : null
+    const toLabel = typeof record.to === 'string' ? record.to : null
+    const fromKept = fromId ? nodeIds.has(fromId) : (fromLabel ? labels.has(fromLabel) : true)
+    const toKept = toId ? nodeIds.has(toId) : (toLabel ? labels.has(toLabel) : true)
+    return fromKept && toKept
+  })
+  if (nextRelationships.length !== relationships.length) {
+    pack.relationships = nextRelationships
+    trimmedFields.push('pack.relationships culled')
+  }
+}
+
+function downgradeWorkflowSpineConfidence(payload: JsonRecord, trimmedFields: string[]): void {
+  const evidence = asJsonRecord(payload.evidence)
+  if (!evidence) {
+    return
+  }
+  const confidenceReasons = asUnknownArray(evidence.confidence_reasons)
+    .flatMap((value) => typeof value === 'string' ? [value] : [])
+  if (!confidenceReasons.includes(WORKFLOW_SPINE_BUDGET_REASON)) {
+    confidenceReasons.push(WORKFLOW_SPINE_BUDGET_REASON)
+  }
+  const coverage = typeof evidence.coverage === 'string' ? evidence.coverage : 'unknown'
+  evidence.pack_confidence = 'low'
+  evidence.confidence_reasons = confidenceReasons
+  evidence.agent_directive = agentDirectiveForEvidence(
+    'low',
+    coverage === 'complete' || coverage === 'partial' || coverage === 'unknown'
+      ? coverage
+      : 'unknown',
+  )
+  trimmedFields.push('evidence.pack_confidence downgraded')
+}
+
+function upsertPackCulledWarning(payload: JsonRecord, droppedNodeIds: readonly string[]): void {
+  if (droppedNodeIds.length === 0) {
+    return
+  }
+  const routing = asJsonRecord(payload.routing)
+  if (!routing) {
+    return
+  }
+  const warnings = asUnknownArray(routing.warnings)
+    .map((entry) => asJsonRecord(entry))
+    .filter((record): record is JsonRecord => record !== null)
+    .filter((record) => record.kind !== 'pack_culled_to_budget')
+  warnings.push({
+    kind: 'pack_culled_to_budget',
+    severity: 'warn',
+    message: 'Answer-ready payload was culled to satisfy the serialized budget.',
+    detail: {
+      dropped_node_ids: [...droppedNodeIds],
+    },
+  })
+  routing.warnings = warnings
+}
+
+function enforceAnswerReadyBudget(
+  payload: JsonRecord,
+  maxTokens: number,
+  trimmedFields: string[],
+  diagnostics?: ContextPackSelectionDiagnostics,
+): void {
+  const summary: AnswerReadyCullSummary = {
+    droppedNodeIds: [],
+    droppedWorkflowSpine: false,
+  }
+  const pack = asJsonRecord(payload.pack)
+
+  if (stripExpandableFocusRanges(payload, trimmedFields)) {
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    if (estimatedJsonTokens(payload) <= maxTokens) {
+      return
+    }
+  }
+
+  if (!pack) {
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    return
+  }
+
+  const candidates = buildAnswerReadyCullCandidates(payload, pack, diagnostics)
+  for (const candidate of candidates) {
+    upsertPackCulledWarning(payload, summary.droppedNodeIds)
+    if (summary.droppedWorkflowSpine) {
+      downgradeWorkflowSpineConfidence(payload, trimmedFields)
+    }
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    if (estimatedJsonTokens(payload) <= maxTokens) {
+      return
+    }
+
+    const removed = removeMatchedNode(pack, candidate.key, trimmedFields)
+    if (!removed) {
+      continue
+    }
+    filterRelationshipsToRemainingNodes(pack, trimmedFields)
+    const removedId = typeof removed.node_id === 'string'
+      ? removed.node_id
+      : candidate.nodeId
+    if (removedId) {
+      summary.droppedNodeIds.push(removedId)
+    }
+    if (candidate.preserved) {
+      summary.droppedWorkflowSpine = true
+    }
+  }
+
+  upsertPackCulledWarning(payload, summary.droppedNodeIds)
+  if (summary.droppedWorkflowSpine) {
+    downgradeWorkflowSpineConfidence(payload, trimmedFields)
+  }
+  attachSerializedBudget(payload, maxTokens, trimmedFields)
 }
 
 function compactAnswerReadyPack(pack: JsonRecord, trimmedFields: string[]): void {
@@ -209,6 +564,264 @@ function compactAnswerReadyPack(pack: JsonRecord, trimmedFields: string[]): void
   trimArrayField(pack, 'community_context', ANSWER_READY_COMMUNITY_CAP, trimmedFields)
 }
 
+function compactAnswerReadyGovernance(payload: JsonRecord, trimmedFields: string[]): void {
+  const governance = asJsonRecord(payload.governance)
+  if (!governance) {
+    return
+  }
+  const surface = typeof governance.surface === 'string' ? governance.surface : null
+
+  const graphFreshness = asJsonRecord(governance.graph_freshness)
+  if (graphFreshness) {
+    if (typeof graphFreshness.graph_modified_at === 'string') {
+      delete graphFreshness.graph_modified_at
+      trimmedFields.push('governance.graph_freshness.graph_modified_at')
+    }
+    if (typeof graphFreshness.graph_modified_ms === 'number') {
+      delete graphFreshness.graph_modified_ms
+      trimmedFields.push('governance.graph_freshness.graph_modified_ms')
+    }
+  }
+
+  const privacyBoundary = asJsonRecord(governance.privacy_boundary)
+  if (privacyBoundary) {
+    for (const field of ['includes_prompt', 'includes_source_content', 'includes_answer_content', 'includes_file_paths']) {
+      if (Object.hasOwn(privacyBoundary, field)) {
+        delete privacyBoundary[field]
+        trimmedFields.push(`governance.privacy_boundary.${field}`)
+      }
+    }
+  }
+
+  const request = asJsonRecord(governance.request)
+  if (request) {
+    if (surface === 'cli_pack') {
+      delete governance.request
+      trimmedFields.push('governance.request')
+    } else if (typeof request.budget === 'number') {
+      delete request.budget
+      trimmedFields.push('governance.request.budget')
+      if (request.resolution === 'detail') {
+        delete request.resolution
+        trimmedFields.push('governance.request.resolution')
+      }
+    }
+  }
+
+  const directive = asJsonRecord(governance.directive)
+  if (directive && asUnknownArray(directive.missing_phases).length === 0) {
+    delete directive.missing_phases
+    trimmedFields.push('governance.directive.missing_phases')
+  }
+
+  const followUp = asJsonRecord(governance.follow_up)
+  if (followUp) {
+    for (const field of ['expandable_evidence_classes', 'expansion_task_kinds']) {
+      if (Array.isArray(followUp[field])) {
+        delete followUp[field]
+        trimmedFields.push(`governance.follow_up.${field}`)
+      }
+    }
+    if (surface === 'cli_pack') {
+      for (const field of ['focus_file_count', 'focus_range_count']) {
+        if (typeof followUp[field] === 'number') {
+          delete followUp[field]
+          trimmedFields.push(`governance.follow_up.${field}`)
+        }
+      }
+    }
+  }
+}
+
+function trimGovernanceBeforeNodeCulling(payload: JsonRecord, maxTokens: number, trimmedFields: string[]): boolean {
+  const governance = asJsonRecord(payload.governance)
+  if (!governance) {
+    return false
+  }
+  const surface = typeof governance.surface === 'string' ? governance.surface : null
+  if (surface !== 'cli_pack') {
+    return false
+  }
+
+  const attempts: Array<() => void> = []
+  const followUp = asJsonRecord(governance.follow_up)
+  if (followUp) {
+    attempts.push(() => {
+      delete governance.follow_up
+      trimmedFields.push('governance.follow_up')
+    })
+  }
+  const directive = asJsonRecord(governance.directive)
+  if (directive && (Object.hasOwn(directive, 'pack_confidence') || Object.hasOwn(directive, 'coverage'))) {
+    attempts.push(() => {
+      delete directive.pack_confidence
+      delete directive.coverage
+      trimmedFields.push('governance.directive.pack_confidence', 'governance.directive.coverage')
+    })
+  }
+  attempts.push(() => {
+    delete payload.governance
+    trimmedFields.push('governance')
+  })
+
+  let trimmed = false
+  for (const attempt of attempts) {
+    attempt()
+    trimmed = true
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    if (estimatedJsonTokens(payload) <= maxTokens) {
+      return true
+    }
+  }
+  return trimmed
+}
+
+function preserveTrimmedRuntimePrimaryPathPreview(pack: JsonRecord, trimmedFields: string[]): void {
+  const executionSlice = asJsonRecord(pack.execution_slice)
+  const primaryPath = executionSlice ? asJsonRecord(executionSlice.primary_path) : null
+  const primarySteps = primaryPath ? asUnknownArray(primaryPath.steps) : []
+  const matchedNodes = asUnknownArray(pack.matched_nodes)
+  if (primarySteps.length === 0 || matchedNodes.length <= ANSWER_READY_MATCHED_NODE_CAP) {
+    return
+  }
+
+  const primaryStepRecords = primarySteps
+    .map((step) => asJsonRecord(step))
+    .filter((record): record is JsonRecord => record !== null)
+  if (primaryStepRecords.length === 0) {
+    return
+  }
+
+  const keptKeys = new Set(
+    matchedNodes
+      .slice(0, ANSWER_READY_MATCHED_NODE_CAP)
+      .flatMap((node) => {
+        const key = runtimePrimaryPathRecordKey(asJsonRecord(node))
+        return key ? [key] : []
+      }),
+  )
+  const matchedByKey = new Map<string, JsonRecord>()
+  for (const node of matchedNodes) {
+    const record = asJsonRecord(node)
+    const key = runtimePrimaryPathRecordKey(record)
+    if (!record || !key || matchedByKey.has(key)) {
+      continue
+    }
+    matchedByKey.set(key, record)
+  }
+
+  const preview: JsonRecord[] = primaryStepRecords.flatMap((stepRecord): JsonRecord[] => {
+    const key = runtimePrimaryPathRecordKey(stepRecord)
+    if (!key || keptKeys.has(key)) {
+      return []
+    }
+    const entry = runtimePrimaryPathPreviewEntry(matchedByKey.get(key) ?? stepRecord)
+    return entry ? [entry] : []
+  })
+
+  if (preview.length === 0) {
+    return
+  }
+
+  const expandable = asUnknownArray(pack.expandable)
+  expandable.unshift({
+    kind: 'nodes',
+    handle_id: 'runtime-primary-path',
+    evidence_class: 'supporting',
+    count: preview.length,
+    preview: preview.slice(0, 3),
+    follow_up: {
+      kind: 'context_pack',
+      task_kind: 'explain',
+      evidence_class: 'supporting',
+      focus_files: [...new Set(preview.map((entry) => entry.source_file))],
+      focus_ranges: [],
+    },
+  })
+  pack.expandable = expandable
+  trimmedFields.push('pack.matched_nodes.primary_path_promoted_to_expandable')
+}
+
+function preserveFinalRuntimePrimaryPathPreview(
+  payload: JsonRecord,
+  pack: JsonRecord,
+  matchedNodeCap: number,
+  trimmedFields: string[],
+): void {
+  const executionSlice = asJsonRecord(pack.execution_slice)
+  const primaryPath = executionSlice ? asJsonRecord(executionSlice.primary_path) : null
+  const primarySteps = primaryPath ? asUnknownArray(primaryPath.steps) : []
+  const matchedNodes = asUnknownArray(pack.matched_nodes)
+  if (primarySteps.length === 0 || matchedNodes.length <= matchedNodeCap) {
+    return
+  }
+
+  const primaryStepRecords = primarySteps
+    .map((step) => asJsonRecord(step))
+    .filter((record): record is JsonRecord => record !== null)
+  if (primaryStepRecords.length === 0) {
+    return
+  }
+
+  const keptKeys = new Set(
+    matchedNodes
+      .slice(0, matchedNodeCap)
+      .flatMap((node) => {
+        const key = runtimePrimaryPathRecordKey(asJsonRecord(node))
+        return key ? [key] : []
+      }),
+  )
+  const existingPreviewKeys = new Set(
+    asUnknownArray(payload.expandable).flatMap((entry) => {
+      const record = asJsonRecord(entry)
+      return asUnknownArray(record?.preview).flatMap((preview) => {
+        const key = runtimePrimaryPathRecordKey(asJsonRecord(preview))
+        return key ? [key] : []
+      })
+    }),
+  )
+  const matchedByKey = new Map<string, JsonRecord>()
+  for (const node of matchedNodes) {
+    const record = asJsonRecord(node)
+    const key = runtimePrimaryPathRecordKey(record)
+    if (!record || !key || matchedByKey.has(key)) {
+      continue
+    }
+    matchedByKey.set(key, record)
+  }
+
+  const preview: JsonRecord[] = primaryStepRecords.flatMap((stepRecord): JsonRecord[] => {
+    const key = runtimePrimaryPathRecordKey(stepRecord)
+    if (!key || keptKeys.has(key) || existingPreviewKeys.has(key)) {
+      return []
+    }
+    const entry = runtimePrimaryPathPreviewEntry(matchedByKey.get(key) ?? stepRecord)
+    return entry ? [entry] : []
+  })
+
+  if (preview.length === 0) {
+    return
+  }
+
+  const expandable = asUnknownArray(payload.expandable)
+  expandable.unshift({
+    kind: 'nodes',
+    handle_id: `runtime-primary-path-${matchedNodeCap}`,
+    evidence_class: 'supporting',
+    count: preview.length,
+    preview: preview.slice(0, 3),
+    follow_up: {
+      kind: 'context_pack',
+      task_kind: 'explain',
+      evidence_class: 'supporting',
+      focus_files: [...new Set(preview.map((entry) => entry.source_file))],
+      focus_ranges: [],
+    },
+  })
+  payload.expandable = expandable
+  trimmedFields.push(`pack.matched_nodes.primary_path_promoted_to_expandable_${matchedNodeCap}`)
+}
+
 function estimatedJsonTokens(payload: JsonRecord): number {
   return estimateQueryTokens(JSON.stringify(payload))
 }
@@ -247,6 +860,7 @@ function attachSerializedBudget(
 export function buildAnswerReadyPackSchema(
   schema: object,
   maxTokens: number,
+  _selectionDiagnostics?: ContextPackSelectionDiagnostics,
 ): JsonRecord {
   const payload = cloneJsonRecord(schema)
   const trimmedFields: string[] = []
@@ -274,6 +888,7 @@ export function buildAnswerReadyPackSchema(
     }
     compactAnswerReadyPack(pack, trimmedFields)
   }
+  compactAnswerReadyGovernance(payload, trimmedFields)
 
   trimArrayField(payload, 'workflow_centers', ANSWER_READY_WORKFLOW_CENTER_CAP, trimmedFields)
   trimArrayField(payload, 'recommended_first_read', ANSWER_READY_FIRST_READ_CAP, trimmedFields)
@@ -340,6 +955,12 @@ export function buildAnswerReadyPackSchema(
   delete payload.retrieval_gate
   delete payload.why_explanation
   trimmedFields.push('retrieval_gate', 'why_explanation')
+  if (trimGovernanceBeforeNodeCulling(payload, maxTokens, trimmedFields)) {
+    attachSerializedBudget(payload, maxTokens, trimmedFields)
+    if (estimatedJsonTokens(payload) <= maxTokens) {
+      return payload
+    }
+  }
   attachSerializedBudget(payload, maxTokens, trimmedFields)
   return payload
 }
@@ -991,11 +1612,28 @@ function buildPackSchemaV1<TPack extends PackPayload>(
     recommended_first_read: firstRead,
     confidence_score: score,
   }
+  const retrievalStrategy = retrieval?.retrieval_strategy ?? ('retrieval_strategy' in response.pack ? response.pack.retrieval_strategy : undefined)
+  const governanceBase = {
+    surface: 'cli_pack' as const,
+    graphFreshness: graphFreshnessMetadata(response.graph_path),
+    task: response.task,
+    taskIntent: response.task_intent,
+    budget: response.budget,
+    evidence,
+    expandable: response.expandable,
+  }
+  const governance = retrievalStrategy
+    ? buildContextPackGovernanceReceipt({
+        ...governanceBase,
+        retrievalStrategy,
+      })
+    : buildContextPackGovernanceReceipt(governanceBase)
 
   return {
     schema_version: 1,
     ...serializableResponse,
     evidence,
+    governance,
     pack: packForSchema(response.task, response.pack, compatibilityFields),
     workflow_centers: centers,
     recommended_first_read: firstRead,

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -36,7 +36,7 @@ import {
   type MadarResponseEvidence,
 } from '../runtime/mcp-response-evidence.js'
 import { buildContextPackGovernanceReceipt } from '../runtime/context-pack-governance.js'
-import { graphFreshnessMetadata } from '../runtime/freshness.js'
+import { graphFreshnessMetadata, type GraphFreshnessMetadata } from '../runtime/freshness.js'
 import { buildRoutingDebug } from '../runtime/routing-debug.js'
 import { communitiesFromGraph, estimateQueryTokens, loadGraph } from '../runtime/serve.js'
 
@@ -979,6 +979,21 @@ function emptyCoverage(): ContextPackCoverage {
   }
 }
 
+function safeGraphFreshnessMetadata(graphPath: string): GraphFreshnessMetadata {
+  try {
+    return graphFreshnessMetadata(graphPath)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Graph file not found:')) {
+      return {
+        graphVersion: 'unavailable',
+        graphModifiedMs: 0,
+        graphModifiedAt: new Date(0).toUTCString(),
+      }
+    }
+    throw error
+  }
+}
+
 function contextMetadata(
   payload: Partial<{
     claims: ContextPackClaim[]
@@ -1615,7 +1630,7 @@ function buildPackSchemaV1<TPack extends PackPayload>(
   const retrievalStrategy = retrieval?.retrieval_strategy ?? ('retrieval_strategy' in response.pack ? response.pack.retrieval_strategy : undefined)
   const governanceBase = {
     surface: 'cli_pack' as const,
-    graphFreshness: graphFreshnessMetadata(response.graph_path),
+    graphFreshness: safeGraphFreshnessMetadata(response.graph_path),
     task: response.task,
     taskIntent: response.task_intent,
     budget: response.budget,

--- a/src/runtime/context-pack-governance.ts
+++ b/src/runtime/context-pack-governance.ts
@@ -1,0 +1,92 @@
+import { createHash } from 'node:crypto'
+
+import type {
+  ContextPackExpandableRef,
+  ContextPackGovernanceReceipt,
+  ContextPackGovernanceResolution,
+  ContextPackGovernanceSurface,
+  ContextPackRetrievalStrategy,
+  ContextPackTaskKind,
+} from '../contracts/context-pack.js'
+import type { TaskIntentKind } from '../contracts/task-intent.js'
+import type { GraphFreshnessMetadata } from './freshness.js'
+import type { MadarResponseEvidence } from './mcp-response-evidence.js'
+
+const GOVERNANCE_HASH_LENGTH = 12
+
+function hashGovernanceIdentifier(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, GOVERNANCE_HASH_LENGTH)
+}
+
+function summarizeFollowUp(expandable: readonly ContextPackExpandableRef[]): ContextPackGovernanceReceipt['follow_up'] {
+  const evidenceClasses = [...new Set(expandable.map((entry) => entry.evidence_class))]
+  const expansionTaskKinds = [...new Set(expandable.map((entry) => entry.follow_up.task_kind))]
+
+  return {
+    expandable_handle_count: expandable.length,
+    expandable_evidence_classes: evidenceClasses,
+    expansion_task_kinds: expansionTaskKinds,
+    preview_item_count: expandable.reduce((total, entry) => total + entry.preview.length, 0),
+    focus_file_count: expandable.reduce((total, entry) => total + entry.follow_up.focus_files.length, 0),
+    focus_range_count: expandable.reduce((total, entry) => total + entry.follow_up.focus_ranges.length, 0),
+  }
+}
+
+export function buildContextPackGovernanceReceipt(input: {
+  surface: ContextPackGovernanceSurface
+  graphFreshness: GraphFreshnessMetadata
+  task: ContextPackTaskKind
+  taskIntent: TaskIntentKind
+  budget: number
+  evidence: Pick<MadarResponseEvidence, 'agent_directive' | 'coverage' | 'missing_phases' | 'pack_confidence'>
+  expandable: readonly ContextPackExpandableRef[]
+  retrievalStrategy?: ContextPackRetrievalStrategy
+  resolution?: ContextPackGovernanceResolution
+  mcpCall?: {
+    cacheEligible: boolean
+    cacheStatus: 'hit' | 'miss' | 'bypass'
+    deltaSessionId?: string
+  }
+}): ContextPackGovernanceReceipt {
+  return {
+    version: 1,
+    surface: input.surface,
+    privacy_boundary: {
+      source_safe: true,
+      includes_prompt: false,
+      includes_source_content: false,
+      includes_answer_content: false,
+      includes_file_paths: false,
+    },
+    graph_freshness: {
+      graph_version: input.graphFreshness.graphVersion,
+      graph_modified_ms: input.graphFreshness.graphModifiedMs,
+      graph_modified_at: input.graphFreshness.graphModifiedAt,
+    },
+    request: {
+      task: input.task,
+      task_intent: input.taskIntent,
+      budget: input.budget,
+      ...(input.retrievalStrategy ? { retrieval_strategy: input.retrievalStrategy } : {}),
+      ...(input.resolution ? { resolution: input.resolution } : {}),
+    },
+    directive: {
+      pack_confidence: input.evidence.pack_confidence,
+      coverage: input.evidence.coverage,
+      agent_directive: input.evidence.agent_directive,
+      missing_phases: [...input.evidence.missing_phases],
+    },
+    follow_up: summarizeFollowUp(input.expandable),
+    ...(input.mcpCall
+      ? {
+          mcp_call: {
+            tool_name: 'context_pack',
+            cache_eligible: input.mcpCall.cacheEligible,
+            cache_status: input.mcpCall.cacheStatus,
+            ...(input.mcpCall.deltaSessionId ? { delta_session_hash: hashGovernanceIdentifier(input.mcpCall.deltaSessionId) } : {}),
+          },
+        }
+      : {}),
+  }
+}
+

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -239,6 +239,15 @@ function isContextPackExpandableRef(value: unknown): value is ContextPackExpanda
     && isContextPackExpandableFollowUp(candidate.follow_up)
 }
 
+function hasCachedExplainContextPackGovernance(value: Record<string, unknown>): boolean {
+  const governance = value.governance
+  if (!governance || typeof governance !== 'object' || Array.isArray(governance)) {
+    return false
+  }
+  const mcpCall = (governance as Record<string, unknown>).mcp_call
+  return !!mcpCall && typeof mcpCall === 'object' && !Array.isArray(mcpCall)
+}
+
 function isCachedExplainContextPackPayload(value: unknown): value is CachedExplainContextPackPayload {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return false
@@ -249,6 +258,7 @@ function isCachedExplainContextPackPayload(value: unknown): value is CachedExpla
     && typeof candidate.task_intent === 'string'
     && Array.isArray(candidate.expandable)
     && candidate.expandable.every((entry) => isContextPackExpandableRef(entry))
+    && hasCachedExplainContextPackGovernance(candidate)
 }
 
 function parseContextPackResolution(raw: string | null): ContextPackResolution {

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -44,6 +44,7 @@ import {
 } from '../retrieve.js'
 import { computeContextPackDiagnostics } from '../context-pack-diagnostics.js'
 import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-delta.js'
+import { buildContextPackGovernanceReceipt } from '../context-pack-governance.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
 import { buildImplementationPackGuidance } from '../implementation-pack.js'
 import {
@@ -291,6 +292,67 @@ function withContextPackCache<T extends Record<string, unknown>>(
   return {
     ...payload,
     cache,
+  }
+}
+
+function withContextPackGovernance<T extends Record<string, unknown>>(
+  payload: T,
+  input: {
+    graphPath: string
+    task: ContextPackTaskKind
+    taskIntent: TaskContextPlan['evidence']['recipe_id']
+    budget: number
+    evidence: Pick<ReturnType<typeof buildMadarResponseEvidence>, 'agent_directive' | 'coverage' | 'missing_phases' | 'pack_confidence'>
+    expandable: readonly ContextPackExpandableRef[]
+    retrievalStrategy?: ContextPackRetrievalStrategy | null
+    resolution?: ContextPackResolution
+    cacheEligible: boolean
+    cacheStatus: 'hit' | 'miss' | 'bypass'
+    deltaSessionId?: string
+  },
+): T & { governance: ReturnType<typeof buildContextPackGovernanceReceipt> } {
+  return {
+    ...payload,
+    governance: buildContextPackGovernanceReceipt({
+      surface: 'mcp_context_pack',
+      graphFreshness: graphFreshnessMetadata(input.graphPath),
+      task: input.task,
+      taskIntent: input.taskIntent,
+      budget: input.budget,
+      evidence: input.evidence,
+      expandable: input.expandable,
+      ...(input.retrievalStrategy ? { retrievalStrategy: input.retrievalStrategy } : {}),
+      ...(input.resolution ? { resolution: input.resolution } : {}),
+      mcpCall: {
+        cacheEligible: input.cacheEligible,
+        cacheStatus: input.cacheStatus,
+        ...(input.deltaSessionId ? { deltaSessionId: input.deltaSessionId } : {}),
+      },
+    }),
+  }
+}
+
+function withUpdatedContextPackGovernanceCacheStatus<T extends Record<string, unknown>>(
+  payload: T,
+  cacheStatus: 'hit' | 'miss',
+): T {
+  const governance = payload.governance
+  if (!governance || typeof governance !== 'object' || Array.isArray(governance)) {
+    return payload
+  }
+  const mcpCall = (governance as Record<string, unknown>).mcp_call
+  if (!mcpCall || typeof mcpCall !== 'object' || Array.isArray(mcpCall)) {
+    return payload
+  }
+  return {
+    ...payload,
+    governance: {
+      ...governance,
+      mcp_call: {
+        ...mcpCall,
+        cache_status: cacheStatus,
+      },
+    },
   }
 }
 
@@ -1154,7 +1216,7 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
               cachedPayload.expandable,
               helpers,
             )
-            return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackCache(cachedPayload, {
+            return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackCache(withUpdatedContextPackGovernanceCacheStatus(cachedPayload, 'hit'), {
               status: 'hit',
               graph_version: cacheGraphVersion!,
             }))))
@@ -1182,11 +1244,30 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           changed_paths: prResult.changed_files,
           focus_paths: [...prResult.review_context.supporting_paths, ...prResult.review_context.test_paths],
         })
-        const payload = {
+        const evidence = buildMadarResponseEvidence({
+          coverage: reviewMetadata.coverage,
+          graphPath,
+          coveredWorkflowOwners: collectWorkflowOwners(
+            prResult.changed_files,
+            prResult.review_context.supporting_paths,
+            prResult.review_context.test_paths,
+          ),
+        })
+        const payload = withContextPackGovernance({
           ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, plan),
           pack: compactPack,
           ...reviewMetadata,
-        }
+          evidence,
+        }, {
+          graphPath,
+          task,
+          taskIntent: initialPlan.evidence.recipe_id,
+          budget: resolvedBudget,
+          evidence,
+          expandable: reviewMetadata.expandable,
+          cacheEligible: false,
+          cacheStatus: 'bypass',
+        })
         return helpers.ok(id, helpers.textToolResult(JSON.stringify(payload)))
       }
 
@@ -1212,12 +1293,32 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         const impactPack = compactImpactResult(impactResult)
         const metadata = impactMetadata(impactResult, resolvedBudget, prompt, initialPlan.evidence.recipe_id, contextPackLevelTyped ?? undefined)
         storeExpandableHandles(prompt, task, initialPlan.evidence.recipe_id, metadata.expandable, helpers)
-        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        const evidence = buildMadarResponseEvidence({
+          coverage: metadata.coverage,
+          graphPath,
+          coveredWorkflowOwners: collectWorkflowOwners(
+            impactResult.target_file ? [impactResult.target_file] : [],
+            impactResult.affected_files ?? [],
+          ),
+        })
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackGovernance({
           ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
           target: impactTarget,
           pack: impactPack,
           ...metadata,
-        })))
+          evidence,
+        }, {
+          graphPath,
+          task,
+          taskIntent: initialPlan.evidence.recipe_id,
+          budget: resolvedBudget,
+          evidence,
+          expandable: metadata.expandable,
+          ...(contextPackStrategy ? { retrievalStrategy: contextPackStrategy } : {}),
+          resolution,
+          cacheEligible: false,
+          cacheStatus: 'bypass',
+        }))))
       }
 
       const fullPack = contextPackFromRetrieveResult(retrieval)
@@ -1295,7 +1396,15 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           return rest
         })
         const resolvedDeltaNodes = applyResolutionToNodes(deltaNodesStripped, deltaResult.delta_pack.relationships)
-        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
+        const deltaEvidence = buildMadarResponseEvidence({
+          answerContract: deltaResult.delta_pack.answer_contract,
+          coverage: deltaResult.delta_pack.coverage,
+          executionSlice: deltaResult.delta_pack.execution_slice,
+          graphPath,
+          missingPhases: missingPhasesFromPayload(deltaResult.delta_pack),
+          coveredWorkflowOwners: collectWorkflowOwners(resolvedDeltaNodes.nodes.map((node) => node.source_file)),
+        })
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(withContextPackGovernance({
           ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
           mode: 'delta',
           delta_session_id: deltaSessionId,
@@ -1317,18 +1426,31 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
             : {}),
           ...(implementation ? { implementation } : {}),
           ...metadata,
-          evidence: buildMadarResponseEvidence({
-            answerContract: deltaResult.delta_pack.answer_contract,
-            coverage: deltaResult.delta_pack.coverage,
-            executionSlice: deltaResult.delta_pack.execution_slice,
-            graphPath,
-            missingPhases: missingPhasesFromPayload(deltaResult.delta_pack),
-            coveredWorkflowOwners: collectWorkflowOwners(resolvedDeltaNodes.nodes.map((node) => node.source_file)),
-          }),
-        })))
+          evidence: deltaEvidence,
+        }, {
+          graphPath,
+          task,
+          taskIntent: initialPlan.evidence.recipe_id,
+          budget: resolvedBudget,
+          evidence: deltaEvidence,
+          expandable: metadata.expandable,
+          ...(contextPackStrategy ? { retrievalStrategy: contextPackStrategy } : {}),
+          resolution,
+          cacheEligible: false,
+          cacheStatus: 'bypass',
+          deltaSessionId,
+        }))))
       }
       const resolvedNodes = applyResolutionToNodes(compactPack.matched_nodes, compactPack.relationships)
-      const basePayload = {
+      const evidence = buildMadarResponseEvidence({
+        answerContract: fullPack.answer_contract,
+        coverage: fullPack.coverage,
+        executionSlice: fullPack.execution_slice,
+        graphPath,
+        missingPhases: missingPhasesFromPayload(fullPack),
+        coveredWorkflowOwners: collectWorkflowOwners(resolvedNodes.nodes.map((node) => node.source_file)),
+      })
+      const basePayload = withContextPackGovernance({
         ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
         resolution,
         pack: {
@@ -1344,15 +1466,19 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
           : {}),
         ...(implementation ? { implementation } : {}),
         ...metadata,
-        evidence: buildMadarResponseEvidence({
-          answerContract: fullPack.answer_contract,
-          coverage: fullPack.coverage,
-          executionSlice: fullPack.execution_slice,
-          graphPath,
-          missingPhases: missingPhasesFromPayload(fullPack),
-          coveredWorkflowOwners: collectWorkflowOwners(resolvedNodes.nodes.map((node) => node.source_file)),
-        }),
-      }
+        evidence,
+      }, {
+        graphPath,
+        task,
+        taskIntent: initialPlan.evidence.recipe_id,
+        budget: resolvedBudget,
+        evidence,
+        expandable: metadata.expandable,
+        ...(contextPackStrategy ? { retrievalStrategy: contextPackStrategy } : {}),
+        resolution,
+        cacheEligible: cacheKey !== null && cacheGraphVersion !== null,
+        cacheStatus: cacheKey && cacheGraphVersion ? 'miss' : 'bypass',
+      })
       const responsePayload = task === 'explain' && !includeSelectionDiagnostics
         ? buildAnswerReadyPackSchema(basePayload, Math.max(plannerBudget, 3000))
         : basePayload

--- a/tests/unit/agent-governance-doc.test.ts
+++ b/tests/unit/agent-governance-doc.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+describe('agent governance docs', () => {
+  it('documents source-safe governance receipts for pack surfaces', () => {
+    const doc = readFileSync(join(process.cwd(), 'docs', 'agent-governance.md'), 'utf8')
+
+    expect(doc).toContain('source-safe governance receipt')
+    expect(doc).toContain('madar pack --format json')
+    expect(doc).toContain('context_pack')
+    expect(doc).toContain('graph_version')
+    expect(doc).toContain('cache_status')
+    expect(doc).toContain('delta_session_hash')
+    expect(doc).toContain('does **not** include')
+    expect(doc).toContain('confidence_reasons')
+    expect(doc).toContain('covered_workflow_owners')
+    expect(doc).toContain('source_file')
+  })
+})

--- a/tests/unit/answer-ready-explain-pack.test.ts
+++ b/tests/unit/answer-ready-explain-pack.test.ts
@@ -106,6 +106,41 @@ describe('answer-ready explain pack', () => {
       why_explanation: [],
       pack: {},
       evidence: {} as any,
+      governance: {
+        version: 1,
+        surface: 'cli_pack',
+        privacy_boundary: {
+          source_safe: true,
+          includes_prompt: false,
+          includes_source_content: false,
+          includes_answer_content: false,
+          includes_file_paths: false,
+        },
+        graph_freshness: {
+          graph_version: 'fixture-graph',
+          graph_modified_ms: 0,
+          graph_modified_at: new Date(0).toUTCString(),
+        },
+        request: {
+          task: 'explain',
+          task_intent: 'explain',
+          budget: 5000,
+        },
+        directive: {
+          pack_confidence: 'high',
+          coverage: 'complete',
+          agent_directive: 'answer_from_pack',
+          missing_phases: [],
+        },
+        follow_up: {
+          expandable_handle_count: 0,
+          expandable_evidence_classes: [],
+          expansion_task_kinds: [],
+          preview_item_count: 0,
+          focus_file_count: 0,
+          focus_range_count: 0,
+        },
+      },
       claims: [],
       expandable: [],
       coverage: {
@@ -218,6 +253,5 @@ describe('answer-ready explain pack', () => {
     expect(result?.answer_outline).toEqual(['Flow execution traced'])
   })
 })
-
 
 

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -908,6 +908,9 @@ describe('context-pack-command', () => {
         execution_slice?: { side_effects?: unknown[] }
       }
       evidence?: { agent_directive?: string }
+      governance?: {
+        request?: { task_intent?: string; retrieval_strategy?: string }
+      }
       recommended_first_read?: Array<{ path?: string }>
     }
 
@@ -921,6 +924,10 @@ describe('context-pack-command', () => {
     expect(payload.pack?.slice?.selected_path_count).toBe(noisySelectedPaths.length)
     expect(payload.pack?.execution_slice?.side_effects).toBeUndefined()
     expect(payload.evidence?.agent_directive).toBe('answer_from_pack')
+    expect(payload.governance?.request).toEqual(expect.objectContaining({
+      task_intent: 'explain',
+      retrieval_strategy: 'slice-v1',
+    }))
     expect(payload.recommended_first_read?.map((entry) => entry.path)).toEqual([
       'src/ideas/controller.ts',
       'src/ideas/report-service.ts',

--- a/tests/unit/context-pack-command.test.ts
+++ b/tests/unit/context-pack-command.test.ts
@@ -1,16 +1,62 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import type { ContextPackSelectionDiagnostics } from '../../src/contracts/context-pack.js'
 import { KnowledgeGraph } from '../../src/contracts/graph.js'
-import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
+import { buildAnswerReadyPackSchema, runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
 import { build } from '../../src/pipeline/build.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../../src/runtime/retrieve.js'
 import { estimateQueryTokens } from '../../src/runtime/serve.js'
 
 const tempFixtureRoots: string[] = []
+const repoGraphFixturePath = join(process.cwd(), 'out', 'graph.json')
+const repoBackendGraphFixturePath = join(process.cwd(), 'backend', 'out', 'graph.json')
+let createdRepoGraphFixture = false
+let createdRepoGraphFixtureDir = false
+let createdRepoBackendGraphFixture = false
+let createdRepoBackendGraphFixtureDir = false
+
+beforeAll(() => {
+  if (existsSync(repoGraphFixturePath)) {
+    // no-op
+  } else {
+    const repoGraphDir = dirname(repoGraphFixturePath)
+    if (!existsSync(repoGraphDir)) {
+      mkdirSync(repoGraphDir, { recursive: true })
+      createdRepoGraphFixtureDir = true
+    }
+    writeFileSync(repoGraphFixturePath, JSON.stringify({ fixture: true }))
+    createdRepoGraphFixture = true
+  }
+  if (existsSync(repoBackendGraphFixturePath)) {
+    return
+  }
+  const repoBackendGraphDir = dirname(repoBackendGraphFixturePath)
+  if (!existsSync(repoBackendGraphDir)) {
+    mkdirSync(repoBackendGraphDir, { recursive: true })
+    createdRepoBackendGraphFixtureDir = true
+  }
+  writeFileSync(repoBackendGraphFixturePath, JSON.stringify({ fixture: true }))
+  createdRepoBackendGraphFixture = true
+})
+
+afterAll(() => {
+  if (createdRepoGraphFixture) {
+    rmSync(repoGraphFixturePath, { force: true })
+  }
+  if (createdRepoGraphFixtureDir) {
+    rmSync(dirname(repoGraphFixturePath), { recursive: true, force: true })
+  }
+  if (createdRepoBackendGraphFixture) {
+    rmSync(repoBackendGraphFixturePath, { force: true })
+  }
+  if (createdRepoBackendGraphFixtureDir) {
+    rmSync(dirname(repoBackendGraphFixturePath), { recursive: true, force: true })
+  }
+})
 
 afterEach(() => {
   while (tempFixtureRoots.length > 0) {
@@ -139,6 +185,193 @@ function buildImplementationPackDistractorGraph() {
   return graph
 }
 
+function buildOversizedAnswerReadySchema() {
+  const repeatedSnippet = (name: string, repeat: number) => Array.from(
+    { length: repeat },
+    (_, index) => `function ${name}_${index}() { return "${name}-${index}"; }`,
+  ).join('\n')
+
+  return {
+    schema_version: 1,
+    task: 'explain',
+    prompt: 'Explain how the runtime pipeline works',
+    budget: 1500,
+    graph_path: 'out/graph.json',
+    evidence: {
+      pack_confidence: 'high' as const,
+      coverage: 'complete' as const,
+      missing_phases: [],
+      covered_workflow_owners: ['src/runtime/controller.ts', 'src/runtime/service.ts'],
+      confidence_reasons: ['all required evidence covered'],
+      agent_directive: 'answer_from_pack' as const,
+    },
+    governance: {
+      version: 1 as const,
+      surface: 'cli_pack' as const,
+      privacy_boundary: {
+        source_safe: true as const,
+        includes_prompt: false as const,
+        includes_source_content: false as const,
+        includes_answer_content: false as const,
+        includes_file_paths: false as const,
+      },
+      graph_freshness: {
+        graph_version: 'fixture-graph',
+        graph_modified_ms: 0,
+        graph_modified_at: new Date(0).toUTCString(),
+      },
+      request: {
+        task: 'explain' as const,
+        task_intent: 'explain' as const,
+        budget: 1500,
+        retrieval_strategy: 'slice-v1' as const,
+      },
+      directive: {
+        pack_confidence: 'high' as const,
+        coverage: 'complete' as const,
+        agent_directive: 'answer_from_pack' as const,
+        missing_phases: [],
+      },
+      follow_up: {
+        expandable_handle_count: 1,
+        expandable_evidence_classes: ['supporting'] as const,
+        expansion_task_kinds: ['explain'] as const,
+        preview_item_count: 2,
+        focus_file_count: 0,
+        focus_range_count: 16,
+      },
+    },
+    workflow_centers: [
+      { label: 'RuntimeController.handle', path: 'src/runtime/controller.ts', reason: 'controller entrypoint' },
+      { label: 'RuntimeService.execute', path: 'src/runtime/service.ts', reason: 'service handoff' },
+    ],
+    recommended_first_read: [
+      { label: 'RuntimeController.handle', path: 'src/runtime/controller.ts', reason: 'entrypoint' },
+    ],
+    pack: {
+      answer_contract: {
+        version: 1,
+        answer_focus: 'runtime_generation',
+        entrypoint_scope: 'setup_context',
+        required_elements: ['main_pipeline_phases'],
+        do_not_claim: ['unverified_background_jobs'],
+        observed_phases: ['controller', 'service'],
+        missing_phases: [],
+        confidence: 'high',
+      },
+      matched_nodes: [
+        {
+          node_id: 'workflow-controller',
+          label: 'RuntimeController.handle',
+          source_file: 'src/runtime/controller.ts',
+          line_number: 10,
+          snippet: repeatedSnippet('controller', 24),
+        },
+        {
+          node_id: 'workflow-service',
+          label: 'RuntimeService.execute',
+          source_file: 'src/runtime/service.ts',
+          line_number: 30,
+          snippet: repeatedSnippet('service', 24),
+        },
+        {
+          node_id: 'helper-low-1',
+          label: 'StatusFormatter.render',
+          source_file: 'src/runtime/status.ts',
+          line_number: 50,
+          snippet: repeatedSnippet('status', 22),
+        },
+        {
+          node_id: 'helper-low-2',
+          label: 'AuditLogger.enqueue',
+          source_file: 'src/runtime/audit.ts',
+          line_number: 70,
+          snippet: repeatedSnippet('audit', 22),
+        },
+      ],
+      relationships: [
+        { from_id: 'workflow-controller', from: 'RuntimeController.handle', to_id: 'workflow-service', to: 'RuntimeService.execute', relation: 'calls' },
+        { from_id: 'workflow-service', from: 'RuntimeService.execute', to_id: 'helper-low-1', to: 'StatusFormatter.render', relation: 'calls' },
+        { from_id: 'workflow-service', from: 'RuntimeService.execute', to_id: 'helper-low-2', to: 'AuditLogger.enqueue', relation: 'calls' },
+      ],
+    },
+    expandable: [
+      {
+        kind: 'more_matches',
+        reason: 'additional supporting nodes',
+        preview: [
+          { node_id: 'helper-low-1', label: 'StatusFormatter.render', source_file: 'src/runtime/status.ts' },
+          { node_id: 'helper-low-2', label: 'AuditLogger.enqueue', source_file: 'src/runtime/audit.ts' },
+        ],
+        follow_up: {
+          focus_ranges: Array.from({ length: 16 }, (_, index) => ({
+            source_file: `src/runtime/focus-${index}.ts`,
+            start_line: index + 1,
+            end_line: index + 12,
+            reason: 'secondary detail',
+          })),
+        },
+      },
+    ],
+    routing: {
+      warnings: [],
+    },
+  }
+}
+function buildAnswerReadySelectionDiagnostics(): ContextPackSelectionDiagnostics {
+  return {
+    selection_strategy: 'value-per-token',
+    budget: 1500,
+    used_tokens: 1400,
+    required_overflow: false,
+    ranking: [
+      {
+        id: 'workflow-controller',
+        label: 'RuntimeController.handle',
+        evidence_class: 'primary',
+        score: 0.99,
+        token_cost: 220,
+        density: 1.2,
+        included: true,
+        reasons: ['entrypoint'],
+        penalties: [],
+      },
+      {
+        id: 'workflow-service',
+        label: 'RuntimeService.execute',
+        evidence_class: 'supporting',
+        score: 0.96,
+        token_cost: 220,
+        density: 1.1,
+        included: true,
+        reasons: ['handoff'],
+        penalties: [],
+      },
+      {
+        id: 'helper-low-1',
+        label: 'StatusFormatter.render',
+        evidence_class: 'supporting',
+        score: 0.52,
+        token_cost: 240,
+        density: 0.12,
+        included: true,
+        reasons: ['secondary formatting detail'],
+        penalties: ['low load-bearing value'],
+      },
+      {
+        id: 'helper-low-2',
+        label: 'AuditLogger.enqueue',
+        evidence_class: 'supporting',
+        score: 0.48,
+        token_cost: 240,
+        density: 0.08,
+        included: true,
+        reasons: ['secondary audit detail'],
+        penalties: ['low load-bearing value'],
+      },
+    ],
+  }
+}
 describe('context-pack-command', () => {
   it('preserves execution_slice for runtime-generation explain packs', async () => {
     const graph = buildRuntimeGenerationGraph()
@@ -300,7 +533,34 @@ describe('context-pack-command', () => {
       ],
       graph_signals: { god_nodes: [], bridge_nodes: [] },
       claims: [],
-      expandable: [],
+      expandable: [
+        {
+          kind: 'nodes',
+          handle_id: 'expand-idea-runtime',
+          evidence_class: 'supporting' as const,
+          count: 2,
+          preview: [
+            {
+              node_id: 'helper-status',
+              label: 'StatusBadge.render',
+              source_file: 'src/ideas/report-status.ts',
+            },
+          ],
+          follow_up: {
+            kind: 'context_pack' as const,
+            task_kind: 'explain' as const,
+            evidence_class: 'supporting' as const,
+            focus_files: ['src/ideas/report-status.ts', 'src/ideas/next-steps.ts'],
+            focus_ranges: [
+              {
+                source_file: 'src/ideas/report-status.ts',
+                start_line: 18,
+                end_line: 42,
+              },
+            ],
+          },
+        },
+      ],
       coverage: {
         required_evidence: ['primary', 'supporting', 'structural'] as const,
         semantic_required: ['implementation', 'structure'] as const,
@@ -417,6 +677,20 @@ describe('context-pack-command', () => {
         coverage?: string
         agent_directive?: string
       }
+      governance?: {
+        version?: number
+        surface?: string
+        privacy_boundary?: {
+          source_safe?: boolean
+        }
+        directive?: {
+          agent_directive?: string
+        }
+        follow_up?: {
+          expandable_handle_count?: number
+          preview_item_count?: number
+        }
+      }
       workflow_centers?: Array<{ path?: string; label?: string }>
       recommended_first_read?: Array<{ path?: string; label?: string }>
       negative_guidance?: string[]
@@ -427,6 +701,22 @@ describe('context-pack-command', () => {
       coverage: 'complete',
       agent_directive: 'answer_from_pack',
     }))
+    expect(payload.governance).toEqual(expect.objectContaining({
+      version: 1,
+      surface: 'cli_pack',
+      privacy_boundary: {
+        source_safe: true,
+      },
+      directive: expect.objectContaining({
+        agent_directive: 'answer_from_pack',
+      }),
+      follow_up: {
+        expandable_handle_count: 1,
+        preview_item_count: 1,
+      },
+    }))
+    expect(JSON.stringify(payload.governance)).not.toContain('How idea report is being generated')
+    expect(JSON.stringify(payload.governance)).not.toContain('src/ideas/')
     expect(payload.workflow_centers?.slice(0, 4)).toEqual([
       expect.objectContaining({
         path: 'src/ideas/controller.ts',

--- a/tests/unit/handoff-command.test.ts
+++ b/tests/unit/handoff-command.test.ts
@@ -197,6 +197,41 @@ function createPackSchema(root: string): ContextPackSchemaV1<TestPack> {
       ],
     },
     evidence: sampleEvidence(root),
+    governance: {
+      version: 1,
+      surface: 'cli_pack',
+      privacy_boundary: {
+        source_safe: true,
+        includes_prompt: false,
+        includes_source_content: false,
+        includes_answer_content: false,
+        includes_file_paths: false,
+      },
+      graph_freshness: {
+        graph_version: 'fixture-graph',
+        graph_modified_ms: 0,
+        graph_modified_at: new Date(0).toUTCString(),
+      },
+      request: {
+        task: 'implement',
+        task_intent: 'implement',
+        budget: 1800,
+      },
+      directive: {
+        pack_confidence: 'high',
+        coverage: 'complete',
+        agent_directive: 'answer_from_pack',
+        missing_phases: [],
+      },
+      follow_up: {
+        expandable_handle_count: 1,
+        expandable_evidence_classes: ['primary'],
+        expansion_task_kinds: ['implement'],
+        preview_item_count: 1,
+        focus_file_count: 1,
+        focus_range_count: 1,
+      },
+    },
     claims: [
       {
         evidence_class: 'primary',

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -367,6 +367,98 @@ describe('stdio slice-v1 surface', () => {
     expect(verbosePayload.pack?.slice?.selected_path_count).toBeUndefined()
   })
 
+  it('emits source-safe governance receipts for context_pack cache and delta flows', async () => {
+    const graphPath = createGraphPath()
+    const sessionState = {
+      logLevel: 'info' as const,
+      subscribedResourceUris: new Set<string>(),
+      resourceVersions: new Map<string, string>(),
+      resourceListSignature: null,
+      contextPromptSessions: new Map(),
+      contextPackHandles: new Map(),
+      contextPackCache: new Map(),
+      contextPackNodeIds: new Map(),
+    }
+    const request = {
+      prompt: 'Trace how `AuthController.login` reaches persistence in the backend runtime pipeline',
+      budget: 3000,
+      task: 'explain',
+      retrieval_level: 4,
+      retrieval_strategy: 'slice-v1',
+    }
+
+    const firstResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 41,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: request,
+      },
+    }, sessionState))
+    const secondResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 42,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: request,
+      },
+    }, sessionState))
+    const deltaSessionId = 'delta-session-governance'
+    const deltaResponse = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 43,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: {
+          ...request,
+          delta_session_id: deltaSessionId,
+        },
+      },
+    }, sessionState))
+
+    const firstPayload = JSON.parse((((firstResponse as { result?: { content?: Array<{ text: string }> } }).result?.content) ?? [])[0]?.text ?? '') as {
+      cache?: { status?: string }
+      governance?: {
+        privacy_boundary?: { source_safe?: boolean }
+        mcp_call?: { cache_eligible?: boolean; cache_status?: string }
+        request?: { retrieval_strategy?: string }
+        follow_up?: { expandable_handle_count?: number; focus_file_count?: number }
+      }
+    }
+    const secondPayload = JSON.parse((((secondResponse as { result?: { content?: Array<{ text: string }> } }).result?.content) ?? [])[0]?.text ?? '') as {
+      cache?: { status?: string }
+      governance?: { mcp_call?: { cache_status?: string } }
+    }
+    const deltaPayload = JSON.parse((((deltaResponse as { result?: { content?: Array<{ text: string }> } }).result?.content) ?? [])[0]?.text ?? '') as {
+      governance?: { mcp_call?: { cache_status?: string; delta_session_hash?: string } }
+    }
+
+    expect(firstPayload.cache?.status).toBe('miss')
+    expect(firstPayload.governance).toEqual(expect.objectContaining({
+      privacy_boundary: expect.objectContaining({
+        source_safe: true,
+      }),
+      mcp_call: expect.objectContaining({
+        cache_eligible: true,
+        cache_status: 'miss',
+      }),
+      request: expect.objectContaining({
+        retrieval_strategy: 'slice-v1',
+      }),
+      follow_up: expect.objectContaining({
+        expandable_handle_count: expect.any(Number),
+        focus_file_count: expect.any(Number),
+      }),
+    }))
+    expect(secondPayload.cache?.status).toBe('hit')
+    expect(secondPayload.governance?.mcp_call?.cache_status).toBe('hit')
+    expect(deltaPayload.governance?.mcp_call?.cache_status).toBe('bypass')
+    expect(deltaPayload.governance?.mcp_call?.delta_session_hash).toMatch(/^[a-f0-9]{12}$/)
+    expect(JSON.stringify(firstPayload.governance)).not.toContain('AuthController.login')
+    expect(JSON.stringify(firstPayload.governance)).not.toContain(graphPath)
+    expect(JSON.stringify(deltaPayload.governance)).not.toContain(deltaSessionId)
+  })
+
   it('rejects retrieval_strategy for review context packs instead of ignoring it', async () => {
     const graphPath = createGraphPath()
 

--- a/tests/unit/stdio-slice-surface.test.ts
+++ b/tests/unit/stdio-slice-surface.test.ts
@@ -459,6 +459,60 @@ describe('stdio slice-v1 surface', () => {
     expect(JSON.stringify(deltaPayload.governance)).not.toContain(deltaSessionId)
   })
 
+  it('treats governance-less cached explain context packs as stale and rebuilds them', async () => {
+    const graphPath = createGraphPath()
+    const sessionState = {
+      logLevel: 'info' as const,
+      subscribedResourceUris: new Set<string>(),
+      resourceVersions: new Map<string, string>(),
+      resourceListSignature: null,
+      contextPromptSessions: new Map(),
+      contextPackHandles: new Map(),
+      contextPackCache: new Map<string, string>(),
+      contextPackNodeIds: new Map(),
+    }
+    const request = {
+      prompt: 'Trace how `AuthController.login` reaches persistence in the backend runtime pipeline',
+      budget: 3000,
+      task: 'explain',
+      retrieval_level: 4,
+      retrieval_strategy: 'slice-v1',
+    }
+
+    await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 51,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: request,
+      },
+    }, sessionState))
+
+    const cachedEntry = [...sessionState.contextPackCache.entries()][0]
+    expect(cachedEntry).toBeDefined()
+    const [cacheKey, cachedPayloadText] = cachedEntry!
+    const stalePayload = JSON.parse(cachedPayloadText) as Record<string, unknown>
+    delete stalePayload.governance
+    sessionState.contextPackCache.set(cacheKey, JSON.stringify(stalePayload))
+
+    const response = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 52,
+      method: 'tools/call',
+      params: {
+        name: 'context_pack',
+        arguments: request,
+      },
+    }, sessionState))
+
+    const payload = JSON.parse((((response as { result?: { content?: Array<{ text: string }> } }).result?.content) ?? [])[0]?.text ?? '') as {
+      cache?: { status?: string }
+      governance?: { mcp_call?: { cache_status?: string } }
+    }
+
+    expect(payload.cache?.status).toBe('miss')
+    expect(payload.governance?.mcp_call?.cache_status).toBe('miss')
+  })
+
   it('rejects retrieval_strategy for review context packs instead of ignoring it', async () => {
     const graphPath = createGraphPath()
 


### PR DESCRIPTION
## Summary
- add versioned, source-safe governance receipts to CLI pack JSON and MCP context_pack responses
- summarize graph freshness, agent directives, follow-up expansion metadata, and MCP cache/delta state without exposing prompts, source content, or file paths
- add regression coverage and agent governance documentation for audit-review workflows

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context pack outputs (CLI and API) now include a versioned, source-safe governance receipt with graph freshness, request/task metadata, directive/coverage summary, follow-up expansion summary, and cache/MCP call status (delta-session hash when applicable).
  * Cached explain responses are rewrapped to reflect updated cache status.

* **Privacy**
  * Receipts exclude sensitive content (prompts, answers, source snippets, file paths, confidence reasons, workflow owners).

* **Documentation**
  * Added governance docs describing receipt fields and audit guidance.

* **Tests**
  * Added/updated tests validating receipt emission, cache behavior, and delta flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->