### PR TITLE
chore: prepare 0.27.9-next.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.9-next.6] - 2026-06-04
+
+### Fixed
+
+- **Windows native-agent `--exec` commands now run under the expected shell contract**: compare, benchmark, and review native-agent runners now use `cmd.exe` on Windows with cmd-compatible quoting and workspace wrapping, so cmd-style exec templates such as `type {prompt_file} | claude -p --output-format stream-json --verbose` no longer hang the Madar arm behind a PowerShell mismatch.
+
 ## [0.27.9-next.5] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ The current telemetry model is local-first and source-safe. It records coarse fu
 
 ## What's New
 
-See the [`0.27.9-next.5` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next5---2026-06-04) for the full release notes.
+See the [`0.27.9-next.6` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next6---2026-06-04) for the full release notes.
 
 Recent highlights:
 
+- `0.27.9-next.6` aligns Windows native-agent `--exec` handling with `cmd.exe`, so cmd-style exec templates such as `type {prompt_file} | claude -p --output-format stream-json --verbose` no longer hang the Madar arm during compare/review/benchmark flows.
 - `0.27.9-next.5` tightens native-agent compare prompts so task-specific runs stay bounded, and it preserves partial stdout/stderr when a timed-out arm settles after abort.
 - `0.27.9-next.4` splits native-agent compare prompt artifacts into explicit baseline and Madar files, records both paths in `report.json`, and keeps the legacy `prompt_file` field aligned with the Madar prompt for compatibility.
 - `0.27.9-next.3` replaces the Claude `UserPromptSubmit` inline shell command with a generated local `.claude/madar-user-prompt-submit.cjs` script, fixing the Windows shell truncation that still broke `0.27.9-next.2`.
@@ -149,7 +150,7 @@ Recent highlights:
 
 ## When To Use `--spi`
 
-`--spi` is still opt-in in `0.27.9-next.5`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.9-next.6`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.9-next.5",
+    "version": "0.27.9-next.6",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.9-next.5",
+            "version": "0.27.9-next.6",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.5",
+    "version": "0.27.9-next.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.9-next.5",
+            "version": "0.27.9-next.6",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.5",
+    "version": "0.27.9-next.6",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump package metadata to `0.27.9-next.6`
- add changelog and README highlights for the Windows cmd.exe compare fix
- sync the MCP registry manifest for the next prerelease

## Testing
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- npm sbom --sbom-format cyclonedx > sbom.cdx.json