### PR TITLE
Prepare 0.27.8 README refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.8] - 2026-06-02
+
+### Added
+
+- **README reference content now has dedicated docs**: long-form Pack Schema v1, adaptive context-pack, execution-slice, MCP tool, installer, strict-profile, MCP Registry, command-reference, and discovery-rule details now live under `docs/concepts/context-packs.md` and `docs/reference/cli-and-mcp.md` so the package README can stay focused on onboarding.
+
+### Changed
+
+- **The README is now a shorter npm-facing landing page**: the public README now leads with the product promise, quickstart, agent choices, core surfaces, evidence boundaries, and documentation index, while keeping claim and release links npm-safe.
+
 ## [0.27.7] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 **Madar is a local, task-aware context-pack compiler for AI coding agents.**
 
-A structural graph tells the agent what exists in your codebase. Madar tells the agent **what runs for this task** — usually a much smaller execution slice or structural subset — then returns a compact pack with inline snippets so the agent can answer from the pack before it starts searching the repo by hand.
+A structural graph tells the agent what exists in your codebase. Madar tells the agent **what runs for this task**: usually a much smaller execution slice or structural subset. It then returns a compact pack with inline snippets so the agent can answer from evidence before it starts searching the repo by hand.
 
-**Primary ICP (near-term):** teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
+Madar is deterministic local context compilation. It complements agents and IDE indexing; it is **not another generic codebase index**.
 
