### PR TITLE
fix: replace Claude prompt hook with generated script

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -8,7 +8,7 @@ import { KnowledgeGraph } from '../contracts/graph.js'
 import type { ContextSessionDiagnostics, ContextSessionState } from '../contracts/context-session.js'
 import { buildContextPrompt, type ContextPromptStableSection } from './context-prompt.js'
 import { buildAnswerReadyPackSchema, buildExplainPackPayloadCore } from './context-pack-command.js'
-import { isMadarProjectHook } from './install.js'
+import { CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH, isMadarProjectHook } from './install.js'
 import { CODE_EXTENSIONS, DOC_EXTENSIONS, MANIFEST_METADATA_KEY, OFFICE_EXTENSIONS, PAPER_EXTENSIONS } from '../pipeline/detect.js'
 import { extractCompareBaselineNonCodeText } from '../pipeline/extract/non-code.js'
 import { loadBenchmarkQuestions } from './benchmark/questions.js'
@@ -3160,6 +3160,8 @@ export function inspectClaudeNativeAgentInstall(projectRoot: string): NativeAgen
   const mcpPath = join(projectRoot, '.mcp.json')
   const claudeRulesPath = join(projectRoot, 'CLAUDE.md')
   const settingsPath = join(projectRoot, '.claude', 'settings.json')
+  const promptHookScriptPath = join(projectRoot, CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH)
+  const hasUserPromptSubmitHook = findHookEntry(settingsPath, 'UserPromptSubmit')
   const artifacts: NativeAgentInstallArtifactCheck[] = [
     {
       label: '.mcp.json',
@@ -3181,6 +3183,12 @@ export function inspectClaudeNativeAgentInstall(projectRoot: string): NativeAgen
         || findHookEntry(settingsPath, 'BeforeTool'),
       detail: '.claude/settings.json missing Madar hook',
       path: settingsPath,
+    },
+    {
+      label: CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH,
+      ok: !hasUserPromptSubmitHook || existsSync(promptHookScriptPath),
+      detail: `${CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH} missing generated Claude prompt hook script`,
+      path: promptHookScriptPath,
     },
   ]
 

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -8,7 +8,7 @@ import {
   renderPlainCodexRoutingGuide,
   renderPlainMcpRoutingGuide,
 } from './install-routing-guidance.js'
