### PR TITLE
docs: define team and enterprise offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Everything stays local by default. No cloud upload, no API key required. Telemet
 
 - [Quick start guide](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) — three reproducible workflows: local proof, A/B compare, federated proof
 - [Claims and evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) — which public claims are demonstrated, in progress, or not yet measured
+- [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) — local-first benchmark setup, proof-report, and procurement/security note options without a hosted control plane
 - [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results
 - [GoValidate shared benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates
 - [Public roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) — contributor-facing priority tracks and issue links

--- a/docs/claims-and-evidence.md
+++ b/docs/claims-and-evidence.md
@@ -37,6 +37,8 @@ This file is the public map between what Madar says and what the repo can actual
 - `README.md` should name the near-term primary ICP directly: teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
 - `README.md` should frame Madar as deterministic local context compilation that complements agents and IDE indexing, not another generic codebase index.
 - `README.md` should call out what is not the primary ICP today instead of implying Madar is already equally ready for every coding-agent workflow or repo shape.
+- The team and enterprise offer should stay service-scoped: benchmark setup, proof report support, and a procurement/security note inside the same local-first trust boundary.
+- Team and enterprise offer docs should say Madar is **not a hosted control plane** and avoid implying managed cloud hosting or source-code custody.
 - Any new public claim should link back to a dated artifact or to the reproducible suite surface under [`docs/benchmarks/suite/`](docs/benchmarks/suite/README.md).
 - When evidence is mixed, the README should say that directly and point to the counterexample note or issue instead of smoothing it into marketing.
 

--- a/docs/team-enterprise-offer.md
+++ b/docs/team-enterprise-offer.md
@@ -1,0 +1,55 @@
+# Team and enterprise offer
+
+Madar stays an open-source, local-first product. The near-term paid offer is service work around adoption and proof, **not a hosted control plane**.
+
+## Who this is for
+
+- **Team evaluation:** small teams that want a bounded setup for one repo, one agent runtime, and one repeatable question or review workflow before they standardize on Madar internally.
+- **Enterprise pilot:** engineering leadership, platform, or security teams that need a local-first evaluation packet they can review with procurement and internal security before broader rollout.
+
+## Offer options
+
+### Team evaluation
+
+- Shared benchmark setup on a representative repo and task.
+- Local install/profile wiring for the selected agent runtime.
+- A first compare/review workflow receipt plus follow-up notes on what Madar changed and what it did not.
+
+### Enterprise pilot
+
+- Everything in the team evaluation package.
+- An **internal proof report** built from local graph, pack, compare, and review artifacts for engineering leadership.
+- A local-only **procurement/security note** covering the local-first trust boundary, telemetry posture, artifact sharing limits, and operator responsibilities.
+
+## What paid support includes
+
+### In scope
+
+- **Shared benchmark setup** for one or more agreed repo/task cells.
+- Local workflow calibration for `pack`, `compare`, `review-compare`, `handoff`, and `proof-report`.
+- An **internal proof report** that leadership can review without exposing workstation paths by leaning on share-safe receipts.
+- Local-only **policy templates** and procurement/security notes that explain how to evaluate Madar inside the existing trust boundary.
+
+### Out of scope
+
+- **Managed cloud hosting** or a managed SaaS control plane.
+- Taking custody of your source code, prompts, or model credentials.
+- Running a remote review/security service on your behalf.
+- Guaranteeing benchmark wins, security findings, or universal productivity gains beyond the measured receipts.
+
+## Local-first trust boundary
+
+The offer must preserve the same **local-first trust boundary** as the product:
+
+- your code and graph artifacts stay local unless you explicitly choose to share a sanitized receipt;
+- benchmark/proof work should prefer `report.share-safe.json` and local markdown reports over raw artifact uploads;
+- procurement/security notes should describe the actual boundary, including that Madar is **not a hosted control plane** and does not remove the need for local least-privilege review.
+
+## Recommended pilot outputs
+
+For most teams, a complete pilot ends with:
+
+1. one verified benchmark setup on a representative repo;
+2. one internal proof report for engineering leadership;
+3. one procurement/security note or policy template the buyer can hand to internal reviewers;
+4. one explicit follow-up list of what remains unmeasured.

--- a/tests/unit/why-madar-doc.test.ts
+++ b/tests/unit/why-madar-doc.test.ts
@@ -172,6 +172,11 @@ describe('public marketing copy honesty', () => {
       expect(lower).toContain('not another generic codebase index')
     })
 
+    it('links a bounded team and enterprise offer instead of implying hosted packaging', () => {
+      expect(content).toContain('docs/team-enterprise-offer.md')
+      expect(lower).toContain('team and enterprise offer')
+    })
+
     it('keeps the README Python support claim conservative and current', () => {
       expect(content).toContain('FastAPI router composition')
       expect(content).toContain('Django URL-conf')
@@ -261,6 +266,41 @@ describe('public marketing copy honesty', () => {
         expect(lower).toContain('complements agents and ide indexing')
         expect(lower).toContain('not another generic codebase index')
       })
+
+      it('keeps the team and enterprise offer guidance local-first and service-scoped', () => {
+        expect(lower).toContain('team and enterprise offer')
+        expect(lower).toContain('benchmark setup')
+        expect(lower).toContain('proof report')
+        expect(lower).toContain('procurement/security note')
+        expect(lower).toContain('local-first trust boundary')
+        expect(lower).toContain('not a hosted control plane')
+      })
+    })
+  })
+
+  describe('docs/team-enterprise-offer.md', () => {
+    const content = readDoc('docs/team-enterprise-offer.md')
+    const lower = content.toLowerCase()
+
+    it('defines concise team and enterprise options around benchmark setup, proof reports, and local-only procurement notes', () => {
+      expect(content).toContain('# Team and enterprise offer')
+      expect(lower).toContain('team evaluation')
+      expect(lower).toContain('enterprise pilot')
+      expect(lower).toContain('benchmark setup')
+      expect(lower).toContain('proof report')
+      expect(lower).toContain('procurement/security note')
+      expect(lower).toContain('local-first trust boundary')
+      expect(lower).toContain('not a hosted control plane')
+    })
+
+    it('spells out what paid support includes and excludes', () => {
+      expect(lower).toContain('in scope')
+      expect(lower).toContain('out of scope')
+      expect(lower).toContain('shared benchmark setup')
+      expect(lower).toContain('internal proof report')
+      expect(lower).toContain('policy templates')
+      expect(lower).toContain('managed cloud hosting')
+      expect(lower).toContain('taking custody of your source code')
     })
   })
 


### PR DESCRIPTION
## Summary
- add a dedicated team and enterprise offer doc covering benchmark setup, internal proof reports, and procurement/security notes
- link the offer from the README and add claims/evidence guardrails that keep the story local-first and service-scoped
- lock the new public-copy expectations in the why-madar doc tests

Closes #427

## Testing
- npm run typecheck
- npm run build
- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added team and enterprise offer documentation outlining service scope, local-first setup, benchmark options, and proof-report support.
  * Clarified that team/enterprise offering excludes hosted control plane and source code custody.

* **Tests**
  * Added documentation validation tests for team/enterprise offering language and scoping constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->