### PR TITLE
chore: prepare 0.27.9-next.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.9-next.2] - 2026-06-03
+
+### Fixed
+
+- **Windows cmd.exe command-line length limit is now respected**: the generated `UserPromptSubmit` hook has been aggressively minified to fit within Windows cmd.exe's 8,191 character limit, resolving the `unexpected eof while looking for matching` shell parse failure on Windows systems.
+
 ## [0.27.9-next.1] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,11 +129,12 @@ The current telemetry model is local-first and source-safe. It records coarse fu
 
 ## What's New
 
-See the [`0.27.9-next.1` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next1---2026-06-03) for the full release notes.
+See the [`0.27.9-next.2` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next2---2026-06-03) for the full release notes.
 
 Recent highlights:
 
-- `0.27.9-next.1` is the current next-track adoption release: it bundles the public benchmark suite, one-command `madar try` proof flow, opt-in funnel telemetry, verified agent quickstarts, design-partner loop, launch checklist from issues #469-#474, and the Windows-safe Claude submit-hook fix.
+- `0.27.9-next.2` fixes the Windows cmd.exe command-line length limit issue by aggressively minifying the hook source code, ensuring the `UserPromptSubmit` hook executes successfully on Windows systems.
+- `0.27.9-next.1` is the prior next-track adoption release: it bundles the public benchmark suite, one-command `madar try` proof flow, opt-in funnel telemetry, verified agent quickstarts, design-partner loop, launch checklist from issues #469-#474, and the Windows-safe Claude submit-hook fix.
 - `0.27.9-next.0` also added scoped graph freshness and stale-context guarantees across `madar pack`, `madar prompt`, `madar handoff`, `madar doctor`, and `madar status`, backed by the tightened git/diff freshness model from #477 and #479.
 - `0.27.8` refactors the README into a shorter npm-facing landing page and moves long-form Pack Schema, context-pack, MCP, installer, command, and discovery-rule details into dedicated docs.
 - `0.27.7` added the checked-in federation flagship proof: a reproducible frontend/backend/shared fixture plus a synthetic federation receipt.
@@ -145,7 +146,7 @@ Recent highlights:
 
 ## When To Use `--spi`
 
-`--spi` is still opt-in in `0.27.9-next.1`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.9-next.2`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.9-next.1",
+    "version": "0.27.9-next.2",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.9-next.1",
+            "version": "0.27.9-next.2",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.1",
+    "version": "0.27.9-next.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.9-next.1",
+            "version": "0.27.9-next.2",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.1",
+    "version": "0.27.9-next.2",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Release: 0.27.9-next.2

This release prepares the next prerelease for 0.27.9-next.2 with the Windows cmd.exe command-line length limit fix.

### Changes

- **CHANGELOG.md**: Added entry for Windows cmd.exe 8,191 character limit fix
- **README.md**: Updated highlights and version references to 0.27.9-next.2
- **package.json/package-lock.json**: Bumped version to 0.27.9-next.2
- **docs/mcp-registry/server.json**: Synced MCP registry metadata

### What's Fixed

The generated `UserPromptSubmit` hook has been aggressively minified to fit within Windows cmd.exe's 8,191 character limit, resolving the 'unexpected eof while looking for matching' shell parse failure on Windows systems.

All tests pass and release hygiene verification completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows command-line parsing failures caused by exceeding shell command-line length limits, preventing successful command execution on Windows systems.

* **Chores**
  * Version bumped to 0.27.9-next.2.
  * Updated changelog documenting resolved issues and release improvements.
  * Updated README and registry metadata with latest version information and release highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->