### PR TITLE
docs: sharpen ICP and product promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A structural graph tells the agent what exists in your codebase. Madar tells the agent **what runs for this task** — usually a much smaller execution slice or structural subset — then returns a compact pack with inline snippets so the agent can answer from the pack before it starts searching the repo by hand.
 
+**Primary ICP (near-term):** teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
+
+**Not the primary ICP today:** tiny repos, throwaway scripts, teams mainly shopping for hosted dashboards, or buyers who need broad cross-language parity before the TypeScript/Node proof deepens.
+
 [![npm](https://img.shields.io/npm/v/%40lubab%2Fmadar)](https://www.npmjs.com/package/@lubab/madar)
 [![node >=20](https://img.shields.io/badge/node-%E2%89%A520-3c873a)](https://nodejs.org/)
 [![Local first](https://img.shields.io/badge/local--first-no%20cloud%20required-0f766e)](#trust--limitations)
@@ -142,7 +146,9 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 A structural graph tells you what exists, but what the agent actually needs is **what runs for this task**, which is usually a much smaller set.
 
-madar indexes a TypeScript/Node workspace (and PR diffs) into local graph artifacts, then compiles those artifacts into a task-aware pack the agent can start from before it decides whether deeper reads are still necessary.
+madar is **deterministic local context compilation** for that repo/task boundary: it indexes a TypeScript/Node workspace (and PR diffs) into local graph artifacts, then compiles those artifacts into a task-aware pack the agent can start from before it decides whether deeper reads are still necessary.
+
+That means Madar **complements agents and IDE indexing** instead of replacing them. IDE indexes and structural graphs tell you what exists; Madar compiles the bounded first-pass evidence for the current task. It is **not another generic codebase index**.
 
 ```
 your prompt

--- a/docs/claims-and-evidence.md
+++ b/docs/claims-and-evidence.md
@@ -34,6 +34,9 @@ This file is the public map between what Madar says and what the repo can actual
 ## How this maps to README.md
 
 - `README.md` should state the demonstrated release cell, the benchmark-suite direction, and the not-yet-measured limits in the same place.
+- `README.md` should name the near-term primary ICP directly: teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
+- `README.md` should frame Madar as deterministic local context compilation that complements agents and IDE indexing, not another generic codebase index.
+- `README.md` should call out what is not the primary ICP today instead of implying Madar is already equally ready for every coding-agent workflow or repo shape.
 - Any new public claim should link back to a dated artifact or to the reproducible suite surface under [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md).
 - When evidence is mixed, the README should say that directly and point to the counterexample note or issue instead of smoothing it into marketing.
 

--- a/examples/why-madar.md
+++ b/examples/why-madar.md
@@ -2,6 +2,10 @@
 
 Madar is for the moment when a structural graph already tells you what exists, but the agent still needs **what runs for this task** — the smaller execution slice or structural subset worth reading first.
 
+Near-term primary ICP: teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
+
+The core promise is deterministic local context compilation that complements agents and IDE indexing rather than trying to be another generic codebase index.
+
 ## Demonstrated today
 
 - Local graph artifacts plus task-aware packs for explain, review, impact, and implementation work.

--- a/tests/unit/why-madar-doc.test.ts
+++ b/tests/unit/why-madar-doc.test.ts
@@ -159,6 +159,19 @@ describe('public marketing copy honesty', () => {
       expect(content).toContain('docs/claims-and-evidence.md')
     })
 
+    it('states the near-term primary ICP and non-ICP explicitly', () => {
+      expect(lower).toContain('primary icp')
+      expect(lower).toContain('medium-to-large typescript/node repos')
+      expect(lower).toContain('cost, latency, privacy, or wrong-file-edit risk')
+      expect(lower).toContain('not the primary icp today')
+    })
+
+    it('frames the core promise as deterministic local context compilation that complements indexing', () => {
+      expect(lower).toContain('deterministic local context compilation')
+      expect(lower).toContain('complements agents and ide indexing')
+      expect(lower).toContain('not another generic codebase index')
+    })
+
     it('keeps the README Python support claim conservative and current', () => {
       expect(content).toContain('FastAPI router composition')
       expect(content).toContain('Django URL-conf')
@@ -240,6 +253,13 @@ describe('public marketing copy honesty', () => {
         expect(content).toContain('Codex Security')
         expect(lower).toContain('workflow guidance, not a measured superiority claim')
         expect(lower).toContain('no comparative review/security evaluation')
+      })
+
+      it('keeps the README ICP and product-promise guidance bounded to the current evidence scope', () => {
+        expect(lower).toContain('medium-to-large typescript/node repos')
+        expect(lower).toContain('deterministic local context compilation')
+        expect(lower).toContain('complements agents and ide indexing')
+        expect(lower).toContain('not another generic codebase index')
       })
     })
   })


### PR DESCRIPTION
## Summary
- name the near-term primary ICP and non-ICP for Madar in the README lead
- frame Madar as deterministic local context compilation that complements agents and IDE indexing instead of another generic index
- keep the claims/evidence map and doc-honesty tests aligned with the new positioning

## Test Plan
- [x] npm run test:run -- tests/unit/why-madar-doc.test.ts
- [x] npm run typecheck
- [x] npm run build
- [x] CI=1 npm run test:run

Closes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified primary target audience and core use cases
  * Refined positioning to emphasize deterministic local context compilation
  * Enhanced clarity on how Madar complements existing development tools
  * Added explicit guidance on supported repository scenarios

* **Tests**
  * Added validation assertions for documentation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->