### PR TITLE
fix: align Windows exec runners with cmd.exe

### DIFF
--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -103,6 +103,8 @@ madar federate frontend/graph.json backend/graph.json
 madar --help
 ```
 
+On Windows, `compare`, `review-compare`, and benchmark `--exec` templates run under `cmd.exe`, so prefer `type {prompt_file} | claude ...` over PowerShell-specific piping or quoting.
+
 ## Default discovery rules
 
 `madar generate` hard-ignores nested VCS/worktree copies and generated/build output by default: `.worktrees/`, `worktrees/`, `.git/`, `out/`, `node_modules/`, `dist/`, `build/`, `coverage/`, cache folders, source maps, lock/build artifacts, and temp/log files.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -99,6 +99,8 @@ madar compare "how does password reset request enqueue the reset email" \
 
 This does **not** measure model quality. It is a safe local smoke check that proves `compare` can build both prompts, isolate one bounded raw-context baseline against one compiled madar pack rendered from the same explain-pack core as `madar pack --task explain`, and save the artifact bundle without requiring a hosted model. Real model-backed compare runs are optional, and compare or benchmark flows only spend paid model tokens once you replace the local smoke-check runner with a real CLI model command.
 
+On Windows, use `--exec "type {prompt_file}"` for the same smoke check because `compare` runs `--exec` through `cmd.exe`.
+
 ## Expected output
 
 - `try` should print one human-readable local result plus a recommended install command
@@ -118,7 +120,7 @@ This does **not** measure model quality. It is a safe local smoke check that pro
 - **`graph.json` missing**: rerun `madar generate . --no-html` before `pack`, `prompt`, or `compare`.
 - **`doctor` or `status` says the install is missing**: rerun your chosen `madar <agent> install` command from the sample workspace root, then rerun the verification commands for Claude, Cursor, Gemini, or Copilot.
 - **Need stronger framework-aware hints?** Regenerate with `madar generate . --spi --no-html` if your real workspace relies on Next.js App Router, NestJS, Prisma, or similar framework-specific boundaries.
-- **`compare` looks noisy**: the `cat {prompt_file}` runner is only a local smoke check. Use a real terminal model runner later if you want meaningful answer comparisons.
+- **`compare` looks noisy**: the `cat {prompt_file}` runner (or `type {prompt_file}` on Windows) is only a local smoke check. Use a real terminal model runner later if you want meaningful answer comparisons.
 - **Need more questions?** Start with `examples/sample-workspace/prompt-examples.json`.
 
 ## Optional next steps

--- a/src/infrastructure/benchmark/runner.ts
+++ b/src/infrastructure/benchmark/runner.ts
@@ -7,6 +7,7 @@ import type { ContextSessionDiagnostics, ContextSessionState } from '../../contr
 import { type RetrieveResult, retrieveContext } from '../../runtime/retrieve.js'
 import { QUERY_TOKEN_ESTIMATOR } from '../../runtime/serve.js'
 import { toShareSafeArtifactPath } from '../../shared/share-safe-artifacts.js'
+import { resolveShellCommand } from '../../shared/shell.js'
 import { validateGraphOutputPath } from '../../shared/security.js'
 import { buildMadarPromptPack, expandCompareExecTemplate } from '../compare.js'
 import { parsePromptRunnerOutput, type PromptRunnerUsage } from '../prompt-runner.js'
@@ -124,16 +125,7 @@ async function defaultBenchmarkPromptRunner(execution: BenchmarkPromptExecution)
   const startedAt = Date.now()
 
   return await new Promise<BenchmarkPromptRunnerResult>((resolveExecution, rejectExecution) => {
-    const command =
-      process.platform === 'win32'
-        ? {
-            file: 'powershell.exe',
-            args: ['-NoProfile', '-Command', execution.command],
-          }
-        : {
-            file: '/bin/sh',
-            args: ['-lc', execution.command],
-          }
+    const command = resolveShellCommand(execution.command)
     const child = spawn(command.file, command.args, {
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/infrastructure/benchmark/suite.ts
+++ b/src/infrastructure/benchmark/suite.ts
@@ -19,6 +19,7 @@ import {
   type BenchmarkExpectedEnvironment,
 } from './environment.js'
 import { generateGraph, type GenerateGraphOptions, type GenerateGraphResult } from '../generate.js'
+import { shellEscape } from '../../shared/shell.js'
 
 export type BenchmarkSuiteMode = 'cold' | 'warm' | 'all'
 export type BenchmarkSuiteEntryStatus = 'ready' | 'planned'
@@ -333,15 +334,11 @@ function copyWorkspace(sourceRoot: string, targetRoot: string): void {
   copyWorkspaceForBenchmark(sourceRoot, targetRoot)
 }
 
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\"'\"'`)}'`
-}
-
 function execTemplateForWorkspace(execTemplate: string, workspaceRoot: string): string {
   if (process.platform === 'win32') {
-    return `Set-Location -LiteralPath ${shellQuote(workspaceRoot)}; ${execTemplate}`
+    return `cd /d ${shellEscape(workspaceRoot, process.platform)} && ${execTemplate}`
   }
-  return `cd ${shellQuote(workspaceRoot)} && ${execTemplate}`
+  return `cd ${shellEscape(workspaceRoot, process.platform)} && ${execTemplate}`
 }
 
 function prepareBenchmarkWorkspace(

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -29,7 +29,7 @@ import { QUERY_TOKEN_ESTIMATOR, estimateQueryTokens, loadGraph } from '../runtim
 import { resolveToolProfileFromEnv, type McpToolProfile } from '../runtime/stdio/definitions.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
 import { sanitizeShareSafeText, toShareSafeArtifactPath, type ShareSafePathRoots } from '../shared/share-safe-artifacts.js'
-import { shellEscape } from '../shared/shell.js'
+import { resolveShellCommand, shellEscape } from '../shared/shell.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 import { copyWorkspaceForBenchmark } from '../shared/workspace-copy.js'
 
@@ -566,16 +566,7 @@ async function defaultComparePromptRunner(execution: ComparePromptExecution): Pr
   const startedAt = Date.now()
 
   return await new Promise<ComparePromptRunnerResult>((resolveExecution, rejectExecution) => {
-    const command =
-      process.platform === 'win32'
-        ? {
-            file: 'powershell.exe',
-            args: ['-NoProfile', '-Command', execution.command],
-          }
-        : {
-            file: '/bin/sh',
-            args: ['-lc', execution.command],
-          }
+    const command = resolveShellCommand(execution.command)
     const child = spawn(command.file, command.args, {
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -2990,11 +2981,8 @@ async function runShellCommand(command: string, options: { cwd?: string; signal?
   stderr: string
 }> {
   return await new Promise((resolveExecution, rejectExecution) => {
-    const useProcessGroup = process.platform !== 'win32'
-    const shellCommand =
-      !useProcessGroup
-        ? { file: 'powershell.exe', args: ['-NoProfile', '-Command', command] }
-        : { file: '/bin/sh', args: ['-lc', command] }
+    const shellCommand = resolveShellCommand(command)
+    const useProcessGroup = shellCommand.useProcessGroup
     const child = spawn(shellCommand.file, shellCommand.args, {
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/infrastructure/review-compare.ts
+++ b/src/infrastructure/review-compare.ts
@@ -10,6 +10,7 @@ import {
   toShareSafeArtifactPath,
   type ShareSafePathRoots,
 } from '../shared/share-safe-artifacts.js'
+import { resolveShellCommand, shellEscape } from '../shared/shell.js'
 import { findNearestExistingAncestor, validateGraphPath } from '../shared/security.js'
 import { buildContextPrompt } from './context-prompt.js'
 
@@ -209,13 +210,6 @@ function createOutputRoot(outputDir: string, date: Date): string {
   return candidate
 }
 
-function shellEscape(value: string, platform: NodeJS.Platform = process.platform): string {
-  if (platform === 'win32') {
-    return `'${value.replaceAll("'", "''")}'`
-  }
-  return `'${value.replaceAll("'", `'\"'\"'`)}'`
-}
-
 function expandExecTemplate(
   template: string,
   values: Pick<ReviewCompareExecution, 'promptFile' | 'mode' | 'outputFile'>,
@@ -239,10 +233,7 @@ function expandExecTemplate(
 async function defaultRunner(execution: ReviewCompareExecution): Promise<ReviewCompareRunnerResult> {
   const startedAt = Date.now()
   return await new Promise<ReviewCompareRunnerResult>((resolveExecution, rejectExecution) => {
-    const command =
-      process.platform === 'win32'
-        ? { file: 'powershell.exe', args: ['-NoProfile', '-Command', execution.command] }
-        : { file: '/bin/sh', args: ['-lc', execution.command] }
+    const command = resolveShellCommand(execution.command)
     const child = spawn(command.file, command.args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
 
     let stdout = ''

--- a/src/shared/shell.ts
+++ b/src/shared/shell.ts
@@ -1,6 +1,12 @@
+export interface ResolvedShellCommand {
+  file: string
+  args: string[]
+  useProcessGroup: boolean
+}
+
 export function shellEscape(value: string, platform: NodeJS.Platform = process.platform): string {
   if (platform === 'win32') {
-    return `'${value.replaceAll("'", "''")}'`
+    return `"${value.replaceAll('%', '%%').replaceAll('"', '""')}"`
   }
   return `'${value.replaceAll("'", `'\"'\"'`)}'`
 }
@@ -10,4 +16,19 @@ export function shellEscapeIfNeeded(value: string, platform: NodeJS.Platform = p
     return value
   }
   return shellEscape(value, platform)
+}
+
+export function resolveShellCommand(command: string, platform: NodeJS.Platform = process.platform): ResolvedShellCommand {
+  if (platform === 'win32') {
+    return {
+      file: process.env.ComSpec ?? 'cmd.exe',
+      args: ['/d', '/s', '/c', command],
+      useProcessGroup: false,
+    }
+  }
+  return {
+    file: '/bin/sh',
+    args: ['-lc', command],
+    useProcessGroup: true,
+  }
 }

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -793,6 +793,131 @@ describe('runBenchmarkSuite', () => {
     })
   })
 
+  it('wraps benchmark workspace exec templates with cmd-compatible Windows syntax', async () => {
+    await withTempDir(async (tempDir) => {
+      const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))
+      const repos: BenchmarkSuiteRepo[] = [
+        {
+          id: 'nestjs-mid',
+          name: 'Fixture NestJS-like service',
+          path: runnableRepoPath,
+          description: 'Ready fixture',
+          size: 'mid',
+          language: 'typescript',
+          shape: 'service',
+          status: 'ready',
+          supportsSpi: false,
+        },
+      ]
+      const tasks: BenchmarkSuiteTask[] = [
+        {
+          id: 'explain-runtime',
+          name: 'Explain runtime flow',
+          description: 'Trace a runtime path end to end.',
+          status: 'ready',
+          prompts: {
+            'nestjs-mid': 'How does login session creation flow work?',
+          },
+        },
+      ]
+      const seenExecTemplates: string[] = []
+      const originalPlatform = process.platform
+
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      })
+
+      try {
+        await runBenchmarkSuite(
+          {
+            repo: null,
+            task: 'explain-runtime',
+            mode: 'cold',
+            trials: 1,
+            outputDir: join(tempDir, 'results'),
+            execTemplate: 'type {prompt_file} | claude -p --output-format json',
+            dryRun: false,
+            yes: true,
+          },
+          {
+            repos,
+            tasks,
+            now: () => new Date('2026-05-27T12:34:56Z'),
+            generateGraph: (rootPath = '.', options = {}) => {
+              const outputDir = join(rootPath, 'out')
+              mkdirSync(outputDir, { recursive: true })
+              const graphPath = join(outputDir, 'graph.json')
+              writeFileSync(graphPath, '{}\n', 'utf8')
+              return {
+                mode: options.useSpi ? 'generate' : 'generate',
+                rootPath,
+                outputDir,
+                graphPath,
+                reportPath: join(outputDir, 'GRAPH_REPORT.md'),
+                htmlPath: null,
+                wikiPath: null,
+                obsidianPath: null,
+                svgPath: null,
+                graphmlPath: null,
+                cypherPath: null,
+                docsPath: null,
+                totalFiles: 1,
+                codeFiles: 1,
+                nonCodeFiles: 0,
+                extractableFiles: 1,
+                extractedFiles: 1,
+                totalWords: 10,
+                nodeCount: 1,
+                edgeCount: 0,
+                communityCount: 1,
+                changedFiles: 0,
+                deletedFiles: 0,
+                cache: null,
+                warning: null,
+                notes: [],
+              } satisfies GenerateGraphResult
+            },
+            executeNativeAgentCompare: async (input) => {
+              seenExecTemplates.push(input.execTemplate)
+              return makeCompareResult({
+                question: input.question ?? 'unknown',
+                graphPath: input.graphPath,
+                outputDir: input.outputDir,
+                baselineInputTokens: 300,
+                madarInputTokens: 200,
+                baselineTurns: 6,
+                madarTurns: 4,
+                baselineDurationMs: 9000,
+                madarDurationMs: 6000,
+                baselineCostUsd: 1.2,
+                madarCostUsd: 0.8,
+                baselineToolTotal: 9,
+                madarToolTotal: 5,
+                baselineRead: 4,
+                madarRead: 3,
+                baselineGlob: 2,
+                madarGlob: 1,
+                baselineGrep: 1,
+                madarGrep: 1,
+              })
+            },
+          },
+        )
+      } finally {
+        Object.defineProperty(process, 'platform', {
+          value: originalPlatform,
+          configurable: true,
+        })
+      }
+
+      expect(seenExecTemplates).toHaveLength(1)
+      expect(seenExecTemplates[0]).toContain('cd /d "')
+      expect(seenExecTemplates[0]).toContain('&& type {prompt_file} | claude -p --output-format json')
+      expect(seenExecTemplates[0]).not.toContain('Set-Location -LiteralPath')
+    })
+  })
+
   it('regenerates fresh workspaces for each cold-cache trial while reusing warm ones', async () => {
     await withTempDir(async (tempDir) => {
       const runnableRepoPath = createFixtureRepo(join(tempDir, 'repos', 'nestjs-mid'))

--- a/tests/unit/benchmark.test.ts
+++ b/tests/unit/benchmark.test.ts
@@ -634,7 +634,7 @@ describe('runBenchmark', () => {
         'what is the main entry point',
       ])
       expect(executions.map((execution) => execution.mode)).toEqual(['madar', 'madar'])
-      expect(executions[0]?.command).toContain("--mode 'madar'")
+      expect(executions[0]?.command).toMatch(/--mode ['"]madar['"]/)
       expect(readFileSync(executions[0]!.promptFile, 'utf8')).toContain('Retrieved graph context:')
       expect(readFileSync(executions[0]!.promptFile, 'utf8')).toContain('Question:\nhow does authentication work')
       expect(readFileSync(executions[1]!.promptFile, 'utf8')).toContain('Session delta:')

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -412,7 +412,7 @@ describe('compare runtime', () => {
     ).toBe("runner --prompt '/tmp/prompt pack.txt' --question 'how does login work?' --mode 'baseline' --out '/tmp/output.txt'")
   })
 
-  it('expands compare exec placeholders safely for PowerShell on Windows', () => {
+  it('expands compare exec placeholders safely for cmd.exe on Windows', () => {
     expect(
       expandCompareExecTemplate(
         'runner --question {question} --prompt {prompt_file}',
@@ -424,7 +424,7 @@ describe('compare runtime', () => {
         },
         'win32',
       ),
-    ).toBe("runner --question 'how''s login work?' --prompt 'C:\\Users\\Jane Doe\\prompt.txt'")
+    ).toBe('runner --question "how\'s login work?" --prompt "C:\\Users\\Jane Doe\\prompt.txt"')
   })
 
   it.each([

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -403,12 +403,16 @@ describe('shared prompt runner parsing', () => {
 describe('compare runtime', () => {
   it('expands compare exec placeholders safely', () => {
     expect(
-      expandCompareExecTemplate('runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}', {
-        promptFile: '/tmp/prompt pack.txt',
-        question: 'how does login work?',
-        mode: 'baseline',
-        outputFile: '/tmp/output.txt',
-      }),
+      expandCompareExecTemplate(
+        'runner --prompt {prompt_file} --question {question} --mode {mode} --out {output_file}',
+        {
+          promptFile: '/tmp/prompt pack.txt',
+          question: 'how does login work?',
+          mode: 'baseline',
+          outputFile: '/tmp/output.txt',
+        },
+        'linux',
+      ),
     ).toBe("runner --prompt '/tmp/prompt pack.txt' --question 'how does login work?' --mode 'baseline' --out '/tmp/output.txt'")
   })
 

--- a/tests/unit/implementation-pack.test.ts
+++ b/tests/unit/implementation-pack.test.ts
@@ -801,8 +801,12 @@ describe('buildImplementationPackGuidance validation commands', () => {
       taskIntent: 'implement',
     })
 
+    const expectedQuotedTestPath = process.platform === 'win32'
+      ? 'npm run test:run -- "tests/unit/login flow $(touch pwned).test.ts"'
+      : "npm run test:run -- 'tests/unit/login flow $(touch pwned).test.ts'"
+
     expect(guidance.validation_commands).toContain(
-      "npm run test:run -- 'tests/unit/login flow $(touch pwned).test.ts'",
+      expectedQuotedTestPath,
     )
   })
 

--- a/tests/unit/shell.test.ts
+++ b/tests/unit/shell.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as shell from '../../src/shared/shell.js'
+
+describe('shared shell helpers', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('quotes Windows values for cmd.exe execution', () => {
+    expect(shell.shellEscape('C:\\Users\\Jane Doe\\prompt.txt', 'win32')).toBe('"C:\\Users\\Jane Doe\\prompt.txt"')
+    expect(shell.shellEscape("how's login work?", 'win32')).toBe("\"how's login work?\"")
+  })
+
+  it('selects cmd.exe for win32 shell execution', () => {
+    vi.stubEnv('ComSpec', 'C:\\Windows\\System32\\cmd.exe')
+
+    const resolveShellCommand = (shell as Record<string, unknown>).resolveShellCommand
+
+    expect(typeof resolveShellCommand).toBe('function')
+    expect((resolveShellCommand as (command: string, platform?: NodeJS.Platform) => unknown)('type "prompt.txt" | claude', 'win32')).toEqual({
+      file: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'type "prompt.txt" | claude'],
+      useProcessGroup: false,
+    })
+  })
+
+  it('selects /bin/sh for non-Windows shell execution', () => {
+    const resolveShellCommand = (shell as Record<string, unknown>).resolveShellCommand
+
+    expect(typeof resolveShellCommand).toBe('function')
+    expect((resolveShellCommand as (command: string, platform?: NodeJS.Platform) => unknown)('cat prompt.txt | claude', 'linux')).toEqual({
+      file: '/bin/sh',
+      args: ['-lc', 'cat prompt.txt | claude'],
+      useProcessGroup: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- switch Windows exec runners to a shared cmd.exe-based shell selector and cmd-compatible quoting
- keep benchmark suite workspace wrapping on the same Windows shell contract
- add Windows regression coverage for shell selection, compare placeholder expansion, and benchmark-suite workspace wrapping

## Context
This fixes the Windows native-agent compare regression where a cmd-style runner such as `type {prompt_file} | claude -p --output-format stream-json --verbose` could complete the baseline arm but stall or time out the Madar arm because the runtime still wrapped `--exec` in PowerShell semantics.

## Testing
- npm run test:run -- tests/unit/compare.test.ts tests/unit/shell.test.ts
- npm run test:run -- tests/unit/compare-native-agent.test.ts tests/unit/review-compare.test.ts tests/unit/benchmark.test.ts tests/unit/compare.test.ts tests/unit/shell.test.ts
- npm run test:run -- tests/unit/benchmark-suite.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run -- --maxWorkers=1