### PR TITLE
chore: prepare 0.27.9-next.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.9-next.4] - 2026-06-03
+
+### Fixed
+
+- **Native-agent compare now keeps baseline and Madar prompt artifacts separate**: compare runs now write dedicated baseline and Madar prompt files, record both paths in `report.json`, and preserve the legacy `prompt_file` field as the Madar prompt so existing consumers stay compatible while prompt inspection becomes clearer and debuggable.
+
 ## [0.27.9-next.3] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ The current telemetry model is local-first and source-safe. It records coarse fu
 
 ## What's New
 
-See the [`0.27.9-next.3` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next3---2026-06-03) for the full release notes.
+See the [`0.27.9-next.4` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next4---2026-06-03) for the full release notes.
 
 Recent highlights:
 
+- `0.27.9-next.4` splits native-agent compare prompt artifacts into explicit baseline and Madar files, records both paths in `report.json`, and keeps the legacy `prompt_file` field aligned with the Madar prompt for compatibility.
 - `0.27.9-next.3` replaces the Claude `UserPromptSubmit` inline shell command with a generated local `.claude/madar-user-prompt-submit.cjs` script, fixing the Windows shell truncation that still broke `0.27.9-next.2`.
 - `0.27.9-next.2` was the intermediate attempt to shrink the Windows Claude hook command, but it still left the installed shell command too large in production.
 - `0.27.9-next.1` is the prior next-track adoption release: it bundles the public benchmark suite, one-command `madar try` proof flow, opt-in funnel telemetry, verified agent quickstarts, design-partner loop, launch checklist from issues #469-#474, and the Windows-safe Claude submit-hook fix.
@@ -147,7 +148,7 @@ Recent highlights:
 
 ## When To Use `--spi`
 
-`--spi` is still opt-in in `0.27.9-next.3`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.9-next.4`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.9-next.3",
+    "version": "0.27.9-next.4",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.9-next.3",
+            "version": "0.27.9-next.4",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.3",
+    "version": "0.27.9-next.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.9-next.3",
+            "version": "0.27.9-next.4",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.3",
+    "version": "0.27.9-next.4",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump the package and registry metadata to `0.27.9-next.4`
- add the `0.27.9-next.4` changelog entry for the native-agent compare prompt artifact split
- refresh the README release references and `--spi` prerelease version mention

## Verification
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
