### PR TITLE
fix: split compare prompt artifacts by run mode

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -2009,6 +2009,38 @@ export function buildNativeAgentPrompt(
   ].join('\n')
 }
 
+function buildNativeAgentBaselinePrompt(
+  question: string,
+  options: {
+    task?: ContextPackTaskKind
+  } = {},
+): string {
+  if (options.task === 'implement') {
+    return [
+      'Implement the requested change using normal repository evidence.',
+      'Do not call Madar-specific tools or assume a Madar context pack is available.',
+      'Start with focused repository inspection, edit only files justified by the code you inspect, and run relevant validation before concluding.',
+      '',
+      `Question: ${question}`,
+      '',
+      'Answer:',
+      '',
+    ].join('\n')
+  }
+
+  return [
+    'Answer the question from normal repository evidence.',
+    'Do not call Madar-specific tools or assume a Madar context pack is available.',
+    'Start with focused repository inspection. Avoid broad repo-wide search unless a focused search does not find the needed files.',
+    'Name the key files and steps that support the answer.',
+    '',
+    `Question: ${question}`,
+    '',
+    'Answer:',
+    '',
+  ].join('\n')
+}
+
 export function resolveCompareQuestions(options: Pick<GenerateCompareArtifactsInput, 'question' | 'questionsPath' | 'limit'>): string[] {
   if (options.question !== undefined && options.question !== null && options.questionsPath !== undefined && options.questionsPath !== null) {
     throw new Error('Compare runtime accepts either a single question or a questions path, but not both.')
@@ -2723,6 +2755,8 @@ export interface NativeAgentCompareReport {
     share_safe_report: string
     baseline_answer: string
     madar_answer: string
+    baseline_prompt: string
+    madar_prompt: string
     prompt_file: string
   }
 }
@@ -4152,12 +4186,18 @@ export async function executeNativeAgentCompare(
           })
         : undefined
 
-    const promptFile = join(questionDir, 'native_agent-prompt.txt')
-    writeFileSync(promptFile, buildNativeAgentPrompt(question, {
+    const baselinePromptFile = join(questionDir, 'baseline-prompt.txt')
+    const madarPromptFile = join(questionDir, 'madar-prompt.txt')
+    const legacyPromptFile = join(questionDir, 'native_agent-prompt.txt')
+    const baselinePrompt = buildNativeAgentBaselinePrompt(question, { task })
+    const madarPrompt = buildNativeAgentPrompt(question, {
       profile: installCheck.tool_profile,
       task,
       ...(implementationGuidance ? { implementation: implementationGuidance } : {}),
-    }), 'utf8')
+    })
+    writeFileSync(baselinePromptFile, baselinePrompt, 'utf8')
+    writeFileSync(madarPromptFile, madarPrompt, 'utf8')
+    writeFileSync(legacyPromptFile, madarPrompt, 'utf8')
     const baselineAnswerPath = answerFilePath(questionDir, 'baseline')
     const madarAnswerPath = answerFilePath(questionDir, 'madar')
     const reportPath = join(questionDir, 'report.json')
