### PR TITLE
fix: use bare madar MCP launcher

### DIFF
--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -43,7 +43,7 @@ The checked-in public registry manifest lives at [`docs/mcp-registry/server.json
 npm run registry:validate
 ```
 
-The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json`, or let `madar <agent> install` write that wiring for you.
+The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json`, or let `madar <agent> install` write that wiring for you. Generated Claude and Cursor MCP configs now call `madar serve --stdio out/graph.json` directly instead of writing a version-pinned `npx` launcher into the repo-local config.
 
 If you still discover older `graphify-ts` links or listings, Madar is the current project name. Use `https://github.com/mohanagy/madar` and `@lubab/madar` as the canonical repository and package surfaces.
 

--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -43,7 +43,7 @@ The checked-in public registry manifest lives at [`docs/mcp-registry/server.json
 npm run registry:validate
 ```
 
-The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json`, or let `madar <agent> install` write that wiring for you. Generated Claude and Cursor MCP configs now call `madar serve --stdio out/graph.json` directly instead of writing a version-pinned `npx` launcher into the repo-local config.
+The official MCP Registry hosts metadata, not Madar code or your local graph artifact. Madar's registry entry points back to the public npm package and the same local-first runtime flow: run `madar generate .` to create `out/graph.json`, then start the local stdio server with `npx @lubab/madar serve --stdio out/graph.json`, or let `madar <agent> install` write that wiring for you. Generated Claude and Cursor MCP configs now call the installed `madar` command as `madar serve --stdio <absolute project graph path>` instead of writing a version-pinned `npx` launcher into the repo-local config.
 
 If you still discover older `graphify-ts` links or listings, Madar is the current project name. Use `https://github.com/mohanagy/madar` and `@lubab/madar` as the canonical repository and package surfaces.
 

--- a/src/infrastructure/install.ts
+++ b/src/infrastructure/install.ts
@@ -11,7 +11,6 @@ import {
 import { buildPromptApplicabilityHookScript } from '../runtime/task-applicability.js'
 import {
   findPackageRoot as resolvePackageRoot,
-  readPackageName as resolvePackageName,
   readPackageVersion as resolvePackageVersion,
 } from '../shared/package-metadata.js'
 
@@ -1468,10 +1467,6 @@ function readPackageVersion(packageRoot: string): string {
   return resolvePackageVersion(packageRoot)
 }
 
-function readPackageName(packageRoot: string): string {
-  return resolvePackageName(packageRoot)
-}
-
 function readPackageCliDeclaration(packageRoot = findPackageRoot()): { packageJsonPath: string, cliPath: string | undefined } {
   const packageJsonPath = join(packageRoot, 'package.json')
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
@@ -1587,20 +1582,9 @@ const MCP_CONFIG_PATHS: Record<McpConfigTarget, string> = {
   copilot: join('.vscode', 'mcp.json'),
 }
 
-function installPackageSpecifier(packageRoot = findPackageRoot()): string {
-  const packageName = readPackageName(packageRoot)
-  const version = readPackageVersion(packageRoot)
-  if (packageName === 'unknown' || version === 'unknown') {
-    throw new Error(`Could not determine package name and version from ${join(packageRoot, 'package.json')}`)
-  }
-
-  return `${packageName}@${version}`
-}
-
 function installMcpServer(
   projectDir: string,
   target: McpConfigTarget = 'claude',
-  nodePlatform = process.platform,
   options: McpInstallOptions = {},
   packageRoot = findPackageRoot(),
 ): string {
@@ -1610,19 +1594,15 @@ function installMcpServer(
 
   const graphPath = join(projectDir, 'out', 'graph.json')
   const isVscode = target === 'copilot'
-  // Use npx.cmd on Windows so MCP server starts without a shell wrapper.
-  // --yes skips the interactive install prompt that hangs in stdio mode.
-  // Scoped name ensures npx resolves the package on first run.
+  const cliArgs = ['serve', '--stdio', graphPath]
   // VS Code uses "servers" key, Claude/Cursor use "mcpServers"
   const serversKey = isVscode ? 'servers' : 'mcpServers'
   const mcpServers = ensureRecord(mcpConfig, serversKey)
   const existed = isRecord(mcpServers[SKILL_SLUG])
 
-  const npxCommand = nodePlatform === 'win32' ? 'npx.cmd' : 'npx'
-  const npxArgs = ['--yes', installPackageSpecifier(), 'serve', '--stdio', graphPath]
   const directCliPath = isVscode ? findPackageCliPath(packageRoot) : undefined
-  const command = directCliPath ? process.execPath : npxCommand
-  const args = directCliPath ? [directCliPath, 'serve', '--stdio', graphPath] : npxArgs
+  const command = directCliPath ? process.execPath : PRIMARY_CLI_BIN_NAME
+  const args = directCliPath ? [directCliPath, ...cliArgs] : cliArgs
   // Default to the lean MCP tool surface ("core" = 6 tools). Reduces cache_creation
   // overhead per session vs. advertising all tools. Users can opt into the full
   // 25-tool surface by setting MADAR_TOOL_PROFILE=full in this env block.
@@ -1638,7 +1618,7 @@ function installMcpServer(
     : { MADAR_TOOL_PROFILE: 'core', ...existingEnv }
   const serverConfig = isVscode
     ? { type: 'stdio', command, args, env }
-    : { command: npxCommand, args: npxArgs, env }
+    : { command, args, env }
 
   mcpServers[SKILL_SLUG] = serverConfig
   writeJson(mcpJsonPath, mcpConfig)
@@ -2050,7 +2030,7 @@ export function geminiUninstall(projectDir = '.', options: Pick<InstallSkillOpti
 }
 
 export function installCopilotMcp(projectDir = '.', options: McpInstallOptions = {}, packageRoot = findPackageRoot()): string {
-  const message = installMcpServer(resolve(projectDir), 'copilot', process.platform, options, resolve(packageRoot))
+  const message = installMcpServer(resolve(projectDir), 'copilot', options, resolve(packageRoot))
   if (options.profile === 'strict') {
     return `${message}\n\nGitHub Copilot will now use the madar strict compact MCP profile: call context_pack once, ${strictContextPackStopRule(false)}, ${strictContextPackNoBroadExplorationRule(false)}, ${strictContextPackExpandRule(false)}, and ${strictGraphReportFallbackRule(false)}.`
   }
@@ -2082,7 +2062,7 @@ export function cursorInstall(projectDir = '.', options: McpInstallOptions = {})
     messages.push(`madar Cursor rule written to ${rulePath}`)
   }
 
-  messages.push(installMcpServer(resolvedProjectDir, 'cursor', process.platform, options))
+  messages.push(installMcpServer(resolvedProjectDir, 'cursor', options))
   if (options.profile === 'strict') {
     messages.push('', 'Cursor will now use the madar strict compact MCP profile:', `call context_pack once, ${strictContextPackStopRule(false)}, ${strictContextPackNoBroadExplorationRule(false)}, ${strictContextPackExpandRule(false)}, and ${strictGraphReportFallbackRule(false)}.`)
   }
@@ -2114,7 +2094,7 @@ export function claudeInstall(projectDir = '.', options: McpInstallOptions = {})
   const messages = [
     writeSection(join(resolvedProjectDir, 'CLAUDE.md'), claudeMdSection(options.profile)),
     installClaudeHook(resolvedProjectDir, options.profile),
-    installMcpServer(resolvedProjectDir, 'claude', process.platform, options),
+    installMcpServer(resolvedProjectDir, 'claude', options),
   ]
   if (options.profile === 'strict') {
     messages.push('', 'Claude Code will now use the madar strict compact MCP profile:', `call context_pack once, ${strictContextPackStopRule(false)}, ${strictContextPackNoBroadExplorationRule(false)}, ${strictContextPackExpandRule(false)}, and ${strictGraphReportFallbackRule(false)}.`)

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -817,20 +817,25 @@ describe('install helpers', () => {
     })
   })
 
-  it('pins the Claude MCP server package to the installed madar version', () => {
+  it('writes the Claude MCP server as a bare madar launcher without a pinned package version', () => {
     withTempDir((projectDir) => {
       claudeInstall(projectDir)
 
       const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.mcp.json'), 'utf8')) as {
         mcpServers?: {
           'madar'?: {
+            command?: string
             args?: string[]
           }
         }
       }
-      const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as { version: string }
 
-      expect(mcpConfig.mcpServers?.['madar']?.args?.[1]).toBe(`@lubab/madar@${packageJson.version}`)
+      expect(mcpConfig.mcpServers?.['madar']?.command).toBe('madar')
+      expect(mcpConfig.mcpServers?.['madar']?.args).toEqual([
+        'serve',
+        '--stdio',
+        join(projectDir, 'out', 'graph.json'),
+      ])
     })
   })
 
@@ -908,6 +913,28 @@ describe('install helpers', () => {
       }
 
       expect(mcpConfig.mcpServers?.['madar']?.env?.MADAR_TOOL_PROFILE).toBe('core')
+    })
+  })
+
+  it('writes the Cursor MCP server as a bare madar launcher without a pinned package version', () => {
+    withTempDir((projectDir) => {
+      cursorInstall(projectDir)
+
+      const mcpConfig = JSON.parse(readFileSync(join(projectDir, '.cursor', 'mcp.json'), 'utf8')) as {
+        mcpServers?: {
+          'madar'?: {
+            command?: string
+            args?: string[]
+          }
+        }
+      }
+
+      expect(mcpConfig.mcpServers?.['madar']?.command).toBe('madar')
+      expect(mcpConfig.mcpServers?.['madar']?.args).toEqual([
+        'serve',
+        '--stdio',
+        join(projectDir, 'out', 'graph.json'),
+      ])
     })
   })
 


### PR DESCRIPTION
## Summary
- switch generated Claude and Cursor MCP configs from version-pinned `npx` launchers to bare `madar serve --stdio`
- keep VS Code Copilot's direct CLI-path wiring unchanged
- clarify the docs distinction between manual registry `npx` usage and repo-local installed MCP configs

## Testing
- npm run test:run -- tests/unit/install.test.ts tests/unit/doctor.test.ts tests/unit/install-docs.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP server configuration documentation for AI agent setups
* **Refactor**
  * Simplified generated configuration to use direct CLI invocation instead of version-pinned packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->