### PR TITLE
Prepare 0.27.9-next.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.9-next.1] - 2026-06-03
+
+### Fixed
+
+- **Windows Claude submit hooks are now shell-safe**: the generated `UserPromptSubmit` hook and related payload builders now pass base64 data through argv instead of embedding it in shell-quoted inline JavaScript, avoiding the Windows `unexpected eof while looking for matching` failure.
+
 ## [0.27.9-next.0] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ The current telemetry model is local-first and source-safe. It records coarse fu
 
 ## What's New
 
-See the [`0.27.9-next.0` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next0---2026-06-03) for the full release notes.
+See the [`0.27.9-next.1` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next1---2026-06-03) for the full release notes.
 
 Recent highlights:
 
-- `0.27.9-next.0` is the current next-track adoption release: it bundles the public benchmark suite, one-command `madar try` proof flow, opt-in funnel telemetry, verified agent quickstarts, design-partner loop, and launch checklist from issues #469-#474.
-- `0.27.9-next.0` also adds scoped graph freshness and stale-context guarantees across `madar pack`, `madar prompt`, `madar handoff`, `madar doctor`, and `madar status`, backed by the tightened git/diff freshness model from #477 and #479.
+- `0.27.9-next.1` is the current next-track adoption release: it bundles the public benchmark suite, one-command `madar try` proof flow, opt-in funnel telemetry, verified agent quickstarts, design-partner loop, launch checklist from issues #469-#474, and the Windows-safe Claude submit-hook fix.
+- `0.27.9-next.0` also added scoped graph freshness and stale-context guarantees across `madar pack`, `madar prompt`, `madar handoff`, `madar doctor`, and `madar status`, backed by the tightened git/diff freshness model from #477 and #479.
 - `0.27.8` refactors the README into a shorter npm-facing landing page and moves long-form Pack Schema, context-pack, MCP, installer, command, and discovery-rule details into dedicated docs.
 - `0.27.7` added the checked-in federation flagship proof: a reproducible frontend/backend/shared fixture plus a synthetic federation receipt.
 - Roadmap docs now cover design-partner workflow loops, plugin distribution channels, and language-expansion decisions.
@@ -145,7 +145,7 @@ Recent highlights:
 
 ## When To Use `--spi`
 
-`--spi` is still opt-in in `0.27.9-next.0`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.9-next.1`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.9-next.0",
+    "version": "0.27.9-next.1",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.9-next.0",
+            "version": "0.27.9-next.1",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.0",
+    "version": "0.27.9-next.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.9-next.0",
+            "version": "0.27.9-next.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.0",
+    "version": "0.27.9-next.1",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary\n- Bump package.json and package-lock.json to 0.27.9-next.1\n- Add a changelog entry for the Windows-safe Claude submit-hook fix\n- Refresh the README next-release links and highlights\n- Align the checked-in MCP registry manifest with the new version\n\n## Testing\n- npm run release:verify\n- CI=1 npm run test:run -- tests/unit/mcp-registry-metadata.test.ts\n- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows compatibility issue affecting Claude submit hooks and payload builders.

* **Chores**
  * Version bumped to 0.27.9-next.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->