### PR TITLE
Prepare 0.27.7-next.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.7-next.1] - 2026-06-01
+
+### Fixed
+
+- **Implement compare validation is now safer and more transparent**: `compare --task implement` now discloses repo-local validation commands in the native-agent warning flow, supports a configurable `--validation-timeout`, aborts hung validation command process groups reliably, and safely handles targeted test paths with spaces, shell metacharacters, or repo-root flag-like names.
+- **Prerelease README links now stay on the published branch**: next-only docs links now target `blob/next`, and release hygiene rejects prerelease README links that drift back to `blob/main`.
+
 ## [0.27.7-next.0] - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ The current telemetry model is still local-first and source-safe. It records onl
 
 ---
 
-## What's new in 0.27.7-next.0
+## What's new in 0.27.7-next.1
 
-See the [`0.27.7-next.0` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next0---2026-06-01) for the full release notes.
+See the [`0.27.7-next.1` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next1---2026-06-01) for the full release notes.
 
 This `@next` build keeps the current `0.27.6` CLI/runtime fixes and adds a checked-in federation flagship proof: a reproducible three-repo fixture, a synthetic federation receipt, and doc updates that make the multi-repo enterprise workflow concrete without overstating the current implementation.
 
@@ -140,7 +140,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.7-next.0. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.7-next.1. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.7-next.0",
+    "version": "0.27.7-next.1",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.7-next.0",
+            "version": "0.27.7-next.1",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.7-next.0",
+    "version": "0.27.7-next.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.7-next.0",
+            "version": "0.27.7-next.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.7-next.0",
+    "version": "0.27.7-next.1",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump @lubab/madar to 0.27.7-next.1
- add the 0.27.7-next.1 changelog entry for the compare/release safety follow-ups
- refresh the README release link text and MCP registry metadata for the new prerelease

## Verification
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- npm sbom --sbom-format cyclonedx > sbom.cdx.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v0.27.7-next.1

* **Bug Fixes**
  * Enhanced validation robustness for `compare --task implement` with improved timeout handling and test path processing.
  * Fixed documentation link consistency in prerelease materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->