### PR TITLE
Fix Windows-safe Claude submit hooks

### DIFF
--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -116,17 +116,17 @@ const PLATFORM_CONFIG: Record<SkillInstallPlatform, InstallPlatformConfig> = {
   },
 }
 
-// Cross-platform hook: base64-encodes JSON payloads so the node -e command has
-// zero special shell characters. Works on macOS, Linux, and Windows (PowerShell/CMD).
+// Cross-platform hook: pass the base64 payload as an argv argument so the
+// node -e command stays shell-neutral on macOS, Linux, and Windows.
 function hookCommand(payloadJson: string): string {
   const b64 = Buffer.from(payloadJson).toString('base64')
-  return `node -e "try{require('fs').accessSync('out/graph.json');process.stdout.write(Buffer.from('${b64}','base64').toString())}catch(e){}"`
+  return `node -e "try{require('fs').accessSync('out/graph.json');process.stdout.write(Buffer.from(process.argv[1],'base64').toString())}catch(e){}" "${b64}"`
 }
 
 function hookCommandWithFallback(matchJson: string, missJson: string): string {
   const b64Match = Buffer.from(matchJson).toString('base64')
   const b64Miss = Buffer.from(missJson).toString('base64')
-  return `node -e "var f;try{require('fs').accessSync('out/graph.json');f='${b64Match}'}catch(e){f='${b64Miss}'}process.stdout.write(Buffer.from(f,'base64').toString())"`
+  return `node -e "var f;try{require('fs').accessSync('out/graph.json');f=process.argv[1]}catch(e){f=process.argv[2]}process.stdout.write(Buffer.from(f,'base64').toString())" "${b64Match}" "${b64Miss}"`
 }
 
 function decodeGeneratedHookPayloads(command: string): string[] {
@@ -140,8 +140,8 @@ function decodeGeneratedHookPayloads(command: string): string[] {
       continue
     }
 
-    for (const match of current.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)) {
-      const value = match[1]
+    for (const match of current.matchAll(/(['"])([A-Za-z0-9+/=]{40,})\1/g)) {
+      const value = match[2]
       if (typeof value !== 'string' || seen.has(value)) {
         continue
       }

--- a/src/runtime/task-applicability.ts
+++ b/src/runtime/task-applicability.ts
@@ -549,5 +549,5 @@ process.stdin.on('end', () => {
 `
 
   const b64Source = Buffer.from(source, 'utf8').toString('base64')
-  return `node -e "eval(Buffer.from('${b64Source}','base64').toString('utf8'))"`
+  return `node -e "eval(Buffer.from(process.argv[1],'base64').toString('utf8'))" "${b64Source}"`
 }

--- a/tests/unit/install-templates.test.ts
+++ b/tests/unit/install-templates.test.ts
@@ -41,8 +41,8 @@ function decodeHookPayload(settingsJson: string): string {
       continue
     }
 
-    for (const match of current.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)) {
-      const value = match[1]
+    for (const match of current.matchAll(/(['"])([A-Za-z0-9+/=]{40,})\1/g)) {
+      const value = match[2]
       if (typeof value !== 'string' || seen.has(value)) {
         continue
       }

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -198,7 +198,7 @@ function decodeHookPayloads(content: string): string {
       continue
     }
 
-    for (const match of current.matchAll(/'([A-Za-z0-9+/=]{40,})'/g)) {
+    for (const match of current.matchAll(/(?:['\"])?([A-Za-z0-9+/=]{40,})(?:['\"])?/g)) {
       const value = match[1]
       if (typeof value !== 'string' || seen.has(value)) {
         continue
@@ -637,6 +637,21 @@ describe('install helpers', () => {
       })
 
       expect(output).toBe('')
+    })
+  })
+
+  it('uses argv-based Node hook commands to stay shell-safe on Windows', () => {
+    withTempDir((projectDir) => {
+      mkdirSync(join(projectDir, 'out'), { recursive: true })
+      writeFileSync(join(projectDir, 'out', 'graph.json'), '{}', 'utf8')
+      claudeInstall(projectDir)
+
+      const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
+      const command = extractHookCommand(settings, 'UserPromptSubmit')
+
+      expect(command).toContain('process.argv[1]')
+      expect(command).toMatch(/"\s*[A-Za-z0-9+/=]{40,}\s*"$/)
+      expect(command).not.toContain('\\"')
     })
   })
 


### PR DESCRIPTION
Switch the Claude UserPromptSubmit hook and related hook builders to pass base64 payloads as argv arguments instead of embedding them in shell-escaped inline strings. This avoids the Windows shell parse failure and keeps the hook behavior unchanged otherwise.\n\nVerification: npm run typecheck && npm run build && CI=1 npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved cross-platform shell compatibility for hook command execution by refining payload delivery mechanisms.
* Enhanced robustness of command parsing to handle multiple quoting style variations, ensuring consistent behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->