-**Not the primary ICP today:** tiny repos, throwaway scripts, teams mainly shopping for hosted dashboards, or buyers who need broad cross-language parity before the TypeScript/Node proof deepens.
+**Primary ICP:** teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
+
+**Not the primary ICP today:** tiny repos, throwaway scripts, hosted-dashboard-first buyers, or teams that need broad cross-language parity before the TypeScript/Node proof deepens.
 
 [![npm](https://img.shields.io/npm/v/%40lubab%2Fmadar)](https://www.npmjs.com/package/@lubab/madar)
 [![node >=20](https://img.shields.io/badge/node-%E2%89%A520-3c873a)](https://nodejs.org/)
@@ -16,100 +18,71 @@ A structural graph tells the agent what exists in your codebase. Madar tells the
 
 ---
 
-## Demo
-
-[![▶ Watch the 30-second demo](https://img.shields.io/badge/%E2%96%B6%EF%B8%8E-Watch%20the%2030%E2%80%91second%20demo-3c873a?style=for-the-badge)](https://github.com/mohanagy/madar#demo)
-
-<!-- GitHub auto-embeds the user-attachment video below; npm renders it as a link only.
-     The shields.io button above is the npm-visible affordance back to the inline player on GitHub. -->
-
-https://github.com/user-attachments/assets/a502185f-fa12-4a8f-80d2-172847f209fd
-
-30 seconds: install → `madar generate .` on the GoValidate repo (1,048 files) → `madar claude install --profile core` → `madar compare "Explain the auth flow End to End"`. The repo includes the saved artifact for that run plus the follow-up benchmark notes and caveats. Treat it as a worked receipt, not a universal benchmark headline. Receipts: [`docs/benchmarks/2026-05-09-govalidate-auth-e2e/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/2026-05-09-govalidate-auth-e2e/).
-
----
-
-## Requirements
-
-Madar is two steps and requires both. Running `madar generate` alone produces a local graph artifact that nothing consumes until you install the agent integration that exposes the Madar MCP tools or prompt flow.
-
-```bash
-madar generate .              # produces out/graph.json
-madar <agent> install         # registers the MCP server / local install rules
-```
-
-Without `<agent> install` (or the equivalent manual wiring for your runtime), the agent has no Madar MCP tools available and the measured benchmark cell below does not apply.
-
 ## Quickstart
+
+Madar is two steps and requires both. `madar generate` creates the local graph artifact; `madar <agent> install` wires that graph into an agent through MCP or local instruction files.
 
 ```bash
 npm install -g @lubab/madar
 
 cd your-project
-madar generate .          # builds out/graph.json (no API key, no cloud)
+madar generate .          # builds out/graph.json, no API key, no cloud
 madar summary             # bounded repo overview before deeper retrieval
-madar claude install      # wires Claude Code to use it via MCP
+madar claude install      # wires Claude Code to use Madar via MCP
 madar doctor              # checks graph freshness + agent/MCP wiring
 madar status              # compact readiness summary + next commands
 
-# Or use the opt-in SPI pipeline for framework-aware metadata + disk cache:
+# Optional framework-aware metadata + disk cache:
 madar generate . --spi
 ```
 
-Now ask Claude something about your codebase. It can start with one bounded `retrieve` or `context_pack` call, get labeled snippets with file paths and community context, and then decide whether focused follow-up reads are still needed.
+Now ask your agent something about the codebase. It can start with one bounded `retrieve` or `context_pack` call, get labeled snippets with file paths and community context, and then decide whether focused follow-up reads are still needed.
+
+Want a tiny reproducible workspace? Start with [`examples/sample-workspace/`](https://github.com/mohanagy/madar/tree/main/examples/sample-workspace/) and the [sample workspace tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md).
+
+Want the broader first-run walkthrough with install verification, one pack, and a safe compare smoke check? Use the [getting started tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md).
+
+---
 
 ## Choose your agent
 
 Pick one install target, then rerun `madar doctor` and `madar status` so the first result is verified before you ask a broader question:
 
-- Claude Code — `madar claude install`
-- Codex CLI — `madar codex install`
-- Cursor — `madar cursor install`
-- GitHub Copilot CLI — `madar copilot install`
-- Gemini CLI — `madar gemini install`
-- Aider — `madar aider install`
-- OpenCode — `madar opencode install`
+- Claude Code: `madar claude install`
+- Codex CLI: `madar codex install`
+- Cursor: `madar cursor install`
+- GitHub Copilot CLI: `madar copilot install`
+- Gemini CLI: `madar gemini install`
+- Aider: `madar aider install`
+- OpenCode: `madar opencode install`
 
-After you generate `out/graph.json`, `madar doctor` and `madar status` check the local install wiring for Claude Code, Cursor, Gemini CLI, and GitHub Copilot CLI, and they also lint the AGENTS-based Madar instruction profiles for Codex CLI, OpenCode, and Aider. If one of those AGENTS profiles goes stale or an expected hook/plugin/MCP file drifts, those commands mark the agent as `partial` and suggest the matching reinstall command.
+After you generate `out/graph.json`, `madar doctor` and `madar status` check the local install wiring for Claude Code, Cursor, Gemini CLI, and GitHub Copilot CLI. They also lint the AGENTS-based Madar instruction profiles for Codex CLI, OpenCode, and Aider; if a profile drifts, they mark the agent as `partial` and suggest the matching reinstall command.
 
-Want the opt-in semantic retrieval / rerank path too? Install the optional local model runtime in the same environment:
+Install details, generated files, profiles, and uninstall behavior live in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md) and [compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md).
+
+**Without MCP**, compile a prompt or pack directly:
+
+```bash
+madar summary
+madar pack "how does auth work?" --task explain --format text
+madar pack "add auth telemetry" --task implement --format json
+madar handoff "add auth telemetry" --task implement --consumer copilot
+madar prompt "how does auth work?" --provider claude
+```
+
+`madar prompt` stays local. `madar pack` stays the richer local/full-context surface. `madar handoff` is the share-safe remote/background-agent artifact for cloud or async workers. Note: compare and benchmark flows can spend paid model tokens when you point them at a real model CLI.
+
+The MCP equivalents include `context_pack`, `context_prompt`, and follow-up expansion through stable session refs. For follow-ups, reuse the same `session_id` with `context_prompt` when a conversation continues; `session_diagnostics` tells you whether the turn reused, added, updated, or invalidated prior context. Expect the biggest reuse gains with a mostly stable retrieved graph context. First turns and heavily changed retrieved context naturally show little or no reuse.
+
+Optional semantic retrieval/rerank support is local too, but requires the model package:
 
 ```bash
 npm install @huggingface/transformers
 ```
 
-`madar prompt` stays local and only compiles a prompt payload. `madar handoff` is the share-safe remote/background-agent artifact when you need to pass a bounded brief to a cloud or async worker without shipping the richer local pack verbatim. `madar pack` stays the richer local/full-context surface. By contrast, compare and benchmark flows can spend paid model tokens when you swap the local smoke-check runner for a real model CLI or hosted model configuration.
+---
 
-For Claude MCP follow-ups, reuse the same `session_id` with the `context_prompt` tool. Its compiled output includes `session_diagnostics`, which shows whether the turn is an initial prompt or a follow-up plus which stable refs were reused, added, updated, or invalidated. Expect the biggest reuse gains when follow-up prompts keep a mostly stable retrieved graph context; first turns, Gemini/plain prompt flows, or heavily changed retrieved context will naturally show little or no reuse.
-
-**Install commands:**
-
-```bash
-madar cursor install      # Cursor
-madar copilot install     # GitHub Copilot CLI
-madar gemini install      # Gemini CLI
-madar aider install       # Aider
-madar codex install       # Codex CLI
-madar opencode install    # OpenCode
-```
-
-**Or use it without MCP** — pipe the compiled prompt directly to your agent's CLI:
-
-```bash
-madar summary                             # bounded JSON overview before pack/prompt
-madar pack "how does auth work?" --task explain --format text   # human-readable execution brief
-madar pack "add auth telemetry" --task implement --format json  # Pack Schema v1 for automation
-madar handoff "add auth telemetry" --task implement --consumer copilot   # share-safe remote/background-agent artifact
-madar prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
-```
-
-If you enable `--semantic` or `--rerank` without that optional package installed, madar now fails with an explicit install hint instead of pulling the transformer/native stack into every default install.
-
-Want a tiny reproducible workspace for local demos? Start with [`examples/sample-workspace/`](https://github.com/mohanagy/madar/tree/main/examples/sample-workspace/) and the [sample workspace tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md).
-
-Want a broader local-first walkthrough that also covers install, one verified pack, and a safe `compare` smoke check? Use the [end-to-end getting started tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md).
-
-### Opt-in telemetry
+## Telemetry
 
 Telemetry is disabled unless you explicitly enable it.
 
@@ -118,281 +91,125 @@ madar telemetry status
 madar telemetry enable
 madar telemetry disable
 
-# One-shot opt-in for the current command only:
 MADAR_ENABLE_TELEMETRY=1 madar generate .
 ```
 
-The current telemetry model is still local-first and source-safe. It records only coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, an optional install target, and an optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full field list and controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
+The current telemetry model is local-first and source-safe. It records coarse success events for `install`, `generate`, `pack`, and `compare`, plus version, OS, optional install target, and optional repo-size bucket. It does **not** record prompt text, answer text, source paths, or source content. Full controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
 
 ---
 
-## What's new in 0.27.7
+## What's New
 
-See the [`0.27.7` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0277---2026-06-02) for the full release notes.
+See the [`0.27.8` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0278---2026-06-02) for the full release notes.
 
-This release keeps the current `0.27.6` CLI/runtime fixes and adds a checked-in federation flagship proof: a reproducible three-repo fixture, a synthetic federation receipt, and doc updates that make the multi-repo enterprise workflow concrete without overstating the current implementation.
+Recent highlights:
 
-It also carries the latest roadmap docs for design-partner workflow loops, plugin distribution channels, and language-expansion decisions, so the stable line stays aligned with the product direction already merged on `main`.
-
-The larger **What's new in 0.23.0** additions are still part of the main flow too: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
-
-If you want the broader proof-oriented workflow behind the current surfaces, start with [proof workflows](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) and the [GoValidate shared benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/govalidate-suite/README.md).
-
-### When to use `--spi`
-
-`--spi` is **still opt-in** in 0.27.7. Use it when your repo is framework-heavy TypeScript/JavaScript and you want the extra framework-shaped metadata plus disk cache behavior.
-
-`--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
+- `0.27.8` refactors the README into a shorter npm-facing landing page and moves long-form Pack Schema, context-pack, MCP, installer, command, and discovery-rule details into dedicated docs.
+- `0.27.7` added the checked-in federation flagship proof: a reproducible frontend/backend/shared fixture plus a synthetic federation receipt.
+- Roadmap docs now cover design-partner workflow loops, plugin distribution channels, and language-expansion decisions.
+- The larger **What's new in 0.23.0** additions remain central: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
+- Public proof workflows are organized under [`docs/proof-workflows.md`](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md), [`docs/claims-and-evidence.md`](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md), and [`docs/benchmarks/suite/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/).
 
 ---
 
-## What madar is
+## When To Use `--spi`
 
-A structural graph tells you what exists, but what the agent actually needs is **what runs for this task**, which is usually a much smaller set.
+`--spi` is still opt-in in `0.27.8`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
-madar is **deterministic local context compilation** for that repo/task boundary: it indexes a TypeScript/Node workspace (and PR diffs) into local graph artifacts, then compiles those artifacts into a task-aware pack the agent can start from before it decides whether deeper reads are still necessary.
+It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 
-That means Madar **complements agents and IDE indexing** instead of replacing them. IDE indexes and structural graphs tell you what exists; Madar compiles the bounded first-pass evidence for the current task. It is **not another generic codebase index**.
+More detail: [context packs and task evidence](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md).
 
-```
+---
+
+## Core Surfaces
+
+Madar builds a local graph once, then compiles task-specific evidence from it:
+
+```text
 your prompt
-  → workspace graph (built once, reused)
-    → relevant nodes + edges + snippets
-      → compact context pack (claims, coverage, missing_context)
-        → AI coding agent
+  -> workspace graph
+    -> relevant nodes + edges + snippets
+      -> compact context pack
+        -> AI coding agent
 ```
 
-When the agent says "tell me more," it expands a stable `handle_id` inside the same MCP session instead of reconstructing the same first-pass context from scratch.
+The output surfaces are deliberately small:
 
-### Pack Schema v1
+- `madar summary`: bounded repo overview.
+- `madar pack`: task-aware local context pack. JSON mode emits Pack Schema v1.
+- `madar prompt`: provider-ready prompt payload.
+- `madar handoff`: share-safe remote/background-agent artifact.
+- `pr_impact` and `review-compare`: diff-aware review evidence.
+- `execution_slice`: static runtime-path hypothesis, not a live trace. Its `phase_coverage` is also static and prompt-scoped; broad report-generation prompts can surface planner/research/report-builder/scoring/renderer/persistence phases without implying live instrumentation.
 
-`madar pack` now emits a stable **Pack Schema v1** envelope around the compiled evidence bundle. In JSON mode (`--format json`), the response includes `schema_version`, `task`, `task_intent`, `workflow_centers`, `recommended_first_read`, `likely_edit_files`, `likely_test_files`, `public_contracts`, `risk_boundaries`, `validation_commands`, `negative_guidance`, `confidence_score`, and `why_explanation`, alongside the existing `pack`, `coverage`, and planner metadata.
+Runtime-generation prompts stay compact: pack shaping follows the strongest backend path first and suppresses sibling-route noise plus shared-hub fan-out on broad runtime-generation questions.
 
-For `--task implement`, `workflow_centers` are scored workflow-owner candidates with a `path`, numeric `score`, and structural `reasons`, so orchestration files can outrank lexically louder helpers when the brief recommends where to start editing.
+These seven MCP tools ship in the default core profile: `retrieve`, `pr_impact`, `impact`, `call_chain`, `community_overview`, `graph_stats`, and `graph_summary`. The full surface is 26 tools, opt-in via `MADAR_TOOL_PROFILE=full` or `--profile full`, including `context_expand` and `get_neighbors`.
 
-The implement brief also keeps `recommended_first_read` separate from ranked `likely_edit_files` and `likely_test_files`. The edit/test sections now carry explicit `score` and `reason` fields so agents can tell orientation reads apart from the files most likely to change or validate.
-
-`negative_guidance` is also task-aware now: implementation packs can explicitly call out helper-like or generated files as supporting context instead of silently letting lexical matches drift into the default edit path.
-
-Use `--format json` when another tool or script will consume the pack directly. Use `--format text` when you want the same schema rendered as a short human/agent-readable execution brief.
-
-### Adaptive context-pack representations
-
-Compiled context packs now have a first-pass **rendering-only** adaptive layer. Retrieval still selects the same nodes and paths first; the runtime only changes how those already-selected nodes are emitted for the task.
-
-That renderer is now budget-aware: tighter budgets compress already-selected nodes down toward summary/signature views, while explain packs only preserve full detail when the budget is large enough to justify it.
-
-The current deterministic core modes are:
-
-- `signature`
-- `behavior_sketch`
-- `call_chain`
-- `contract_view`
-- `implementation_excerpt`
-- `dependency_record`
-
-That means the same selected nodes can render differently for `explain`, `review`, and `impact` work without changing retrieval selection. The tradeoff is explicit: lower-token renderings carry less raw implementation detail, while explain-oriented packs keep full code snippets when the runtime already has them.
-
-**What it's good at today:**
-- Giving agents a bounded first pass for explain / review / impact work instead of starting from arbitrary repo-wide search.
-- Turning the current git diff into ranked review risks, structural hotspots, and likely test files with `pr_impact` and `review-compare`.
-- Producing deterministic, share-safe artifacts (`report.share-safe.json`, Pack Schema v1, static `execution_slice` output) that can be reviewed without sharing workstation paths.
-- Staying local-first: tree-sitter AST, BM25 retrieval, optional ONNX embeddings — all on your machine unless you explicitly invoke a model you configured yourself.
-
-### Review and security workflows
-
-Madar is a local **context/evidence layer** for review and security workflows, not a PR reviewer or vulnerability scanner. CodeRabbit, Qodo, Codex Security, and similar tools still decide findings, policy, and remediation behavior; Madar's role is to compile a bounded local-first view of the repo or diff before those tools start broader exploration.
-
-In practice, that means using `pr_impact`, `review-compare`, `madar handoff`, and `report.share-safe.json` artifacts to supply workflow ownership, likely test files, compact prompt evidence, and share-safe receipts to the review/security agent or to the human comparing multiple agents. Madar helps make those workflows more inspectable and more reproducible, but it does **not** claim better findings than CodeRabbit, Qodo, or Codex Security today.
-
-Public positioning and benchmark claims for that workflow stay grounded in [`docs/claims-and-evidence.md`](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md), including what is demonstrated now versus what still needs comparative review/security evaluation evidence.
-
-> Deepest extraction is still **TypeScript/JavaScript** with framework-aware passes for Express, NestJS, Next.js, React Router, Redux Toolkit, **Hono, Fastify, tRPC, Prisma, and routing-controllers** (10 substrates via `--spi`). Python now has a conservative semantic layer for cross-file import/call resolution, FastAPI router composition plus route/dependency semantics, and first-pass Django URL-conf route-to-view mapping. Go now has a conservative first semantic pass for local-package import resolution, receiver/method call edges, and statically visible `net/http` / Gin / Chi route relationships. Ruby, Java, and Rust still use the tree-sitter AST baseline. C / Kotlin / C# / Scala / PHP / Swift / Zig use a generic structural extractor. Full matrix: [`docs/language-capability-matrix.md`](https://github.com/mohanagy/madar/blob/main/docs/language-capability-matrix.md).
+Full command and MCP reference: [`docs/reference/cli-and-mcp.md`](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md).
 
 ---
 
-## Demonstrated today
+## Evidence And Limits
 
-On the GoValidate backend service (NestJS + BullMQ, SPI graph, install verified), for the prompt *"How idea report is being generated"*, Madar produced this measured release cell versus the same agent without Madar:
+The current headline proof is one verified GoValidate backend service cell for the prompt *"How idea report is being generated"*:
 
 | metric | baseline | Madar | delta |
 | --- | --- | --- | --- |
-| total tool calls | 28 | 7 | **4x fewer** |
-| broad search (`Glob`/`Grep`/`Bash`) after first Madar call | 11 | 0 | eliminated |
-| input tokens (Anthropic-reported) | 2,366,946 | 498,688 | **4.75x less** |
-| uncached input tokens | 229,691 | 103,764 | 125,927 fewer |
-| wall-clock latency | 158,995 ms | 72,420 ms | **2.2x faster** |
-| cost (USD) | 2.6595 | 0.9728 | **2.73x cheaper** |
-| `measurement_validity` | n/a | `valid` | — |
-| `token_regression` | n/a | `false` | — |
+| total tool calls | 28 | 7 | 4x fewer |
+| broad search after first Madar call | 11 | 0 | eliminated |
+| input tokens | 2,366,946 | 498,688 | 4.75x less |
+| wall-clock latency | 158,995 ms | 72,420 ms | 2.2x faster |
+| cost | 2.6595 USD | 0.9728 USD | 2.73x cheaper |
 
-This cell also recorded `install_verified: true`, `madar_mcp_call_count: 1`, and `exploration_outcome: madar_invoked`, meaning the first Madar tool call was `mcp__madar__retrieve` and there was no broad exploration after it. Trace artifact: [`docs/benchmarks/regression/0.27.0-next.4-govalidate-explain/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/regression/0.27.0-next.4-govalidate-explain/).
+This is one cell: one prompt, one repo, one agent runtime, one verified install path. Your results will vary by repo shape, prompt type, agent runtime, and other installed tools. Published benchmark cells run in isolation mode. Your local numbers may differ if your Claude Code config differs.
 
-This is **one cell**: one prompt, one repo, one agent runtime, one verified install path. Your results will vary by repo shape, prompt type, agent runtime, and what other MCPs or skills you have loaded.
+Current evidence also includes a public benchmark suite with per-repo spread, initial fixture-proxy implement/review/impact rows, and workflow-outcome receipts. There is still no single-number cross-repo headline. Mixed evidence and counterexamples are tracked openly, including [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/2026-05-25-founder-command-center-auth-flow/).
 
-Runtime-generation prompts stay compact: the pack shaping follows the strongest backend path first and suppresses sibling-route noise plus shared-hub fan-out on broad runtime-generation questions.
+Madar is a context/evidence layer for review and security workflows, not a PR reviewer or vulnerability scanner. CodeRabbit, Qodo, Codex Security, and similar tools still decide findings, policy, and remediation behavior. Madar supplies bounded local evidence through `pr_impact`, `review-compare`, `madar handoff`, and `report.share-safe.json`.
 
-## In progress
-
-- **Reproducible benchmark suite with per-repo spread.** The public suite now ships fixed manifests, methodology, the `madar bench:suite` runner, and published fixture-proxy rows across a small library, a service, and a monorepo under [`docs/benchmarks/suite/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/).
-- **Exploration behavior across more repos and prompts.** Strict install guidance now pushes agents toward one graph/pack-first pass, but the public evidence is still mixed. The current counterexample note is in [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/2026-05-25-founder-command-center-auth-flow/).
-- **Clearer compare evidence.** Native-agent compare traces now preserve more machine-readable metadata, but we still treat them as repo/task-specific receipts rather than a universal claim.
-
-## Not yet measured
-
-- **Broad implement-task claims.** The suite now has initial fixture-proxy implement/review/impact rows plus workflow-outcome receipts, but that is still not enough to claim universal implementation improvement or wrong-file edit gains across repos. Broader validation stays under [#332](https://github.com/mohanagy/madar/issues/332).
-- **Lower-confidence packs.** This release cell is a strong-path, install-verified receipt; lower-confidence prompt behavior still needs its own measured cells.
-- **Repos beyond the demonstrated GoValidate backend cell.** Current public artifacts do not justify a universal turns / latency / exploration claim across repo shapes.
-- **Cross-repo aggregate benchmark marketing.** We do not publish a single-number cross-repo headline.
-
-## What Madar does not do today
-
-- It does **not** control the agent runtime. The agent can still ignore the pack and keep exploring.
-- It does **not** guarantee fewer tool calls, fewer turns, or lower latency on every repo or prompt.
-- It does **not** turn static analysis into live instrumentation. `execution_slice` stays a static runtime-path hypothesis, not a trace.
-- It does **not** replace targeted reads, tests, or review when you are changing code.
-
-## How we measure
-
-- We publish dated artifact folders under [`docs/benchmarks/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/) and map each public claim to evidence in [`docs/claims-and-evidence.md`](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md).
-- This release README cites one verified cell under [`docs/benchmarks/regression/0.27.0-next.4-govalidate-explain/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/regression/0.27.0-next.4-govalidate-explain/), not a universal benchmark headline.
-- The benchmark-suite direction is **per-repo spread**, fixed tasks, and reproducible artifacts under [`docs/benchmarks/suite/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/). There is **no single-number cross-repo headline** in the public docs.
-- The latest suite bundle includes initial fixture-proxy implement/review/impact rows plus workflow-outcome summaries, but those rows still count as per-cell receipts rather than a universal product claim.
-- Suite runs use the same prompt against a baseline path and an install-verified Madar path, capture verbose tool traces, and keep multi-trial reporting attached to the specific repo/task cell rather than flattening it into one marketing number.
-- Published benchmark cells run in isolation mode ([`docs/benchmarks/suite/isolation/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/isolation/)). Your local numbers may differ if your Claude Code config differs.
-- Run `madar bench:suite --dry-run` to inspect the current matrix, then `madar bench:suite --repo nestjs-mid --task explain-runtime ...` to populate a wired cell.
-- Any stronger public claim belongs behind a reproducible suite artifact, not a one-off anecdote.
+Read the public claim map before using numbers in customer-facing copy: [`docs/claims-and-evidence.md`](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md).
 
 ---
 
-## Works with your AI tools
+## Trust + Limitations
 
-madar produces local context packs that any modern coding agent can consume — over MCP or by piping the compiled prompt to its CLI.
+Everything stays local by default. No cloud upload, no API key required. Your code never crosses an HTTP boundary unless you explicitly invoke a model or remote system you configured yourself.
 
-| Agent | Connection | Install command | `doctor` / `status` lint surface |
-|---|---|---|---|
-| Claude Code | MCP via `.mcp.json` | `madar claude <install\|uninstall> [--profile core\|full\|strict]` | `CLAUDE.md` + `.claude/settings.json` hook + `.mcp.json` |
-| Cursor | MCP via `.cursor/mcp.json` | `madar cursor <install\|uninstall> [--profile core\|full\|strict]` | `.cursor/rules/madar.mdc` + `.cursor/mcp.json` |
-| GitHub Copilot CLI | MCP via `.vscode/mcp.json` | `madar copilot <install\|uninstall> [--profile core\|full\|strict]` | `.vscode/mcp.json` |
-| Gemini CLI | MCP server | `madar gemini <install\|uninstall> [--profile core\|full\|strict]` | `GEMINI.md` + `.gemini/settings.json` hook |
-| Aider | AGENTS.md context-pack-first profile | `madar aider install` | `AGENTS.md` Aider profile |
-| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` | `AGENTS.md` OpenCode profile + plugin registration + MCP entry |
-| Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `madar codex install` | `AGENTS.md` Codex profile + `.codex/hooks.json` |
-| Windsurf / others | Pipe `madar prompt` output | `madar prompt "..." --provider claude` | n/a |
+- Build: tree-sitter AST extraction and Louvain community detection, CPU-local.
+- Query: BM25 lexical scoring, reciprocal-rank fusion, optional ONNX embeddings, and optional cross-encoder reranker.
+- MCP: local stdio subprocess of your agent.
+- Security boundary: local-first is not automatically safe. Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary. Only enable it for repositories and local agent runtimes you trust. Prefer `--profile strict` when you only need the lean core MCP tools. Threat model: [`docs/security/mcp-threat-model.md`](https://github.com/mohanagy/madar/blob/main/docs/security/mcp-threat-model.md).
 
-These are local installers that write project instructions and, when the platform supports it, local MCP config or plugin files that point at the madar subprocess. No code is uploaded.
+Limitations to know:
 
-Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary. Only enable it for repositories and local agent runtimes you trust. Prefer `--profile strict` when you only need the lean core MCP tools. The checked-in threat model and mitigations live in [`docs/security/mcp-threat-model.md`](https://github.com/mohanagy/madar/blob/main/docs/security/mcp-threat-model.md).
-
-For Claude, Cursor, Copilot, and Gemini, `--profile strict` keeps the lean core MCP tool surface but rewrites the generated guidance into a compact flow: call `context_pack` once for the task before broader exploration, answer after one high- or medium-confidence pack when `diagnostics.quality_score >= 0.5` and `missing_context` is empty, do not run broad `Glob` patterns, repo-wide `grep` / `find` searches, or raw file sweeps after that strong pack, prefer Madar over non-Madar MCPs for codebase questions unless Madar returns `agent_directive: explore_with_caution`, let that Madar guidance override conflicting auto-activated exploration skills, expand only when `missing_context` / `missing_semantic` or diagnostics justify it (or the user asks for deeper verification), and keep `out/GRAPH_REPORT.md` as a fallback-only read when the pack or graph tools are unavailable, stale, or insufficient. Strict mode is about a bounded first pass, not a guarantee that exploration will always decrease.
-
-Aider and OpenCode are intentionally context-pack-first: run `madar generate .`, install the profile, and start broad codebase work with `madar pack "<task>" --task explain` before raw file search. In those installed profiles, `out/GRAPH_REPORT.md` stays a fallback-only read when the pack or graph tools are unavailable, stale, or insufficient, rather than a default first file. `madar aider install` writes an AGENTS.md profile only; remove it with `madar aider uninstall`. `madar opencode install` writes the AGENTS.md profile, `.opencode/plugins/madar.js`, and the madar MCP entry in `opencode.json` or `opencode.jsonc`; remove only madar-owned content with `madar opencode uninstall`. Manual verification does not require either agent binary: inspect the generated files after install, then confirm uninstall removes only the madar entries.
-
-Codex is intentionally context-pack-first: run `madar generate .`, install with `madar codex install`, and start broad codebase work with `madar pack "<task>" --task explain` before raw file search. In the installed guidance, `out/GRAPH_REPORT.md` remains fallback-only when the pack or graph tools are unavailable, stale, or insufficient. To remove the profile, run `madar codex uninstall`; it removes the madar AGENTS.md section and Codex hook while preserving unrelated content. Manual verification does not require Codex to be installed: inspect `AGENTS.md` and `.codex/hooks.json` after install, then confirm uninstall removes only madar content.
-
-For the full install matrix — generated files, verification paths, profile behavior, and known limitations for both dedicated installers and `madar install --platform ...` — see the [compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md).
-
-For practical multi-agent workflows across Claude Code, Codex, Copilot, Cursor, and Gemini, see the [agent orchestration guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/agent-orchestration.md).
-
-### MCP Registry metadata
-
-The checked-in public registry manifest lives at [`docs/mcp-registry/server.json`](https://github.com/mohanagy/madar/blob/main/docs/mcp-registry/server.json). Validate it locally with `npm run registry:validate`.
-
-The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry still points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json` (or let `madar <agent> install` write that wiring for you).
-
-Private registry usage stays out of scope for the public Madar listing because the official MCP Registry only accepts public package sources. Keep private or self-hosted registry workflows separate from this metadata file.
+1. Cold-start sessions add a one-time MCP/tool-schema cost. Core profile is about ~3,200 bytes / ~800 tokens, down about 25% from the original surface.
+2. Deep extraction is still best on JS/TS. Python has conservative cross-file import/call resolution, FastAPI router composition, and first-pass Django URL-conf route-to-view mapping. Go has conservative local-package import, receiver-call, and `net/http` / Gin / Chi route support. Python and Go are still not near JS/TS parity.
+3. Static analysis cannot resolve every dynamic runtime behavior.
+4. Token reduction depends on project and task.
+5. Some workflows still need full file reads, tests, and review.
 
 ---
 
-## MCP tools
+## Documentation
 
-These seven MCP tools handle the most common agent workflows in the default **core** profile. The full surface is 26 tools, opt-in via `MADAR_TOOL_PROFILE=full` or `--profile full` on install. `--profile strict` still uses the lean core tool surface, but changes the installed guidance so the agent starts with one `context_pack` call and expands only when the pack diagnostics say evidence is missing. Start with `graph_summary` for a bounded deterministic first-turn overview, then use `retrieve` or `context_pack` when you need task-specific evidence. It is intentionally a compact at-a-glance summary, not a full runtime trace.
-
-| Tool | When the agent uses it |
-|---|---|
-| `retrieve` | "How does X work?" — ranked nodes + code snippets + community context |
-| `pr_impact` | "Is this PR safe to merge?" — diff-aware blast radius + ranked review risks |
-| `impact` | "What breaks if I refactor X?" — directed dependents + affected communities |
-| `call_chain` | "How does request flow from X to Y?" — shortest execution paths |
-| `community_overview` | "Show me the architecture" — communities + sizes + bridges |
-| `graph_stats` | "How big is this graph?" — node/edge counts, density, file-type mix |
-| `graph_summary` | "Give me the repo at a glance" — bounded deterministic overview of counts, domains, top modules, entrypoints, frameworks, and runtime paths |
-
-Full-profile additions: `context_pack`, `context_expand`, `context_prompt`, `context_session_reset`, `risk_map`, `implementation_checklist`, `relevant_files`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `get_neighbors`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`. Full reference: [examples/mcp-tool-examples.md](https://github.com/mohanagy/madar/blob/main/examples/mcp-tool-examples.md).
-
-Within one MCP stdio session, identical `context_pack` requests for `task=explain` are reused automatically when the graph version and relevant prompt/options match. The cache is memory-only, skips delta-session packs, and invalidates itself when `graph.json` changes.
-
-When the selected question is a runtime-generation flow, the shared compact response can also carry an `execution_slice` section with ordered steps and partial-path signaling. That gives agents a stable "what happens next" sketch without forcing them to read the full raw slice first. It is a static runtime-path hypothesis from graph evidence, not a live trace. Its nested `phase_coverage` is the same kind of static, prompt-scoped model, so broad report-generation questions can surface planner/research/report-builder/scoring/renderer/persistence phases without implying live instrumentation.
-
----
-
-## Common commands
-
-```bash
-madar generate .                          # build the graph
-madar generate . --spi                    # opt-in SPI pipeline (framework metadata + disk cache)
-madar watch .                             # rebuild on file change
-madar summary                             # bounded JSON overview before deeper retrieval
-madar pack "how does auth work?" --task explain --format text   # human-readable execution brief
-madar pack "add auth telemetry" --task implement --format json  # Pack Schema v1 for automation
-madar pack "why does auth fail?" --task explain --retrieval-strategy slice-v1
-madar prompt "how does auth work?" --provider claude     # provider-ready compiled prompt
-madar review-compare out/graph.json --exec '...' --yes  # PR review benchmark
-madar compare "How does auth work?" --exec '...' --yes           # general benchmark
-madar compare "How does auth work?" --baseline-mode pack_only --exec '...' --yes  # bounded raw context vs compiled madar pack
-madar telemetry enable                     # persist opt-in source-safe local telemetry
-madar telemetry status                     # inspect telemetry state and cache path
-madar time-travel main HEAD --view risk   # what changed between two refs
-madar federate frontend/graph.json backend/graph.json  # multi-repo merge
-madar --help                              # full surface
-```
-
----
-
-## Default discovery rules
-
-`madar generate` now hard-ignores nested VCS/worktree copies and generated/build output by default: `.worktrees/`, `worktrees/`, `.git/`, `out/`, `node_modules/`, `dist/`, `build/`, `coverage/`, cache folders, source maps, lock/build artifacts, and temp/log files.
-
-Tests, benchmarks, fixtures, mocks, and config files are **not** hard-ignored anymore. They still get indexed so retrieval can use them when you ask for them, but production/runtime prompts now soft-penalize them and honor prompt exclusions like "exclude tests, benchmarks, fixtures".
-
-`.madarignore` still adds extra ignore rules, and negated entries such as `!vendor/**` or `!lib/**` can re-include a default hard-ignore when you intentionally want it indexed.
-
----
-
-## Trust + limitations
-
-Everything stays local by default. No cloud upload, no API key required. Telemetry is disabled unless you explicitly enable it, and the current telemetry surface stores only a bounded local event log.
-
-- **Build:** tree-sitter AST extraction + Louvain community detection — all CPU-local.
-- **Query:** BM25 lexical scoring + reciprocal-rank fusion + optional ONNX embeddings (`Xenova/all-MiniLM-L6-v2`, ~25 MB) + optional cross-encoder reranker.
-- **Integration:** MCP stdio server runs as a local subprocess of your agent. Your code never crosses an HTTP boundary unless you explicitly invoke `compare` against a model you've configured yourself.
-- **Security boundary:** local-first is not the same as automatically safe. An MCP install, plugin, hook, or AGENTS profile can still steer a local agent toward sensitive files or secrets, so keep installs least-privilege and review the threat model before enabling Madar on untrusted repositories or shared machines.
-
-**Limitations to know:**
-
-1. **Cold-start sessions add a one-time MCP/tool-schema cost.** Core profile is ~3,200 bytes / ~800 tokens (still down about 25% from the original 4,270-byte surface). Multi-question sessions amortize this and end up cheaper.
-2. **Deep extraction is still best on JS/TS.** Python now has conservative cross-file import/call resolution, FastAPI router composition plus route/dependency semantics, and first-pass Django URL-conf route-to-view mapping. Go now has a conservative first-pass semantic layer for local-package imports, receiver calls, and statically visible `net/http` / Gin / Chi routes, but Python and Go are still not near JS/TS parity. Ruby / Java / Rust still use the tree-sitter AST baseline. C / Kotlin / C# / Scala / PHP / Swift / Zig use a generic structural extractor.
-3. **Static analysis can't resolve every dynamic runtime behavior.** Runtime-generated routes, heavy meta-programmed decorators, and string-built imports fall back to the base AST graph. SPI can tag common Prisma model operations and repository read/write methods so persistence-oriented prompts prefer likely storage endpoints, but that remains first-pass static coverage rather than full ORM/dataflow understanding.
-4. **Token reduction depends on project + task.** "How does auth work?" benefits more than "fix this typo." Always validate important code changes with tests and review.
-5. **Some workflows still need full file reads** — large multi-file refactors, generated-code spelunking. madar narrows the agent's first read; it doesn't replace its ability to read.
-
----
-
-## Documentation & receipts
-
-- [Quick start guide](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) — three reproducible workflows: local proof, A/B compare, federated proof
-- [Claims and evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) — which public claims are demonstrated, in progress, or not yet measured
-- [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) — local-first benchmark setup, proof-report, and procurement/security note options without a hosted control plane
-- [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) — fixed manifests, methodology, CLI runner, and per-repo spread results
-- [GoValidate shared benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/govalidate-suite/README.md) — public prompt set plus deterministic pack/answer quality gates
-- [Public roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) — contributor-facing priority tracks and issue links
-- [Language and capability matrix](https://github.com/mohanagy/madar/blob/main/docs/language-capability-matrix.md) — exactly what each file type and language gets
-- [Performance benchmark harness](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/performance/README.md) — repeatable `generate` / `update` / `cluster-only` measurements
-- [MCP tool examples](https://github.com/mohanagy/madar/blob/main/examples/mcp-tool-examples.md) — real input/output for every tool
-- [Benchmark hub](https://github.com/mohanagy/madar/tree/main/docs/benchmarks) — committed wrappers and provider-reported evidence
-- [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) — opt-in controls, collected fields, excluded fields, and local storage behavior
-- [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) — full per-release notes
-- [Contributing](https://github.com/mohanagy/madar/blob/main/CONTRIBUTING.md) · [Security](https://github.com/mohanagy/madar/blob/main/SECURITY.md)
+| Need | Link |
+| --- | --- |
+| First run | [Getting started](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md) |
+| Small demo repo | [Sample workspace](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md) |
+| Context packs, Pack Schema v1, adaptive renderings | [Context packs and task evidence](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md) |
+| CLI commands, MCP tools, agent installers | [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md) |
+| Install matrix | [Compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md) |
+| Proof workflows | [Proof workflows](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) |
+| Claims and evidence | [Claims and evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) |
+| Team and enterprise offer | [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) |
+| Benchmark suite | [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) |
+| Language coverage | [Language and capability matrix](https://github.com/mohanagy/madar/blob/main/docs/language-capability-matrix.md) |
+| Roadmap | [Public roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) |
+| Telemetry | [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) |
+| MCP Registry metadata | [`docs/mcp-registry/server.json`](https://github.com/mohanagy/madar/blob/main/docs/mcp-registry/server.json) |
+| Full release notes | [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) |
 
 ---
 
@@ -444,7 +261,7 @@ Thanks to everyone shaping madar. The list below is regenerated automatically on
 </table>
 <!-- readme: contributors -end -->
 
-A specific shout-out to [@jamemackson](https://github.com/jamemackson) for [#54](https://github.com/mohanagy/madar/pull/54) — adding OpenCode MCP installer support, the first community-contributed feature in madar.
+A specific shout-out to [@jamemackson](https://github.com/jamemackson) for [#54](https://github.com/mohanagy/madar/pull/54), adding OpenCode MCP installer support, the first community-contributed feature in madar.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Madar is deterministic local context compilation. It complements agents and IDE 
 
 ## Quickstart
 
-Madar is two steps and requires both. `madar generate` creates the local graph artifact; `madar <agent> install` wires that graph into an agent through MCP or local instruction files.
+Start with the generated graph. `madar generate` creates the local graph artifact; `madar summary`, `madar pack`, `madar prompt`, and `madar handoff` can use that graph without any agent install. Run `madar <agent> install` only when you want Madar wired into an agent through MCP or local instruction files.
 
 ```bash
 npm install -g @lubab/madar

--- a/docs/concepts/context-packs.md
+++ b/docs/concepts/context-packs.md
@@ -1,0 +1,74 @@
+# Context packs and task evidence
+
+Madar is deterministic local context compilation for the repo/task boundary. It indexes a workspace into local graph artifacts, then compiles those artifacts into a task-aware pack the agent can start from before it decides whether deeper reads are still necessary.
+
+The core distinction is simple:
+
+- Structural graphs and IDE indexes tell the agent what exists.
+- Madar compiles what runs for this task.
+- The result is a bounded context pack with evidence, coverage, missing-context notes, and expansion handles.
+
+```text
+your prompt
+  -> workspace graph built once and reused
+    -> relevant nodes + edges + snippets
+      -> compact context pack
+        -> AI coding agent
+```
+
+When the agent says "tell me more," it can expand a stable `handle_id` inside the same MCP session instead of reconstructing the same first-pass context from scratch.
+
+## Pack Schema v1
+
+`madar pack` emits a stable Pack Schema v1 envelope around the compiled evidence bundle. In JSON mode (`--format json`), the response includes `schema_version`, `task`, `task_intent`, `workflow_centers`, `recommended_first_read`, `likely_edit_files`, `likely_test_files`, `public_contracts`, `risk_boundaries`, `validation_commands`, `negative_guidance`, `confidence_score`, and `why_explanation`, alongside the existing `pack`, `coverage`, and planner metadata.
+
+For `--task implement`, `workflow_centers` are scored workflow-owner candidates with a `path`, numeric `score`, and structural `reasons`, so orchestration files can outrank lexically louder helpers when the brief recommends where to start editing.
+
+The implement brief keeps `recommended_first_read` separate from ranked `likely_edit_files` and `likely_test_files`. The edit/test sections carry explicit `score` and `reason` fields so agents can tell orientation reads apart from the files most likely to change or validate.
+
+`negative_guidance` is task-aware too: implementation packs can explicitly call out helper-like or generated files as supporting context instead of silently letting lexical matches drift into the default edit path.
+
+Use `--format json` when another tool or script will consume the pack directly. Use `--format text` when you want the same schema rendered as a short human/agent-readable execution brief.
+
+## Adaptive context-pack representations
+
+Compiled context packs have a first-pass rendering-only adaptive layer. Retrieval still selects the same nodes and paths first; the runtime only changes how those already-selected nodes are emitted for the task.
+
+That renderer is budget-aware: tighter budgets compress already-selected nodes down toward summary/signature views, while explain packs preserve full detail only when the budget is large enough to justify it.
+
+The deterministic core modes are:
+
+- `signature`
+- `behavior_sketch`
+- `call_chain`
+- `contract_view`
+- `implementation_excerpt`
+- `dependency_record`
+
+That means the same selected nodes can render differently for `explain`, `review`, and `impact` work without changing retrieval selection. Lower-token renderings carry less raw implementation detail, while explain-oriented packs keep full code snippets when the runtime already has them.
+
+## Execution slices
+
+When the selected question is a runtime-generation flow, compact responses can carry an `execution_slice` section with ordered steps and partial-path signaling. This gives agents a stable "what happens next" sketch without forcing them to read the full raw slice first.
+
+`execution_slice` is a static runtime-path hypothesis from graph evidence, not a live trace. Its nested `phase_coverage` is also a static, prompt-scoped phase model, so broad report-generation questions can surface planner/research/report-builder/scoring/renderer/persistence phases without claiming runtime tracing.
+
+Runtime-generation prompts stay compact by following the strongest backend path first and suppressing sibling-route noise plus shared-hub fan-out on broad runtime-generation questions.
+
+## When to use `--spi`
+
+`--spi` is still opt-in in `0.27.7`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+
+`--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
+
+Deepest extraction is still TypeScript/JavaScript with framework-aware passes for Express, NestJS, Next.js, React Router, Redux Toolkit, Hono, Fastify, tRPC, Prisma, and routing-controllers. Python now has conservative cross-file import/call resolution, FastAPI router composition plus route/dependency semantics, and first-pass Django URL-conf route-to-view mapping. Go has conservative local-package import resolution, receiver/method call edges, and statically visible `net/http` / Gin / Chi route relationships. Ruby, Java, and Rust still use the tree-sitter AST baseline. C / Kotlin / C# / Scala / PHP / Swift / Zig use a generic structural extractor.
+
+Full coverage details: [`docs/language-capability-matrix.md`](../language-capability-matrix.md).
+
+## Review and security workflows
+
+Madar is a local context/evidence layer for review and security workflows, not a PR reviewer or vulnerability scanner. CodeRabbit, Qodo, Codex Security, and similar tools still decide findings, policy, and remediation behavior.
+
+Madar's role is to compile a bounded local-first view of the repo or diff before those tools start broader exploration. Use `pr_impact`, `review-compare`, `madar handoff`, and `report.share-safe.json` artifacts to supply workflow ownership, likely test files, compact prompt evidence, and share-safe receipts to the review/security agent or to the human comparing multiple agents.
+
+Madar helps make those workflows more inspectable and reproducible, but it does not claim better findings than CodeRabbit, Qodo, or Codex Security today. Public positioning and benchmark claims stay grounded in [`docs/claims-and-evidence.md`](../claims-and-evidence.md).

--- a/docs/concepts/context-packs.md
+++ b/docs/concepts/context-packs.md
@@ -57,7 +57,7 @@ Runtime-generation prompts stay compact by following the strongest backend path 
 
 ## When to use `--spi`
 
-`--spi` is still opt-in in `0.27.7`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.8`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 `--spi` is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or quick first runs when you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.7",
+    "version": "0.27.8",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.7",
+            "version": "0.27.8",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -1,0 +1,98 @@
+# CLI and MCP reference
+
+This page keeps the command, installer, and MCP tool details out of the README while preserving the same local-first trust boundary.
+
+## Agent installs
+
+Madar produces local context packs that any modern coding agent can consume over MCP or by piping the compiled prompt to its CLI.
+
+| Agent | Connection | Install command | `doctor` / `status` lint surface |
+|---|---|---|---|
+| Claude Code | MCP via `.mcp.json` | `madar claude <install\|uninstall> [--profile core\|full\|strict]` | `CLAUDE.md` + `.claude/settings.json` hook + `.mcp.json` |
+| Cursor | MCP via `.cursor/mcp.json` | `madar cursor <install\|uninstall> [--profile core\|full\|strict]` | `.cursor/rules/madar.mdc` + `.cursor/mcp.json` |
+| GitHub Copilot CLI | MCP via `.vscode/mcp.json` | `madar copilot <install\|uninstall> [--profile core\|full\|strict]` | `.vscode/mcp.json` |
+| Gemini CLI | MCP server | `madar gemini <install\|uninstall> [--profile core\|full\|strict]` | `GEMINI.md` + `.gemini/settings.json` hook |
+| Aider | AGENTS.md context-pack-first profile | `madar aider install` | `AGENTS.md` Aider profile |
+| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` | `AGENTS.md` OpenCode profile + plugin registration + MCP entry |
+| Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `madar codex install` | `AGENTS.md` Codex profile + `.codex/hooks.json` |
+| Windsurf / others | Pipe `madar prompt` output | `madar prompt "..." --provider claude` | n/a |
+
+These are local installers that write project instructions and, when the platform supports it, local MCP config or plugin files that point at the Madar subprocess. No code is uploaded.
+
+After `madar generate .`, `madar doctor` and `madar status` check the local install wiring. If one of those AGENTS profiles or an expected hook/plugin/MCP file drifts, those commands mark the agent as `partial` and suggest the matching reinstall command.
+
+For the full install matrix, generated files, verification paths, profile behavior, and known limitations for both dedicated installers and `madar install --platform ...`, see the [compatibility guide](../integrations/compatibility.md).
+
+For practical multi-agent workflows across Claude Code, Codex, Copilot, Cursor, and Gemini, see the [agent orchestration guide](../integrations/agent-orchestration.md).
+
+## Strict and context-pack-first profiles
+
+Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary. Only enable it for repositories and local agent runtimes you trust. Prefer `--profile strict` when you only need the lean core MCP tools.
+
+For Claude, Cursor, Copilot, and Gemini, `--profile strict` keeps the lean core MCP tool surface but rewrites the generated guidance into a compact flow: call `context_pack` once for the task before broader exploration, answer after one high- or medium-confidence pack when `diagnostics.quality_score >= 0.5` and `missing_context` is empty, do not run broad `Glob` patterns, repo-wide `grep` / `find` searches, or raw file sweeps after that strong pack, prefer Madar over non-Madar MCPs for codebase questions unless Madar returns `agent_directive: explore_with_caution`, let that Madar guidance override conflicting auto-activated exploration skills, expand only when `missing_context` / `missing_semantic` or diagnostics justify it, and keep `out/GRAPH_REPORT.md` as a fallback-only read when the pack or graph tools are unavailable, stale, or insufficient.
+
+Aider and OpenCode are intentionally context-pack-first: run `madar generate .`, install the profile, and start broad codebase work with `madar pack "<task>" --task explain` before raw file search. `madar aider install` writes an AGENTS.md profile only; remove it with `madar aider uninstall`. `madar opencode install` writes the AGENTS.md profile, `.opencode/plugins/madar.js`, and the Madar MCP entry in `opencode.json` or `opencode.jsonc`; remove only Madar-owned content with `madar opencode uninstall`.
+
+Codex is intentionally context-pack-first too: run `madar generate .`, install with `madar codex install`, and start broad codebase work with `madar pack "<task>" --task explain` before raw file search. To remove the profile, run `madar codex uninstall`; it removes the Madar AGENTS.md section and Codex hook while preserving unrelated content.
+
+## MCP Registry metadata
+
+The checked-in public registry manifest lives at [`docs/mcp-registry/server.json`](../mcp-registry/server.json). Validate it locally with:
+
+```bash
+npm run registry:validate
+```
+
+The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json`, or let `madar <agent> install` write that wiring for you.
+
+Private registry usage stays out of scope for the public Madar listing because the official MCP Registry only accepts public package sources. Keep private or self-hosted registry workflows separate from this metadata file.
+
+## MCP tools
+
+These seven MCP tools handle the most common agent workflows in the default core profile. Start with `graph_summary` for a bounded deterministic first-turn overview, then use `retrieve` or `context_pack` when you need task-specific evidence.
+
+| Tool | When the agent uses it |
+|---|---|
+| `retrieve` | "How does X work?" - ranked nodes + code snippets + community context |
+| `pr_impact` | "Is this PR safe to merge?" - diff-aware blast radius + ranked review risks |
+| `impact` | "What breaks if I refactor X?" - directed dependents + affected communities |
+| `call_chain` | "How does request flow from X to Y?" - shortest execution paths |
+| `community_overview` | "Show me the architecture" - communities + sizes + bridges |
+| `graph_stats` | "How big is this graph?" - node/edge counts, density, file-type mix |
+| `graph_summary` | "Give me the repo at a glance" - bounded deterministic overview of counts, domains, top modules, entrypoints, frameworks, and runtime paths |
+
+The full surface is 26 tools, opt-in via `MADAR_TOOL_PROFILE=full` or `--profile full` on install. Full-profile additions: `context_pack`, `context_expand`, `context_prompt`, `context_session_reset`, `risk_map`, `implementation_checklist`, `relevant_files`, `feature_map`, `time_travel_compare`, `community_details`, `query_graph`, `get_node`, `get_neighbors`, `explain_node`, `shortest_path`, `graph_diff`, `god_nodes`, `semantic_anomalies`, `get_community`.
+
+Full request/response examples live in [`examples/mcp-tool-examples.md`](../../examples/mcp-tool-examples.md).
+
+Within one MCP stdio session, identical `context_pack` requests for `task=explain` are reused automatically when the graph version and relevant prompt/options match. The cache is memory-only, skips delta-session packs, and invalidates itself when `graph.json` changes.
+
+## Common commands
+
+```bash
+madar generate .                          # build the graph
+madar generate . --spi                    # framework metadata + disk cache
+madar watch .                             # rebuild on file change
+madar summary                             # bounded JSON overview
+madar pack "how does auth work?" --task explain --format text
+madar pack "add auth telemetry" --task implement --format json
+madar pack "why does auth fail?" --task explain --retrieval-strategy slice-v1
+madar prompt "how does auth work?" --provider claude
+madar handoff "add auth telemetry" --task implement --consumer copilot
+madar review-compare out/graph.json --exec '...' --yes
+madar compare "How does auth work?" --exec '...' --yes
+madar compare "How does auth work?" --baseline-mode pack_only --exec '...' --yes
+madar telemetry enable
+madar telemetry status
+madar time-travel main HEAD --view risk
+madar federate frontend/graph.json backend/graph.json
+madar --help
+```
+
+## Default discovery rules
+
+`madar generate` hard-ignores nested VCS/worktree copies and generated/build output by default: `.worktrees/`, `worktrees/`, `.git/`, `out/`, `node_modules/`, `dist/`, `build/`, `coverage/`, cache folders, source maps, lock/build artifacts, and temp/log files.
+
+Tests, benchmarks, fixtures, mocks, and config files are not hard-ignored. They still get indexed so retrieval can use them when you ask for them, but production/runtime prompts soft-penalize them and honor prompt exclusions like "exclude tests, benchmarks, fixtures".
+
+`.madarignore` adds extra ignore rules, and negated entries such as `!vendor/**` or `!lib/**` can re-include a default hard-ignore when you intentionally want it indexed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.7",
+    "version": "0.27.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.7",
+            "version": "0.27.8",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.7",
+    "version": "0.27.8",
     "description": "Local task-aware context packs for AI coding agents. Start from what runs for this task and turn TypeScript/Node workspaces plus PR diffs into compact, verifiable context packs for Claude Code, Codex, Copilot, Cursor, and other agents.",
     "license": "MIT",
     "author": "mohanagy",

--- a/tests/unit/install-docs.test.ts
+++ b/tests/unit/install-docs.test.ts
@@ -5,27 +5,27 @@ import { describe, expect, it } from 'vitest'
 
 describe('install documentation', () => {
   it('documents Aider and OpenCode install artifacts and context-pack-first workflow', () => {
-    const readme = readFileSync(resolve('README.md'), 'utf8')
+    const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
-    expect(readme).toContain('| Aider | AGENTS.md context-pack-first profile | `madar aider install` |')
-    expect(readme).toContain(
+    expect(reference).toContain('| Aider | AGENTS.md context-pack-first profile | `madar aider install` |')
+    expect(reference).toContain(
       '| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` |',
     )
-    expect(readme).toContain('Aider and OpenCode are intentionally context-pack-first')
-    expect(readme).toContain('madar pack "<task>" --task explain')
-    expect(readme).toContain('madar aider uninstall')
-    expect(readme).toContain('madar opencode uninstall')
+    expect(reference).toContain('Aider and OpenCode are intentionally context-pack-first')
+    expect(reference).toContain('madar pack "<task>" --task explain')
+    expect(reference).toContain('madar aider uninstall')
+    expect(reference).toContain('madar opencode uninstall')
   })
 
   it('documents doctor/status instruction lint surfaces per agent', () => {
-    const readme = readFileSync(resolve('README.md'), 'utf8')
+    const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
-    expect(readme).toContain('`doctor` / `status` lint surface')
-    expect(readme).toContain('| Claude Code | MCP via `.mcp.json` | `madar claude <install\\|uninstall> [--profile core\\|full\\|strict]` | `CLAUDE.md` + `.claude/settings.json` hook + `.mcp.json` |')
-    expect(readme).toContain('| Aider | AGENTS.md context-pack-first profile | `madar aider install` | `AGENTS.md` Aider profile |')
-    expect(readme).toContain('| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` | `AGENTS.md` OpenCode profile + plugin registration + MCP entry |')
-    expect(readme).toContain('| Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `madar codex install` | `AGENTS.md` Codex profile + `.codex/hooks.json` |')
-    expect(readme).toContain('mark the agent as `partial` and suggest the matching reinstall command')
+    expect(reference).toContain('`doctor` / `status` lint surface')
+    expect(reference).toContain('| Claude Code | MCP via `.mcp.json` | `madar claude <install\\|uninstall> [--profile core\\|full\\|strict]` | `CLAUDE.md` + `.claude/settings.json` hook + `.mcp.json` |')
+    expect(reference).toContain('| Aider | AGENTS.md context-pack-first profile | `madar aider install` | `AGENTS.md` Aider profile |')
+    expect(reference).toContain('| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` | `AGENTS.md` OpenCode profile + plugin registration + MCP entry |')
+    expect(reference).toContain('| Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `madar codex install` | `AGENTS.md` Codex profile + `.codex/hooks.json` |')
+    expect(reference).toContain('mark the agent as `partial` and suggest the matching reinstall command')
   })
 
   it('documents handoff as the share-safe remote-agent artifact distinct from local pack and prompt flows', () => {
@@ -38,16 +38,16 @@ describe('install documentation', () => {
   })
 
   it('documents the strict MCP install profile for claude, cursor, copilot, and gemini', () => {
-    const readme = readFileSync(resolve('README.md'), 'utf8')
+    const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
-    expect(readme).toContain('claude <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(readme).toContain('cursor <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(readme).toContain('copilot <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(readme).toContain('gemini <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(readme).toContain('`--profile strict` keeps the lean core MCP tool surface')
-    expect(readme).toContain('call `context_pack` once for the task before broader exploration')
-    expect(readme).toContain('prefer Madar over non-Madar MCPs for codebase questions')
-    expect(readme).toContain('override conflicting auto-activated exploration skills')
+    expect(reference).toContain('claude <install\\|uninstall> [--profile core\\|full\\|strict]')
+    expect(reference).toContain('cursor <install\\|uninstall> [--profile core\\|full\\|strict]')
+    expect(reference).toContain('copilot <install\\|uninstall> [--profile core\\|full\\|strict]')
+    expect(reference).toContain('gemini <install\\|uninstall> [--profile core\\|full\\|strict]')
+    expect(reference).toContain('`--profile strict` keeps the lean core MCP tool surface')
+    expect(reference).toContain('call `context_pack` once for the task before broader exploration')
+    expect(reference).toContain('prefer Madar over non-Madar MCPs for codebase questions')
+    expect(reference).toContain('override conflicting auto-activated exploration skills')
   })
 
   it('documents the local trust boundary and least-privilege install guidance', () => {

--- a/tests/unit/install-docs.test.ts
+++ b/tests/unit/install-docs.test.ts
@@ -7,11 +7,14 @@ describe('install documentation', () => {
   it('documents Aider and OpenCode install artifacts and context-pack-first workflow', () => {
     const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
-    expect(reference).toContain('| Aider | AGENTS.md context-pack-first profile | `madar aider install` |')
-    expect(reference).toContain(
-      '| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` |',
-    )
-    expect(reference).toContain('Aider and OpenCode are intentionally context-pack-first')
+    expect(reference).toContain('Aider')
+    expect(reference).toContain('AGENTS.md context-pack-first profile')
+    expect(reference).toContain('madar aider install')
+    expect(reference).toContain('OpenCode')
+    expect(reference).toContain('.opencode/plugins/madar.js')
+    expect(reference).toContain('opencode.json')
+    expect(reference).toContain('madar opencode install')
+    expect(reference).toContain('context-pack-first')
     expect(reference).toContain('madar pack "<task>" --task explain')
     expect(reference).toContain('madar aider uninstall')
     expect(reference).toContain('madar opencode uninstall')
@@ -21,10 +24,18 @@ describe('install documentation', () => {
     const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
     expect(reference).toContain('`doctor` / `status` lint surface')
-    expect(reference).toContain('| Claude Code | MCP via `.mcp.json` | `madar claude <install\\|uninstall> [--profile core\\|full\\|strict]` | `CLAUDE.md` + `.claude/settings.json` hook + `.mcp.json` |')
-    expect(reference).toContain('| Aider | AGENTS.md context-pack-first profile | `madar aider install` | `AGENTS.md` Aider profile |')
-    expect(reference).toContain('| OpenCode | AGENTS.md + `.opencode/plugins/madar.js` + MCP via `opencode.json` / `opencode.jsonc` | `madar opencode install` | `AGENTS.md` OpenCode profile + plugin registration + MCP entry |')
-    expect(reference).toContain('| Codex CLI | AGENTS.md + `.codex/hooks.json` context-pack-first profile | `madar codex install` | `AGENTS.md` Codex profile + `.codex/hooks.json` |')
+    expect(reference).toContain('Claude Code')
+    expect(reference).toContain('madar claude <install\\|uninstall>')
+    expect(reference).toContain('CLAUDE.md')
+    expect(reference).toContain('.claude/settings.json')
+    expect(reference).toContain('.mcp.json')
+    expect(reference).toContain('Aider profile')
+    expect(reference).toContain('OpenCode profile')
+    expect(reference).toContain('plugin registration')
+    expect(reference).toContain('MCP entry')
+    expect(reference).toContain('Codex CLI')
+    expect(reference).toContain('madar codex install')
+    expect(reference).toContain('.codex/hooks.json')
     expect(reference).toContain('mark the agent as `partial` and suggest the matching reinstall command')
   })
 
@@ -40,10 +51,11 @@ describe('install documentation', () => {
   it('documents the strict MCP install profile for claude, cursor, copilot, and gemini', () => {
     const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
-    expect(reference).toContain('claude <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(reference).toContain('cursor <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(reference).toContain('copilot <install\\|uninstall> [--profile core\\|full\\|strict]')
-    expect(reference).toContain('gemini <install\\|uninstall> [--profile core\\|full\\|strict]')
+    for (const agent of ['claude', 'cursor', 'copilot', 'gemini']) {
+      expect(reference).toContain(`${agent} <install\\|uninstall>`)
+    }
+
+    expect(reference).toContain('[--profile core\\|full\\|strict]')
     expect(reference).toContain('`--profile strict` keeps the lean core MCP tool surface')
     expect(reference).toContain('call `context_pack` once for the task before broader exploration')
     expect(reference).toContain('prefer Madar over non-Madar MCPs for codebase questions')

--- a/tests/unit/mcp-registry-metadata.test.ts
+++ b/tests/unit/mcp-registry-metadata.test.ts
@@ -155,13 +155,13 @@ describe('MCP Registry metadata', () => {
   })
 
   it('documents the public-registry decision, validation command, and local-first trust boundary', () => {
-    const readme = readFileSync(resolve('README.md'), 'utf8')
+    const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
     const releaseDoc = readFileSync(resolve('docs/release.md'), 'utf8')
 
-    expect(readme).toContain('docs/mcp-registry/server.json')
-    expect(readme).toContain('npm run registry:validate')
-    expect(readme).toContain('The official MCP Registry hosts metadata, not Madar code or your local graph artifact.')
-    expect(readme).toContain('Private registry usage stays out of scope for the public Madar listing')
+    expect(reference).toContain('docs/mcp-registry/server.json')
+    expect(reference).toContain('npm run registry:validate')
+    expect(reference).toContain('The official MCP Registry hosts metadata, not Madar code or your local graph artifact.')
+    expect(reference).toContain('Private registry usage stays out of scope for the public Madar listing')
     expect(releaseDoc).toContain('npm run registry:validate')
   })
 })

--- a/tests/unit/why-madar-doc.test.ts
+++ b/tests/unit/why-madar-doc.test.ts
@@ -39,6 +39,11 @@ describe('public marketing copy honesty', () => {
   describe('README.md', () => {
     const content = readDoc('README.md')
     const lower = content.toLowerCase()
+    const contextPacks = readDoc('docs/concepts/context-packs.md')
+    const cliReference = readDoc('docs/reference/cli-and-mcp.md')
+    const claims = readDoc('docs/claims-and-evidence.md')
+    const publicDocs = [content, contextPacks, cliReference, claims].join('\n')
+    const publicLower = publicDocs.toLowerCase()
 
     for (const stale of STALE_PHRASES) {
       it(`does not contain the stale "${stale}" claim`, () => {
@@ -71,16 +76,16 @@ describe('public marketing copy honesty', () => {
     })
 
     it('describes execution_slice as a static hypothesis rather than a live trace', () => {
-      expect(lower).toMatch(
+      expect(publicLower).toMatch(
         /execution_slice[\s\S]{0,220}static runtime-path hypothesis[\s\S]{0,220}not a live trace/i,
       )
     })
 
     it('describes phase_coverage as a static prompt-scoped phase model', () => {
-      expect(lower).toMatch(
+      expect(publicLower).toMatch(
         /phase_coverage[\s\S]{0,260}static[\s\S]{0,120}prompt-scoped/i,
       )
-      expect(lower).toMatch(
+      expect(publicLower).toMatch(
         /phase_coverage[\s\S]{0,260}planner\/research\/report-builder\/scoring\/renderer\/persistence/i,
       )
     })
@@ -102,22 +107,21 @@ describe('public marketing copy honesty', () => {
     })
 
     it('keeps the README core MCP surface aligned with the shipped graph_summary tool', () => {
-      expect(content).toContain('These seven MCP tools')
-      expect(content).toContain('`graph_stats`')
-      expect(content).toContain('`graph_summary`')
+      expect(publicDocs).toContain('These seven MCP tools')
+      expect(publicDocs).toContain('`graph_stats`')
+      expect(publicDocs).toContain('`graph_summary`')
     })
 
     it('states that core is the default MCP profile and full is opt-in', () => {
-      expect(lower).toContain('by default')
-      expect(content).toContain('core')
-      expect(content).toContain('MADAR_TOOL_PROFILE=full')
-      expect(content).toContain('--profile full')
+      expect(publicLower).toContain('default core profile')
+      expect(publicDocs).toContain('MADAR_TOOL_PROFILE=full')
+      expect(publicDocs).toContain('--profile full')
     })
 
     it('keeps the README full MCP additions list aligned with the shipped get_neighbors tool', () => {
-      expect(content).toContain('The full surface is 26 tools')
-      expect(content).toContain('`context_expand`')
-      expect(content).toContain('`get_neighbors`')
+      expect(publicDocs).toContain('The full surface is 26 tools')
+      expect(publicDocs).toContain('`context_expand`')
+      expect(publicDocs).toContain('`get_neighbors`')
     })
 
     it('pins the measured post-#82 core-profile schema overhead numbers in the Honest disclosure section', () => {
@@ -131,14 +135,13 @@ describe('public marketing copy honesty', () => {
       expect(lower).toMatch(/25%/)
     })
 
-    it('adds explicit claim buckets and a measurement methodology section', () => {
-      expect(content).toContain('## Demonstrated today')
-      expect(content).toContain('## In progress')
-      expect(content).toContain('## Not yet measured')
-      expect(content).toContain('## What Madar does not do today')
-      expect(content).toContain('## How we measure')
-      expect(lower).toContain('per-repo spread')
-      expect(lower).toContain('no single-number cross-repo headline')
+    it('keeps claim buckets and measurement methodology in the evidence docs, with a compact README pointer', () => {
+      expect(claims).toContain('## Demonstrated today')
+      expect(claims).toContain('## In progress')
+      expect(claims).toContain('## Not yet measured')
+      expect(claims).toContain('How this maps to README.md')
+      expect(publicLower).toContain('per-repo spread')
+      expect(publicLower).toContain('no single-number cross-repo headline')
       expect(content).toContain('Published benchmark cells run in isolation mode')
       expect(content).toContain('Your local numbers may differ if your Claude Code config differs.')
     })
@@ -150,12 +153,12 @@ describe('public marketing copy honesty', () => {
     })
 
     it('positions Madar as a context/evidence layer for review and security tools without overclaiming outcomes', () => {
-      expect(lower).toContain('review and security workflows')
-      expect(lower).toContain('context/evidence layer')
-      expect(content).toContain('CodeRabbit')
-      expect(content).toContain('Qodo')
-      expect(content).toContain('Codex Security')
-      expect(lower).toContain('not a pr reviewer or vulnerability scanner')
+      expect(publicLower).toContain('review and security workflows')
+      expect(publicLower).toContain('context/evidence layer')
+      expect(publicDocs).toContain('CodeRabbit')
+      expect(publicDocs).toContain('Qodo')
+      expect(publicDocs).toContain('Codex Security')
+      expect(publicLower).toContain('not a pr reviewer or vulnerability scanner')
       expect(content).toContain('docs/claims-and-evidence.md')
     })
 
@@ -178,9 +181,9 @@ describe('public marketing copy honesty', () => {
     })
 
     it('keeps the README Python support claim conservative and current', () => {
-      expect(content).toContain('FastAPI router composition')
-      expect(content).toContain('Django URL-conf')
-      expect(lower).toContain('not near js/ts parity')
+      expect(publicDocs).toContain('FastAPI router composition')
+      expect(publicDocs).toContain('Django URL-conf')
+      expect(publicLower).toContain('not near js/ts parity')
     })
   })
 


### PR DESCRIPTION
## Summary
- Bump package, lockfile, changelog, and MCP Registry metadata to 0.27.8.
- Refactor README into a shorter npm-facing landing page and remove the demo section.
- Move long-form context-pack and CLI/MCP reference details into dedicated docs.
- Update doc tests to assert the moved content in the new docs.

## Testing
- npm run typecheck
- npm run test:run
- npm run release:verify
- npm run registry:validate
- npm run build
- npm audit --omit=dev
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured README into a concise npm-facing landing page with an updated quickstart and agent guidance.
  * Added dedicated docs for context-packs and CLI/MCP usage; consolidated documentation links and trust/limits guidance.
  * Clarified telemetry docs with explicit environment-variable examples and updated “What’s New”.

* **Tests**
  * Updated documentation-focused tests to validate the new docs corpus and CLI/MCP guidance.

* **Chores**
  * Version bumped to 0.27.8 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->