### PR TITLE
Fix compare validation safety followups

### DIFF
--- a/.github/scripts/verify-release-hygiene.mjs
+++ b/.github/scripts/verify-release-hygiene.mjs
@@ -10,6 +10,10 @@ const REPOSITORY_WEB_URL = 'https://github.com/mohanagy/madar'
 const REPOSITORY_GIT_URL = 'git+https://github.com/mohanagy/madar.git'
 const BUGS_URL = `${REPOSITORY_WEB_URL}/issues`
 const HOMEPAGE_URL = `${REPOSITORY_WEB_URL}#readme`
+const NEXT_ONLY_README_PATHS = new Set([
+  'docs/team-enterprise-offer.md',
+  'docs/telemetry.md',
+])
 
 function loadJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'))
@@ -38,6 +42,23 @@ function changelogAnchorForVersion(version) {
 
 function changelogBranchForVersion(version) {
   return version.includes('-') ? 'next' : 'main'
+}
+
+function assertPrereleaseReadmeLinks(readme, version) {
+  if (!version.includes('-')) {
+    return
+  }
+
+  const invalidTargets = collectMarkdownLinkTargets(readme).filter((target) => {
+    const match = target.match(/^https:\/\/github\.com\/mohanagy\/madar\/blob\/([^/]+)\/(.+)$/)
+    return match !== null && NEXT_ONLY_README_PATHS.has(match[2]) && match[1] !== 'next'
+  })
+
+  assert.deepEqual(
+    invalidTargets,
+    [],
+    'next-only README doc links must target blob/next for prereleases',
+  )
 }
 
 function main() {
@@ -70,6 +91,7 @@ function main() {
     readme.includes(expectedVersionedChangelogLink),
     'README.md must link the current "What\'s new" section to the matching changelog entry',
   )
+  assertPrereleaseReadmeLinks(readme, packageManifest.version)
 
   console.log('Validated package metadata, changelog version, and npm-visible README links for release hygiene.')
 }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ madar telemetry disable
 MADAR_ENABLE_TELEMETRY=1 madar generate .
 ```
 
-The current telemetry model is still local-first and source-safe. It records only coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, an optional install target, and an optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full field list and controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
+The current telemetry model is still local-first and source-safe. It records only coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, an optional install target, and an optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full field list and controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/next/docs/telemetry.md).
 
 ---
 
@@ -382,7 +382,7 @@ Everything stays local by default. No cloud upload, no API key required. Telemet
 
 - [Quick start guide](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) — three reproducible workflows: local proof, A/B compare, federated proof
 - [Claims and evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) — which public claims are demonstrated, in progress, or not yet measured
-- [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) — local-first benchmark setup, proof-report, and procurement/security note options without a hosted control plane
+- [Team and enterprise offer](https://github.com/mohanagy/madar/blob/next/docs/team-enterprise-offer.md) — local-first benchmark setup, proof-report, and procurement/security note options without a hosted control plane
 - [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results
 - [GoValidate shared benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates
 - [Public roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) — contributor-facing priority tracks and issue links
@@ -390,7 +390,7 @@ Everything stays local by default. No cloud upload, no API key required. Telemet
 - [Performance benchmark harness](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/performance/README.md) — repeatable `generate` / `update` / `cluster-only` measurements
 - [MCP tool examples](https://github.com/mohanagy/madar/blob/main/examples/mcp-tool-examples.md) — real input/output for every tool
 - [Benchmark hub](https://github.com/mohanagy/madar/tree/main/docs/benchmarks) — committed wrappers and provider-reported evidence
-- [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) — opt-in controls, collected fields, excluded fields, and local storage behavior
+- [Telemetry guide](https://github.com/mohanagy/madar/blob/next/docs/telemetry.md) — opt-in controls, collected fields, excluded fields, and local storage behavior
 - [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) — full per-release notes
 - [Contributing](https://github.com/mohanagy/madar/blob/main/CONTRIBUTING.md) · [Security](https://github.com/mohanagy/madar/blob/main/SECURITY.md)
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -192,6 +192,13 @@ export interface CliDependencies {
 }
 
 const COMPARE_WARNING_MESSAGE = 'compare will execute a baseline prompt and a madar prompt for each question. This may consume paid model tokens.'
+function compareWarningMessage(options: CompareCliOptions): string {
+  if (options.task === 'implement' && options.baselineMode === 'native_agent') {
+    return `${COMPARE_WARNING_MESSAGE} For --task implement with --baseline-mode native_agent, it will also run local validation commands derived from package.json scripts after each arm with a ${options.validationTimeoutSeconds}s timeout.`
+  }
+  return COMPARE_WARNING_MESSAGE
+}
+
 const REVIEW_COMPARE_WARNING_MESSAGE = 'review-compare will execute verbose and compact pr_impact prompts for the current git diff. This may consume paid model tokens.'
 const BENCHMARK_WARNING_MESSAGE = 'benchmark will execute the benchmark/eval runner. This may consume paid model tokens.'
 const BENCH_SUITE_WARNING_MESSAGE = 'bench:suite will execute baseline, madar, and SPI suite prompts. This may consume paid model tokens.'
@@ -228,6 +235,7 @@ const DEFAULT_DEPENDENCIES: CliDependencies = {
         execTemplate: options.execTemplate,
         baselineMode: options.baselineMode,
         perArmTimeoutSeconds: options.perArmTimeoutSeconds,
+        validationTimeoutSeconds: options.validationTimeoutSeconds,
         heartbeatIntervalMs: options.heartbeatIntervalMs,
         strictMadarFirst: options.strictMadarFirst,
         strictBenchmarkReadiness: options.strictBenchmarkReadiness,
@@ -482,6 +490,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)',
     '      For Claude MCP attribution in native_agent mode, include --verbose with --output-format json',
     '    --per-arm-timeout S   per-arm timeout seconds for native_agent runs (default 600)',
+    '    --validation-timeout S  timeout seconds for implement validation commands run after native_agent compare arms (default 120)',
     '    --heartbeat-interval-ms N  stderr heartbeat interval for native_agent runs (default 30000; 0 disables)',
     '    --strict-madar-first  treat pre-Madar broad exploration as degraded/non-winning in native_agent mode',
     '    --strict / --strict-benchmark-readiness  fail native_agent compare before runner spend when benchmark readiness is degraded or not_ready',
@@ -691,9 +700,10 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
     if (command === 'compare') {
       const options = parseCompareArgs(args)
       const confirm = async (message: string) => await dependencies.confirm(message)
+      const warningMessage = compareWarningMessage(options)
       if (!options.yes) {
-        io.log(`Warning: ${COMPARE_WARNING_MESSAGE}`)
-        if (!(await confirm(COMPARE_WARNING_MESSAGE))) {
+        io.log(`Warning: ${warningMessage}`)
+        if (!(await confirm(warningMessage))) {
           io.log('Compare cancelled.')
           return 1
         }

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -117,6 +117,7 @@ export interface CompareCliOptions {
   task: 'explain' | 'implement'
   baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent'
   perArmTimeoutSeconds: number
+  validationTimeoutSeconds: number
   heartbeatIntervalMs: number
   strictMadarFirst: boolean
   strictBenchmarkReadiness: boolean
@@ -213,7 +214,7 @@ export interface TelemetryCliOptions {
   action: 'enable' | 'disable' | 'status'
 }
 
-const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'
+const COMPARE_USAGE = 'Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--validation-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'
 
 export interface PlatformActionCliOptions {
   action: 'install' | 'uninstall'
@@ -1224,6 +1225,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
   let task: 'explain' | 'implement' = 'explain'
   let baselineMode: 'full' | 'bounded' | 'pack_only' | 'native_agent' = 'full'
   let perArmTimeoutSeconds = 600
+  let validationTimeoutSeconds = 120
   let heartbeatIntervalMs = 30000
   let strictMadarFirst = false
   let strictBenchmarkReadiness = false
@@ -1334,6 +1336,18 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
       continue
     }
 
+    if (argument === '--validation-timeout') {
+      validationTimeoutSeconds = parsePositiveDecimalInteger('--validation-timeout', requireOptionValue('--validation-timeout', args[index + 1]))
+      index += 1
+      continue
+    }
+
+    if (argument.startsWith('--validation-timeout=')) {
+      const [, value] = argument.split('=', 2)
+      validationTimeoutSeconds = parsePositiveDecimalInteger('--validation-timeout', requireOptionValue('--validation-timeout', value))
+      continue
+    }
+
     if (argument === '--heartbeat-interval-ms') {
       heartbeatIntervalMs = parseNonNegativeInteger('--heartbeat-interval-ms', requireOptionValue('--heartbeat-interval-ms', args[index + 1]))
       index += 1
@@ -1409,6 +1423,7 @@ export function parseCompareArgs(args: string[]): CompareCliOptions {
     task,
     baselineMode,
     perArmTimeoutSeconds,
+    validationTimeoutSeconds,
     heartbeatIntervalMs,
     strictMadarFirst,
     strictBenchmarkReadiness,

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -29,6 +29,7 @@ import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtim
 import { resolveToolProfileFromEnv, type McpToolProfile } from '../runtime/stdio/definitions.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
 import { sanitizeShareSafeText, toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
+import { shellEscape } from '../shared/shell.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 import { copyWorkspaceForBenchmark } from '../shared/workspace-copy.js'
 
@@ -236,6 +237,7 @@ export interface GenerateCompareArtifactsInput {
   task?: ContextPackTaskKind
   baselineMode: CompareBaselineMode
   perArmTimeoutSeconds?: number
+  validationTimeoutSeconds?: number
   heartbeatIntervalMs?: number
   strictMadarFirst?: boolean
   strictBenchmarkReadiness?: boolean
@@ -397,13 +399,6 @@ function validateCompareExecTemplate(template: string): void {
       'Exec templates must not expand {prompt_file} with shell command substitution. Use stdin or file redirection with {prompt_file}, for example: cat {prompt_file} | claude -p',
     )
   }
-}
-
-function shellEscape(value: string, platform: NodeJS.Platform = process.platform): string {
-  if (platform === 'win32') {
-    return `'${value.replaceAll("'", "''")}'`
-  }
-  return `'${value.replaceAll("'", `'\"'\"'`)}'`
 }
 
 export function expandCompareExecTemplate(
@@ -2805,6 +2800,7 @@ interface NativeAgentRunStateRecord {
 }
 
 const DEFAULT_COMPARE_PER_ARM_TIMEOUT_SECONDS = 600
+const DEFAULT_COMPARE_VALIDATION_TIMEOUT_SECONDS = 120
 const DEFAULT_COMPARE_HEARTBEAT_INTERVAL_MS = 30000
 
 const MADAR_SECTION_MARKER = '## madar'
@@ -3000,6 +2996,7 @@ async function runShellCommand(command: string, options: { cwd?: string; signal?
 async function runImplementationValidationCommands(
   commands: readonly string[],
   workspaceRoot: string,
+  timeoutMs: number,
 ): Promise<ImplementValidationResult> {
   if (commands.length === 0) {
     return { status: 'not_run', commands: [] }
@@ -3007,13 +3004,28 @@ async function runImplementationValidationCommands(
 
   const results: ImplementValidationCommandResult[] = []
   for (const command of commands) {
-    const execution = await runShellCommand(command, { cwd: workspaceRoot })
+    const controller = new AbortController()
+    const timeoutHandle = setTimeout(() => {
+      controller.abort()
+    }, timeoutMs)
+    let execution: { exitCode: number; stdout: string; stderr: string }
+    try {
+      execution = await runShellCommand(command, { cwd: workspaceRoot, signal: controller.signal })
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
+    const timedOut = controller.signal.aborted
+    const stderr = timedOut
+      ? execution.stderr.length > 0
+        ? `${execution.stderr}\nValidation command timed out after ${timeoutMs}ms.`
+        : `Validation command timed out after ${timeoutMs}ms.`
+      : execution.stderr
     results.push({
       command,
-      status: execution.exitCode === 0 ? 'passed' : classifyValidationFailure(execution.stdout, execution.stderr),
+      status: timedOut ? 'failed' : execution.exitCode === 0 ? 'passed' : classifyValidationFailure(execution.stdout, stderr),
       exit_code: execution.exitCode,
       stdout: execution.stdout.length > 0 ? execution.stdout : null,
-      stderr: execution.stderr.length > 0 ? execution.stderr : null,
+      stderr: stderr.length > 0 ? stderr : null,
     })
   }
 
@@ -3417,6 +3429,16 @@ function perArmTimeoutMs(seconds: number | undefined): number {
   }
   if (!Number.isFinite(seconds) || seconds <= 0) {
     throw new Error(`[madar compare] per-arm timeout must be > 0 seconds, got ${seconds}`)
+  }
+  return Math.max(1, Math.round(seconds * 1000))
+}
+
+function validationTimeoutMs(seconds: number | undefined): number {
+  if (seconds === undefined) {
+    return DEFAULT_COMPARE_VALIDATION_TIMEOUT_SECONDS * 1000
+  }
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error(`[madar compare] validation timeout must be > 0 seconds, got ${seconds}`)
   }
   return Math.max(1, Math.round(seconds * 1000))
 }
@@ -4054,6 +4076,7 @@ export async function executeNativeAgentCompare(
   const now = dependencies.now ?? (() => new Date())
   const writeStderr = dependencies.writeStderr ?? ((message: string) => process.stderr.write(message))
   const timeoutMs = perArmTimeoutMs(input.perArmTimeoutSeconds)
+  const validationTimeout = validationTimeoutMs(input.validationTimeoutSeconds)
   const heartbeatIntervalMs = compareHeartbeatIntervalMs(input.heartbeatIntervalMs)
   const retrievalBudget = input.retrievalBudget ?? DEFAULT_RETRIEVAL_BUDGET
   const task = compareTaskKind(input)
@@ -4549,11 +4572,11 @@ export async function executeNativeAgentCompare(
       const baselineValidation =
         reportShell.baseline.kind === 'runner_error'
           ? { status: 'not_run' as const, commands: [] }
-          : await runImplementationValidationCommands(implementationGuidance.validation_commands, baselineWorkspace.workspaceRoot)
+          : await runImplementationValidationCommands(implementationGuidance.validation_commands, baselineWorkspace.workspaceRoot, validationTimeout)
       const madarValidation =
         reportShell.madar.kind === 'runner_error'
           ? { status: 'not_run' as const, commands: [] }
-          : await runImplementationValidationCommands(implementationGuidance.validation_commands, madarWorkspace.workspaceRoot)
+          : await runImplementationValidationCommands(implementationGuidance.validation_commands, madarWorkspace.workspaceRoot, validationTimeout)
       const baselineReviewerVisible =
         reportShell.baseline.kind === 'runner_error'
           ? { status: 'not_scored' as const, checks: [] }

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2951,20 +2951,41 @@ async function runShellCommand(command: string, options: { cwd?: string; signal?
   stderr: string
 }> {
   return await new Promise((resolveExecution, rejectExecution) => {
+    const useProcessGroup = process.platform !== 'win32'
     const shellCommand =
-      process.platform === 'win32'
+      !useProcessGroup
         ? { file: 'powershell.exe', args: ['-NoProfile', '-Command', command] }
         : { file: '/bin/sh', args: ['-lc', command] }
     const child = spawn(shellCommand.file, shellCommand.args, {
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
+      ...(useProcessGroup ? { detached: true } : {}),
       ...(options.cwd ? { cwd: options.cwd } : {}),
     })
     let stdout = ''
     let stderr = ''
 
     const handleAbort = () => {
-      child.kill()
+      if (!useProcessGroup || child.pid === undefined) {
+        child.kill()
+        return
+      }
+      try {
+        process.kill(-child.pid, 'SIGTERM')
+      } catch {
+        child.kill()
+        return
+      }
+      setTimeout(() => {
+        if (child.exitCode !== null) {
+          return
+        }
+        try {
+          process.kill(-child.pid!, 'SIGKILL')
+        } catch {
+          child.kill('SIGKILL')
+        }
+      }, 250).unref()
     }
     if (options.signal) {
       if (options.signal.aborted) {
@@ -2984,6 +3005,9 @@ async function runShellCommand(command: string, options: { cwd?: string; signal?
       rejectExecution(error)
     })
     child.on('close', (code) => {
+      if (options.signal) {
+        options.signal.removeEventListener('abort', handleAbort)
+      }
       resolveExecution({
         exitCode: code ?? 1,
         stdout,

--- a/src/runtime/implementation-pack.ts
+++ b/src/runtime/implementation-pack.ts
@@ -14,6 +14,7 @@ import type {
 } from '../contracts/context-pack.js'
 import type { KnowledgeGraph } from '../contracts/graph.js'
 import type { TaskIntentKind } from '../contracts/task-intent.js'
+import { shellEscapeIfNeeded } from '../shared/shell.js'
 import { classifySourceDomain } from '../shared/source-discovery.js'
 import { lineNumberFromSourceLocation } from '../shared/source-location.js'
 import { relativizeSourceFile } from '../shared/source-path.js'
@@ -1335,7 +1336,7 @@ function readWorkspacePackageScripts(rootPath?: string): { scripts: PackageScrip
 function testCommandForScripts(scripts: PackageScripts, testFiles: readonly string[]): string[] {
   const commands: string[] = []
   if (testFiles.length > 0 && Object.hasOwn(scripts, 'test:run')) {
-    commands.push(`npm run test:run -- ${testFiles.slice(0, 5).join(' ')}`)
+    commands.push(`npm run test:run -- ${testFiles.slice(0, 5).map((path) => shellEscapeIfNeeded(prefixTestPathFlagLikeArg(path))).join(' ')}`)
   }
   if (Object.hasOwn(scripts, 'test:run')) {
     commands.push('npm run test:run')
@@ -1343,6 +1344,10 @@ function testCommandForScripts(scripts: PackageScripts, testFiles: readonly stri
     commands.push('npm run test')
   }
   return commands
+}
+
+function prefixTestPathFlagLikeArg(path: string): string {
+  return path.startsWith('-') ? `./${path}` : path
 }
 
 function validationCommands(rootPath: string | undefined, testFiles: readonly ImplementationPackFileHint[]): {

--- a/src/shared/shell.ts
+++ b/src/shared/shell.ts
@@ -1,0 +1,13 @@
+export function shellEscape(value: string, platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    return `'${value.replaceAll("'", "''")}'`
+  }
+  return `'${value.replaceAll("'", `'\"'\"'`)}'`
+}
+
+export function shellEscapeIfNeeded(value: string, platform: NodeJS.Platform = process.platform): string {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
+    return value
+  }
+  return shellEscape(value, platform)
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -571,6 +571,7 @@ describe('cli parser', () => {
       task: 'explain',
       baselineMode: 'full',
       perArmTimeoutSeconds: 600,
+      validationTimeoutSeconds: 120,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
       strictBenchmarkReadiness: false,
@@ -588,6 +589,7 @@ describe('cli parser', () => {
       task: 'explain',
       baselineMode: 'full',
       perArmTimeoutSeconds: 600,
+      validationTimeoutSeconds: 120,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
       strictBenchmarkReadiness: false,
@@ -611,6 +613,8 @@ describe('cli parser', () => {
         'bounded',
         '--per-arm-timeout',
         '900',
+        '--validation-timeout',
+        '45',
         '--heartbeat-interval-ms',
         '15000',
         '--strict-madar-first',
@@ -629,6 +633,7 @@ describe('cli parser', () => {
       task: 'explain',
       baselineMode: 'bounded',
       perArmTimeoutSeconds: 900,
+      validationTimeoutSeconds: 45,
       heartbeatIntervalMs: 15000,
       strictMadarFirst: true,
       strictBenchmarkReadiness: true,
@@ -656,6 +661,7 @@ describe('cli parser', () => {
       task: 'explain',
       baselineMode: 'pack_only',
       perArmTimeoutSeconds: 600,
+      validationTimeoutSeconds: 120,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
       strictBenchmarkReadiness: false,
@@ -684,6 +690,7 @@ describe('cli parser', () => {
       outputDir: resolve('out/compare'),
       baselineMode: 'native_agent',
       perArmTimeoutSeconds: 600,
+      validationTimeoutSeconds: 120,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
       strictBenchmarkReadiness: false,
@@ -711,6 +718,7 @@ describe('cli parser', () => {
       task: 'explain',
       baselineMode: 'full',
       perArmTimeoutSeconds: 600,
+      validationTimeoutSeconds: 120,
       heartbeatIntervalMs: 30000,
       strictMadarFirst: false,
       strictBenchmarkReadiness: true,
@@ -737,6 +745,7 @@ describe('cli parser', () => {
     task: 'explain',
     baselineMode: 'full',
     perArmTimeoutSeconds: 600,
+    validationTimeoutSeconds: 120,
     heartbeatIntervalMs: 30000,
     strictMadarFirst: false,
     strictBenchmarkReadiness: false,
@@ -769,6 +778,9 @@ describe('cli parser', () => {
     )
     expect(() => parseCompareArgs(['how does login work', '--exec', 'claude -p "$(cat {prompt_file})"', '--per-arm-timeout', '0'])).toThrow(
       'error: --per-arm-timeout must be a positive integer',
+    )
+    expect(() => parseCompareArgs(['how does login work', '--exec', 'claude -p "$(cat {prompt_file})"', '--validation-timeout', '0'])).toThrow(
+      'error: --validation-timeout must be a positive integer',
     )
     expect(() => parseCompareArgs(['how does login work', '--exec', 'claude -p "$(cat {prompt_file})"', '--heartbeat-interval-ms', '-1'])).toThrow(
       'error: --heartbeat-interval-ms must be a non-negative integer',
@@ -1208,6 +1220,7 @@ describe('cli main', () => {
     expect(help).toContain('    --baseline-mode MODE  full | bounded | pack_only | native_agent (default full; pack_only compares one bounded raw-context prompt against one compiled madar pack; native_agent runs --exec twice, uses Anthropic JSON usage when available, and otherwise saves answer-only artifacts)')
     expect(help).toContain('      For Claude MCP attribution in native_agent mode, include --verbose with --output-format json')
     expect(help).toContain('    --per-arm-timeout S   per-arm timeout seconds for native_agent runs (default 600)')
+    expect(help).toContain('    --validation-timeout S  timeout seconds for implement validation commands run after native_agent compare arms (default 120)')
     expect(help).toContain('    --heartbeat-interval-ms N  stderr heartbeat interval for native_agent runs (default 30000; 0 disables)')
     expect(help).toContain('    --strict-madar-first  treat pre-Madar broad exploration as degraded/non-winning in native_agent mode')
     expect(help).toContain('    --strict / --strict-benchmark-readiness  fail native_agent compare before runner spend when benchmark readiness is degraded or not_ready')
@@ -1282,6 +1295,8 @@ describe('cli main', () => {
         'bounded',
         '--per-arm-timeout',
         '900',
+        '--validation-timeout',
+        '45',
         '--heartbeat-interval-ms',
         '15000',
         '--strict-madar-first',
@@ -1312,6 +1327,7 @@ describe('cli main', () => {
       task: 'explain',
       baselineMode: 'bounded',
       perArmTimeoutSeconds: 900,
+      validationTimeoutSeconds: 45,
       heartbeatIntervalMs: 15000,
       strictMadarFirst: true,
       strictBenchmarkReadiness: true,
@@ -1732,6 +1748,45 @@ describe('cli main', () => {
     expect(errors).toEqual([])
   })
 
+  it('warns implement compare about local validation commands and timeout', async () => {
+    const { io, logs, errors } = createIo()
+    const dependencies = createDependencies()
+    const prompts: string[] = []
+
+    dependencies.confirm = async (message) => {
+      prompts.push(message)
+      return true
+    }
+    dependencies.runCompare = async () => 'compare result'
+
+    const exitCode = await executeCli(
+      [
+        'compare',
+        'implement sliding expiration',
+        '--exec',
+        'claude -p "$(cat {prompt_file})"',
+        '--task',
+        'implement',
+        '--baseline-mode',
+        'native_agent',
+        '--validation-timeout',
+        '45',
+      ],
+      io,
+      dependencies,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(prompts).toEqual([
+      'compare will execute a baseline prompt and a madar prompt for each question. This may consume paid model tokens. For --task implement with --baseline-mode native_agent, it will also run local validation commands derived from package.json scripts after each arm with a 45s timeout.',
+    ])
+    expect(logs).toEqual([
+      'Warning: compare will execute a baseline prompt and a madar prompt for each question. This may consume paid model tokens. For --task implement with --baseline-mode native_agent, it will also run local validation commands derived from package.json scripts after each arm with a 45s timeout.',
+      'compare result',
+    ])
+    expect(errors).toEqual([])
+  })
+
   it('cancels compare when confirmation is declined', async () => {
     const { io, logs, errors } = createIo()
     const dependencies = createDependencies()
@@ -1845,7 +1900,7 @@ describe('cli main', () => {
 
     expect(exitCode).toBe(2)
     expect(logs).toEqual([])
-    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'])
+    expect(errors).toEqual(['Usage: madar compare [question] --exec TEMPLATE [--graph path] [--questions PATH] [--output-dir DIR] [--task TASK] [--baseline-mode MODE] [--per-arm-timeout S] [--validation-timeout S] [--heartbeat-interval-ms N] [--strict-madar-first] [--strict] [--allow-no-install] [--yes] [--limit N] [--why]'])
   })
 
   it('prefers the explicit compare command over an implicit generate path match', async () => {

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -1252,6 +1252,90 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
+  it('times out implement validation commands instead of hanging after the agent run', async () => {
+    const { projectDir, graphPath, outputDir, questionsPath } = makeImplementationFixtureProject()
+    try {
+      writeFileSync(
+        join(projectDir, 'package.json'),
+        JSON.stringify({
+          name: 'implement-timeout-fixture',
+          private: true,
+          type: 'module',
+          scripts: {
+            typecheck: 'node -e "setTimeout(() => process.exit(0), 5000)"',
+          },
+        }, null, 2),
+        'utf8',
+      )
+
+      const runner: NativeAgentRunner = async (input) => {
+        const workspaceRoot = input.cwd ?? projectDir
+        writeFileSync(
+          join(workspaceRoot, 'src', 'session.ts'),
+          [
+            'export class SessionManager {',
+            '  readonly slidingExpirationMs = 30000',
+            '',
+            '  createSession(userId: string) {',
+            '    return `session:${userId}`',
+            '  }',
+            '}',
+            '',
+          ].join('\n'),
+          'utf8',
+        )
+
+        return {
+          exitCode: 0,
+          stdout: `${JSON.stringify({
+            ...(input.mode === 'baseline' ? BASELINE_USAGE_PAYLOAD : MADAR_USAGE_PAYLOAD),
+            result: 'updated session manager',
+          })}\n`,
+          stderr: '',
+          elapsedMs: 5,
+        }
+      }
+
+      const request = {
+        graphPath,
+        questionsPath,
+        outputDir,
+        execTemplate: 'mock-runner',
+        baselineMode: 'native_agent',
+        task: 'implement',
+        validationTimeoutSeconds: 0.01,
+      } as Parameters<typeof executeNativeAgentCompare>[0] & { validationTimeoutSeconds: number }
+
+      const outcome = await Promise.race([
+        executeNativeAgentCompare(
+          request,
+          {
+            runner,
+            now: () => new Date('2026-06-01T00:00:00Z'),
+          },
+        ).then((result) => ({ kind: 'resolved' as const, result })),
+        new Promise<{ kind: 'hung' }>((resolve) => {
+          setTimeout(() => resolve({ kind: 'hung' }), 1000)
+        }),
+      ])
+
+      if (outcome.kind !== 'resolved') {
+        throw new Error('compare hung instead of timing out implement validation commands')
+      }
+
+      const report = outcome.result.reports[0] as NativeAgentCompareReport
+      expect(['failed', 'setup_error']).toContain(report.implement_outcome?.baseline.validation.status)
+      expect(['failed', 'setup_error']).toContain(report.implement_outcome?.madar.validation.status)
+      expect(report.implement_outcome?.baseline.validation.commands).toEqual([
+        expect.objectContaining({
+          command: 'npm run typecheck',
+        }),
+      ])
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('fails early when strict benchmark readiness is poor', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     let runnerCalled = false

--- a/tests/unit/implementation-pack.test.ts
+++ b/tests/unit/implementation-pack.test.ts
@@ -17,6 +17,39 @@ afterEach(() => {
   }
 })
 
+function buildQuotedTestPathGraph(testFilePath: string) {
+  const root = mkdtempSync(join(tmpdir(), 'madar-quoted-tests-'))
+  tempFixtureRoots.push(root)
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'madar-quoted-tests-fixture',
+    private: true,
+    scripts: {
+      'test:run': 'vitest run',
+    },
+  }))
+
+  const graph = build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'route', label: 'POST /quote', file_type: 'code', source_file: `${root}/src/quote-route.ts`, source_location: 'L10', node_kind: 'route', community: 0 },
+          { id: 'service', label: 'QuoteService.run', file_type: 'code', source_file: `${root}/src/quote-service.ts`, source_location: 'L20', node_kind: 'method', community: 0 },
+          { id: 'test', label: 'QuoteService.run.spec', file_type: 'code', source_file: `${root}/${testFilePath}`, source_location: 'L1', node_kind: 'function', community: 1 },
+        ],
+        edges: [
+          { source: 'route', target: 'service', relation: 'calls', confidence: 'EXTRACTED', source_file: `${root}/src/quote-route.ts` },
+          { source: 'service', target: 'test', relation: 'covered_by', confidence: 'EXTRACTED', source_file: `${root}/src/quote-service.ts` },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+
+  graph.graph.root_path = root
+  return graph
+}
+
 function buildWorkflowCenterGraph() {
   const root = mkdtempSync(join(tmpdir(), 'madar-workflow-center-'))
   tempFixtureRoots.push(root)
@@ -556,6 +589,104 @@ describe('buildImplementationPackGuidance workflow-center scoring (#295)', () =>
     expect(guidance.cautions).toEqual(expect.arrayContaining([
       expect.stringContaining('Treat src/http/app.ts as supporting context first'),
     ]))
+  })
+})
+
+describe('buildImplementationPackGuidance validation commands', () => {
+  it('shell-quotes test file paths with spaces and shell metacharacters', () => {
+    const graph = buildQuotedTestPathGraph('tests/unit/login flow $(touch pwned).test.ts')
+    const retrieval = {
+      question: 'implement login flow validation',
+      token_count: 120,
+      matched_nodes: [
+        {
+          node_id: 'service',
+          label: 'QuoteService.run',
+          source_file: `${graph.graph.root_path}/src/quote-service.ts`,
+          line_number: 20,
+          node_kind: 'method',
+          file_type: 'code',
+          snippet: 'export class QuoteService { run() {} }',
+          match_score: 0.9,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Workflow',
+        },
+        {
+          node_id: 'test',
+          label: 'QuoteService.run.spec',
+          source_file: `${graph.graph.root_path}/tests/unit/login flow $(touch pwned).test.ts`,
+          line_number: 1,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'it("works", () => {})',
+          match_score: 0.7,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Tests',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 2000,
+      taskIntent: 'implement',
+    })
+
+    expect(guidance.validation_commands).toContain(
+      "npm run test:run -- 'tests/unit/login flow $(touch pwned).test.ts'",
+    )
+  })
+
+  it('prefixes repo-root test paths that start with a dash so runners do not parse them as flags', () => {
+    const graph = buildQuotedTestPathGraph('--help.test.ts')
+    const retrieval = {
+      question: 'implement login flow validation',
+      token_count: 120,
+      matched_nodes: [
+        {
+          node_id: 'service',
+          label: 'QuoteService.run',
+          source_file: `${graph.graph.root_path}/src/quote-service.ts`,
+          line_number: 20,
+          node_kind: 'method',
+          file_type: 'code',
+          snippet: 'export class QuoteService { run() {} }',
+          match_score: 0.9,
+          relevance_band: 'direct' as const,
+          community: 0,
+          community_label: 'Workflow',
+        },
+        {
+          node_id: 'test',
+          label: 'QuoteService.run.spec',
+          source_file: `${graph.graph.root_path}/--help.test.ts`,
+          line_number: 1,
+          node_kind: 'function',
+          file_type: 'code',
+          snippet: 'it("works", () => {})',
+          match_score: 0.7,
+          relevance_band: 'direct' as const,
+          community: 1,
+          community_label: 'Tests',
+        },
+      ],
+      relationships: [],
+      community_context: [],
+      graph_signals: { god_nodes: [], bridge_nodes: [] },
+    } satisfies import('../../src/runtime/retrieve.js').RetrieveResult
+
+    const guidance = buildImplementationPackGuidance(graph, retrieval, {
+      budget: 2000,
+      taskIntent: 'implement',
+    })
+
+    expect(guidance.validation_commands).toContain(
+      'npm run test:run -- ./--help.test.ts',
+    )
   })
 })
 

--- a/tests/unit/release-hygiene.test.ts
+++ b/tests/unit/release-hygiene.test.ts
@@ -30,6 +30,14 @@ function withReleaseFixture(
   readmeLink: string,
   runAssertion: (runVerify: () => string) => void,
 ): void {
+  withReleaseReadmeFixture(version, `[release notes](${readmeLink})\n`, runAssertion)
+}
+
+function withReleaseReadmeFixture(
+  version: string,
+  readmeMarkdown: string,
+  runAssertion: (runVerify: () => string) => void,
+): void {
   const fixtureDir = mkdtempSync(join(tmpdir(), 'madar-release-hygiene-'))
 
   try {
@@ -52,7 +60,7 @@ function withReleaseFixture(
         2,
       ),
     )
-    writeFileSync(join(fixtureDir, 'README.md'), `[release notes](${readmeLink})\n`)
+    writeFileSync(join(fixtureDir, 'README.md'), readmeMarkdown)
     writeFileSync(join(fixtureDir, 'CHANGELOG.md'), `## [${version}] - 2026-05-29\n`)
 
     runAssertion(() =>
@@ -121,6 +129,21 @@ describe('release hygiene', () => {
       'https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next0---2026-05-29',
       (runVerify) => {
         expect(runVerify).not.toThrow()
+      },
+    )
+  })
+
+  it('requires next-only README doc links to target next for prereleases', () => {
+    withReleaseReadmeFixture(
+      '0.27.7-next.0',
+      [
+        '[release notes](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next0---2026-05-29)',
+        '[enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md)',
+        '[telemetry](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md)',
+        '',
+      ].join('\n'),
+      (runVerify) => {
+        expect(runVerify).toThrow(/next-only README doc links must target blob\/next/)
       },
     )
   })


### PR DESCRIPTION
## Summary\n- disclose native-agent implement validation work in compare warnings and add a dedicated validation timeout\n- bound post-run validation commands and harden targeted test-path command construction\n- fix prerelease README next-only links and extend release hygiene coverage\n\n## Testing\n- npm run release:verify\n- npm run typecheck\n- npm run build\n- CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--validation-timeout` CLI option for compare (default 120s); warnings surface timeout info when relevant
  * Validation commands now time out instead of hanging during implement runs with native-agent mode

* **Bug Fixes**
  * Test paths with special characters or leading `-` are properly escaped/prefixed to avoid misinterpretation

* **Documentation**
  * README telemetry and docs links updated to point to prerelease branch

* **Tests**
  * Added coverage for validation timeout behavior, test-path escaping, and prerelease README link checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->