-import { buildPromptApplicabilityHookCommand } from '../runtime/task-applicability.js'
+import { buildPromptApplicabilityHookScript } from '../runtime/task-applicability.js'
 import {
   findPackageRoot as resolvePackageRoot,
   readPackageName as resolvePackageName,
@@ -34,6 +34,8 @@ export const INSTALL_PROFILES = [...MCP_TOOL_PROFILES, 'strict'] as const
 export type InstallProfile = (typeof INSTALL_PROFILES)[number]
 const MANAGED_HOOK_NAME = 'madar'
 const MANAGED_HOOK_SOURCE = 'madar'
+export const CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH = '.claude/madar-user-prompt-submit.cjs'
+const CLAUDE_PROMPT_HOOK_COMMAND = `node ${CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH}`
 
 interface InstallPlatformConfig {
   skillFile: string
@@ -632,18 +634,28 @@ function settingsHook(profile?: InstallProfile): Record<string, unknown> {
     hooks: [
       {
         type: 'command',
-        command: buildPromptApplicabilityHookCommand(
-          JSON.stringify({
-            hookSpecificOutput: {
-              hookEventName: 'UserPromptSubmit',
-              additionalContext: profile === 'strict' ? STRICT_CONTEXT_PACK_MESSAGE : RETRIEVE_FIRST_MESSAGE,
-            },
-          }),
-          'UserPromptSubmit',
-        ),
+        command: CLAUDE_PROMPT_HOOK_COMMAND,
       },
     ],
   })
+}
+
+function writeClaudePromptHookScript(projectDir: string, profile?: InstallProfile): void {
+  const hookScriptPath = join(projectDir, CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH)
+  mkdirSync(dirname(hookScriptPath), { recursive: true })
+  writeFileSync(
+    hookScriptPath,
+    buildPromptApplicabilityHookScript(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'UserPromptSubmit',
+          additionalContext: profile === 'strict' ? STRICT_CONTEXT_PACK_MESSAGE : RETRIEVE_FIRST_MESSAGE,
+        },
+      }),
+      'UserPromptSubmit',
+    ),
+    'utf8',
+  )
 }
 
 function geminiHook(profile?: InstallProfile): Record<string, unknown> {
@@ -1672,6 +1684,8 @@ function installClaudeHook(projectDir: string, profile?: InstallProfile): string
   const userPromptSubmit = ensureArray(hooks, 'UserPromptSubmit')
   const preToolUse = ensureArray(hooks, 'PreToolUse')
 
+  writeClaudePromptHookScript(projectDir, profile)
+
   const existingIndex = userPromptSubmit.findIndex((hook) => isMadarProjectHook(hook))
   if (existingIndex >= 0) {
     userPromptSubmit[existingIndex] = settingsHook(profile)
@@ -1687,9 +1701,13 @@ function installClaudeHook(projectDir: string, profile?: InstallProfile): string
 }
 
 function uninstallClaudeHook(projectDir: string): string | undefined {
+  const hookScriptPath = join(projectDir, CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH)
+  const removedHookScript = existsSync(hookScriptPath)
+  rmSync(hookScriptPath, { force: true })
+
   const settingsPath = join(projectDir, '.claude', 'settings.json')
   if (!existsSync(settingsPath)) {
-    return undefined
+    return removedHookScript ? `${CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH} -> hook script removed` : undefined
   }
 
   const settings = readJsonObject(settingsPath)
@@ -1700,7 +1718,7 @@ function uninstallClaudeHook(projectDir: string): string | undefined {
   const filteredPreToolUse = preToolUse.filter((hook) => !isMadarProjectHook(hook, 'Glob|Grep|Bash|Agent|Read'))
 
   if (filteredUserPromptSubmit.length === userPromptSubmit.length && filteredPreToolUse.length === preToolUse.length) {
-    return undefined
+    return removedHookScript ? `${CLAUDE_PROMPT_HOOK_SCRIPT_RELATIVE_PATH} -> hook script removed` : undefined
   }
 
   hooks.UserPromptSubmit = filteredUserPromptSubmit

--- a/src/runtime/task-applicability.ts
+++ b/src/runtime/task-applicability.ts
@@ -356,15 +356,194 @@ export function formatTaskApplicabilityDebugMessage(classification: TaskApplicab
   return `Skipped Madar: task is ${TASK_APPLICABILITY_REASON_LABELS[classification.reason]}, not local codebase context.`
 }
 
-export function buildPromptApplicabilityHookCommand(
+export function buildPromptApplicabilityHookScript(
   matchPayloadJson: string,
   hookEventName: string,
 ): string {
-  const b64MatchPayload = Buffer.from(matchPayloadJson).toString('base64')
-  const b64HookConfig = Buffer.from(JSON.stringify(HOOK_CONFIG)).toString('base64')
-  // Heavily minified for Windows cmd.exe 8191 char limit
-  const source = `const fs=require('fs'),cfg=JSON.parse(Buffer.from('${b64HookConfig}','base64').toString('utf8')),mp=Buffer.from('${b64MatchPayload}','base64').toString('utf8'),fRe=/(?:^|\\s)(?:[\\w@\\.\\/-]+\\/)*[\\w.\\/@-]+\\.[A-Za-z]{1,8}(?=\\b|$)/i,uRe=/https?:\\/\\/\\S+/i,gRe=/https?:\\/\\/github\\.com\\/.*\\/projects\\/\\d+/i,pRe=/https?:\\/\\/(?:npmjs|socket|snyk|packagephobia)/i;let inp='';const norm=p=>String(p||'').toLowerCase().replace(/[^a-z0-9]+/g,' ').trim().replace(/\\s+/g,' '),has=(np,t)=>{const nt=norm(t);return np&&nt?(' '+np+' ').includes(' '+nt+' '):false},mat=(np,ts)=>[...new Set(ts.map(norm).filter(t=>has(np,t)))].sort(),local=(p,np)=>{const mt=mat(np,cfg.local_code_terms),hf=fRe.test(p);return{detected:mt.length>0||hf,matched_terms:hf?[...new Set([...mt,'file path'])].sort():mt}},neg=(p,np)=>{if(gRe.test(p))return{reason:'github_project',matched_terms:['github project url']};let x=mat(np,cfg.github_project_terms);if(x.length)return{reason:'github_project',matched_terms:x};if(pRe.test(p))return{reason:'package_registry',matched_terms:['package registry url']};x=mat(np,cfg.package_registry_terms);if(x.length)return{reason:'package_registry',matched_terms:x};x=mat(np,cfg.auth_setup_terms);if(x.length)return{reason:'auth_setup',matched_terms:x};x=mat(np,cfg.marketing_copy_terms);if(x.length)return{reason:'marketing_copy',matched_terms:x};if(uRe.test(p))return{reason:'external_url',matched_terms:['external url']};x=mat(np,cfg.general_research_terms);return x.length?{reason:'general_research',matched_terms:x}:null},loc=(p,np)=>{const lc=local(p,np),it=mat(np,cfg.implement_terms);if(it.length)return{reason:'implement',matched_terms:it};let x=mat(np,cfg.debug_terms);if(x.length&&lc.detected)return{reason:'debug',matched_terms:[...new Set([...x,...lc.matched_terms])].sort()};x=mat(np,cfg.test_terms);if(x.length)return{reason:'test',matched_terms:x};x=mat(np,cfg.review_terms);if(x.length&&lc.detected)return{reason:'review',matched_terms:[...new Set([...x,...lc.matched_terms])].sort()};x=mat(np,cfg.refactor_terms);if(x.length)return{reason:'refactor',matched_terms:x};x=mat(np,cfg.explain_terms);if(x.length&&lc.detected)return{reason:'explain',matched_terms:[...new Set([...x,...lc.matched_terms])].sort()};return lc.detected?{reason:'explain',matched_terms:lc.matched_terms}:null},clf=p=>{const np=norm(p),n=neg(p,np);return n?{needs_local_code_context:false,reason:n.reason}:(l=>{const res={needs_local_code_context:!!l,reason:l?l.reason:'general_research'};return res;})(loc(p,np))};process.stdin.on('data',c=>{inp+=c});process.stdin.on('end',()=>{try{fs.accessSync('out/graph.json')}catch(e){return}let p='';try{const pl=inp.length>0?JSON.parse(inp):{};p=typeof pl.prompt==='string'?pl.prompt:''}catch(e){p=''}const cl=clf(p);const deb=/^(1|true|yes)${'$'}/i.test(String(process.env.MADAR_HOOK_DEBUG||''));if(!cl.needs_local_code_context){if(!deb)return;process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'${hookEventName}',additionalContext:'Skipped Madar: task is '+(cfg.reason_labels||{})[cl.reason]+', not local codebase context.'}}));return}process.stdout.write(mp)});`
+  return `const fs = require('fs')
 
-  const b64Source = Buffer.from(source, 'utf8').toString('base64')
-  return `node -e "eval(Buffer.from(process.argv[1],'base64').toString('utf8'))" "${b64Source}"`
+const config = ${JSON.stringify(HOOK_CONFIG, null, 2)}
+const matchPayload = ${JSON.stringify(matchPayloadJson)}
+const hookEventName = ${JSON.stringify(hookEventName)}
+const filePathRe = ${FILE_PATH_RE}
+const urlRe = ${URL_RE}
+const githubProjectUrlRe = ${GITHUB_PROJECT_URL_RE}
+const packageRegistryUrlRe = ${PACKAGE_REGISTRY_URL_RE}
+let input = ''
+
+function normalizePrompt(prompt) {
+  return String(prompt || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\\s+/g, ' ')
+}
+
+function containsTerm(normalizedPrompt, term) {
+  const normalizedTerm = normalizePrompt(term)
+  if (!normalizedPrompt || !normalizedTerm) {
+    return false
+  }
+
+  return \` \${normalizedPrompt} \`.includes(\` \${normalizedTerm} \`)
+}
+
+function matchTerms(normalizedPrompt, terms) {
+  return [...new Set(terms.map(normalizePrompt).filter((term) => containsTerm(normalizedPrompt, term)))].sort()
+}
+
+function hasLocalCodeCue(prompt, normalizedPrompt) {
+  const matchedTerms = matchTerms(normalizedPrompt, config.local_code_terms)
+  const hasFilePath = filePathRe.test(prompt)
+  return {
+    detected: matchedTerms.length > 0 || hasFilePath,
+    matched_terms: hasFilePath ? [...new Set([...matchedTerms, 'file path'])].sort() : matchedTerms,
+  }
+}
+
+function negativeClassification(prompt, normalizedPrompt) {
+  if (githubProjectUrlRe.test(prompt)) {
+    return { reason: 'github_project', matched_terms: ['github project url'] }
+  }
+
+  const githubProjectTerms = matchTerms(normalizedPrompt, config.github_project_terms)
+  if (githubProjectTerms.length > 0) {
+    return { reason: 'github_project', matched_terms: githubProjectTerms }
+  }
+
+  if (packageRegistryUrlRe.test(prompt)) {
+    return { reason: 'package_registry', matched_terms: ['package registry url'] }
+  }
+
+  const packageRegistryTerms = matchTerms(normalizedPrompt, config.package_registry_terms)
+  if (packageRegistryTerms.length > 0) {
+    return { reason: 'package_registry', matched_terms: packageRegistryTerms }
+  }
+
+  const authSetupTerms = matchTerms(normalizedPrompt, config.auth_setup_terms)
+  if (authSetupTerms.length > 0) {
+    return { reason: 'auth_setup', matched_terms: authSetupTerms }
+  }
+
+  const marketingTerms = matchTerms(normalizedPrompt, config.marketing_copy_terms)
+  if (marketingTerms.length > 0) {
+    return { reason: 'marketing_copy', matched_terms: marketingTerms }
+  }
+
+  if (urlRe.test(prompt)) {
+    return { reason: 'external_url', matched_terms: ['external url'] }
+  }
+
+  const generalResearchTerms = matchTerms(normalizedPrompt, config.general_research_terms)
+  if (generalResearchTerms.length > 0) {
+    return { reason: 'general_research', matched_terms: generalResearchTerms }
+  }
+
+  return null
+}
+
+function localClassification(prompt, normalizedPrompt) {
+  const localCodeCue = hasLocalCodeCue(prompt, normalizedPrompt)
+
+  const implementTerms = matchTerms(normalizedPrompt, config.implement_terms)
+  if (implementTerms.length > 0) {
+    return { reason: 'implement', matched_terms: implementTerms }
+  }
+
+  const debugTerms = matchTerms(normalizedPrompt, config.debug_terms)
+  if (debugTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'debug', matched_terms: [...new Set([...debugTerms, ...localCodeCue.matched_terms])].sort() }
+  }
+
+  const testTerms = matchTerms(normalizedPrompt, config.test_terms)
+  if (testTerms.length > 0) {
+    return { reason: 'test', matched_terms: testTerms }
+  }
+
+  const reviewTerms = matchTerms(normalizedPrompt, config.review_terms)
+  if (reviewTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'review', matched_terms: [...new Set([...reviewTerms, ...localCodeCue.matched_terms])].sort() }
+  }
+
+  const refactorTerms = matchTerms(normalizedPrompt, config.refactor_terms)
+  if (refactorTerms.length > 0) {
+    return { reason: 'refactor', matched_terms: refactorTerms }
+  }
+
+  const explainTerms = matchTerms(normalizedPrompt, config.explain_terms)
+  if (explainTerms.length > 0 && localCodeCue.detected) {
+    return { reason: 'explain', matched_terms: [...new Set([...explainTerms, ...localCodeCue.matched_terms])].sort() }
+  }
+
+  return localCodeCue.detected
+    ? { reason: 'explain', matched_terms: localCodeCue.matched_terms }
+    : null
+}
+
+function classifyTaskApplicability(prompt) {
+  const normalizedPrompt = normalizePrompt(prompt)
+  const negative = negativeClassification(prompt, normalizedPrompt)
+  if (negative) {
+    return {
+      needs_local_code_context: false,
+      reason: negative.reason,
+    }
+  }
+
+  const local = localClassification(prompt, normalizedPrompt)
+  if (local) {
+    return {
+      needs_local_code_context: true,
+      reason: local.reason,
+    }
+  }
+
+  return {
+    needs_local_code_context: false,
+    reason: 'general_research',
+  }
+}
+
+process.stdin.on('data', (chunk) => {
+  input += chunk
+})
+
+process.stdin.on('end', () => {
+  try {
+    fs.accessSync('out/graph.json')
+  } catch {
+    return
+  }
+
+  let prompt = ''
+  try {
+    const payload = input.length > 0 ? JSON.parse(input) : {}
+    if (typeof payload.prompt === 'string') {
+      prompt = payload.prompt
+    }
+  } catch {
+    prompt = ''
+  }
+
+  const classification = classifyTaskApplicability(prompt)
+  const debugEnabled = /^(1|true|yes)$/i.test(String(process.env.MADAR_HOOK_DEBUG || ''))
+  if (!classification.needs_local_code_context) {
+    if (!debugEnabled) {
+      return
+    }
+
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName,
+        additionalContext: 'Skipped Madar: task is '
+          + ((config.reason_labels || {})[classification.reason] || classification.reason)
+          + ', not local codebase context.',
+      },
+    }))
+    return
+  }
+
+  process.stdout.write(matchPayload)
+})
+`
 }

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -1787,6 +1787,17 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
+  it('does not treat a missing generated Claude hook script as a verified install', () => {
+    const { projectDir } = makeFixtureProject({ installState: 'managed' })
+    try {
+      rmSync(join(projectDir, '.claude', 'madar-user-prompt-submit.cjs'), { force: true })
+
+      expect(inspectClaudeNativeAgentInstall(projectDir).verified).toBe(false)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('classifies broad exploration after a Madar MCP call as madar_invoked_with_followup_exploration', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     try {

--- a/tests/unit/install-templates.test.ts
+++ b/tests/unit/install-templates.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -18,7 +18,7 @@ function withTempDir(callback: (dir: string) => void): void {
   }
 }
 
-function decodeHookPayload(settingsJson: string): string {
+function decodeHookPayload(projectDir: string, settingsJson: string): string {
   const parsed = JSON.parse(settingsJson) as {
     hooks?: {
       PreToolUse?: Array<{ hooks?: Array<{ command?: string }> }>
@@ -28,6 +28,18 @@ function decodeHookPayload(settingsJson: string): string {
   const command = parsed.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command
     ?? parsed.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command
     ?? ''
+
+  if (command === 'node .claude/madar-user-prompt-submit.cjs') {
+    const hookScriptPath = join(projectDir, '.claude', 'madar-user-prompt-submit.cjs')
+    if (!existsSync(hookScriptPath)) {
+      return ''
+    }
+
+    const hookScript = readFileSync(hookScriptPath, 'utf8')
+    const matchPayload = hookScript.match(/const matchPayload = ("(?:\\.|[^"])*")/)
+    return matchPayload?.[1] ? JSON.parse(matchPayload[1]) : hookScript
+  }
+
   // Hook command embeds the payload as a base64 literal inside a node -e wrapper.
   // Extract every base64-looking chunk and decode each, concatenating the results
   // so we capture both the match and miss payloads when present.
@@ -124,7 +136,7 @@ describe('install hook payload', () => {
     withTempDir((projectDir) => {
       claudeInstall(projectDir)
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
-      const decoded = decodeHookPayload(settings)
+      const decoded = decodeHookPayload(projectDir, settings)
       expect(decoded).toContain('Use the graph result as the first bounded pass')
       expect(decoded.toLowerCase()).not.toContain('3x fewer turns')
     })
@@ -134,7 +146,7 @@ describe('install hook payload', () => {
     withTempDir((projectDir) => {
       claudeInstall(projectDir)
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
-      const decoded = decodeHookPayload(settings)
+      const decoded = decodeHookPayload(projectDir, settings)
       const decodedLower = decoded.toLowerCase()
       for (const stale of STALE_PHRASES) {
         expect(decodedLower).not.toContain(stale.toLowerCase())
@@ -146,7 +158,7 @@ describe('install hook payload', () => {
     withTempDir((projectDir) => {
       claudeInstall(projectDir)
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
-      const decoded = decodeHookPayload(settings)
+      const decoded = decodeHookPayload(projectDir, settings)
       expect(decoded).toContain('retrieve')
     })
   })
@@ -155,7 +167,7 @@ describe('install hook payload', () => {
     withTempDir((projectDir) => {
       claudeInstall(projectDir)
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
-      const decoded = decodeHookPayload(settings)
+      const decoded = decodeHookPayload(projectDir, settings)
       expectPlainRoutingGuide(decoded)
       expect(decoded).toContain('feature_map')
       expect(decoded).toContain('risk_map')
@@ -167,7 +179,7 @@ describe('install hook payload', () => {
     withTempDir((projectDir) => {
       agentsInstall(projectDir, 'codex')
       const settings = readFileSync(join(projectDir, '.codex', 'hooks.json'), 'utf8')
-      const decoded = decodeHookPayload(settings)
+      const decoded = decodeHookPayload(projectDir, settings)
       expect(decoded).toContain('context-pack-first')
       expect(decoded).toContain('madar pack')
       expect(decoded).toContain('use Madar tools only')

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -640,18 +640,42 @@ describe('install helpers', () => {
     })
   })
 
-  it('uses argv-based Node hook commands to stay shell-safe on Windows', () => {
+  it('installs UserPromptSubmit as a short project-local .cjs hook script', () => {
     withTempDir((projectDir) => {
       mkdirSync(join(projectDir, 'out'), { recursive: true })
       writeFileSync(join(projectDir, 'out', 'graph.json'), '{}', 'utf8')
+      writeFileSync(join(projectDir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8')
       claudeInstall(projectDir)
 
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
       const command = extractHookCommand(settings, 'UserPromptSubmit')
+      const hookScriptPath = join(projectDir, '.claude', 'madar-user-prompt-submit.cjs')
 
-      expect(command).toContain('process.argv[1]')
-      expect(command).toMatch(/"\s*[A-Za-z0-9+/=]{40,}\s*"$/)
-      expect(command).not.toContain('\\"')
+      expect(command).toBe('node .claude/madar-user-prompt-submit.cjs')
+      expect(command.length).toBeLessThan(80)
+      expect(existsSync(hookScriptPath)).toBe(true)
+
+      const output = runHookCommand(command, projectDir, {
+        prompt: 'Implement issue #275 by collecting implementation context for changed files',
+      })
+
+      expect(output).toContain('retrieve')
+
+      claudeUninstall(projectDir)
+      expect(existsSync(hookScriptPath)).toBe(false)
+    })
+  })
+
+  it('removes the generated Claude hook script even if settings.json is already gone', () => {
+    withTempDir((projectDir) => {
+      claudeInstall(projectDir)
+
+      const hookScriptPath = join(projectDir, '.claude', 'madar-user-prompt-submit.cjs')
+      rmSync(join(projectDir, '.claude', 'settings.json'), { force: true })
+
+      claudeUninstall(projectDir)
+
+      expect(existsSync(hookScriptPath)).toBe(false)
     })
   })
 
@@ -700,14 +724,16 @@ describe('install helpers', () => {
 
       const message = claudeInstall(projectDir)
       const settings = readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf8')
-      const decodedPayloads = decodeHookPayloads(settings)
+      const command = extractHookCommand(settings, 'UserPromptSubmit')
+      const hookScript = readFileSync(join(projectDir, '.claude', 'madar-user-prompt-submit.cjs'), 'utf8')
 
       expect(message).toContain('hook updated')
       expect(countOccurrences(settings, 'UserPromptSubmit')).toBe(1)
-      expect(decodedPayloads).not.toContain('3x fewer turns')
-      expect(decodedPayloads).toContain('Use the graph result as the first bounded pass')
-      expect(decodedPayloads).toContain(STRICT_NON_MADAR_MCP_RULE_PLAIN)
-      expect(decodedPayloads).toContain(STRICT_SKILL_OVERRIDE_RULE_PLAIN)
+      expect(command).toBe('node .claude/madar-user-prompt-submit.cjs')
+      expect(hookScript).not.toContain('3x fewer turns')
+      expect(hookScript).toContain('Use the graph result as the first bounded pass')
+      expect(hookScript).toContain(STRICT_NON_MADAR_MCP_RULE_PLAIN)
+      expect(hookScript).toContain(STRICT_SKILL_OVERRIDE_RULE_PLAIN)
     })
   })
 


### PR DESCRIPTION
## Summary
- replace the Claude UserPromptSubmit inline node -e hook with a generated project-local .claude/madar-user-prompt-submit.cjs script
- keep the prompt applicability logic the same while making the installed shell command short and Windows-safe
- tighten uninstall and native-agent install verification so the generated script lifecycle is covered

## Root cause
The previous minification-only fix was still shipping an installed UserPromptSubmit command around 8,857 characters long. That left it over the practical Windows shell budget, so the command could still be truncated and fail with unexpected EOF while looking for matching a quote.

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Claude hook installation now generates and manages a local hook script file within the project directory.
  * Enhanced installation verification to validate generated hook script artifacts.
  * Updated hook uninstallation to properly remove generated script files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->