### PR TITLE
Prepare 0.27.7-next.0 release

### DIFF
--- a/.github/scripts/verify-release-hygiene.mjs
+++ b/.github/scripts/verify-release-hygiene.mjs
@@ -36,6 +36,10 @@ function changelogAnchorForVersion(version) {
     .replaceAll(' ', '-')
 }
 
+function changelogBranchForVersion(version) {
+  return version.includes('-') ? 'next' : 'main'
+}
+
 function main() {
   const packageManifest = loadJson(PACKAGE_JSON_PATH)
   const readme = loadText(README_PATH)
@@ -61,7 +65,7 @@ function main() {
   )
 
   const expectedVersionedChangelogLink =
-    `${REPOSITORY_WEB_URL}/blob/main/CHANGELOG.md#${changelogAnchorForVersion(packageManifest.version)}`
+    `${REPOSITORY_WEB_URL}/blob/${changelogBranchForVersion(packageManifest.version)}/CHANGELOG.md#${changelogAnchorForVersion(packageManifest.version)}`
   assert.ok(
     readme.includes(expectedVersionedChangelogLink),
     'README.md must link the current "What\'s new" section to the matching changelog entry',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.7-next.0] - 2026-06-01
+
+### Added
+
+- **Federation is now documented as a flagship multi-repo workflow proof**: Madar now ships a reproducible three-repo federation fixture plus a checked-in synthetic federation receipt and supporting docs so the enterprise/multi-repo workflow claim has a concrete local artifact without overstating the current implementation. Closes #429.
+
+### Changed
+
+- **The next-track roadmap docs are more decision-ready**: the `next` line now includes design-partner workflow loop drafts, plugin distribution-channel research, and the current language-expansion decision so the upcoming beta reflects the product direction already merged on `next`. Closes #425, #431, and #432.
+
 ## [0.27.6] - 2026-05-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The current telemetry model is still local-first and source-safe. It records onl
 
 ## What's new in 0.27.7-next.0
 
-See the [`0.27.7-next.0` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277-next0---2026-06-01) for the full release notes.
+See the [`0.27.7-next.0` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next0---2026-06-01) for the full release notes.
 
 This `@next` build keeps the current `0.27.6` CLI/runtime fixes and adds a checked-in federation flagship proof: a reproducible three-repo fixture, a synthetic federation receipt, and doc updates that make the multi-repo enterprise workflow concrete without overstating the current implementation.
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ The current telemetry model is still local-first and source-safe. It records onl
 
 ---
 
-## What's new in 0.27.6
+## What's new in 0.27.7-next.0
 
-See the [`0.27.6` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0276---2026-05-29) for the full release notes.
+See the [`0.27.7-next.0` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277-next0---2026-06-01) for the full release notes.
 
-This patch removes the legacy `madar add <url>` ingest surface, keeps `save-result` available for exporting query results, and preserves backward-compatible legacy ingest provenance for older saved artifacts.
+This `@next` build keeps the current `0.27.6` CLI/runtime fixes and adds a checked-in federation flagship proof: a reproducible three-repo fixture, a synthetic federation receipt, and doc updates that make the multi-repo enterprise workflow concrete without overstating the current implementation.
+
+It also carries the latest next-track roadmap docs for design-partner workflow loops, plugin distribution channels, and language-expansion decisions, so the beta line stays aligned with the product direction already merged on `next`.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -138,7 +140,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.6. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.7-next.0. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.6",
+    "version": "0.27.7-next.0",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.6",
+            "version": "0.27.7-next.0",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/docs/release.md
+++ b/docs/release.md
@@ -51,8 +51,11 @@ Recommended follow-up checks:
 
 After the verification steps are green:
 
-1. Push and merge the verified release commit so the published README links already exist on the `main` branch.
-2. Publish from that merged `main` commit with `npm publish --access public --provenance` when the release environment supports npm provenance attestations.
+1. Push and merge the verified release commit so the published README links already exist on the target release branch (`main` for stable releases, `next` for prereleases).
+2. Publish from that merged release commit:
+   - stable releases: `npm publish --access public --provenance`
+   - prereleases / `next`: `npm publish --tag next --access public --provenance`
+   If the release environment does not support npm provenance attestations, rerun the same command without `--provenance`.
 3. Create the matching Git tag if `npm version` did not already do so in your workflow.
 4. Draft or publish the GitHub release notes from the changelog entry.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.6",
+    "version": "0.27.7-next.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.6",
+            "version": "0.27.7-next.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.6",
+    "version": "0.27.7-next.0",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "prepack": "npm run clean && npm run build",
         "pack:dry-run": "npm pack --dry-run",
         "publish:public": "npm publish --access public",
+        "publish:next": "npm publish --tag next --access public",
         "publish:dry-run": "npm publish --dry-run",
         "release:verify": "node .github/scripts/verify-release-hygiene.mjs",
         "registry:validate": "node .github/scripts/validate-mcp-registry.mjs"

--- a/tests/unit/release-hygiene.test.ts
+++ b/tests/unit/release-hygiene.test.ts
@@ -28,7 +28,7 @@ function collectMarkdownLinkTargets(markdown: string): string[] {
 function withReleaseFixture(
   version: string,
   readmeLink: string,
-  runAssertion: (fixtureDir: string) => void,
+  runAssertion: (runVerify: () => string) => void,
 ): void {
   const fixtureDir = mkdtempSync(join(tmpdir(), 'madar-release-hygiene-'))
 
@@ -55,7 +55,13 @@ function withReleaseFixture(
     writeFileSync(join(fixtureDir, 'README.md'), `[release notes](${readmeLink})\n`)
     writeFileSync(join(fixtureDir, 'CHANGELOG.md'), `## [${version}] - 2026-05-29\n`)
 
-    runAssertion(fixtureDir)
+    runAssertion(() =>
+      execFileSync(process.execPath, [releaseVerifyScriptPath()], {
+        cwd: fixtureDir,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }),
+    )
   } finally {
     rmSync(fixtureDir, { recursive: true, force: true })
   }
@@ -86,14 +92,8 @@ describe('release hygiene', () => {
   })
 
   it('requires the README changelog link to match the current release heading exactly', () => {
-    withReleaseFixture('0.27.4', 'https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0274---wrong-date', (fixtureDir) => {
-      expect(() =>
-        execFileSync(process.execPath, [releaseVerifyScriptPath()], {
-          cwd: fixtureDir,
-          encoding: 'utf8',
-          stdio: 'pipe',
-        }),
-      ).toThrow(/matching changelog entry/)
+    withReleaseFixture('0.27.4', 'https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0274---wrong-date', (runVerify) => {
+      expect(runVerify).toThrow(/matching changelog entry/)
     })
   })
 
@@ -109,14 +109,8 @@ describe('release hygiene', () => {
     withReleaseFixture(
       '0.27.7-next.0',
       'https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277-next0---2026-05-29',
-      (fixtureDir) => {
-      expect(() =>
-        execFileSync(process.execPath, [releaseVerifyScriptPath()], {
-          cwd: fixtureDir,
-          encoding: 'utf8',
-          stdio: 'pipe',
-        }),
-      ).toThrow(/matching changelog entry/)
+      (runVerify) => {
+        expect(runVerify).toThrow(/matching changelog entry/)
       },
     )
   })
@@ -125,14 +119,8 @@ describe('release hygiene', () => {
     withReleaseFixture(
       '0.27.7-next.0',
       'https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next0---2026-05-29',
-      (fixtureDir) => {
-      expect(() =>
-        execFileSync(process.execPath, [releaseVerifyScriptPath()], {
-          cwd: fixtureDir,
-          encoding: 'utf8',
-          stdio: 'pipe',
-        }),
-      ).not.toThrow()
+      (runVerify) => {
+        expect(runVerify).not.toThrow()
       },
     )
   })

--- a/tests/unit/release-hygiene.test.ts
+++ b/tests/unit/release-hygiene.test.ts
@@ -25,6 +25,42 @@ function collectMarkdownLinkTargets(markdown: string): string[] {
   return [...markdown.matchAll(/\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)].map((match) => match[1] ?? '')
 }
 
+function withReleaseFixture(
+  version: string,
+  readmeLink: string,
+  runAssertion: (fixtureDir: string) => void,
+): void {
+  const fixtureDir = mkdtempSync(join(tmpdir(), 'madar-release-hygiene-'))
+
+  try {
+    writeFileSync(
+      join(fixtureDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@lubab/madar',
+          version,
+          repository: {
+            type: 'git',
+            url: 'git+https://github.com/mohanagy/madar.git',
+          },
+          bugs: {
+            url: 'https://github.com/mohanagy/madar/issues',
+          },
+          homepage: 'https://github.com/mohanagy/madar#readme',
+        },
+        null,
+        2,
+      ),
+    )
+    writeFileSync(join(fixtureDir, 'README.md'), `[release notes](${readmeLink})\n`)
+    writeFileSync(join(fixtureDir, 'CHANGELOG.md'), `## [${version}] - 2026-05-29\n`)
+
+    runAssertion(fixtureDir)
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+}
+
 describe('release hygiene', () => {
   it('keeps npm-visible README links stable', () => {
     const readme = loadFile('README.md')
@@ -50,34 +86,7 @@ describe('release hygiene', () => {
   })
 
   it('requires the README changelog link to match the current release heading exactly', () => {
-    const fixtureDir = mkdtempSync(join(tmpdir(), 'madar-release-hygiene-'))
-
-    try {
-      writeFileSync(
-        join(fixtureDir, 'package.json'),
-        JSON.stringify(
-          {
-            name: '@lubab/madar',
-            version: '0.27.4',
-            repository: {
-              type: 'git',
-              url: 'git+https://github.com/mohanagy/madar.git',
-            },
-            bugs: {
-              url: 'https://github.com/mohanagy/madar/issues',
-            },
-            homepage: 'https://github.com/mohanagy/madar#readme',
-          },
-          null,
-          2,
-        ),
-      )
-      writeFileSync(
-        join(fixtureDir, 'README.md'),
-        '[release notes](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0274---wrong-date)\n',
-      )
-      writeFileSync(join(fixtureDir, 'CHANGELOG.md'), '## [0.27.4] - 2026-05-29\n')
-
+    withReleaseFixture('0.27.4', 'https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0274---wrong-date', (fixtureDir) => {
       expect(() =>
         execFileSync(process.execPath, [releaseVerifyScriptPath()], {
           cwd: fixtureDir,
@@ -85,9 +94,7 @@ describe('release hygiene', () => {
           stdio: 'pipe',
         }),
       ).toThrow(/matching changelog entry/)
-    } finally {
-      rmSync(fixtureDir, { recursive: true, force: true })
-    }
+    })
   })
 
   it('documents the release verification command in the release checklist', () => {
@@ -99,34 +106,10 @@ describe('release hygiene', () => {
   })
 
   it('requires prerelease README changelog links to target next', () => {
-    const fixtureDir = mkdtempSync(join(tmpdir(), 'madar-release-hygiene-prerelease-'))
-
-    try {
-      writeFileSync(
-        join(fixtureDir, 'package.json'),
-        JSON.stringify(
-          {
-            name: '@lubab/madar',
-            version: '0.27.7-next.0',
-            repository: {
-              type: 'git',
-              url: 'git+https://github.com/mohanagy/madar.git',
-            },
-            bugs: {
-              url: 'https://github.com/mohanagy/madar/issues',
-            },
-            homepage: 'https://github.com/mohanagy/madar#readme',
-          },
-          null,
-          2,
-        ),
-      )
-      writeFileSync(
-        join(fixtureDir, 'README.md'),
-        '[release notes](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277-next0---2026-06-01)\n',
-      )
-      writeFileSync(join(fixtureDir, 'CHANGELOG.md'), '## [0.27.7-next.0] - 2026-06-01\n')
-
+    withReleaseFixture(
+      '0.27.7-next.0',
+      'https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277-next0---2026-05-29',
+      (fixtureDir) => {
       expect(() =>
         execFileSync(process.execPath, [releaseVerifyScriptPath()], {
           cwd: fixtureDir,
@@ -134,8 +117,23 @@ describe('release hygiene', () => {
           stdio: 'pipe',
         }),
       ).toThrow(/matching changelog entry/)
-    } finally {
-      rmSync(fixtureDir, { recursive: true, force: true })
-    }
+      },
+    )
+  })
+
+  it('accepts prerelease README changelog links that target next', () => {
+    withReleaseFixture(
+      '0.27.7-next.0',
+      'https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next0---2026-05-29',
+      (fixtureDir) => {
+      expect(() =>
+        execFileSync(process.execPath, [releaseVerifyScriptPath()], {
+          cwd: fixtureDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).not.toThrow()
+      },
+    )
   })
 })

--- a/tests/unit/release-hygiene.test.ts
+++ b/tests/unit/release-hygiene.test.ts
@@ -39,6 +39,7 @@ describe('release hygiene', () => {
     const scripts = loadPackageManifest().scripts ?? {}
 
     expect(scripts['release:verify']).toBe('node .github/scripts/verify-release-hygiene.mjs')
+    expect(scripts['publish:next']).toBe('npm publish --tag next --access public')
     expect(() =>
       execFileSync(process.execPath, [releaseVerifyScriptPath()], {
         cwd: process.cwd(),
@@ -93,6 +94,48 @@ describe('release hygiene', () => {
     const releaseDoc = loadFile('docs/release.md')
 
     expect(releaseDoc).toContain('npm run release:verify')
-    expect(releaseDoc).toContain('merged `main` commit')
+    expect(releaseDoc).toContain('`main` for stable releases, `next` for prereleases')
+    expect(releaseDoc).toContain('npm publish --tag next --access public --provenance')
+  })
+
+  it('requires prerelease README changelog links to target next', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'madar-release-hygiene-prerelease-'))
+
+    try {
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: '@lubab/madar',
+            version: '0.27.7-next.0',
+            repository: {
+              type: 'git',
+              url: 'git+https://github.com/mohanagy/madar.git',
+            },
+            bugs: {
+              url: 'https://github.com/mohanagy/madar/issues',
+            },
+            homepage: 'https://github.com/mohanagy/madar#readme',
+          },
+          null,
+          2,
+        ),
+      )
+      writeFileSync(
+        join(fixtureDir, 'README.md'),
+        '[release notes](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277-next0---2026-06-01)\n',
+      )
+      writeFileSync(join(fixtureDir, 'CHANGELOG.md'), '## [0.27.7-next.0] - 2026-06-01\n')
+
+      expect(() =>
+        execFileSync(process.execPath, [releaseVerifyScriptPath()], {
+          cwd: fixtureDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow(/matching changelog entry/)
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- bump the package to 0.27.7-next.0 and align release docs/registry metadata
- point prerelease README changelog links at next and add an explicit next publish path
- extend release hygiene checks so prerelease branches validate next-tagged changelog links

## Verification
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documented federation workflow proof with reproducible fixture and checked-in resources.
  * Updated roadmap with more decision-ready workflow and distribution-channel research.

* **Documentation**
  * Updated release notes, README, and publishing docs to reflect prerelease vs stable flows and changelog linking behavior.
  * Aligned registry manifest and “What’s new” content to 0.27.7-next.0.

* **Chores**
  * Bumped package to 0.27.7-next.0 and added a publish:next command.

* **Tests**
  * Strengthened release hygiene tests to validate prerelease changelog/link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->