### PR TITLE
chore: prepare 0.27.9-next.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.9-next.3] - 2026-06-03
+
+### Fixed
+
+- **Windows Claude prompt hooks now run from a generated local script instead of an oversized inline shell command**: `claudeInstall` now writes `.claude/madar-user-prompt-submit.cjs` and points `UserPromptSubmit` at `node .claude/madar-user-prompt-submit.cjs`, eliminating the shell-length truncation that still broke `0.27.9-next.2` with `unexpected EOF while looking for matching '"'`.
+
 ## [0.27.9-next.2] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,11 +129,12 @@ The current telemetry model is local-first and source-safe. It records coarse fu
 
 ## What's New
 
-See the [`0.27.9-next.2` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next2---2026-06-03) for the full release notes.
+See the [`0.27.9-next.3` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next3---2026-06-03) for the full release notes.
 
 Recent highlights:
 
-- `0.27.9-next.2` fixes the Windows cmd.exe command-line length limit issue by aggressively minifying the hook source code, ensuring the `UserPromptSubmit` hook executes successfully on Windows systems.
+- `0.27.9-next.3` replaces the Claude `UserPromptSubmit` inline shell command with a generated local `.claude/madar-user-prompt-submit.cjs` script, fixing the Windows shell truncation that still broke `0.27.9-next.2`.
+- `0.27.9-next.2` was the intermediate attempt to shrink the Windows Claude hook command, but it still left the installed shell command too large in production.
 - `0.27.9-next.1` is the prior next-track adoption release: it bundles the public benchmark suite, one-command `madar try` proof flow, opt-in funnel telemetry, verified agent quickstarts, design-partner loop, launch checklist from issues #469-#474, and the Windows-safe Claude submit-hook fix.
 - `0.27.9-next.0` also added scoped graph freshness and stale-context guarantees across `madar pack`, `madar prompt`, `madar handoff`, `madar doctor`, and `madar status`, backed by the tightened git/diff freshness model from #477 and #479.
 - `0.27.8` refactors the README into a shorter npm-facing landing page and moves long-form Pack Schema, context-pack, MCP, installer, command, and discovery-rule details into dedicated docs.
@@ -146,7 +147,7 @@ Recent highlights:
 
 ## When To Use `--spi`
 
-`--spi` is still opt-in in `0.27.9-next.2`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.9-next.3`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.9-next.2",
+    "version": "0.27.9-next.3",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.9-next.2",
+            "version": "0.27.9-next.3",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.2",
+    "version": "0.27.9-next.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.9-next.2",
+            "version": "0.27.9-next.3",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.2",
+    "version": "0.27.9-next.3",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump the package and registry metadata to 0.27.9-next.3
- document the generated Claude prompt hook script fix in the changelog and README
- keep the next-track release metadata aligned for publish

## Included fix
0.27.9-next.3 ships the follow-up Windows Claude hook fix from #493, replacing the oversized inline UserPromptSubmit shell command with a generated local .claude/madar-user-prompt-submit.cjs script.

## Verification
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows command execution issue that previously caused truncation errors.

* **Chores**
  * Updated to version 0.27.9-next.3.
  * The `--spi` option is now opt-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->