### PR TITLE
chore: prepare 0.27.9-next.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.27.9-next.7] - 2026-06-04
+
+### Fixed
+
+- **Generated Claude and Cursor MCP configs now launch Madar directly**: repo-local installs now write the bare `madar` command with `serve --stdio <graph path>` instead of version-pinned `npx` / `npx.cmd` launchers, so Windows installs no longer depend on the `.cmd` shim and the generated MCP config matches the installed CLI contract.
+
 ## [0.27.9-next.6] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ The current telemetry model is local-first and source-safe. It records coarse fu
 
 ## What's New
 
-See the [`0.27.9-next.6` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next6---2026-06-04) for the full release notes.
+See the [`0.27.9-next.7` changelog entry](https://github.com/mohanagy/madar/blob/next/CHANGELOG.md#0279-next7---2026-06-04) for the full release notes.
 
 Recent highlights:
 
+- `0.27.9-next.7` makes generated Claude and Cursor MCP configs launch the installed `madar` CLI directly, so repo-local installs no longer write version-pinned `npx` / `npx.cmd` launchers into the MCP config.
 - `0.27.9-next.6` aligns Windows native-agent `--exec` handling with `cmd.exe`, so cmd-style exec templates such as `type {prompt_file} | claude -p --output-format stream-json --verbose` no longer hang the Madar arm during compare/review/benchmark flows.
 - `0.27.9-next.5` tightens native-agent compare prompts so task-specific runs stay bounded, and it preserves partial stdout/stderr when a timed-out arm settles after abort.
 - `0.27.9-next.4` splits native-agent compare prompt artifacts into explicit baseline and Madar files, records both paths in `report.json`, and keeps the legacy `prompt_file` field aligned with the Madar prompt for compatibility.
@@ -150,7 +151,7 @@ Recent highlights:
 
 ## When To Use `--spi`
 
-`--spi` is still opt-in in `0.27.9-next.6`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+`--spi` is still opt-in in `0.27.9-next.7`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
 
 It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.27.9-next.6",
+    "version": "0.27.9-next.7",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.27.9-next.6",
+            "version": "0.27.9-next.7",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.6",
+    "version": "0.27.9-next.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@lubab/madar",
-            "version": "0.27.9-next.6",
+            "version": "0.27.9-next.7",
             "license": "MIT",
             "dependencies": {
                 "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.27.9-next.6",
+    "version": "0.27.9-next.7",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary
- bump package metadata to `0.27.9-next.7`
- add changelog and README notes for the bare `madar` MCP launcher install change
- sync the MCP registry manifest for the next prerelease

## Testing
- npm run release:verify
- npm run registry:validate
- npm run typecheck
- npm run build
- CI=1 npm run test:run
- npm pack --dry-run
- npm sbom --sbom-format cyclonedx > <temp sbom file>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Claude and Cursor MCP configurations now launch the locally installed CLI directly, eliminating version-pinned launcher scripts and resolving Windows `.cmd` shim dependency compatibility issues.

* **Documentation**
  * Updated changelog, README, and package registry entries to version 0.27.9-next.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->