@@ -4209,7 +4249,9 @@ export async function executeNativeAgentCompare(
         share_safe_report: shareSafeReportPath,
         baseline_answer: baselineAnswerPath,
         madar_answer: madarAnswerPath,
-        prompt_file: promptFile,
+        baseline_prompt: baselinePromptFile,
+        madar_prompt: madarPromptFile,
+        prompt_file: madarPromptFile,
       },
     }
     if (implementationGuidance) {
@@ -4232,7 +4274,8 @@ export async function executeNativeAgentCompare(
     }
     return {
       question,
-      promptFile,
+      baselinePromptFile,
+      madarPromptFile,
       baselineAnswerPath,
       madarAnswerPath,
       reportPath,
@@ -4258,7 +4301,8 @@ export async function executeNativeAgentCompare(
   for (const entry of preparedQuestions) {
     const {
       question,
-      promptFile,
+      baselinePromptFile,
+      madarPromptFile,
       baselineAnswerPath,
       madarAnswerPath,
       runStatePath,
@@ -4288,7 +4332,7 @@ export async function executeNativeAgentCompare(
       try {
         snapshot = snapshotMadarArtifacts(baselineWorkspace?.workspaceRoot ?? projectRoot, stamp)
       const baselineCommand = expandCompareExecTemplate(input.execTemplate, {
-        promptFile,
+        promptFile: baselinePromptFile,
         question,
         mode: 'baseline',
         outputFile: baselineAnswerPath,
@@ -4301,7 +4345,7 @@ export async function executeNativeAgentCompare(
           {
             mode: 'baseline',
             question,
-            promptFile,
+            promptFile: baselinePromptFile,
             outputFile: baselineAnswerPath,
             command: baselineCommand,
             ...(baselineWorkspace ? { cwd: baselineWorkspace.workspaceRoot, workspaceRoot: baselineWorkspace.workspaceRoot } : {}),
@@ -4419,7 +4463,7 @@ export async function executeNativeAgentCompare(
       ...runStateDetails({ baseline: reportShell.baseline }),
       })
       const madarCommand = expandCompareExecTemplate(input.execTemplate, {
-      promptFile,
+      promptFile: madarPromptFile,
       question,
       mode: 'madar',
       outputFile: madarAnswerPath,
@@ -4432,7 +4476,7 @@ export async function executeNativeAgentCompare(
         {
           mode: 'madar',
           question,
-          promptFile,
+          promptFile: madarPromptFile,
           outputFile: madarAnswerPath,
           command: madarCommand,
           ...(madarWorkspace ? { cwd: madarWorkspace.workspaceRoot, workspaceRoot: madarWorkspace.workspaceRoot } : {}),
@@ -4679,6 +4723,8 @@ function writeNativeAgentReport(report: NativeAgentCompareReport): void {
       share_safe_report: portablePath(report.paths.share_safe_report),
       baseline_answer: portablePath(report.paths.baseline_answer),
       madar_answer: portablePath(report.paths.madar_answer),
+      baseline_prompt: portablePath(report.paths.baseline_prompt),
+      madar_prompt: portablePath(report.paths.madar_prompt),
       prompt_file: portablePath(report.paths.prompt_file),
     },
   }

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -106,13 +106,18 @@ function makeCompareResult(input: {
   mkdirSync(input.outputDir, { recursive: true })
   const baselineAnswerPath = join(input.outputDir, 'baseline-answer.txt')
   const madarAnswerPath = join(input.outputDir, 'madar-answer.txt')
-  const promptPath = join(input.outputDir, 'native_agent-prompt.txt')
+  const baselinePromptPath = join(input.outputDir, 'baseline-prompt.txt')
+  const madarPromptPath = join(input.outputDir, 'madar-prompt.txt')
+  const promptPath = madarPromptPath
+  const legacyPromptPath = join(input.outputDir, 'native_agent-prompt.txt')
   const reportPath = join(input.outputDir, 'report.json')
   const shareSafeReportPath = join(input.outputDir, 'report.share-safe.json')
 
   writeFileSync(baselineAnswerPath, 'baseline\n', 'utf8')
   writeFileSync(madarAnswerPath, 'madar\n', 'utf8')
-  writeFileSync(promptPath, `${input.question}\n`, 'utf8')
+  writeFileSync(baselinePromptPath, `${input.question}\n`, 'utf8')
+  writeFileSync(madarPromptPath, `${input.question}\n`, 'utf8')
+  writeFileSync(legacyPromptPath, `${input.question}\n`, 'utf8')
 
   const publishedReport = {
     graph_path: input.graphPath,
@@ -234,6 +239,8 @@ function makeCompareResult(input: {
       share_safe_report: shareSafeReportPath,
       baseline_answer: baselineAnswerPath,
       madar_answer: madarAnswerPath,
+      baseline_prompt: baselinePromptPath,
+      madar_prompt: madarPromptPath,
       prompt_file: promptPath,
     },
     ...(input.workflowOutcome

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -1015,7 +1015,9 @@ function buildSummaryResult(overrides: {
           share_safe_report: '/tmp/project/out/compare/2026-05-12T00-00-00Z/report.share-safe.json',
           baseline_answer: '/tmp/project/out/compare/2026-05-12T00-00-00Z/baseline.md',
           madar_answer: '/tmp/project/out/compare/2026-05-12T00-00-00Z/madar.md',
-          prompt_file: '/tmp/project/out/compare/2026-05-12T00-00-00Z/prompt.txt',
+          baseline_prompt: '/tmp/project/out/compare/2026-05-12T00-00-00Z/baseline-prompt.txt',
+          madar_prompt: '/tmp/project/out/compare/2026-05-12T00-00-00Z/madar-prompt.txt',
+          prompt_file: '/tmp/project/out/compare/2026-05-12T00-00-00Z/madar-prompt.txt',
         },
       },
     ],
@@ -1067,7 +1069,7 @@ describe('parseAnthropicResultEvent', () => {
 })
 
 describe('executeNativeAgentCompare', () => {
-  it('writes a native-agent prompt that targets retrieve first on the default core profile', async () => {
+  it('writes separate native-agent prompts for the baseline and Madar arms', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject()
     try {
       const result = await executeNativeAgentCompare(
@@ -1085,14 +1087,23 @@ describe('executeNativeAgentCompare', () => {
       )
 
       const report = result.reports[0] as NativeAgentCompareReport
-      const prompt = readFileSync(report.paths.prompt_file, 'utf8')
+      const baselinePrompt = readFileSync(report.paths.baseline_prompt, 'utf8')
+      const madarPrompt = readFileSync(report.paths.madar_prompt, 'utf8')
 
-      expect(prompt).toContain('Call retrieve first')
-      expect(prompt).toContain('Inspect matched_nodes, snippets, relationships, and community context before deciding what to do next')
-      expect(prompt).toContain('If retrieve already answers the question, answer from the retrieved evidence and stop without raw search')
-      expect(prompt).toContain('Allow at most one focused Madar follow-up before raw search')
-      expect(prompt).toContain('Broad raw search requires an explicit missing-context reason')
-      expect(prompt).toContain('Question: What is the cluster module?')
+      expect(baselinePrompt).toContain('Answer the question from normal repository evidence.')
+      expect(baselinePrompt).toContain('Do not call Madar-specific tools')
+      expect(baselinePrompt).not.toContain('Call retrieve first')
+      expect(baselinePrompt).not.toContain('Follow the Madar pack contract')
+      expect(baselinePrompt).toContain('Question: What is the cluster module?')
+
+      expect(madarPrompt).toContain('Call retrieve first')
+      expect(madarPrompt).toContain('Inspect matched_nodes, snippets, relationships, and community context before deciding what to do next')
+      expect(madarPrompt).toContain('If retrieve already answers the question, answer from the retrieved evidence and stop without raw search')
+      expect(madarPrompt).toContain('Allow at most one focused Madar follow-up before raw search')
+      expect(madarPrompt).toContain('Broad raw search requires an explicit missing-context reason')
+      expect(madarPrompt).toContain('Question: What is the cluster module?')
+
+      expect(report.paths.prompt_file).toBe(report.paths.madar_prompt)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -1116,7 +1127,7 @@ describe('executeNativeAgentCompare', () => {
       )
 
       const report = result.reports[0] as NativeAgentCompareReport
-      const prompt = readFileSync(report.paths.prompt_file, 'utf8')
+      const prompt = readFileSync(report.paths.madar_prompt, 'utf8')
 
       expect(prompt).toContain('Call context_pack first')
       expect(prompt).toContain('Inspect evidence.pack_confidence, evidence.coverage, evidence.agent_directive, missing_context, and recommended_first_read')
@@ -1213,10 +1224,14 @@ describe('executeNativeAgentCompare', () => {
         }),
       })
 
-      const prompt = readFileSync(report.paths.prompt_file, 'utf8')
-      expect(prompt).toContain('Implement the requested change using the Madar implementation pack.')
-      expect(prompt).toContain('src/session.ts')
-      expect(prompt).toContain('npm run typecheck')
+      const baselinePrompt = readFileSync(report.paths.baseline_prompt, 'utf8')
+      const madarPrompt = readFileSync(report.paths.madar_prompt, 'utf8')
+      expect(baselinePrompt).toContain('Implement the requested change using normal repository evidence.')
+      expect(baselinePrompt).toContain('Do not call Madar-specific tools')
+      expect(baselinePrompt).not.toContain('Implement the requested change using the Madar implementation pack.')
+      expect(madarPrompt).toContain('Implement the requested change using the Madar implementation pack.')
+      expect(madarPrompt).toContain('src/session.ts')
+      expect(madarPrompt).toContain('npm run typecheck')
 
       const savedReport = JSON.parse(readFileSync(report.paths.report, 'utf8')) as Record<string, unknown>
       const shareSafeReport = JSON.parse(readFileSync(report.paths.share_safe_report, 'utf8')) as Record<string, unknown>
@@ -2784,9 +2799,9 @@ describe('executeNativeAgentCompare', () => {
       // If the snapshot renamed out/ wholesale, the path would be missing
       // and the runner would have observed it. The runner returns whether each call
       // saw the file present.
-      const probeResults: Array<{ mode: CompareRunMode; promptFileExists: boolean }> = []
+      const probeResults: Array<{ mode: CompareRunMode; promptFileExists: boolean; promptFile: string }> = []
       const probingRunner: NativeAgentRunner = async (input) => {
-        probeResults.push({ mode: input.mode, promptFileExists: existsSync(input.promptFile) })
+        probeResults.push({ mode: input.mode, promptFileExists: existsSync(input.promptFile), promptFile: input.promptFile })
         const payload = input.mode === 'baseline' ? BASELINE_USAGE_PAYLOAD : MADAR_USAGE_PAYLOAD
         return {
           exitCode: 0,
@@ -2812,6 +2827,14 @@ describe('executeNativeAgentCompare', () => {
 
       expect(probeResults).toHaveLength(2)
       expect(probeResults.every((probe) => probe.promptFileExists)).toBe(true)
+      expect(probeResults[0]).toEqual(expect.objectContaining({
+        mode: 'baseline',
+        promptFile: expect.stringContaining('baseline-prompt.txt'),
+      }))
+      expect(probeResults[1]).toEqual(expect.objectContaining({
+        mode: 'madar',
+        promptFile: expect.stringContaining('madar-prompt.txt'),
+      }))
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -2940,7 +2940,9 @@ describe('compare runtime', () => {
           share_safe_report: '<artifact-root>/report.share-safe.json',
           baseline_answer: '<artifact-root>/baseline-answer.txt',
           madar_answer: '<artifact-root>/madar-answer.txt',
-          prompt_file: '<artifact-root>/native_agent-prompt.txt',
+          baseline_prompt: '<artifact-root>/baseline-prompt.txt',
+          madar_prompt: '<artifact-root>/madar-prompt.txt',
+          prompt_file: '<artifact-root>/madar-prompt.txt',
         }),
         baseline: expect.objectContaining({
           kind: 'answer_only',


### PR DESCRIPTION
## Summary
- write separate baseline and Madar prompt files for native-agent compare runs
- keep the legacy `prompt_file` field pointing at the Madar prompt for compatibility while adding explicit `baseline_prompt` and `madar_prompt` report paths
- update compare and benchmark tests to assert the split prompt artifacts

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm run test:run -- tests/unit/generate-performance-benchmark.test.ts -t "covers generate, update, cluster-only, and SPI cache variants with structured metrics"
- npm run test:run -- tests/unit/pack-quality-fixtures.test.ts -t "does not report workflow centers as omitted slice-path warnings on the explain fixture"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated comparison reports to track and record separate prompt configurations for different test arms, improving transparency and debuggability of comparison results.

* **Chores**
  * Updated internal test fixtures and assertions to align with revised report structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->