### PR TITLE
feat: add opt-in local telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ Want a tiny reproducible workspace for local demos? Start with [`examples/sample
 
 Want a broader local-first walkthrough that also covers install, one verified pack, and a safe `compare` smoke check? Use the [end-to-end getting started tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md).
 
+### Opt-in telemetry
+
+Telemetry is disabled unless you explicitly enable it.
+
+```bash
+madar telemetry status
+madar telemetry enable
+madar telemetry disable
+
+# One-shot opt-in for the current command only:
+MADAR_ENABLE_TELEMETRY=1 madar generate .
+```
+
+The current telemetry model is still local-first and source-safe. It records only coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, an optional install target, and an optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full field list and controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
+
 ---
 
 ## What's new in 0.27.4
@@ -305,6 +320,8 @@ madar prompt "how does auth work?" --provider claude     # provider-ready compil
 madar review-compare out/graph.json --exec '...' --yes  # PR review benchmark
 madar compare "How does auth work?" --exec '...' --yes           # general benchmark
 madar compare "How does auth work?" --baseline-mode pack_only --exec '...' --yes  # bounded raw context vs compiled madar pack
+madar telemetry enable                     # persist opt-in source-safe local telemetry
+madar telemetry status                     # inspect telemetry state and cache path
 madar time-travel main HEAD --view risk   # what changed between two refs
 madar federate frontend/graph.json backend/graph.json  # multi-repo merge
 madar --help                              # full surface
@@ -324,7 +341,7 @@ Tests, benchmarks, fixtures, mocks, and config files are **not** hard-ignored an
 
 ## Trust + limitations
 
-Everything stays local by default. No telemetry, no cloud upload, no API key required.
+Everything stays local by default. No cloud upload, no API key required. Telemetry is disabled unless you explicitly enable it, and the current telemetry surface stores only a bounded local event log.
 
 - **Build:** tree-sitter AST extraction + Louvain community detection — all CPU-local.
 - **Query:** BM25 lexical scoring + reciprocal-rank fusion + optional ONNX embeddings (`Xenova/all-MiniLM-L6-v2`, ~25 MB) + optional cross-encoder reranker.
@@ -352,6 +369,7 @@ Everything stays local by default. No telemetry, no cloud upload, no API key req
 - [Performance benchmark harness](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/performance/README.md) — repeatable `generate` / `update` / `cluster-only` measurements
 - [MCP tool examples](https://github.com/mohanagy/madar/blob/main/examples/mcp-tool-examples.md) — real input/output for every tool
 - [Benchmark hub](https://github.com/mohanagy/madar/tree/main/docs/benchmarks) — committed wrappers and provider-reported evidence
+- [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) — opt-in controls, collected fields, excluded fields, and local storage behavior
 - [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) — full per-release notes
 - [Contributing](https://github.com/mohanagy/madar/blob/main/CONTRIBUTING.md) · [Security](https://github.com/mohanagy/madar/blob/main/SECURITY.md)
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,77 @@
+# Telemetry
+
+Madar ships an **opt-in**, **source-safe**, **local-first** telemetry model for coarse adoption signals.
+
+Telemetry is **disabled by default**. No event is recorded unless you explicitly enable it with `madar telemetry enable` or opt in for the current process with `MADAR_ENABLE_TELEMETRY=1`.
+
+## Controls
+
+```bash
+madar telemetry status
+madar telemetry enable
+madar telemetry disable
+```
+
+Environment overrides:
+
+- `MADAR_ENABLE_TELEMETRY=1` — enable telemetry for the current command without changing the persisted preference.
+- `MADAR_DISABLE_TELEMETRY=1` — force telemetry off for the current command even if the persisted preference is enabled.
+- `DO_NOT_TRACK=1` — force telemetry off for the current command.
+- `CI=1` — telemetry stays off in CI to avoid polluting adoption data with automated runs.
+
+## What is collected
+
+The current implementation records only these coarse success events:
+
+- `install_success`
+- `generate_success`
+- `pack_success`
+- `compare_success`
+
+Each stored event can include:
+
+- `event`
+- `recorded_at`
+- `version`
+- `os`
+- `install_platform` (only for install flows)
+- `repo_size_bucket` (only for repo-scoped flows such as `generate`, `pack`, and `compare`)
+
+`repo_size_bucket` is intentionally coarse:
+
+- `1-24`
+- `25-99`
+- `100-499`
+- `500-999`
+- `1000+`
+
+## What is excluded
+
+Madar does **not** record:
+
+- prompt text
+- answer text
+- source paths
+- source content
+- raw snippets
+- full file counts
+- graph contents
+
+## Storage model
+
+This release stores telemetry locally only:
+
+- persisted opt-in preference under the platform config directory
+- bounded event spool under the platform cache directory
+
+There is **no cloud upload by default** in this implementation. The goal of this issue is to define the opt-in event model, controls, and source-safe field contract without introducing mandatory network traffic.
+
+## Current tracked command surfaces
+
+When telemetry is enabled, Madar records a coarse success event after these CLI flows complete successfully:
+
+- `madar install --platform <platform>`
+- `madar <agent> install`
+- `madar generate`
+- `madar pack`
+- `madar compare`

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -42,6 +42,15 @@ import { serveGraphStdio } from '../runtime/stdio-server.js'
 import { getNeighbors, getNode, loadGraph, queryGraph, shortestPath } from '../runtime/serve.js'
 import { formatTimeTravelResult } from '../runtime/time-travel.js'
 import { findPackageRoot, readPackageName, readPackageVersion } from '../shared/package-metadata.js'
+import {
+  disableTelemetry,
+  enableTelemetry,
+  formatTelemetryStatus,
+  getTelemetryStatus,
+  recordTelemetryEvent as persistTelemetryEvent,
+  repoSizeBucketFromFileCount,
+  type TelemetryEventInput,
+} from '../shared/telemetry.js'
 import { getUpdateNotification } from '../shared/update-notifier.js'
 import {
   parseBenchmarkArgs,
@@ -67,6 +76,7 @@ import {
   parseSaveResultArgs,
   parseSummaryArgs,
   parseServeArgs,
+  parseTelemetryArgs,
   parseTimeTravelArgs,
   type HandoffCliOptions,
   type PackCliOptions,
@@ -177,6 +187,10 @@ export interface CliDependencies {
   agentsUninstall: typeof agentsUninstall
   notifyUpdate?: () => Promise<string | null> | string | null
   readInstalledVersion?: () => string
+  enableTelemetry?: () => string
+  disableTelemetry?: () => string
+  readTelemetryStatus?: () => string
+  recordTelemetryEvent?: (event: TelemetryEventInput) => void
 }
 
 const COMPARE_WARNING_MESSAGE = 'compare will execute a baseline prompt and a madar prompt for each question. This may consume paid model tokens.'
@@ -301,6 +315,12 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
     currentVersion: readPackageVersion(findPackageRoot()),
   }),
   readInstalledVersion: () => readPackageVersion(findPackageRoot()),
+  enableTelemetry: () => enableTelemetry(),
+  disableTelemetry: () => disableTelemetry(),
+  readTelemetryStatus: () => formatTelemetryStatus(getTelemetryStatus()),
+  recordTelemetryEvent: (event) => {
+    persistTelemetryEvent(event)
+  },
 }
 
 function messageFromError(error: unknown): string {
@@ -313,6 +333,26 @@ function formatProgress(progress: ProgressStep): string {
     return `${prefix} ${progress.message} (${progress.current}/${progress.total})`
   }
   return `${prefix} ${progress.message}`
+}
+
+function readInstalledVersionForTelemetry(dependencies: CliDependencies): string {
+  const readInstalledVersion = dependencies.readInstalledVersion ?? (() => readPackageVersion(findPackageRoot()))
+  return readInstalledVersion()
+}
+
+function emitTelemetry(io: CliIO, dependencies: CliDependencies, event: TelemetryEventInput): void {
+  if (!dependencies.recordTelemetryEvent) {
+    return
+  }
+  try {
+    dependencies.recordTelemetryEvent(event)
+  } catch (error) {
+    io.error(`[madar telemetry] ${messageFromError(error)}`)
+  }
+}
+
+function repoSizeBucketForGraph(dependencies: CliDependencies, graphPath: string) {
+  return repoSizeBucketFromFileCount(buildGraphSummary(dependencies.loadGraph(graphPath)).file_count)
 }
 
 async function confirmPaidCommand(
@@ -482,6 +522,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    install              install post-commit and post-checkout hooks',
     '    uninstall            remove madar hook sections',
     '    status               show whether madar hooks are installed',
+    '  telemetry <enable|disable|status> manage opt-in source-safe local telemetry',
     '  aider <install|uninstall>   manage local AGENTS.md rules',
     '  claude <install|uninstall> [--profile core|full|strict]  manage local CLAUDE.md madar rules',
     '  cursor <install|uninstall> [--profile core|full|strict]  manage local Cursor madar rules',
@@ -614,6 +655,12 @@ function handleAgentCommand(command: AgentPlatform, args: string[], io: CliIO, d
   const options = parsePlatformActionArgs(command, args)
   if (options.action === 'install') {
     io.log(dependencies.agentsInstall('.', command))
+    emitTelemetry(io, dependencies, {
+      event: 'install_success',
+      version: readInstalledVersionForTelemetry(dependencies),
+      os: process.platform,
+      installPlatform: command,
+    })
     return 0
   }
 
@@ -665,6 +712,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (output !== undefined) {
         io.log(output)
       }
+      emitTelemetry(io, dependencies, {
+        event: 'compare_success',
+        version: readInstalledVersionForTelemetry(dependencies),
+        os: process.platform,
+        repoSizeBucket: repoSizeBucketForGraph(dependencies, options.graphPath),
+      })
       return 0
     }
 
@@ -733,6 +786,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (output !== undefined) {
         io.log(output)
       }
+      emitTelemetry(io, dependencies, {
+        event: 'pack_success',
+        version: readInstalledVersionForTelemetry(dependencies),
+        os: process.platform,
+        repoSizeBucket: repoSizeBucketForGraph(dependencies, options.graphPath),
+      })
       return 0
     }
 
@@ -751,6 +810,20 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (output !== undefined) {
         io.log(output)
       }
+      return 0
+    }
+
+    if (command === 'telemetry') {
+      const options = parseTelemetryArgs(args)
+      if (options.action === 'enable') {
+        io.log((dependencies.enableTelemetry ?? (() => enableTelemetry()))())
+        return 0
+      }
+      if (options.action === 'disable') {
+        io.log((dependencies.disableTelemetry ?? (() => disableTelemetry()))())
+        return 0
+      }
+      io.log((dependencies.readTelemetryStatus ?? (() => formatTelemetryStatus(getTelemetryStatus())))())
       return 0
     }
 
@@ -788,6 +861,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         io.log(`[madar neo4j] Pushed ${pushResult.nodes} nodes and ${pushResult.edges} edges to ${pushResult.uri} (database ${pushResult.database})`)
       }
 
+      emitTelemetry(io, dependencies, {
+        event: 'generate_success',
+        version: readInstalledVersionForTelemetry(dependencies),
+        os: process.platform,
+        repoSizeBucket: repoSizeBucketFromFileCount(result.totalFiles),
+      })
       if (options.watch) {
         await dependencies.watchGraph(options.path, options.debounceSeconds, {
           followSymlinks: options.followSymlinks,
@@ -978,6 +1057,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       } else {
         io.log(dependencies.installSkill(options.platform))
       }
+      emitTelemetry(io, dependencies, {
+        event: 'install_success',
+        version: readInstalledVersionForTelemetry(dependencies),
+        os: process.platform,
+        installPlatform: options.platform,
+      })
       return 0
     }
 
@@ -1003,6 +1088,14 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       io.log(options.action === 'install'
         ? dependencies.claudeInstall('.', options.profile ? { profile: options.profile } : {})
         : dependencies.claudeUninstall('.'))
+      if (options.action === 'install') {
+        emitTelemetry(io, dependencies, {
+          event: 'install_success',
+          version: readInstalledVersionForTelemetry(dependencies),
+          os: process.platform,
+          installPlatform: 'claude',
+        })
+      }
       return 0
     }
 
@@ -1014,6 +1107,14 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       io.log(options.action === 'install'
         ? dependencies.cursorInstall('.', options.profile ? { profile: options.profile } : {})
         : dependencies.cursorUninstall('.'))
+      if (options.action === 'install') {
+        emitTelemetry(io, dependencies, {
+          event: 'install_success',
+          version: readInstalledVersionForTelemetry(dependencies),
+          os: process.platform,
+          installPlatform: 'cursor',
+        })
+      }
       return 0
     }
 
@@ -1023,6 +1124,14 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         io.log("Warning: out/graph.json not found. Run 'madar generate .' first, then re-run this command.")
       }
       io.log(options.action === 'install' ? dependencies.geminiInstall('.', options.profile ? { profile: options.profile } : {}) : dependencies.geminiUninstall('.'))
+      if (options.action === 'install') {
+        emitTelemetry(io, dependencies, {
+          event: 'install_success',
+          version: readInstalledVersionForTelemetry(dependencies),
+          os: process.platform,
+          installPlatform: 'gemini',
+        })
+      }
       return 0
     }
 
@@ -1034,6 +1143,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         }
         io.log(dependencies.installSkill('copilot'))
         io.log(dependencies.installCopilotMcp('.', options.profile ? { profile: options.profile } : {}))
+        emitTelemetry(io, dependencies, {
+          event: 'install_success',
+          version: readInstalledVersionForTelemetry(dependencies),
+          os: process.platform,
+          installPlatform: 'copilot',
+        })
       } else {
         io.log(dependencies.uninstallCopilotMcp('.'))
         io.log(dependencies.uninstallSkill('copilot'))

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -340,12 +340,12 @@ function readInstalledVersionForTelemetry(dependencies: CliDependencies): string
   return readInstalledVersion()
 }
 
-function emitTelemetry(io: CliIO, dependencies: CliDependencies, event: TelemetryEventInput): void {
+function emitTelemetry(io: CliIO, dependencies: CliDependencies, buildEvent: () => TelemetryEventInput): void {
   if (!dependencies.recordTelemetryEvent) {
     return
   }
   try {
-    dependencies.recordTelemetryEvent(event)
+    dependencies.recordTelemetryEvent(buildEvent())
   } catch (error) {
     io.error(`[madar telemetry] ${messageFromError(error)}`)
   }
@@ -655,12 +655,12 @@ function handleAgentCommand(command: AgentPlatform, args: string[], io: CliIO, d
   const options = parsePlatformActionArgs(command, args)
   if (options.action === 'install') {
     io.log(dependencies.agentsInstall('.', command))
-    emitTelemetry(io, dependencies, {
+    emitTelemetry(io, dependencies, () => ({
       event: 'install_success',
       version: readInstalledVersionForTelemetry(dependencies),
       os: process.platform,
       installPlatform: command,
-    })
+    }))
     return 0
   }
 
@@ -712,12 +712,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (output !== undefined) {
         io.log(output)
       }
-      emitTelemetry(io, dependencies, {
+      emitTelemetry(io, dependencies, () => ({
         event: 'compare_success',
         version: readInstalledVersionForTelemetry(dependencies),
         os: process.platform,
         repoSizeBucket: repoSizeBucketForGraph(dependencies, options.graphPath),
-      })
+      }))
       return 0
     }
 
@@ -786,12 +786,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (output !== undefined) {
         io.log(output)
       }
-      emitTelemetry(io, dependencies, {
+      emitTelemetry(io, dependencies, () => ({
         event: 'pack_success',
         version: readInstalledVersionForTelemetry(dependencies),
         os: process.platform,
         repoSizeBucket: repoSizeBucketForGraph(dependencies, options.graphPath),
-      })
+      }))
       return 0
     }
 
@@ -861,12 +861,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         io.log(`[madar neo4j] Pushed ${pushResult.nodes} nodes and ${pushResult.edges} edges to ${pushResult.uri} (database ${pushResult.database})`)
       }
 
-      emitTelemetry(io, dependencies, {
+      emitTelemetry(io, dependencies, () => ({
         event: 'generate_success',
         version: readInstalledVersionForTelemetry(dependencies),
         os: process.platform,
         repoSizeBucket: repoSizeBucketFromFileCount(result.totalFiles),
-      })
+      }))
       if (options.watch) {
         await dependencies.watchGraph(options.path, options.debounceSeconds, {
           followSymlinks: options.followSymlinks,
@@ -1057,12 +1057,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       } else {
         io.log(dependencies.installSkill(options.platform))
       }
-      emitTelemetry(io, dependencies, {
+      emitTelemetry(io, dependencies, () => ({
         event: 'install_success',
         version: readInstalledVersionForTelemetry(dependencies),
         os: process.platform,
         installPlatform: options.platform,
-      })
+      }))
       return 0
     }
 
@@ -1089,12 +1089,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         ? dependencies.claudeInstall('.', options.profile ? { profile: options.profile } : {})
         : dependencies.claudeUninstall('.'))
       if (options.action === 'install') {
-        emitTelemetry(io, dependencies, {
+        emitTelemetry(io, dependencies, () => ({
           event: 'install_success',
           version: readInstalledVersionForTelemetry(dependencies),
           os: process.platform,
           installPlatform: 'claude',
-        })
+        }))
       }
       return 0
     }
@@ -1108,12 +1108,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         ? dependencies.cursorInstall('.', options.profile ? { profile: options.profile } : {})
         : dependencies.cursorUninstall('.'))
       if (options.action === 'install') {
-        emitTelemetry(io, dependencies, {
+        emitTelemetry(io, dependencies, () => ({
           event: 'install_success',
           version: readInstalledVersionForTelemetry(dependencies),
           os: process.platform,
           installPlatform: 'cursor',
-        })
+        }))
       }
       return 0
     }
@@ -1125,12 +1125,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       }
       io.log(options.action === 'install' ? dependencies.geminiInstall('.', options.profile ? { profile: options.profile } : {}) : dependencies.geminiUninstall('.'))
       if (options.action === 'install') {
-        emitTelemetry(io, dependencies, {
+        emitTelemetry(io, dependencies, () => ({
           event: 'install_success',
           version: readInstalledVersionForTelemetry(dependencies),
           os: process.platform,
           installPlatform: 'gemini',
-        })
+        }))
       }
       return 0
     }
@@ -1143,12 +1143,12 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         }
         io.log(dependencies.installSkill('copilot'))
         io.log(dependencies.installCopilotMcp('.', options.profile ? { profile: options.profile } : {}))
-        emitTelemetry(io, dependencies, {
+        emitTelemetry(io, dependencies, () => ({
           event: 'install_success',
           version: readInstalledVersionForTelemetry(dependencies),
           os: process.platform,
           installPlatform: 'copilot',
-        })
+        }))
       } else {
         io.log(dependencies.uninstallCopilotMcp('.'))
         io.log(dependencies.uninstallSkill('copilot'))

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -209,6 +209,10 @@ export interface InstallCliOptions {
   platform: InstallPlatform
 }
 
+export interface TelemetryCliOptions {
+  action: 'enable' | 'disable' | 'status'
+}
+
 const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'
 
 export interface PlatformActionCliOptions {
@@ -2065,6 +2069,18 @@ export function parseHookArgs(args: string[]): HookCliOptions {
   }
 
   throw new UsageError('Usage: madar hook <install|uninstall|status>')
+}
+
+export function parseTelemetryArgs(args: string[]): TelemetryCliOptions {
+  const action = args[0]
+  if (action === 'enable' || action === 'disable' || action === 'status') {
+    if (args.length > 1) {
+      throw new UsageError('Usage: madar telemetry <enable|disable|status>')
+    }
+    return { action }
+  }
+
+  throw new UsageError('Usage: madar telemetry <enable|disable|status>')
 }
 
 export function parseInstallArgs(args: string[], defaultPlatform: InstallPlatform): InstallCliOptions {

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,0 +1,332 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir, platform } from 'node:os'
+import { dirname, join } from 'node:path'
+
+export type TelemetryEventName = 'install_success' | 'generate_success' | 'pack_success' | 'compare_success'
+export type TelemetryRepoSizeBucket = '1-24' | '25-99' | '100-499' | '500-999' | '1000+'
+
+export interface TelemetryEventInput {
+  event: TelemetryEventName
+  version: string
+  os: NodeJS.Platform
+  repoSizeBucket?: TelemetryRepoSizeBucket
+  installPlatform?: string
+}
+
+export interface TelemetryOptions {
+  configRoot?: string
+  cacheRoot?: string
+  env?: NodeJS.ProcessEnv
+  now?: () => number
+  maxEvents?: number
+}
+
+export interface TelemetryStatus {
+  enabled: boolean
+  reason: string
+  configFile: string
+  spoolFile: string
+  eventCount: number
+}
+
+interface TelemetryConfig {
+  schema_version: 1
+  enabled: boolean
+  updated_at: number
+}
+
+interface PersistedTelemetryEvent {
+  event: TelemetryEventName
+  recorded_at: string
+  version: string
+  os: NodeJS.Platform
+  repo_size_bucket?: TelemetryRepoSizeBucket
+  install_platform?: string
+}
+
+interface TelemetrySpool {
+  schema_version: 1
+  events: PersistedTelemetryEvent[]
+}
+
+const DEFAULT_MAX_EVENTS = 200
+
+function defaultConfigRoot(env: NodeJS.ProcessEnv): string {
+  if (typeof env.XDG_CONFIG_HOME === 'string' && env.XDG_CONFIG_HOME.trim().length > 0) {
+    return env.XDG_CONFIG_HOME
+  }
+
+  if (platform() === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support')
+  }
+
+  if (platform() === 'win32') {
+    if (typeof env.APPDATA === 'string' && env.APPDATA.trim().length > 0) {
+      return env.APPDATA
+    }
+    return join(homedir(), 'AppData', 'Roaming')
+  }
+
+  return join(homedir(), '.config')
+}
+
+function defaultCacheRoot(env: NodeJS.ProcessEnv): string {
+  if (typeof env.XDG_CACHE_HOME === 'string' && env.XDG_CACHE_HOME.trim().length > 0) {
+    return env.XDG_CACHE_HOME
+  }
+
+  if (platform() === 'darwin') {
+    return join(homedir(), 'Library', 'Caches')
+  }
+
+  if (platform() === 'win32') {
+    if (typeof env.LOCALAPPDATA === 'string' && env.LOCALAPPDATA.trim().length > 0) {
+      return env.LOCALAPPDATA
+    }
+    return join(homedir(), 'AppData', 'Local')
+  }
+
+  return join(homedir(), '.cache')
+}
+
+function telemetryConfigFilePath(configRoot: string): string {
+  return join(configRoot, 'madar', 'telemetry.json')
+}
+
+function telemetrySpoolFilePath(cacheRoot: string): string {
+  return join(cacheRoot, 'madar', 'telemetry-events.json')
+}
+
+function parseConfig(text: string): TelemetryConfig | null {
+  try {
+    const parsed = JSON.parse(text) as Partial<TelemetryConfig>
+    if (parsed.schema_version !== 1 || typeof parsed.enabled !== 'boolean' || typeof parsed.updated_at !== 'number') {
+      return null
+    }
+    return {
+      schema_version: 1,
+      enabled: parsed.enabled,
+      updated_at: parsed.updated_at,
+    }
+  } catch {
+    return null
+  }
+}
+
+function loadConfig(configFile: string): TelemetryConfig | null {
+  if (!existsSync(configFile)) {
+    return null
+  }
+  return parseConfig(readFileSync(configFile, 'utf8'))
+}
+
+function parseSpool(text: string): TelemetrySpool | null {
+  try {
+    const parsed = JSON.parse(text) as Partial<TelemetrySpool>
+    if (parsed.schema_version !== 1 || !Array.isArray(parsed.events)) {
+      return null
+    }
+    return {
+      schema_version: 1,
+      events: parsed.events
+        .filter((event): event is PersistedTelemetryEvent => typeof event === 'object' && event !== null)
+        .map((event) => {
+          const record = event as Partial<PersistedTelemetryEvent>
+          return {
+            event: record.event as TelemetryEventName,
+            recorded_at: String(record.recorded_at ?? ''),
+            version: String(record.version ?? ''),
+            os: (record.os as NodeJS.Platform | undefined) ?? platform(),
+            ...(record.repo_size_bucket ? { repo_size_bucket: record.repo_size_bucket } : {}),
+            ...(record.install_platform ? { install_platform: String(record.install_platform) } : {}),
+          }
+        })
+        .filter((event) => event.recorded_at.length > 0 && event.version.length > 0),
+    }
+  } catch {
+    return null
+  }
+}
+
+function loadSpool(spoolFile: string): TelemetrySpool {
+  if (!existsSync(spoolFile)) {
+    return { schema_version: 1, events: [] }
+  }
+  return parseSpool(readFileSync(spoolFile, 'utf8')) ?? { schema_version: 1, events: [] }
+}
+
+function writeJsonAtomic(targetPath: string, value: unknown): void {
+  mkdirSync(dirname(targetPath), { recursive: true })
+  const tempPath = `${targetPath}.tmp`
+  try {
+    writeFileSync(tempPath, JSON.stringify(value, null, 2))
+    renameSync(tempPath, targetPath)
+  } catch (error) {
+    rmSync(tempPath, { force: true })
+    throw error
+  }
+}
+
+export function repoSizeBucketFromFileCount(fileCount: number): TelemetryRepoSizeBucket {
+  if (fileCount <= 24) {
+    return '1-24'
+  }
+  if (fileCount <= 99) {
+    return '25-99'
+  }
+  if (fileCount <= 499) {
+    return '100-499'
+  }
+  if (fileCount <= 999) {
+    return '500-999'
+  }
+  return '1000+'
+}
+
+export function getTelemetryStatus(options: TelemetryOptions = {}): TelemetryStatus {
+  const env = options.env ?? process.env
+  const configRoot = options.configRoot ?? defaultConfigRoot(env)
+  const cacheRoot = options.cacheRoot ?? defaultCacheRoot(env)
+  const configFile = telemetryConfigFilePath(configRoot)
+  const spoolFile = telemetrySpoolFilePath(cacheRoot)
+  const eventCount = loadSpool(spoolFile).events.length
+
+  if (env.CI) {
+    return {
+      enabled: false,
+      reason: 'disabled in CI',
+      configFile,
+      spoolFile,
+      eventCount,
+    }
+  }
+
+  if (env.DO_NOT_TRACK === '1') {
+    return {
+      enabled: false,
+      reason: 'disabled by DO_NOT_TRACK=1',
+      configFile,
+      spoolFile,
+      eventCount,
+    }
+  }
+
+  if (env.MADAR_DISABLE_TELEMETRY === '1') {
+    return {
+      enabled: false,
+      reason: 'disabled by MADAR_DISABLE_TELEMETRY=1',
+      configFile,
+      spoolFile,
+      eventCount,
+    }
+  }
+
+  if (env.MADAR_ENABLE_TELEMETRY === '1') {
+    return {
+      enabled: true,
+      reason: 'enabled by MADAR_ENABLE_TELEMETRY=1',
+      configFile,
+      spoolFile,
+      eventCount,
+    }
+  }
+
+  const config = loadConfig(configFile)
+  if (config?.enabled) {
+    return {
+      enabled: true,
+      reason: 'enabled by persisted preference',
+      configFile,
+      spoolFile,
+      eventCount,
+    }
+  }
+
+  return {
+    enabled: false,
+    reason: 'disabled by default',
+    configFile,
+    spoolFile,
+    eventCount,
+  }
+}
+
+export function formatTelemetryStatus(status: TelemetryStatus): string {
+  return [
+    `Telemetry: ${status.enabled ? 'enabled' : 'disabled'}`,
+    `Reason: ${status.reason}`,
+    `Event cache: ${status.eventCount} event(s) at ${status.spoolFile}`,
+    'Tracked fields: event, version, os, optional install target, optional repo-size bucket',
+    'Excluded fields: prompts, answers, source paths, source content',
+  ].join('\n')
+}
+
+function formatTelemetryPreferenceUpdate(preferenceEnabled: boolean, runtimeStatus: TelemetryStatus): string {
+  const persistedReason = preferenceEnabled ? 'enabled by persisted preference' : 'disabled by persisted preference'
+  const lines = [
+    `Telemetry preference: ${preferenceEnabled ? 'enabled' : 'disabled'}`,
+    `Config file: ${runtimeStatus.configFile}`,
+    `Event cache: ${runtimeStatus.eventCount} event(s) at ${runtimeStatus.spoolFile}`,
+    'Tracked fields: event, version, os, optional install target, optional repo-size bucket',
+    'Excluded fields: prompts, answers, source paths, source content',
+  ]
+
+  if (runtimeStatus.enabled !== preferenceEnabled || runtimeStatus.reason !== persistedReason) {
+    lines.splice(1, 0, `Current runtime override: ${runtimeStatus.reason}`)
+  }
+
+  return lines.join('\n')
+}
+
+export function enableTelemetry(options: TelemetryOptions = {}): string {
+  const env = options.env ?? process.env
+  const configRoot = options.configRoot ?? defaultConfigRoot(env)
+  const cacheRoot = options.cacheRoot ?? defaultCacheRoot(env)
+  const now = options.now ?? Date.now
+  writeJsonAtomic(telemetryConfigFilePath(configRoot), {
+    schema_version: 1,
+    enabled: true,
+    updated_at: now(),
+  } satisfies TelemetryConfig)
+  return formatTelemetryPreferenceUpdate(true, getTelemetryStatus({ ...options, configRoot, cacheRoot, env }))
+}
+
+export function disableTelemetry(options: TelemetryOptions = {}): string {
+  const env = options.env ?? process.env
+  const configRoot = options.configRoot ?? defaultConfigRoot(env)
+  const cacheRoot = options.cacheRoot ?? defaultCacheRoot(env)
+  const now = options.now ?? Date.now
+  writeJsonAtomic(telemetryConfigFilePath(configRoot), {
+    schema_version: 1,
+    enabled: false,
+    updated_at: now(),
+  } satisfies TelemetryConfig)
+  return formatTelemetryPreferenceUpdate(false, getTelemetryStatus({ ...options, configRoot, cacheRoot, env }))
+}
+
+export function recordTelemetryEvent(input: TelemetryEventInput, options: TelemetryOptions = {}): boolean {
+  const env = options.env ?? process.env
+  const cacheRoot = options.cacheRoot ?? defaultCacheRoot(env)
+  const status = getTelemetryStatus(options)
+  if (!status.enabled) {
+    return false
+  }
+
+  const now = options.now ?? Date.now
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS
+  const spoolFile = telemetrySpoolFilePath(cacheRoot)
+  const spool = loadSpool(spoolFile)
+  spool.events.push({
+    event: input.event,
+    recorded_at: new Date(now()).toISOString(),
+    version: input.version,
+    os: input.os,
+    ...(input.repoSizeBucket ? { repo_size_bucket: input.repoSizeBucket } : {}),
+    ...(input.installPlatform ? { install_platform: input.installPlatform } : {}),
+  })
+  if (spool.events.length > maxEvents) {
+    spool.events = spool.events.slice(-maxEvents)
+  }
+  writeJsonAtomic(spoolFile, spool)
+  return true
+}

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, platform } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -50,6 +50,8 @@ interface TelemetrySpool {
 }
 
 const DEFAULT_MAX_EVENTS = 200
+const LOCK_RETRY_DELAY_MS = 10
+const LOCK_TIMEOUT_MS = 1_000
 
 function defaultConfigRoot(env: NodeJS.ProcessEnv): string {
   if (typeof env.XDG_CONFIG_HOME === 'string' && env.XDG_CONFIG_HOME.trim().length > 0) {
@@ -155,9 +157,43 @@ function loadSpool(spoolFile: string): TelemetrySpool {
   return parseSpool(readFileSync(spoolFile, 'utf8')) ?? { schema_version: 1, events: [] }
 }
 
+function uniqueTempPath(targetPath: string): string {
+  return `${targetPath}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+}
+
+function sleepMs(durationMs: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, durationMs)
+}
+
+function withExclusiveLock<T>(targetPath: string, action: () => T): T {
+  const lockPath = `${targetPath}.lock`
+  const start = Date.now()
+  mkdirSync(dirname(lockPath), { recursive: true })
+
+  while (true) {
+    try {
+      const lockFd = openSync(lockPath, 'wx')
+      try {
+        return action()
+      } finally {
+        closeSync(lockFd)
+        rmSync(lockPath, { force: true })
+      }
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error) || error.code !== 'EEXIST') {
+        throw error
+      }
+      if (Date.now() - start >= LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for telemetry lock at ${lockPath}`)
+      }
+      sleepMs(LOCK_RETRY_DELAY_MS)
+    }
+  }
+}
+
 function writeJsonAtomic(targetPath: string, value: unknown): void {
   mkdirSync(dirname(targetPath), { recursive: true })
-  const tempPath = `${targetPath}.tmp`
+  const tempPath = uniqueTempPath(targetPath)
   try {
     writeFileSync(tempPath, JSON.stringify(value, null, 2))
     renameSync(tempPath, targetPath)
@@ -283,11 +319,14 @@ export function enableTelemetry(options: TelemetryOptions = {}): string {
   const configRoot = options.configRoot ?? defaultConfigRoot(env)
   const cacheRoot = options.cacheRoot ?? defaultCacheRoot(env)
   const now = options.now ?? Date.now
-  writeJsonAtomic(telemetryConfigFilePath(configRoot), {
-    schema_version: 1,
-    enabled: true,
-    updated_at: now(),
-  } satisfies TelemetryConfig)
+  const configFile = telemetryConfigFilePath(configRoot)
+  withExclusiveLock(configFile, () => {
+    writeJsonAtomic(configFile, {
+      schema_version: 1,
+      enabled: true,
+      updated_at: now(),
+    } satisfies TelemetryConfig)
+  })
   return formatTelemetryPreferenceUpdate(true, getTelemetryStatus({ ...options, configRoot, cacheRoot, env }))
 }
 
@@ -296,11 +335,14 @@ export function disableTelemetry(options: TelemetryOptions = {}): string {
   const configRoot = options.configRoot ?? defaultConfigRoot(env)
   const cacheRoot = options.cacheRoot ?? defaultCacheRoot(env)
   const now = options.now ?? Date.now
-  writeJsonAtomic(telemetryConfigFilePath(configRoot), {
-    schema_version: 1,
-    enabled: false,
-    updated_at: now(),
-  } satisfies TelemetryConfig)
+  const configFile = telemetryConfigFilePath(configRoot)
+  withExclusiveLock(configFile, () => {
+    writeJsonAtomic(configFile, {
+      schema_version: 1,
+      enabled: false,
+      updated_at: now(),
+    } satisfies TelemetryConfig)
+  })
   return formatTelemetryPreferenceUpdate(false, getTelemetryStatus({ ...options, configRoot, cacheRoot, env }))
 }
 
@@ -313,20 +355,25 @@ export function recordTelemetryEvent(input: TelemetryEventInput, options: Teleme
   }
 
   const now = options.now ?? Date.now
-  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS
+  const requestedMaxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS
+  const maxEvents = Number.isInteger(requestedMaxEvents) && requestedMaxEvents > 0
+    ? requestedMaxEvents
+    : DEFAULT_MAX_EVENTS
   const spoolFile = telemetrySpoolFilePath(cacheRoot)
-  const spool = loadSpool(spoolFile)
-  spool.events.push({
-    event: input.event,
-    recorded_at: new Date(now()).toISOString(),
-    version: input.version,
-    os: input.os,
-    ...(input.repoSizeBucket ? { repo_size_bucket: input.repoSizeBucket } : {}),
-    ...(input.installPlatform ? { install_platform: input.installPlatform } : {}),
+  withExclusiveLock(spoolFile, () => {
+    const spool = loadSpool(spoolFile)
+    spool.events.push({
+      event: input.event,
+      recorded_at: new Date(now()).toISOString(),
+      version: input.version,
+      os: input.os,
+      ...(input.repoSizeBucket ? { repo_size_bucket: input.repoSizeBucket } : {}),
+      ...(input.installPlatform ? { install_platform: input.installPlatform } : {}),
+    })
+    if (spool.events.length > maxEvents) {
+      spool.events = spool.events.slice(-maxEvents)
+    }
+    writeJsonAtomic(spoolFile, spool)
   })
-  if (spool.events.length > maxEvents) {
-    spool.events = spool.events.slice(-maxEvents)
-  }
-  writeJsonAtomic(spoolFile, spool)
   return true
 }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -24,6 +24,7 @@ import {
   parseSaveResultArgs,
   parseSummaryArgs,
   parseServeArgs,
+  parseTelemetryArgs,
   parseTimeTravelArgs,
   parseWatchArgs,
 } from '../../src/cli/parser.js'
@@ -1075,6 +1076,13 @@ describe('cli parser', () => {
     expect(() => parseHookArgs([])).toThrow('Usage: madar hook <install|uninstall|status>')
   })
 
+  it('parses telemetry args', () => {
+    expect(parseTelemetryArgs(['enable'])).toEqual({ action: 'enable' })
+    expect(parseTelemetryArgs(['disable'])).toEqual({ action: 'disable' })
+    expect(parseTelemetryArgs(['status'])).toEqual({ action: 'status' })
+    expect(() => parseTelemetryArgs([])).toThrow('Usage: madar telemetry <enable|disable|status>')
+  })
+
   it('parses install args and platform actions', () => {
     expect(parseInstallArgs([], 'claude')).toEqual({ platform: 'claude' })
     expect(parseInstallArgs(['--platform', 'aider'], 'claude')).toEqual({ platform: 'aider' })
@@ -1244,6 +1252,7 @@ describe('cli main', () => {
     expect(help).toContain('    --pack PATH           optional saved context-pack JSON for pack-quality evidence')
     expect(help).toContain('question coverage')
     expect(help).toContain('hook <action>')
+    expect(help).toContain('telemetry <enable|disable|status>')
     expect(help).toContain('install [--platform P]')
     expect(help).toContain('If you update madar, re-run your platform install command to refresh local agent rules:')
     expect(help).toContain('madar install --platform <platform>')
@@ -1259,9 +1268,13 @@ describe('cli main', () => {
 
   it('routes compare through the injected dependency after parsing args', async () => {
     const { io, logs, errors } = createIo()
-    const dependencies = createDependencies()
+    const dependencies = createDependencies() as CliDependencies & {
+      recordTelemetryEvent: (event: unknown) => void
+      readInstalledVersion: () => string
+    }
     let capturedRequest: unknown
     let confirmCalls = 0
+    const telemetryEvents: unknown[] = []
 
     dependencies.runCompare = async (request) => {
       capturedRequest = request
@@ -1271,6 +1284,10 @@ describe('cli main', () => {
       confirmCalls += 1
       return true
     }
+    dependencies.recordTelemetryEvent = (event) => {
+      telemetryEvents.push(event)
+    }
+    dependencies.readInstalledVersion = () => '0.27.4'
 
     const exitCode = await executeCli(
       [
@@ -1329,6 +1346,157 @@ describe('cli main', () => {
     expect(compareRequest.io).toBe(io)
     await expect(compareRequest.confirm('Proceed?')).resolves.toBe(true)
     expect(confirmCalls).toBe(1)
+    expect(telemetryEvents).toEqual([
+      {
+        event: 'compare_success',
+        version: '0.27.4',
+        os: process.platform,
+        repoSizeBucket: '1-24',
+      },
+    ])
+  })
+
+  it('routes telemetry commands through the injected dependencies', async () => {
+    const enable = createIo()
+    const disable = createIo()
+    const status = createIo()
+    const enabledDependencies = createDependencies() as CliDependencies & {
+      enableTelemetry: () => string
+    }
+    const disabledDependencies = createDependencies() as CliDependencies & {
+      disableTelemetry: () => string
+    }
+    const statusDependencies = createDependencies() as CliDependencies & {
+      readTelemetryStatus: () => string
+    }
+
+    enabledDependencies.enableTelemetry = () => 'Telemetry enabled.'
+    disabledDependencies.disableTelemetry = () => 'Telemetry disabled.'
+    statusDependencies.readTelemetryStatus = () => 'Telemetry: disabled'
+
+    await expect(executeCli(['telemetry', 'enable'], enable.io, enabledDependencies)).resolves.toBe(0)
+    await expect(executeCli(['telemetry', 'disable'], disable.io, disabledDependencies)).resolves.toBe(0)
+    await expect(executeCli(['telemetry', 'status'], status.io, statusDependencies)).resolves.toBe(0)
+
+    expect(enable.logs).toContain('Telemetry enabled.')
+    expect(disable.logs).toContain('Telemetry disabled.')
+    expect(status.logs).toContain('Telemetry: disabled')
+  })
+
+  it('prefers the telemetry command over implicit generate when a telemetry path exists', async () => {
+    const sandboxRoot = resolve('out', 'test-runtime', 'telemetry-command-shadow')
+    const originalCwd = process.cwd()
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      readTelemetryStatus: () => string
+    }
+
+    rmSync(sandboxRoot, { recursive: true, force: true })
+    mkdirSync(resolve(sandboxRoot, 'telemetry'), { recursive: true })
+    dependencies.readTelemetryStatus = () => 'Telemetry: disabled'
+
+    try {
+      process.chdir(sandboxRoot)
+      await expect(executeCli(['telemetry', 'status'], io, dependencies)).resolves.toBe(0)
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(sandboxRoot, { recursive: true, force: true })
+    }
+
+    expect(errors).toEqual([])
+    expect(logs).toContain('Telemetry: disabled')
+  })
+
+  it('records telemetry after pack success', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      recordTelemetryEvent: (event: unknown) => void
+      readInstalledVersion: () => string
+    }
+    const telemetryEvents: unknown[] = []
+
+    dependencies.runContextPack = async () => 'pack result'
+    dependencies.recordTelemetryEvent = (event) => {
+      telemetryEvents.push(event)
+    }
+    dependencies.readInstalledVersion = () => '0.27.4'
+
+    const exitCode = await executeCli(['pack', 'explain auth flow'], io, dependencies)
+
+    expect(exitCode).toBe(0)
+    expect(errors).toEqual([])
+    expect(logs).toEqual(['pack result'])
+    expect(telemetryEvents).toEqual([
+      {
+        event: 'pack_success',
+        version: '0.27.4',
+        os: process.platform,
+        repoSizeBucket: '1-24',
+      },
+    ])
+  })
+
+  it('records telemetry after generate success', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      recordTelemetryEvent: (event: unknown) => void
+      readInstalledVersion: () => string
+    }
+    const telemetryEvents: unknown[] = []
+
+    dependencies.recordTelemetryEvent = (event) => {
+      telemetryEvents.push(event)
+    }
+    dependencies.readInstalledVersion = () => '0.27.4'
+
+    const exitCode = await executeCli(['generate', '.'], io, dependencies)
+
+    expect(exitCode).toBe(0)
+    expect(errors).toEqual([])
+    expect(logs[0]).toContain('[madar generate]')
+    expect(telemetryEvents).toEqual([
+      {
+        event: 'generate_success',
+        version: '0.27.4',
+        os: process.platform,
+        repoSizeBucket: '1-24',
+      },
+    ])
+  })
+
+  it('records telemetry after install success across install entrypoints', async () => {
+    const generic = createIo()
+    const agent = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      recordTelemetryEvent: (event: unknown) => void
+      readInstalledVersion: () => string
+    }
+    const telemetryEvents: unknown[] = []
+
+    dependencies.recordTelemetryEvent = (event) => {
+      telemetryEvents.push(event)
+    }
+    dependencies.readInstalledVersion = () => '0.27.4'
+
+    await expect(executeCli(['install', '--platform', 'aider'], generic.io, dependencies)).resolves.toBe(0)
+    await expect(executeCli(['aider', 'install'], agent.io, dependencies)).resolves.toBe(0)
+
+    expect(generic.errors).toEqual([])
+    expect(agent.errors).toEqual([])
+    expect(telemetryEvents).toEqual([
+      {
+        event: 'install_success',
+        version: '0.27.4',
+        os: process.platform,
+        installPlatform: 'aider',
+      },
+      {
+        event: 'install_success',
+        version: '0.27.4',
+        os: process.platform,
+        installPlatform: 'aider',
+      },
+    ])
   })
 
   it('routes proof-report through the injected dependency after parsing args', async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1499,6 +1499,26 @@ describe('cli main', () => {
     ])
   })
 
+  it('treats telemetry helper failures as non-fatal command warnings', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies() as CliDependencies & {
+      recordTelemetryEvent: (event: unknown) => void
+      readInstalledVersion: () => string
+    }
+
+    dependencies.runContextPack = async () => 'pack result'
+    dependencies.recordTelemetryEvent = () => {}
+    dependencies.readInstalledVersion = () => {
+      throw new Error('version unavailable')
+    }
+
+    const exitCode = await executeCli(['pack', 'explain auth flow'], io, dependencies)
+
+    expect(exitCode).toBe(0)
+    expect(logs).toEqual(['pack result'])
+    expect(errors).toContain('[madar telemetry] version unavailable')
+  })
+
   it('routes proof-report through the injected dependency after parsing args', async () => {
     const { io, logs, errors } = createIo()
     const dependencies = createDependencies() as CliDependencies & {

--- a/tests/unit/telemetry-doc.test.ts
+++ b/tests/unit/telemetry-doc.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+describe('telemetry documentation', () => {
+  it('documents the opt-in controls in the README', () => {
+    const readme = readFileSync(resolve('README.md'), 'utf8')
+
+    expect(readme).toContain('madar telemetry enable')
+    expect(readme).toContain('madar telemetry disable')
+    expect(readme).toContain('MADAR_ENABLE_TELEMETRY=1')
+    expect(readme).toContain('docs/telemetry.md')
+    expect(readme).toContain('Telemetry is disabled unless you explicitly enable it')
+  })
+
+  it('documents collected and excluded telemetry fields explicitly', () => {
+    const doc = readFileSync(resolve('docs/telemetry.md'), 'utf8')
+
+    expect(doc).toContain('install_success')
+    expect(doc).toContain('generate_success')
+    expect(doc).toContain('pack_success')
+    expect(doc).toContain('compare_success')
+    expect(doc).toContain('version')
+    expect(doc).toContain('os')
+    expect(doc).toContain('repo_size_bucket')
+    expect(doc).toContain('prompt text')
+    expect(doc).toContain('answer text')
+    expect(doc).toContain('source paths')
+    expect(doc).toContain('source content')
+    expect(doc).toContain('DO_NOT_TRACK=1')
+    expect(doc).toContain('MADAR_DISABLE_TELEMETRY=1')
+  })
+})

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  disableTelemetry,
+  enableTelemetry,
+  formatTelemetryStatus,
+  getTelemetryStatus,
+  recordTelemetryEvent,
+  repoSizeBucketFromFileCount,
+} from '../../src/shared/telemetry.js'
+
+describe('telemetry', () => {
+  it('is disabled by default until explicitly enabled', () => {
+    const configRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-config-'))
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-cache-'))
+
+    try {
+      const status = getTelemetryStatus({
+        configRoot,
+        cacheRoot,
+        env: {},
+      })
+
+      expect(status.enabled).toBe(false)
+      expect(formatTelemetryStatus(status)).toContain('Telemetry: disabled')
+      expect(formatTelemetryStatus(status)).toContain('disabled by default')
+    } finally {
+      rmSync(configRoot, { recursive: true, force: true })
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('records bounded source-safe events after explicit enable', () => {
+    const configRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-config-'))
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-cache-'))
+
+    try {
+      enableTelemetry({
+        configRoot,
+        cacheRoot,
+        env: {},
+        now: () => 1_700_000_000_000,
+      })
+
+      expect(recordTelemetryEvent({
+        event: 'generate_success',
+        version: '0.27.4',
+        os: 'darwin',
+        repoSizeBucket: repoSizeBucketFromFileCount(240),
+      }, {
+        configRoot,
+        cacheRoot,
+        env: {},
+        now: () => 1_700_000_010_000,
+        maxEvents: 2,
+      })).toBe(true)
+
+      expect(recordTelemetryEvent({
+        event: 'pack_success',
+        version: '0.27.4',
+        os: 'darwin',
+        repoSizeBucket: repoSizeBucketFromFileCount(12),
+      }, {
+        configRoot,
+        cacheRoot,
+        env: {},
+        now: () => 1_700_000_020_000,
+        maxEvents: 2,
+      })).toBe(true)
+
+      expect(recordTelemetryEvent({
+        event: 'compare_success',
+        version: '0.27.4',
+        os: 'darwin',
+        repoSizeBucket: repoSizeBucketFromFileCount(2_100),
+      }, {
+        configRoot,
+        cacheRoot,
+        env: {},
+        now: () => 1_700_000_030_000,
+        maxEvents: 2,
+      })).toBe(true)
+
+      const spoolFile = join(cacheRoot, 'madar', 'telemetry-events.json')
+      expect(JSON.parse(readFileSync(spoolFile, 'utf8'))).toEqual({
+        schema_version: 1,
+        events: [
+          expect.objectContaining({
+            event: 'pack_success',
+            version: '0.27.4',
+            os: 'darwin',
+            repo_size_bucket: '1-24',
+          }),
+          expect.objectContaining({
+            event: 'compare_success',
+            version: '0.27.4',
+            os: 'darwin',
+            repo_size_bucket: '1000+',
+          }),
+        ],
+      })
+    } finally {
+      rmSync(configRoot, { recursive: true, force: true })
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('honors disable controls even when config is enabled', () => {
+    const configRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-config-'))
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-cache-'))
+
+    try {
+      enableTelemetry({
+        configRoot,
+        cacheRoot,
+        env: {},
+      })
+
+      const status = getTelemetryStatus({
+        configRoot,
+        cacheRoot,
+        env: { MADAR_DISABLE_TELEMETRY: '1' },
+      })
+
+      expect(status.enabled).toBe(false)
+      expect(formatTelemetryStatus(status)).toContain('MADAR_DISABLE_TELEMETRY=1')
+      expect(recordTelemetryEvent({
+        event: 'generate_success',
+        version: '0.27.4',
+        os: 'darwin',
+        repoSizeBucket: '100-499',
+      }, {
+        configRoot,
+        cacheRoot,
+        env: { MADAR_DISABLE_TELEMETRY: '1' },
+      })).toBe(false)
+
+      disableTelemetry({
+        configRoot,
+        cacheRoot,
+        env: {},
+      })
+    } finally {
+      rmSync(configRoot, { recursive: true, force: true })
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('reports persisted preference changes even when env overrides the current runtime state', () => {
+    const configRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-config-'))
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-cache-'))
+
+    try {
+      const enabled = enableTelemetry({
+        configRoot,
+        cacheRoot,
+        env: { MADAR_DISABLE_TELEMETRY: '1' },
+        now: () => 1_700_000_000_000,
+      })
+      const disabled = disableTelemetry({
+        configRoot,
+        cacheRoot,
+        env: { MADAR_ENABLE_TELEMETRY: '1' },
+        now: () => 1_700_000_010_000,
+      })
+
+      expect(enabled).toContain('Telemetry preference: enabled')
+      expect(enabled).toContain('Current runtime override: disabled by MADAR_DISABLE_TELEMETRY=1')
+      expect(disabled).toContain('Telemetry preference: disabled')
+      expect(disabled).toContain('Current runtime override: enabled by MADAR_ENABLE_TELEMETRY=1')
+    } finally {
+      rmSync(configRoot, { recursive: true, force: true })
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -177,4 +177,49 @@ describe('telemetry', () => {
       rmSync(cacheRoot, { recursive: true, force: true })
     }
   })
+
+  it('falls back to the default cap when maxEvents is zero or negative', () => {
+    const configRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-config-'))
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'madar-telemetry-cache-'))
+
+    try {
+      enableTelemetry({
+        configRoot,
+        cacheRoot,
+        env: {},
+      })
+
+      expect(recordTelemetryEvent({
+        event: 'generate_success',
+        version: '0.27.4',
+        os: 'darwin',
+        repoSizeBucket: '25-99',
+      }, {
+        configRoot,
+        cacheRoot,
+        env: {},
+        maxEvents: 0,
+        now: () => 1_700_000_000_000,
+      })).toBe(true)
+
+      expect(recordTelemetryEvent({
+        event: 'pack_success',
+        version: '0.27.4',
+        os: 'darwin',
+        repoSizeBucket: '25-99',
+      }, {
+        configRoot,
+        cacheRoot,
+        env: {},
+        maxEvents: -5,
+        now: () => 1_700_000_010_000,
+      })).toBe(true)
+
+      const spoolFile = join(cacheRoot, 'madar', 'telemetry-events.json')
+      expect(JSON.parse(readFileSync(spoolFile, 'utf8')).events).toHaveLength(2)
+    } finally {
+      rmSync(configRoot, { recursive: true, force: true })
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- add an opt-in local telemetry helper with persisted preference, bounded event spool, and env override controls
- record coarse source-safe success events for install, generate, pack, and compare
- document the telemetry controls, collected fields, and excluded fields in the README and docs

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

Closes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in, local-only telemetry with CLI subcommands to enable, disable, and check status; telemetry disabled by default and can be enabled temporarily via environment variable.

* **Documentation**
  * Added a telemetry guide and updated README to document workflow, controls, collected/excluded data, and CLI help text.

* **Tests**
  * Added comprehensive tests covering telemetry behavior, CLI parsing/routing, and status/help reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->