### PR TITLE
Prepare 0.27.7 release

### DIFF
--- a/.github/scripts/verify-release-hygiene.mjs
+++ b/.github/scripts/verify-release-hygiene.mjs
@@ -10,7 +10,7 @@ const REPOSITORY_WEB_URL = 'https://github.com/mohanagy/madar'
 const REPOSITORY_GIT_URL = 'git+https://github.com/mohanagy/madar.git'
 const BUGS_URL = `${REPOSITORY_WEB_URL}/issues`
 const HOMEPAGE_URL = `${REPOSITORY_WEB_URL}#readme`
-const NEXT_ONLY_README_PATHS = new Set([
+const RELEASE_BRANCHED_README_PATHS = new Set([
   'docs/team-enterprise-offer.md',
   'docs/telemetry.md',
 ])
@@ -44,20 +44,17 @@ function changelogBranchForVersion(version) {
   return version.includes('-') ? 'next' : 'main'
 }
 
-function assertPrereleaseReadmeLinks(readme, version) {
-  if (!version.includes('-')) {
-    return
-  }
-
+function assertReleaseBranchedReadmeLinks(readme, version) {
+  const expectedBranch = version.includes('-') ? 'next' : 'main'
   const invalidTargets = collectMarkdownLinkTargets(readme).filter((target) => {
     const match = target.match(/^https:\/\/github\.com\/mohanagy\/madar\/blob\/([^/]+)\/(.+)$/)
-    return match !== null && NEXT_ONLY_README_PATHS.has(match[2]) && match[1] !== 'next'
+    return match !== null && RELEASE_BRANCHED_README_PATHS.has(match[2]) && match[1] !== expectedBranch
   })
 
   assert.deepEqual(
     invalidTargets,
     [],
-    'next-only README doc links must target blob/next for prereleases',
+    `release-sensitive README doc links must target blob/${expectedBranch} for ${version.includes('-') ? 'prereleases' : 'stable releases'}`,
   )
 }
 
@@ -91,7 +88,7 @@ function main() {
     readme.includes(expectedVersionedChangelogLink),
     'README.md must link the current "What\'s new" section to the matching changelog entry',
   )
-  assertPrereleaseReadmeLinks(readme, packageManifest.version)
+  assertReleaseBranchedReadmeLinks(readme, packageManifest.version)
 
   console.log('Validated package metadata, changelog version, and npm-visible README links for release hygiene.')
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.7] - 2026-06-02
+
+### Added
+
+- **Federation is now documented as a flagship multi-repo workflow proof**: Madar now ships a reproducible three-repo federation fixture plus a checked-in synthetic federation receipt and supporting docs so the enterprise/multi-repo workflow claim has a concrete local artifact without overstating the current implementation. Closes #429.
+
+### Changed
+
+- **The roadmap docs are more decision-ready**: the main release now includes design-partner workflow loop drafts, plugin distribution-channel research, and the current language-expansion decision so the stable line reflects the product direction already merged on `main`. Closes #425, #431, and #432.
+
+### Fixed
+
+- **Implement compare validation is now safer and more transparent**: `compare --task implement` now discloses repo-local validation commands in the native-agent warning flow, supports a configurable `--validation-timeout`, aborts hung validation command process groups reliably, and safely handles targeted test paths with spaces, shell metacharacters, or repo-root flag-like names.
+- **Release README links now stay on the correct published branch**: stable README changelog and release-sensitive docs links now target `blob/main`, prerelease links still target `blob/next`, and release hygiene catches branch drift for both channels.
+
 ## [0.27.7-next.1] - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,17 +122,17 @@ madar telemetry disable
 MADAR_ENABLE_TELEMETRY=1 madar generate .
 ```
 
-The current telemetry model is still local-first and source-safe. It records only coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, an optional install target, and an optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full field list and controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/next/docs/telemetry.md).
+The current telemetry model is still local-first and source-safe. It records only coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, an optional install target, and an optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full field list and controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
 
 ---
 
-## What's new in 0.27.7-next.1
+## What's new in 0.27.7
 
-See the [`0.27.7-next.1` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0277-next1---2026-06-01) for the full release notes.
+See the [`0.27.7` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277---2026-06-02) for the full release notes.
 
-This `@next` build keeps the current `0.27.6` CLI/runtime fixes and adds a checked-in federation flagship proof: a reproducible three-repo fixture, a synthetic federation receipt, and doc updates that make the multi-repo enterprise workflow concrete without overstating the current implementation.
+This release keeps the current `0.27.6` CLI/runtime fixes and adds a checked-in federation flagship proof: a reproducible three-repo fixture, a synthetic federation receipt, and doc updates that make the multi-repo enterprise workflow concrete without overstating the current implementation.
 
-It also carries the latest next-track roadmap docs for design-partner workflow loops, plugin distribution channels, and language-expansion decisions, so the beta line stays aligned with the product direction already merged on `next`.
+It also carries the latest roadmap docs for design-partner workflow loops, plugin distribution channels, and language-expansion decisions, so the stable line stays aligned with the product direction already merged on `main`.
 
 The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
 
@@ -140,7 +140,7 @@ If you want the broader proof-oriented workflow behind the current surfaces, sta
 
 ### When to use `--spi`
 
-`--spi` is **still opt-in** in 0.27.7-next.1. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
+`--spi` is **still opt-in** in 0.27.7. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 
@@ -382,7 +382,7 @@ Everything stays local by default. No cloud upload, no API key required. Telemet
 
 - [Quick start guide](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) — three reproducible workflows: local proof, A/B compare, federated proof
 - [Claims and evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) — which public claims are demonstrated, in progress, or not yet measured
-- [Team and enterprise offer](https://github.com/mohanagy/madar/blob/next/docs/team-enterprise-offer.md) — local-first benchmark setup, proof-report, and procurement/security note options without a hosted control plane
+- [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) — local-first benchmark setup, proof-report, and procurement/security note options without a hosted control plane
 - [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results
 - [GoValidate shared benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates
 - [Public roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) — contributor-facing priority tracks and issue links
@@ -390,7 +390,7 @@ Everything stays local by default. No cloud upload, no API key required. Telemet
 - [Performance benchmark harness](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/performance/README.md) — repeatable `generate` / `update` / `cluster-only` measurements
 - [MCP tool examples](https://github.com/mohanagy/madar/blob/main/examples/mcp-tool-examples.md) — real input/output for every tool
 - [Benchmark hub](https://github.com/mohanagy/madar/tree/main/docs/benchmarks) — committed wrappers and provider-reported evidence
-- [Telemetry guide](https://github.com/mohanagy/madar/blob/next/docs/telemetry.md) — opt-in controls, collected fields, excluded fields, and local storage behavior
+- [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) — opt-in controls, collected fields, excluded fields, and local storage behavior
 - [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) — full per-release notes
 - [Contributing](https://github.com/mohanagy/madar/blob/main/CONTRIBUTING.md) · [Security](https://github.com/mohanagy/madar/blob/main/SECURITY.md)
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.7-next.1",
+    "version": "0.27.7",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.7-next.1",
+            "version": "0.27.7",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.7-next.1",
+    "version": "0.27.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.7-next.1",
+            "version": "0.27.7",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.7-next.1",
+    "version": "0.27.7",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/tests/unit/release-hygiene.test.ts
+++ b/tests/unit/release-hygiene.test.ts
@@ -143,7 +143,22 @@ describe('release hygiene', () => {
         '',
       ].join('\n'),
       (runVerify) => {
-        expect(runVerify).toThrow(/next-only README doc links must target blob\/next/)
+        expect(runVerify).toThrow(/release-sensitive README doc links must target blob\/next/)
+      },
+    )
+  })
+
+  it('requires release-sensitive README doc links to target main for stable releases', () => {
+    withReleaseReadmeFixture(
+      '0.27.7',
+      [
+        '[release notes](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277---2026-05-29)',
+        '[enterprise offer](https://github.com/mohanagy/madar/blob/next/docs/team-enterprise-offer.md)',
+        '[telemetry](https://github.com/mohanagy/madar/blob/next/docs/telemetry.md)',
+        '',
+      ].join('\n'),
+      (runVerify) => {
+        expect(runVerify).toThrow(/release-sensitive README doc links must target blob\/main/)
       },
     )
   })


### PR DESCRIPTION
## Summary
- promote the main branch from 0.27.7-next.1 to stable 0.27.7 metadata
- update the changelog, README release copy, and MCP registry manifest for the stable release
- extend release hygiene so branch-sensitive README docs must point at `main` for stable releases and `next` for prereleases

## Verification
- npm run test:run -- tests/unit/release-hygiene.test.ts
- npm install
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- npm sbom --sbom-format cyclonedx > sbom.cdx.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version promoted from 0.27.7-next.1 to 0.27.7 across package and registry files.
  * Updated changelog and README with stable release information.
  * Corrected documentation links to target the appropriate release branch.
  * Enhanced release validation to verify correct documentation branching.

* **Tests**
  * Updated release hygiene test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->