### PR TITLE
docs: refresh README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
 # Madar
 
-**Stop Claude Code, Cursor, Codex, and Copilot from wasting tokens rediscovering the same large TypeScript/Node repo.**
-
-Madar compiles a task-aware local context pack from **the execution paths and structures relevant to this task**. That first pass is usually a much smaller execution slice or structural subset, with inline snippets and citations, so the agent can start from evidence before it starts searching the repo by hand.
+**Give coding agents the repo context they need before they start searching.**
 
 Madar builds a local graph of your TypeScript/Node repo, then gives agents like Claude Code, Cursor, Codex, Copilot, Gemini, Aider, and OpenCode a task-aware context pack for the question you are asking.
-
-Madar is deterministic local context compilation. It complements agents and IDE indexing; it is **not another generic codebase index**.
 
 It helps agents spend less time rediscovering the same files, routes, imports, and flows.
 
 [![npm](https://img.shields.io/npm/v/%40lubab%2Fmadar)](https://www.npmjs.com/package/@lubab/madar)
 [![node >=20](https://img.shields.io/badge/node-%E2%89%A520-3c873a)](https://nodejs.org/)
 [![local first](https://img.shields.io/badge/local--first-no%20cloud%20required-0f766e)](#privacy)
-[![No API keys](https://img.shields.io/badge/API%20keys-none%20required-111827)](#trust--limitations)
 [![license MIT](https://img.shields.io/badge/license-MIT-16a34a)](https://github.com/mohanagy/madar/blob/main/LICENSE)
 
 ## Why
@@ -27,26 +22,6 @@ On large repos, coding agents often burn context before they can answer:
 Madar gives the agent a smaller, repo-grounded starting point.
 
 It does not replace the agent. It helps the agent start from better evidence.
-
-## Who Madar is for
-
-- Teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
-- Explain, review, and impact workflows where a bounded first pass is more useful than a broad repo crawl.
-
-## Who Madar is not for
-
-- Tiny repos, throwaway scripts, or one-off prompts where full-repo search is already cheap.
-- Hosted-dashboard-first buyers or teams that need broad cross-language parity before the TypeScript/Node proof deepens.
-
-## Madar vs Repomix vs Context7
-
-| Tool | Best first use | Where it stops |
-| --- | --- | --- |
-| **Madar** | Task-scoped local repo evidence for explain, review, and impact work on large TypeScript/Node repos | Not a hosted knowledge base or broad cross-language parity tool today |
-| **Repomix** | Exporting or sharing a broad repo snapshot/prompt bundle | Not a task-aware local retrieval layer, PR-impact surface, or agent install flow |
-| **Context7** | Pulling external library/framework docs into prompts | Not a local codebase analysis, PR-impact, or graph-backed repository context tool |
-
-Capability/scope summary only. See the [claims-and-evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md#competitive-positioning) before turning this into a stronger claim.
 
 ## Install
 
@@ -75,10 +50,6 @@ madar doctor
 madar status
 ```
 
-Want a tiny reproducible workspace? Start with [`examples/sample-workspace/`](https://github.com/mohanagy/madar/tree/main/examples/sample-workspace/) and the [sample workspace tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md).
-
-Want the broader first-run walkthrough with install verification, one pack, and a safe compare smoke check? Use the [getting started tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md).
-
 Then connect an agent:
 
 ```bash
@@ -96,7 +67,7 @@ Why does this endpoint return 403?
 
 The agent can ask Madar for relevant files, symbols, snippets, and relationships before doing raw repo search.
 
-## Choose your agent
+## Supported Agents
 
 ```bash
 madar claude install
@@ -108,9 +79,7 @@ madar aider install
 madar opencode install
 ```
 
-After you generate `out/graph.json`, `madar doctor` and `madar status` check the local install wiring for Claude Code, Cursor, Gemini CLI, and GitHub Copilot CLI. They also lint the AGENTS-based Madar instruction profiles for Codex CLI, OpenCode, and Aider; if a profile drifts, they mark the agent as `partial` and suggest the matching reinstall command.
-
-Install details, generated files, profiles, uninstall behavior, and verified copy/paste quickstarts live in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md), the [compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md), the [agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md), and the [launch checklist](https://github.com/mohanagy/madar/blob/main/docs/launch-checklist.md) for proof-first release/distribution copy.
+After installing a profile, run `madar doctor` and `madar status`. Installer details are in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md).
 
 ## Use Without MCP
 
@@ -131,10 +100,6 @@ Create a share-safe handoff for another coding tool:
 ```bash
 madar handoff "add auth telemetry" --task implement --consumer copilot
 ```
-
-`madar prompt` stays local. `madar pack` stays the richer local/full-context surface. `madar handoff` is the share-safe remote/background-agent artifact for cloud or async workers. Note: compare and benchmark flows can spend paid model tokens when you point them at a real model CLI.
-
-The MCP equivalents include `context_pack`, `context_prompt`, and follow-up expansion through stable session refs. `context_pack` and `context_prompt` accept both `require_fresh_context` and `require_fresh_graph` for the same scoped-vs-global strictness choices. For follow-ups, reuse the same `session_id` with `context_prompt` when a conversation continues; `session_diagnostics` tells you whether the turn reused, added, updated, or invalidated prior context. Expect the biggest reuse gains with a mostly stable retrieved graph context. First turns and heavily changed retrieved context naturally show little or no reuse.
 
 ## What It Builds
 
@@ -178,12 +143,6 @@ madar pack "how does auth work?" --require-fresh-graph
 
 Use `--require-fresh-context` when the selected files must be fresh. Use `--require-fresh-graph` when the whole graph must match the current repo.
 
-## When To Use `--spi`
-
-`--spi` is still opt-in in `0.27.9`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
-
-It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
-
 ## Evidence
 
 On one verified GoValidate backend explain task, Madar reduced:
@@ -199,10 +158,6 @@ This is not a universal benchmark claim. It is one repo, one prompt, one agent r
 
 The public evidence map tracks what is proven, what is mixed, and what should not be claimed yet: [claims and evidence](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md).
 
-Published benchmark cells run in isolation mode. Your local numbers may differ if your Claude Code config differs.
-
-Current evidence also includes a public benchmark suite with per-repo spread, initial fixture-proxy implement/review/impact rows, and workflow-outcome receipts. There is still no single-number cross-repo headline. Mixed evidence and counterexamples are tracked openly, including [docs/benchmarks/2026-05-25-founder-command-center-auth-flow/](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/2026-05-25-founder-command-center-auth-flow/).
-
 ## Privacy
 
 Madar runs locally. Generating a graph does not require an API key or a cloud service. Your code does not leave your machine through Madar graph generation.
@@ -210,20 +165,6 @@ Madar runs locally. Generating a graph does not require an API key or a cloud se
 Your coding agent may still send prompts or selected file context to its own model provider, depending on how that agent is configured.
 
 Treat every local MCP install, hook, or agent profile as part of your local trust boundary. The threat model is documented here: [MCP threat model](https://github.com/mohanagy/madar/blob/main/docs/security/mcp-threat-model.md).
-
-## Trust + Limitations
-
-Everything stays local by default. No cloud upload, no API key required. Your code never crosses an HTTP boundary unless you explicitly invoke a model or remote system you configured yourself.
-
-Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary. Only enable it for repositories and local agent runtimes you trust. Prefer `--profile strict` when you only need the lean core MCP tools. `--profile strict` keeps the lean core MCP tools but still uses one bounded `context_pack` call per task before broader exploration.
-
-Limitations to know:
-
-1. Cold-start sessions add a one-time MCP/tool-schema cost. Core profile is about ~3,200 bytes / ~800 tokens, down about 25% from the original surface.
-2. Deep extraction is still best on JS/TS. Python has conservative cross-file import/call resolution, FastAPI router composition, and first-pass Django URL-conf route-to-view mapping. Python and Go are still not near JS/TS parity.
-3. Static analysis cannot resolve every dynamic runtime behavior.
-4. Token reduction depends on project and task.
-5. Some workflows still need full file reads, tests, and review.
 
 ## Telemetry
 
@@ -249,29 +190,17 @@ This release includes the stable next-track adoption bundle: the one-command `ma
 
 Read the full notes in the [0.27.9 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0279---2026-06-04).
 
-Recent highlights:
-
-- `0.27.9` makes the whole next-track rollout stable: the public benchmark suite and language fixtures, one-command `madar try` proof flow, opt-in telemetry funnel, verified agent quickstarts, design-partner loop, and the proof-first launch/distribution checklist now ship on `main`.
-- The larger **What's new in 0.23.0** additions remain central: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
-- Public proof workflows are organized under [docs/proof-workflows.md](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md), [docs/claims-and-evidence.md](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md), [docs/benchmarks/suite/](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/), and [docs/launch-checklist.md](https://github.com/mohanagy/madar/blob/main/docs/launch-checklist.md).
-
 ## Docs
 
 | Need | Link |
 | --- | --- |
 | First run | [Getting started](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md) |
-| Small demo repo | [Sample workspace](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md) |
 | Agent setup | [Agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md) |
 | CLI and MCP tools | [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md) |
-| Install matrix | [Compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md) |
 | Context-pack model | [Context packs](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md) |
 | Claims and limits | [Claims and evidence](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) |
-| Proof workflows | [Proof workflows](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) |
-| Design partner program | [Design partners](https://github.com/mohanagy/madar/blob/main/docs/design-partners.md) |
-| Team and enterprise offer | [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) |
 | Benchmarks | [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) |
 | Roadmap | [Roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) |
-| Telemetry | [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) |
 | Changelog | [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,113 +1,170 @@
-# madar
+# Madar
 
-**Stop Claude Code, Cursor, Codex, and Copilot from wasting tokens rediscovering the same large TypeScript/Node repo.**
+**Give coding agents the repo context they need before they start searching.**
 
-Madar compiles a task-aware local context pack from **the execution paths and structures relevant to this task**. That first pass is usually a much smaller execution slice or structural subset, with inline snippets and citations, so the agent can start from evidence before it starts searching the repo by hand.
+Madar builds a local graph of your TypeScript/Node repo, then gives agents like Claude Code, Cursor, Codex, Copilot, Gemini, Aider, and OpenCode a task-aware context pack for the question you are asking.
 
-Madar is deterministic local context compilation. It complements agents and IDE indexing; it is **not another generic codebase index**.
+It helps agents spend less time rediscovering the same files, routes, imports, and flows.
 
 [![npm](https://img.shields.io/npm/v/%40lubab%2Fmadar)](https://www.npmjs.com/package/@lubab/madar)
 [![node >=20](https://img.shields.io/badge/node-%E2%89%A520-3c873a)](https://nodejs.org/)
-[![Local first](https://img.shields.io/badge/local--first-no%20cloud%20required-0f766e)](#trust--limitations)
-[![No API keys](https://img.shields.io/badge/API%20keys-none%20required-111827)](#trust--limitations)
+[![local first](https://img.shields.io/badge/local--first-no%20cloud%20required-0f766e)](#privacy)
 [![license MIT](https://img.shields.io/badge/license-MIT-16a34a)](https://github.com/mohanagy/madar/blob/main/LICENSE)
 
----
+## Why
 
-## Rename and migration
+On large repos, coding agents often burn context before they can answer:
 
-Madar is the current project name and package. If you arrived from older `graphify-ts` links, listings, or git remotes, use `@lubab/madar`, `https://github.com/mohanagy/madar`, and `git@github.com:mohanagy/madar.git`. Any remaining `graphify-ts` mentions in this repository are historical migration context only.
+- broad searches across unrelated folders
+- repeated file discovery every session
+- wrong-file edits because the first context was too shallow
 
----
+Madar gives the agent a smaller, repo-grounded starting point.
 
-## Who Madar is for
+It does not replace the agent. It helps the agent start from better evidence.
 
-- Teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
-- Explain, review, and impact workflows where a bounded first pass is more useful than a broad repo crawl.
-
-## Who Madar is not for
-
-- Tiny repos, throwaway scripts, or one-off prompts where full-repo search is already cheap.
-- Hosted-dashboard-first buyers or teams that need broad cross-language parity before the TypeScript/Node proof deepens.
-
-## Madar vs Repomix vs Context7
-
-| Tool | Best first use | Where it stops |
-| --- | --- | --- |
-| **Madar** | Task-scoped local repo evidence for explain, review, and impact work on large TypeScript/Node repos | Not a hosted knowledge base or broad cross-language parity tool today |
-| **Repomix** | Exporting or sharing a broad repo snapshot/prompt bundle | Not a task-aware local retrieval layer, PR-impact surface, or agent install flow |
-| **Context7** | Pulling external library/framework docs into prompts | Not a local codebase analysis, PR-impact, or graph-backed repository context tool |
-
-Capability/scope summary only. See the [claims-and-evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md#competitive-positioning) before turning this into a stronger claim.
-
----
-
-## Quickstart
-
-Start with a one-command local proof. `madar try` builds or reuses `out/graph.json`, prints one human-readable explain-pack result, and recommends the next install command without requiring MCP first. When you want more control, drop down to `madar generate`, `madar summary`, `madar pack`, `madar prompt`, and `madar handoff` directly.
+## Install
 
 ```bash
 npm install -g @lubab/madar
-
-cd your-project
-madar try "how does auth work?"  # one-command local proof before agent install
-madar generate .          # builds out/graph.json, no API key, no cloud
-madar summary             # bounded repo overview before deeper retrieval
-madar claude install      # wires Claude Code to use Madar via MCP
-madar doctor              # checks graph freshness + agent/MCP wiring
-madar status              # compact readiness summary + next commands
-
-# Optional framework-aware metadata + disk cache:
-madar generate . --spi
 ```
 
-Now ask your agent something about the codebase. It can start with one bounded `retrieve` or `context_pack` call, get labeled snippets with file paths and community context, and then decide whether focused follow-up reads are still needed.
+Madar requires Node.js 20 or newer.
 
-Want a tiny reproducible workspace? Start with [`examples/sample-workspace/`](https://github.com/mohanagy/madar/tree/main/examples/sample-workspace/) and the [sample workspace tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md).
+## Quick Start
 
-Want the broader first-run walkthrough with install verification, one pack, and a safe compare smoke check? Use the [getting started tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md).
-
----
-
-## Choose your agent
-
-Pick one install target, then rerun `madar doctor` and `madar status` so the first result is verified before you ask a broader question:
-
-- Claude Code: `madar claude install`
-- Codex CLI: `madar codex install`
-- Cursor: `madar cursor install`
-- GitHub Copilot CLI: `madar copilot install`
-- Gemini CLI: `madar gemini install`
-- Aider: `madar aider install`
-- OpenCode: `madar opencode install`
-
-After you generate `out/graph.json`, `madar doctor` and `madar status` check the local install wiring for Claude Code, Cursor, Gemini CLI, and GitHub Copilot CLI. They also lint the AGENTS-based Madar instruction profiles for Codex CLI, OpenCode, and Aider; if a profile drifts, they mark the agent as `partial` and suggest the matching reinstall command.
-
-Install details, generated files, profiles, uninstall behavior, and verified copy/paste quickstarts live in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md), [compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md), [agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md), and the [launch checklist](https://github.com/mohanagy/madar/blob/main/docs/launch-checklist.md) for proof-first release/distribution copy.
-
-**Without MCP**, compile a prompt or pack directly:
+Run this inside your repo:
 
 ```bash
+madar try "how does auth work?"
+```
+
+That command builds or reuses the local graph, prints a first context-pack result, and suggests the next install command.
+
+For the manual flow:
+
+```bash
+madar generate .
 madar summary
+madar doctor
+madar status
+```
+
+Then connect an agent:
+
+```bash
+madar claude install
+```
+
+Now ask your agent normal repo questions:
+
+```text
+How does auth work?
+Where is the report generated?
+Add telemetry to this flow.
+Why does this endpoint return 403?
+```
+
+The agent can ask Madar for relevant files, symbols, snippets, and relationships before doing raw repo search.
+
+## Supported Agents
+
+```bash
+madar claude install
+madar codex install
+madar cursor install
+madar copilot install
+madar gemini install
+madar aider install
+madar opencode install
+```
+
+After installing a profile, run `madar doctor` and `madar status`. Installer details are in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md).
+
+## Use Without MCP
+
+You can also generate context directly from the CLI:
+
+```bash
 madar pack "how does auth work?" --task explain --format text
-madar pack "add auth telemetry" --task implement --format json
-madar handoff "add auth telemetry" --task implement --consumer copilot
+```
+
+Create an agent-ready prompt:
+
+```bash
 madar prompt "how does auth work?" --provider claude
 ```
 
-`madar prompt` stays local. `madar pack` stays the richer local/full-context surface. `madar handoff` is the share-safe remote/background-agent artifact for cloud or async workers. Note: compare and benchmark flows can spend paid model tokens when you point them at a real model CLI.
-
-`madar pack`, `madar prompt`, and `madar handoff` now surface graph freshness so the consumer can distinguish whole-repo drift from selected-context drift. On git workspaces, freshness compares the graph's recorded build commit plus dirty-file snapshot against the current HEAD and working-tree diff instead of relying on source mtimes; non-git workspaces fall back to stored file fingerprints. The overall status can be `fresh`, `partially_stale`, `possibly_stale`, `stale`, or `missing`, and the receipt also reports a selected context status so unrelated changes do not block by default. `madar doctor` and `madar status` use the same freshness labels and next-step guidance. Add `--require-fresh-context` to refuse selected context that may be stale, or `--require-fresh-graph` to require a fully fresh repo snapshot.
-
-The MCP equivalents include `context_pack`, `context_prompt`, and follow-up expansion through stable session refs. `context_pack` and `context_prompt` accept both `require_fresh_context` and `require_fresh_graph` for the same scoped-vs-global strictness choices. The share-safe governance receipt keeps aggregate freshness counts and versions, but omits local graph paths. For follow-ups, reuse the same `session_id` with `context_prompt` when a conversation continues; `session_diagnostics` tells you whether the turn reused, added, updated, or invalidated prior context. Expect the biggest reuse gains with a mostly stable retrieved graph context. First turns and heavily changed retrieved context naturally show little or no reuse.
-
-Optional semantic retrieval/rerank support is local too, but requires the model package:
+Create a share-safe handoff for another coding tool:
 
 ```bash
-npm install @huggingface/transformers
+madar handoff "add auth telemetry" --task implement --consumer copilot
 ```
 
----
+## What It Builds
+
+Madar analyzes your local repo and creates a graph of files, imports, exports, symbols, routes, handlers, call relationships, dependency relationships, framework metadata, and task-relevant snippets.
+
+The graph is stored locally in your project output folder.
+
+## Fit
+
+Madar is most useful when:
+
+- your repo is medium or large
+- the project is TypeScript or Node.js
+- agents keep opening too many files
+- you ask architecture, flow, review, or impact questions
+- you want more task-aware context before edits
+- token usage, latency, or local repo privacy matter
+
+It helps less when:
+
+- the repo is small
+- the task is obvious from one file
+- the question needs live runtime behavior
+- the code relies heavily on dynamic patterns static analysis cannot see
+- the generated graph is stale after large repo changes
+
+If the repo changed a lot, regenerate:
+
+```bash
+madar generate .
+```
+
+## Freshness
+
+Madar records graph freshness so agents can tell whether context still matches the repo. On git workspaces, freshness is tied to the graph build commit plus the working-tree diff, so unrelated changes do not have to block a focused task by default.
+
+```bash
+madar pack "how does auth work?" --require-fresh-context
+madar pack "how does auth work?" --require-fresh-graph
+```
+
+Use `--require-fresh-context` when the selected files must be fresh. Use `--require-fresh-graph` when the whole graph must match the current repo.
+
+## Evidence
+
+On one verified GoValidate backend explain task, Madar reduced:
+
+| Metric | Without Madar | With Madar |
+| --- | ---: | ---: |
+| Tool calls | 28 | 7 |
+| Input tokens | 2,366,946 | 498,688 |
+| Wall-clock latency | 158,995 ms | 72,420 ms |
+| Cost | $2.6595 | $0.9728 |
+
+This is not a universal benchmark claim. It is one repo, one prompt, one agent runtime, and one verified install path.
+
+The public evidence map tracks what is proven, what is mixed, and what should not be claimed yet: [claims and evidence](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md).
+
+## Privacy
+
+Madar runs locally. Generating a graph does not require an API key or a cloud service. Your code does not leave your machine through Madar graph generation.
+
+Your coding agent may still send prompts or selected file context to its own model provider, depending on how that agent is configured.
+
+Treat every local MCP install, hook, or agent profile as part of your local trust boundary. The threat model is documented here: [MCP threat model](https://github.com/mohanagy/madar/blob/main/docs/security/mcp-threat-model.md).
 
 ## Telemetry
 
@@ -123,135 +180,54 @@ madar telemetry report
 MADAR_ENABLE_TELEMETRY=1 madar generate .
 ```
 
-The current telemetry model is local-first and source-safe. It records coarse funnel events for `install`, `generate`, `pack`, `prompt`, MCP `context_pack`, `doctor`, `status`, and `compare`, plus command stage, version, OS, Node major version, and optional coarse buckets such as agent target, repo size, graph size, SPI enabled, failure bucket, and status bucket. It does **not** record prompt text, answer text, source paths, source content, or repository names. Full controls: [`docs/telemetry.md`](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
-
----
+It does not record prompt text, answer text, source paths, source content, or repository names. Full controls: [docs/telemetry.md](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md).
 
 ## What's New
 
-See the [`0.27.9` changelog entry](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0279---2026-06-04) for the full release notes.
+Current version: `0.27.9`.
 
-Recent highlights:
+This release includes the stable next-track adoption bundle: the one-command `madar try` flow, opt-in telemetry, verified agent quickstarts, public benchmark-suite work, freshness improvements, and Windows Claude workflow fixes.
 
-- `0.27.9` makes the whole next-track rollout stable: the public benchmark suite and language fixtures, one-command `madar try` proof flow, opt-in telemetry funnel, verified agent quickstarts, design-partner loop, and the proof-first launch/distribution checklist now ship on `main`.
-- Git-backed freshness and stale-context guarantees now cover `madar pack`, `madar prompt`, `madar handoff`, `madar doctor`, and `madar status`, so the stable line keeps the scoped graph freshness model from the next track.
-- Native-agent compare is tighter and more debuggable: stable now carries stricter task-bounded prompt contracts, separate baseline/Madar prompt artifacts, clearer install/trace attribution, and preserved partial stdout/stderr when timed-out arms settle after abort.
-- Windows Claude and native-agent workflows are now safe on the stable line: Claude installs write a generated local `.claude/madar-user-prompt-submit.cjs` script instead of an oversized inline hook, Windows `--exec` flows honor the `cmd.exe` contract, and generated Claude/Cursor MCP configs launch the installed `madar` CLI directly.
-- `madar install <platform>` now works alongside `--platform`, and compare traces distinguish deferred `ToolSearch` Madar-tool selection from actual broad exploration so benchmark/runtime receipts stay honest.
-- `0.27.8` refactors the README into a shorter npm-facing landing page and moves long-form Pack Schema, context-pack, MCP, installer, command, and discovery-rule details into dedicated docs.
-- `0.27.7` added the checked-in federation flagship proof: a reproducible frontend/backend/shared fixture plus a synthetic federation receipt.
-- Roadmap docs now cover design-partner workflow loops, plugin distribution channels, and language-expansion decisions.
-- The larger **What's new in 0.23.0** additions remain central: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
-- Public proof workflows are organized under [`docs/proof-workflows.md`](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md), [`docs/claims-and-evidence.md`](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md), [`docs/benchmarks/suite/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/), and [`docs/launch-checklist.md`](https://github.com/mohanagy/madar/blob/main/docs/launch-checklist.md).
+Read the full notes in the [0.27.9 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0279---2026-06-04).
 
----
-
-## When To Use `--spi`
-
-`--spi` is still opt-in in `0.27.9`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
-
-It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
-
-More detail: [context packs and task evidence](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md).
-
----
-
-## Core Surfaces
-
-Madar builds a local graph once, then compiles task-specific evidence from it:
-
-```text
-your prompt
-  -> workspace graph
-    -> relevant nodes + edges + snippets
-      -> compact context pack
-        -> AI coding agent
-```
-
-The output surfaces are deliberately small:
-
-- `madar summary`: bounded repo overview.
-- `madar pack`: task-aware local context pack. JSON mode emits Pack Schema v1.
-- `madar prompt`: provider-ready prompt payload.
-- `madar handoff`: share-safe remote/background-agent artifact.
-- `pr_impact` and `review-compare`: diff-aware review evidence.
-- `execution_slice`: static runtime-path hypothesis, not a live trace. Its `phase_coverage` is also static and prompt-scoped; broad report-generation prompts can surface planner/research/report-builder/scoring/renderer/persistence phases without implying live instrumentation.
-
-Runtime-generation prompts stay compact: pack shaping follows the strongest backend path first and suppresses sibling-route noise plus shared-hub fan-out on broad runtime-generation questions.
-
-These seven MCP tools ship in the default core profile: `retrieve`, `pr_impact`, `impact`, `call_chain`, `community_overview`, `graph_stats`, and `graph_summary`. The full surface is 26 tools, opt-in via `MADAR_TOOL_PROFILE=full` or `--profile full`, including `context_expand` and `get_neighbors`.
-
-Full command and MCP reference: [`docs/reference/cli-and-mcp.md`](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md).
-
----
-
-## Evidence And Limits
-
-The current headline proof is one verified GoValidate backend service cell for the prompt *"How idea report is being generated"*:
-
-| metric | baseline | Madar | delta |
-| --- | --- | --- | --- |
-| total tool calls | 28 | 7 | 4x fewer |
-| broad search after first Madar call | 11 | 0 | eliminated |
-| input tokens | 2,366,946 | 498,688 | 4.75x less |
-| wall-clock latency | 158,995 ms | 72,420 ms | 2.2x faster |
-| cost | 2.6595 USD | 0.9728 USD | 2.73x cheaper |
-
-This is one cell: one prompt, one repo, one agent runtime, one verified install path. Your results will vary by repo shape, prompt type, agent runtime, and other installed tools. Published benchmark cells run in isolation mode. Your local numbers may differ if your Claude Code config differs.
-
-Current evidence also includes a public benchmark suite with per-repo spread, initial fixture-proxy implement/review/impact rows, and workflow-outcome receipts. There is still no single-number cross-repo headline. Mixed evidence and counterexamples are tracked openly, including [`docs/benchmarks/2026-05-25-founder-command-center-auth-flow/`](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/2026-05-25-founder-command-center-auth-flow/).
-
-Madar is a context/evidence layer for review and security workflows, not a PR reviewer or vulnerability scanner. CodeRabbit, Qodo, Codex Security, and similar tools still decide findings, policy, and remediation behavior. Madar supplies bounded local evidence through `pr_impact`, `review-compare`, `madar handoff`, and `report.share-safe.json`.
-
-Read the public claim map before using numbers in customer-facing copy: [`docs/claims-and-evidence.md`](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md).
-
----
-
-## Trust + Limitations
-
-Everything stays local by default. No cloud upload, no API key required. Your code never crosses an HTTP boundary unless you explicitly invoke a model or remote system you configured yourself.
-
-- Build: tree-sitter AST extraction and Louvain community detection, CPU-local.
-- Query: BM25 lexical scoring, reciprocal-rank fusion, optional ONNX embeddings, and optional cross-encoder reranker.
-- MCP: local stdio subprocess of your agent.
-- Security boundary: local-first is not automatically safe. Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary. Only enable it for repositories and local agent runtimes you trust. Prefer `--profile strict` when you only need the lean core MCP tools. `--profile strict` keeps the lean core MCP tools but still uses one bounded `context_pack` call per task before broader exploration. Threat model: [`docs/security/mcp-threat-model.md`](https://github.com/mohanagy/madar/blob/main/docs/security/mcp-threat-model.md).
-
-Limitations to know:
-
-1. Cold-start sessions add a one-time MCP/tool-schema cost. Core profile is about ~3,200 bytes / ~800 tokens, down about 25% from the original surface.
-2. Deep extraction is still best on JS/TS. Python has conservative cross-file import/call resolution, FastAPI router composition, and first-pass Django URL-conf route-to-view mapping. Go has conservative local-package import, receiver-call, and `net/http` / Gin / Chi route support. Python and Go are still not near JS/TS parity.
-3. Static analysis cannot resolve every dynamic runtime behavior.
-4. Token reduction depends on project and task.
-5. Some workflows still need full file reads, tests, and review.
-
----
-
-## Documentation
+## Docs
 
 | Need | Link |
 | --- | --- |
 | First run | [Getting started](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md) |
-| Agent quickstarts | [Agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md) |
-| Small demo repo | [Sample workspace](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md) |
-| Context packs, Pack Schema v1, adaptive renderings | [Context packs and task evidence](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md) |
-| CLI commands, MCP tools, agent installers | [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md) |
-| Install matrix | [Compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md) |
-| Proof workflows | [Proof workflows](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) |
-| Design partner program | [Design partners](https://github.com/mohanagy/madar/blob/main/docs/design-partners.md) |
-| Claims and evidence | [Claims and evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) |
-| Team and enterprise offer | [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) |
-| Benchmark suite | [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) |
-| Language coverage | [Language and capability matrix](https://github.com/mohanagy/madar/blob/main/docs/language-capability-matrix.md) |
-| Roadmap | [Public roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) |
-| Telemetry | [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) |
-| MCP Registry metadata | [`docs/mcp-registry/server.json`](https://github.com/mohanagy/madar/blob/main/docs/mcp-registry/server.json) |
-| Full release notes | [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) |
+| Agent setup | [Agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md) |
+| CLI and MCP tools | [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md) |
+| Context-pack model | [Context packs](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md) |
+| Claims and limits | [Claims and evidence](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) |
+| Benchmarks | [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) |
+| Roadmap | [Roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) |
+| Changelog | [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) |
 
----
+## Contributing
+
+The most useful contributions right now are:
+
+- testing Madar on real TypeScript and Node.js repos
+- reporting cases where the context pack misses important files
+- improving Windows, WSL, and MCP setup reliability
+- adding framework detection for common repo patterns
+- improving docs with real setup examples
+
+For active development, open issues or PRs against the `next` branch.
+
+Before opening a PR, run:
+
+```bash
+npm test
+npm run build
+npm run release:verify
+```
+
+See the full contributor graph on [GitHub contributors](https://github.com/mohanagy/madar/graphs/contributors).
 
 ## Contributors
 
-Thanks to everyone shaping madar. The list below is regenerated automatically on every push to `main` by [`.github/workflows/contributors.yml`](https://github.com/mohanagy/madar/blob/main/.github/workflows/contributors.yml).
+Thanks to everyone shaping Madar. The list below is regenerated automatically on every push to `main`.
 
 <!-- readme: contributors -start -->
 <table>
@@ -293,13 +269,11 @@ Thanks to everyone shaping madar. The list below is regenerated automatically on
                 </a>
             </td>
 		</tr>
-	<tbody>
+	</tbody>
 </table>
 <!-- readme: contributors -end -->
 
-A specific shout-out to [@jamemackson](https://github.com/jamemackson) for [#54](https://github.com/mohanagy/madar/pull/54), adding OpenCode MCP installer support, the first community-contributed feature in madar.
-
----
+Special thanks to [@jamemackson](https://github.com/jamemackson) for [#54](https://github.com/mohanagy/madar/pull/54), the first community-contributed feature in Madar.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Madar
 
-**Give coding agents the repo context they need before they start searching.**
+**Stop Claude Code, Cursor, Codex, and Copilot from wasting tokens rediscovering the same large TypeScript/Node repo.**
+
+Madar compiles a task-aware local context pack from **the execution paths and structures relevant to this task**. That first pass is usually a much smaller execution slice or structural subset, with inline snippets and citations, so the agent can start from evidence before it starts searching the repo by hand.
 
 Madar builds a local graph of your TypeScript/Node repo, then gives agents like Claude Code, Cursor, Codex, Copilot, Gemini, Aider, and OpenCode a task-aware context pack for the question you are asking.
+
+Madar is deterministic local context compilation. It complements agents and IDE indexing; it is **not another generic codebase index**.
 
 It helps agents spend less time rediscovering the same files, routes, imports, and flows.
 
 [![npm](https://img.shields.io/npm/v/%40lubab%2Fmadar)](https://www.npmjs.com/package/@lubab/madar)
 [![node >=20](https://img.shields.io/badge/node-%E2%89%A520-3c873a)](https://nodejs.org/)
 [![local first](https://img.shields.io/badge/local--first-no%20cloud%20required-0f766e)](#privacy)
+[![No API keys](https://img.shields.io/badge/API%20keys-none%20required-111827)](#trust--limitations)
 [![license MIT](https://img.shields.io/badge/license-MIT-16a34a)](https://github.com/mohanagy/madar/blob/main/LICENSE)
 
 ## Why
@@ -22,6 +27,26 @@ On large repos, coding agents often burn context before they can answer:
 Madar gives the agent a smaller, repo-grounded starting point.
 
 It does not replace the agent. It helps the agent start from better evidence.
+
+## Who Madar is for
+
+- Teams using AI coding agents on medium-to-large TypeScript/Node repos where broad exploration creates cost, latency, privacy, or wrong-file-edit risk.
+- Explain, review, and impact workflows where a bounded first pass is more useful than a broad repo crawl.
+
+## Who Madar is not for
+
+- Tiny repos, throwaway scripts, or one-off prompts where full-repo search is already cheap.
+- Hosted-dashboard-first buyers or teams that need broad cross-language parity before the TypeScript/Node proof deepens.
+
+## Madar vs Repomix vs Context7
+
+| Tool | Best first use | Where it stops |
+| --- | --- | --- |
+| **Madar** | Task-scoped local repo evidence for explain, review, and impact work on large TypeScript/Node repos | Not a hosted knowledge base or broad cross-language parity tool today |
+| **Repomix** | Exporting or sharing a broad repo snapshot/prompt bundle | Not a task-aware local retrieval layer, PR-impact surface, or agent install flow |
+| **Context7** | Pulling external library/framework docs into prompts | Not a local codebase analysis, PR-impact, or graph-backed repository context tool |
+
+Capability/scope summary only. See the [claims-and-evidence map](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md#competitive-positioning) before turning this into a stronger claim.
 
 ## Install
 
@@ -50,6 +75,10 @@ madar doctor
 madar status
 ```
 
+Want a tiny reproducible workspace? Start with [`examples/sample-workspace/`](https://github.com/mohanagy/madar/tree/main/examples/sample-workspace/) and the [sample workspace tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md).
+
+Want the broader first-run walkthrough with install verification, one pack, and a safe compare smoke check? Use the [getting started tutorial](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md).
+
 Then connect an agent:
 
 ```bash
@@ -67,7 +96,7 @@ Why does this endpoint return 403?
 
 The agent can ask Madar for relevant files, symbols, snippets, and relationships before doing raw repo search.
 
-## Supported Agents
+## Choose your agent
 
 ```bash
 madar claude install
@@ -79,7 +108,9 @@ madar aider install
 madar opencode install
 ```
 
-After installing a profile, run `madar doctor` and `madar status`. Installer details are in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md).
+After you generate `out/graph.json`, `madar doctor` and `madar status` check the local install wiring for Claude Code, Cursor, Gemini CLI, and GitHub Copilot CLI. They also lint the AGENTS-based Madar instruction profiles for Codex CLI, OpenCode, and Aider; if a profile drifts, they mark the agent as `partial` and suggest the matching reinstall command.
+
+Install details, generated files, profiles, uninstall behavior, and verified copy/paste quickstarts live in the [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md), the [compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md), the [agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md), and the [launch checklist](https://github.com/mohanagy/madar/blob/main/docs/launch-checklist.md) for proof-first release/distribution copy.
 
 ## Use Without MCP
 
@@ -100,6 +131,10 @@ Create a share-safe handoff for another coding tool:
 ```bash
 madar handoff "add auth telemetry" --task implement --consumer copilot
 ```
+
+`madar prompt` stays local. `madar pack` stays the richer local/full-context surface. `madar handoff` is the share-safe remote/background-agent artifact for cloud or async workers. Note: compare and benchmark flows can spend paid model tokens when you point them at a real model CLI.
+
+The MCP equivalents include `context_pack`, `context_prompt`, and follow-up expansion through stable session refs. `context_pack` and `context_prompt` accept both `require_fresh_context` and `require_fresh_graph` for the same scoped-vs-global strictness choices. For follow-ups, reuse the same `session_id` with `context_prompt` when a conversation continues; `session_diagnostics` tells you whether the turn reused, added, updated, or invalidated prior context. Expect the biggest reuse gains with a mostly stable retrieved graph context. First turns and heavily changed retrieved context naturally show little or no reuse.
 
 ## What It Builds
 
@@ -143,6 +178,12 @@ madar pack "how does auth work?" --require-fresh-graph
 
 Use `--require-fresh-context` when the selected files must be fresh. Use `--require-fresh-graph` when the whole graph must match the current repo.
 
+## When To Use `--spi`
+
+`--spi` is still opt-in in `0.27.9`. Use it when your repo is framework-heavy TypeScript/JavaScript and you want extra framework-shaped metadata plus disk cache behavior.
+
+It is usually worth it for NestJS, Next.js App Router, Prisma, tRPC, Hono, Fastify, and similar repos where users ask storage-oriented prompts, client/server boundary questions, or request-flow questions. The default pipeline is still fine for simpler repos, non-JS/TS workspaces, or first runs where you do not need the extra framework detail yet.
+
 ## Evidence
 
 On one verified GoValidate backend explain task, Madar reduced:
@@ -158,6 +199,10 @@ This is not a universal benchmark claim. It is one repo, one prompt, one agent r
 
 The public evidence map tracks what is proven, what is mixed, and what should not be claimed yet: [claims and evidence](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md).
 
+Published benchmark cells run in isolation mode. Your local numbers may differ if your Claude Code config differs.
+
+Current evidence also includes a public benchmark suite with per-repo spread, initial fixture-proxy implement/review/impact rows, and workflow-outcome receipts. There is still no single-number cross-repo headline. Mixed evidence and counterexamples are tracked openly, including [docs/benchmarks/2026-05-25-founder-command-center-auth-flow/](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/2026-05-25-founder-command-center-auth-flow/).
+
 ## Privacy
 
 Madar runs locally. Generating a graph does not require an API key or a cloud service. Your code does not leave your machine through Madar graph generation.
@@ -165,6 +210,20 @@ Madar runs locally. Generating a graph does not require an API key or a cloud se
 Your coding agent may still send prompts or selected file context to its own model provider, depending on how that agent is configured.
 
 Treat every local MCP install, hook, or agent profile as part of your local trust boundary. The threat model is documented here: [MCP threat model](https://github.com/mohanagy/madar/blob/main/docs/security/mcp-threat-model.md).
+
+## Trust + Limitations
+
+Everything stays local by default. No cloud upload, no API key required. Your code never crosses an HTTP boundary unless you explicitly invoke a model or remote system you configured yourself.
+
+Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary. Only enable it for repositories and local agent runtimes you trust. Prefer `--profile strict` when you only need the lean core MCP tools. `--profile strict` keeps the lean core MCP tools but still uses one bounded `context_pack` call per task before broader exploration.
+
+Limitations to know:
+
+1. Cold-start sessions add a one-time MCP/tool-schema cost. Core profile is about ~3,200 bytes / ~800 tokens, down about 25% from the original surface.
+2. Deep extraction is still best on JS/TS. Python has conservative cross-file import/call resolution, FastAPI router composition, and first-pass Django URL-conf route-to-view mapping. Python and Go are still not near JS/TS parity.
+3. Static analysis cannot resolve every dynamic runtime behavior.
+4. Token reduction depends on project and task.
+5. Some workflows still need full file reads, tests, and review.
 
 ## Telemetry
 
@@ -190,17 +249,29 @@ This release includes the stable next-track adoption bundle: the one-command `ma
 
 Read the full notes in the [0.27.9 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0279---2026-06-04).
 
+Recent highlights:
+
+- `0.27.9` makes the whole next-track rollout stable: the public benchmark suite and language fixtures, one-command `madar try` proof flow, opt-in telemetry funnel, verified agent quickstarts, design-partner loop, and the proof-first launch/distribution checklist now ship on `main`.
+- The larger **What's new in 0.23.0** additions remain central: `madar summary`, the core MCP `graph_summary` tool, runtime `execution_slice` output, share-safe `report.share-safe.json` compare artifacts, and `compare --baseline-mode pack_only`.
+- Public proof workflows are organized under [docs/proof-workflows.md](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md), [docs/claims-and-evidence.md](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md), [docs/benchmarks/suite/](https://github.com/mohanagy/madar/tree/main/docs/benchmarks/suite/), and [docs/launch-checklist.md](https://github.com/mohanagy/madar/blob/main/docs/launch-checklist.md).
+
 ## Docs
 
 | Need | Link |
 | --- | --- |
 | First run | [Getting started](https://github.com/mohanagy/madar/blob/main/docs/tutorials/getting-started.md) |
+| Small demo repo | [Sample workspace](https://github.com/mohanagy/madar/blob/main/docs/tutorials/sample-workspace.md) |
 | Agent setup | [Agent quickstarts](https://github.com/mohanagy/madar/blob/main/docs/tutorials/agent-quickstarts.md) |
 | CLI and MCP tools | [CLI and MCP reference](https://github.com/mohanagy/madar/blob/main/docs/reference/cli-and-mcp.md) |
+| Install matrix | [Compatibility guide](https://github.com/mohanagy/madar/blob/main/docs/integrations/compatibility.md) |
 | Context-pack model | [Context packs](https://github.com/mohanagy/madar/blob/main/docs/concepts/context-packs.md) |
 | Claims and limits | [Claims and evidence](https://github.com/mohanagy/madar/blob/main/docs/claims-and-evidence.md) |
+| Proof workflows | [Proof workflows](https://github.com/mohanagy/madar/blob/main/docs/proof-workflows.md) |
+| Design partner program | [Design partners](https://github.com/mohanagy/madar/blob/main/docs/design-partners.md) |
+| Team and enterprise offer | [Team and enterprise offer](https://github.com/mohanagy/madar/blob/main/docs/team-enterprise-offer.md) |
 | Benchmarks | [Benchmark suite](https://github.com/mohanagy/madar/blob/main/docs/benchmarks/suite/README.md) |
 | Roadmap | [Roadmap](https://github.com/mohanagy/madar/blob/main/docs/roadmap.md) |
+| Telemetry | [Telemetry guide](https://github.com/mohanagy/madar/blob/main/docs/telemetry.md) |
 | Changelog | [Changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md) |
 
 ## Contributing

--- a/tests/unit/benchmark-suite-docs.test.ts
+++ b/tests/unit/benchmark-suite-docs.test.ts
@@ -81,13 +81,13 @@ describe('benchmark suite docs', () => {
 
   it('keeps claims conservative while acknowledging initial workflow-outcome receipts', () => {
     const claims = readDoc('docs/claims-and-evidence.md')
-    const readme = readDoc('README.md')
+    const whyMadar = readDoc('examples/why-madar.md')
 
     expect(claims).toContain('small-library, service, and monorepo fixture-style rows')
     expect(claims).toContain('initial implement/review workflow-outcome receipts')
     expect(claims).toContain('results/2026-05-31T12-00-00/summary.md')
-    expect(readme).toContain('initial fixture-proxy implement/review/impact rows')
-    expect(readme).toContain('no single-number cross-repo headline')
+    expect(whyMadar).toContain('per-repo spread')
+    expect(whyMadar).toContain('no single-number cross-repo headline')
   })
 
   it('publishes the latest suite bundle under the canonical timestamp without nested trial directories', () => {

--- a/tests/unit/design-partners-doc.test.ts
+++ b/tests/unit/design-partners-doc.test.ts
@@ -7,7 +7,6 @@ describe('design partner program docs', () => {
   it('publishes a share-safe design partner guide, tracker, and issue template', () => {
     const guide = readFileSync(resolve('docs/design-partners.md'), 'utf8')
     const template = readFileSync(resolve('.github/ISSUE_TEMPLATE/design_partner_report.yml'), 'utf8')
-    const readme = readFileSync(resolve('README.md'), 'utf8')
     const gettingStarted = readFileSync(resolve('docs/tutorials/getting-started.md'), 'utf8')
     const trackerRows = guide
       .split('\n')
@@ -42,7 +41,6 @@ describe('design partner program docs', () => {
     expect(template).toContain('Do not include source paths')
     expect(template).toContain('Do not include source code')
 
-    expect(readme).toContain('docs/design-partners.md')
     expect(gettingStarted).toContain('docs/design-partners.md')
   })
 })

--- a/tests/unit/getting-started-docs.test.ts
+++ b/tests/unit/getting-started-docs.test.ts
@@ -24,7 +24,7 @@ describe('getting started tutorial', () => {
     expect(readme).toContain('docs/tutorials/getting-started.md')
   })
 
-  it('keeps the first-run path focused on install, install verification, one pack, and a safe compare', () => {
+  it('keeps the first-run path focused on try, install, doctor/status, and the supported agent commands', () => {
     const tutorial = readFileSync(resolve('docs/tutorials/getting-started.md'), 'utf8')
     const readme = readFileSync(resolve('README.md'), 'utf8')
 
@@ -40,19 +40,24 @@ describe('getting started tutorial', () => {
     expect(tutorial).toContain('madar generate . --spi --no-html')
     expect(tutorial.toLowerCase()).toContain('paid model')
     expect(tutorial.toLowerCase()).toContain('10-minute')
-    expect(readme).toContain('## Choose your agent')
+    expect(readme).toContain('## Supported Agents')
     expect(readme).toContain('madar try')
     expect(readme.indexOf('madar try')).toBeLessThan(readme.indexOf('madar generate .'))
-    expect(readme).toContain('Claude Code')
-    expect(readme).toContain('Codex CLI')
-    expect(readme).toContain('Cursor')
-    expect(readme).toContain('GitHub Copilot CLI')
-    expect(readme).toContain('Gemini CLI')
-    expect(readme).toContain('Aider')
-    expect(readme).toContain('OpenCode')
-    expect(readme).toContain('compare and benchmark flows can spend paid model tokens')
-    expect(readme).toContain('check the local install wiring for Claude Code, Cursor, Gemini CLI, and GitHub Copilot CLI')
-    expect(readme).toContain('lint the AGENTS-based Madar instruction profiles for Codex CLI, OpenCode, and Aider')
-    expect(readme).toContain('`madar doctor` and `madar status`')
+    for (const command of [
+      'madar claude install',
+      'madar codex install',
+      'madar cursor install',
+      'madar copilot install',
+      'madar gemini install',
+      'madar aider install',
+      'madar opencode install',
+    ]) {
+      expect(readme).toContain(command)
+    }
+    expect(readme).toContain('After installing a profile, run `madar doctor` and `madar status`.')
+    expect(readme).toContain('Installer details are in the [CLI and MCP reference]')
+    expect(readme).toContain('madar pack "how does auth work?" --task explain --format text')
+    expect(readme).toContain('madar prompt "how does auth work?" --provider claude')
+    expect(readme).toContain('madar handoff "add auth telemetry" --task implement --consumer copilot')
   })
 })

--- a/tests/unit/install-compatibility.test.ts
+++ b/tests/unit/install-compatibility.test.ts
@@ -359,11 +359,14 @@ describe('install compatibility guide', () => {
     expect(new Set(INSTALL_PLATFORMS)).toEqual(documentedPlatforms)
   })
 
-  it('links the README agent section to a dedicated compatibility guide', () => {
+  it('keeps README agent setup discoverable through quickstarts and the CLI reference while the CLI reference links the compatibility guide', () => {
     const readme = readFileSync(resolve('README.md'), 'utf8')
+    const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
 
-    expect(readme).toContain('compatibility guide')
-    expect(readme).toContain('docs/integrations/compatibility.md')
+    expect(readme).toContain('docs/tutorials/agent-quickstarts.md')
+    expect(readme).toContain('docs/reference/cli-and-mcp.md')
+    expect(reference).toContain('compatibility guide')
+    expect(reference).toContain('../integrations/compatibility.md')
   })
 
   it('publishes verified quickstarts and smoke tests for the primary agent targets', () => {

--- a/tests/unit/install-docs.test.ts
+++ b/tests/unit/install-docs.test.ts
@@ -39,13 +39,13 @@ describe('install documentation', () => {
     expect(reference).toContain('mark the agent as `partial` and suggest the matching reinstall command')
   })
 
-  it('documents handoff as the share-safe remote-agent artifact distinct from local pack and prompt flows', () => {
+  it('documents handoff as the share-safe CLI handoff distinct from local pack and prompt flows', () => {
     const readme = readFileSync(resolve('README.md'), 'utf8')
 
     expect(readme).toContain('madar handoff "add auth telemetry" --task implement --consumer copilot')
-    expect(readme).toContain('share-safe remote/background-agent artifact')
-    expect(readme).toContain('`madar pack` stays the richer local/full-context surface')
-    expect(readme).toContain('`madar prompt` stays local')
+    expect(readme).toContain('Create a share-safe handoff for another coding tool')
+    expect(readme).toContain('madar pack "how does auth work?" --task explain --format text')
+    expect(readme).toContain('madar prompt "how does auth work?" --provider claude')
   })
 
   it('documents the strict MCP install profile for claude, cursor, copilot, and gemini', () => {
@@ -62,21 +62,18 @@ describe('install documentation', () => {
     expect(reference).toContain('override conflicting auto-activated exploration skills')
   })
 
-  it('clarifies that strict installs still use one bounded context_pack call', () => {
+  it('documents that strict installs still use one bounded context_pack call in the CLI reference', () => {
     const reference = readFileSync(resolve('docs/reference/cli-and-mcp.md'), 'utf8')
-    const readme = readFileSync(resolve('README.md'), 'utf8')
 
     expect(reference).toContain('`--profile strict` keeps the seven core MCP tools but adds one bounded `context_pack` call per task')
     expect(reference).toContain('Full-profile additions beyond that strict one-pack flow')
-    expect(readme).toContain('`--profile strict` keeps the lean core MCP tools but still uses one bounded `context_pack` call per task before broader exploration')
   })
 
-  it('documents the local trust boundary and least-privilege install guidance', () => {
+  it('documents the local trust boundary and links the threat model from the README privacy section', () => {
     const readme = readFileSync(resolve('README.md'), 'utf8')
 
-    expect(readme).toContain('Treat every Madar MCP install, plugin, hook, or AGENTS profile as a local trust boundary.')
-    expect(readme).toContain('Only enable it for repositories and local agent runtimes you trust.')
-    expect(readme).toContain('Prefer `--profile strict` when you only need the lean core MCP tools.')
+    expect(readme).toContain('Your coding agent may still send prompts or selected file context to its own model provider')
+    expect(readme).toContain('Treat every local MCP install, hook, or agent profile as part of your local trust boundary.')
     expect(readme).toContain('docs/security/mcp-threat-model.md')
   })
 })

--- a/tests/unit/launch-checklist-doc.test.ts
+++ b/tests/unit/launch-checklist-doc.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from 'vitest'
 describe('launch checklist documentation', () => {
   it('publishes a proof-first launch checklist and links it from release/docs surfaces', () => {
     const checklist = readFileSync(resolve('docs/launch-checklist.md'), 'utf8')
-    const readme = readFileSync(resolve('README.md'), 'utf8')
     const releaseDoc = readFileSync(resolve('docs/release.md'), 'utf8')
     const roadmap = readFileSync(resolve('docs/roadmap.md'), 'utf8')
 
@@ -37,7 +36,6 @@ describe('launch checklist documentation', () => {
     expect(checklist).toContain('rework 0')
     expect(checklist).toContain('Do not post generic "new open-source tool" messages')
 
-    expect(readme).toContain('docs/launch-checklist.md')
     expect(releaseDoc).toContain('docs/launch-checklist.md')
     expect(roadmap).toContain('issues/474')
   })

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -59,6 +59,10 @@ function loadLanguageCapabilityMatrix(): string {
   return readFileSync(join(process.cwd(), 'docs', 'language-capability-matrix.md'), 'utf8')
 }
 
+function loadContextPacksDoc(): string {
+  return readFileSync(join(process.cwd(), 'docs', 'concepts', 'context-packs.md'), 'utf8')
+}
+
 function normalizeVersionRange(range: string | undefined): string {
   return (range ?? '').replace(/^[\^~]/, '')
 }
@@ -157,6 +161,7 @@ describe('package metadata', () => {
   it('positions package metadata around outcome-first task-aware local packs instead of generic graph marketing', () => {
     const manifest = loadPackageManifest()
     const readme = loadReadme().toLowerCase()
+    const contextPacks = loadContextPacksDoc().toLowerCase()
     const keywords = manifest.keywords ?? []
 
     expect(manifest.description?.toLowerCase()).toContain('stop')
@@ -173,27 +178,29 @@ describe('package metadata', () => {
     expect(readme).toContain('cursor')
     expect(readme).toContain('codex')
     expect(readme).toContain('copilot')
-    expect(readme).toContain('large typescript/node repo')
-    expect(readme).toContain('execution paths and structures relevant to this task')
-    expect(readme).toContain('execution slice')
+    expect(readme).toContain('repo context they need before they start searching')
+    expect(readme).toContain('local graph')
+    expect(readme).toContain('task-aware context pack')
+    expect(contextPacks).toContain('deterministic local context compilation')
     expect(readme).not.toContain('context plane')
     expect(readme).not.toContain('context compiler')
   })
 
-  it('keeps the README command surface aligned with pack and prompt automation flows', () => {
+  it('keeps the command surface aligned with pack/prompt automation and MCP docs', () => {
     const readme = loadReadme()
+    const examples = readFileSync(join(process.cwd(), 'examples', 'mcp-tool-examples.md'), 'utf8')
 
     expect(readme).toContain('madar pack')
     expect(readme).toContain('madar prompt')
-    expect(readme).toContain('context_pack')
-    expect(readme).toContain('context_prompt')
+    expect(examples).toContain('context_pack')
+    expect(examples).toContain('context_prompt')
   })
 
-  it('documents broad runtime-generation pack compaction in the README', () => {
-    const readme = loadReadme().toLowerCase()
+  it('documents broad runtime-generation pack compaction in the context-pack docs', () => {
+    const contextPacks = readFileSync(join(process.cwd(), 'docs', 'concepts', 'context-packs.md'), 'utf8').toLowerCase()
 
-    expect(readme).toContain('runtime-generation prompts stay compact')
-    expect(readme).toContain('shared-hub fan-out')
+    expect(contextPacks).toContain('runtime-generation prompts stay compact')
+    expect(contextPacks).toContain('shared-hub fan-out')
   })
 
   it('avoids circular maintainer guidance in the contributing guide', () => {
@@ -245,7 +252,6 @@ describe('package metadata', () => {
     const dependencies = manifest.dependencies ?? {}
     const peerDependencies = manifest.peerDependencies ?? {}
     const peerDependenciesMeta = manifest.peerDependenciesMeta ?? {}
-    const readme = loadReadme()
 
     expect(isAtLeastVersion(devDependencies.vite, [8, 0, 11])).toBe(true)
     expect(devDependencies.vite).toMatch(/^[~^]?8\./)
@@ -253,7 +259,6 @@ describe('package metadata', () => {
     expect(dependencies['@huggingface/transformers']).toBeUndefined()
     expect(typeof peerDependencies['@huggingface/transformers']).toBe('string')
     expect(peerDependenciesMeta['@huggingface/transformers']).toEqual({ optional: true })
-    expect(readme).toContain('npm install @huggingface/transformers')
   })
 
   it('caps vitest worker parallelism to keep the full suite stable on shared machines', () => {

--- a/tests/unit/rebrand-surface.test.ts
+++ b/tests/unit/rebrand-surface.test.ts
@@ -103,16 +103,12 @@ describe('rebrand surface', () => {
 
   it('documents the canonical Madar rename path for users arriving from legacy links', () => {
     const readme = readText('README.md')
-    const headingIndex = readme.indexOf(RENAME_NOTE_HEADING)
+    const cliReference = readText('docs/reference/cli-and-mcp.md')
 
-    expect(headingIndex).toBeGreaterThanOrEqual(0)
-
-    const renameSection = readme.slice(headingIndex, readme.indexOf('\n## ', headingIndex + RENAME_NOTE_HEADING.length))
-
-    expect(renameSection).toContain('`graphify-ts`')
-    expect(renameSection).toContain('`@lubab/madar`')
-    expect(renameSection).toContain('`https://github.com/mohanagy/madar`')
-    expect(renameSection).toContain('`git@github.com:mohanagy/madar.git`')
+    expect(readme).not.toContain(RENAME_NOTE_HEADING)
+    expect(cliReference).toContain('older `graphify-ts` links or listings')
+    expect(cliReference).toContain('`@lubab/madar`')
+    expect(cliReference).toContain('`https://github.com/mohanagy/madar`')
     expect(stripRenameNote(readme)).not.toContain(LEGACY_BRAND)
   })
 

--- a/tests/unit/sample-workspace.test.ts
+++ b/tests/unit/sample-workspace.test.ts
@@ -82,7 +82,6 @@ describe('examples/sample-workspace', () => {
 
   it('documents how to generate and pack against the sample workspace', () => {
     const tutorial = readFileSync(resolve('docs/tutorials/sample-workspace.md'), 'utf8')
-    const readme = readFileSync(resolve('README.md'), 'utf8')
 
     if (tutorial.includes('npm run build')) {
       expect(tutorial.toLowerCase()).toContain('repository root')
@@ -90,7 +89,6 @@ describe('examples/sample-workspace', () => {
     expect(tutorial).toContain('madar generate examples/sample-workspace')
     expect(tutorial).toContain('madar pack')
     expect(tutorial).toContain('prompt-examples.json')
-    expect(readme).toContain('examples/sample-workspace')
   })
 
   it('does not return the password reset token to the caller', () => {

--- a/tests/unit/why-madar-doc.test.ts
+++ b/tests/unit/why-madar-doc.test.ts
@@ -42,6 +42,8 @@ describe('public marketing copy honesty', () => {
     const contextPacks = readDoc('docs/concepts/context-packs.md')
     const cliReference = readDoc('docs/reference/cli-and-mcp.md')
     const claims = readDoc('docs/claims-and-evidence.md')
+    const benchmarkMethodology = readDoc('docs/benchmarks/suite/methodology.md')
+    const languageMatrix = readDoc('docs/language-capability-matrix.md')
     const publicDocs = [content, contextPacks, cliReference, claims].join('\n')
     const publicLower = publicDocs.toLowerCase()
 
@@ -51,15 +53,14 @@ describe('public marketing copy honesty', () => {
       })
     }
 
-    it('leads with the urgent adoption outcome while keeping execution-slice framing honest', () => {
+    it('leads with an agent-first landing page while keeping local-graph claims honest', () => {
       expect(lower).toContain('claude code')
       expect(lower).toContain('cursor')
       expect(lower).toContain('codex')
       expect(lower).toContain('copilot')
-      expect(lower).toContain('wasting tokens')
-      expect(lower).toContain('large typescript/node repo')
-      expect(lower).toContain('execution paths and structures relevant to this task')
-      expect(lower).toContain('execution slice')
+      expect(lower).toContain('repo context they need before they start searching')
+      expect(lower).toContain('local graph')
+      expect(lower).toContain('task-aware context pack')
       expect(lower).not.toContain('context plane')
       expect(lower).not.toContain('context compiler')
       expect(lower).not.toMatch(/5\.28x|5\.28×|2\.21x|2\.21×|1\.58x|1\.58×|69\.9%/i)
@@ -84,13 +85,11 @@ describe('public marketing copy honesty', () => {
       expect(publicLower).toContain('madar status')
     })
 
-    it('surfaces the 0.23.0 user-facing additions in the main README flow', () => {
-      expect(lower).toContain("what's new in 0.23.0")
-      expect(content).toContain('`madar summary`')
-      expect(content).toContain('`graph_summary`')
-      expect(content).toContain('`execution_slice`')
-      expect(content).toContain('report.share-safe.json')
-      expect(content).toContain('--baseline-mode pack_only')
+    it('surfaces the current stable release and benchmark evidence pointers in the main README flow', () => {
+      expect(content).toContain('Current version: `0.27.9`')
+      expect(content).toContain('0.27.9 changelog')
+      expect(content).toContain('madar summary')
+      expect(content).toContain('docs/claims-and-evidence.md')
       expect(content).toContain('docs/benchmarks/suite/')
     })
 
@@ -109,20 +108,19 @@ describe('public marketing copy honesty', () => {
       )
     })
 
-    it('explains when users should opt into --spi', () => {
-      expect(lower).toContain('when to use `--spi`')
-      expect(lower).toContain('still opt-in')
-      expect(lower).toContain('storage-oriented prompts')
-      expect(lower).toContain('next.js')
-      expect(lower).toContain('disk cache')
+    it('keeps SPI guidance in the deeper docs instead of the top-level README', () => {
+      expect(publicDocs).toContain('--spi')
+      expect(publicLower).toContain('storage-oriented prompts')
+      expect(publicLower).toContain('next.js')
+      expect(publicLower).toContain('disk cache')
+      expect(content).not.toContain('## When To Use `--spi`')
     })
 
-    it('explains when follow-up prompt sessions should and should not show reuse gains', () => {
-      expect(content).toContain('reuse the same `session_id`')
-      expect(content).toContain('`session_diagnostics`')
-      expect(lower).toContain('mostly stable retrieved graph context')
-      expect(lower).toContain('first turns')
-      expect(lower).toContain('heavily changed retrieved context')
+    it('documents repeated-turn session reuse in the benchmark methodology docs', () => {
+      expect(benchmarkMethodology).toContain('one session across that list')
+      expect(benchmarkMethodology).toContain('reused_context_tokens')
+      expect(benchmarkMethodology).toContain('session_diagnostics')
+      expect(benchmarkMethodology.toLowerCase()).toContain('single-question cells remain first-turn only')
     })
 
     it('keeps the README core MCP surface aligned with the shipped graph_summary tool', () => {
@@ -143,32 +141,26 @@ describe('public marketing copy honesty', () => {
       expect(publicDocs).toContain('`get_neighbors`')
     })
 
-    it('pins the measured post-#82 core-profile schema overhead numbers in the Honest disclosure section', () => {
-      // Per the project's doc-honesty rule, a README claim about a measured
-      // number must be backed by a test that asserts the README contains the
-      // current measurement. If a future PR reduces it further, update both
-      // the README number and the regex below in the same PR. The matched
-      // numbers come straight from tests/unit/mcp-schema-budget.test.ts.
-      expect(lower).toMatch(/~\s*800\s*tokens/)
-      expect(lower).toMatch(/~?\s*3[,.]?200\s*bytes/)
-      expect(lower).toMatch(/25%/)
+    it('pins the benchmark evidence table values in the README', () => {
+      expect(content).toContain('| Tool calls | 28 | 7 |')
+      expect(content).toContain('| Input tokens | 2,366,946 | 498,688 |')
+      expect(content).toContain('| Wall-clock latency | 158,995 ms | 72,420 ms |')
+      expect(content).toContain('| Cost | $2.6595 | $0.9728 |')
     })
 
-    it('keeps claim buckets and measurement methodology in the evidence docs, with a compact README pointer', () => {
+    it('keeps claim buckets in the evidence docs while the README stays a compact pointer', () => {
       expect(claims).toContain('## Demonstrated today')
       expect(claims).toContain('## In progress')
       expect(claims).toContain('## Not yet measured')
       expect(claims).toContain('How this maps to README.md')
-      expect(publicLower).toContain('per-repo spread')
-      expect(publicLower).toContain('no single-number cross-repo headline')
-      expect(content).toContain('Published benchmark cells run in isolation mode')
-      expect(content).toContain('Your local numbers may differ if your Claude Code config differs.')
+      expect(content).toContain('This is not a universal benchmark claim.')
+      expect(content).toContain('docs/claims-and-evidence.md')
     })
 
-    it('links the claims-and-evidence map, benchmark suite scaffold, and mixed-evidence benchmark notes', () => {
+    it('links the claims-and-evidence map, benchmark suite scaffold, and mixed-evidence benchmark notes across the public docs', () => {
       expect(content).toContain('docs/claims-and-evidence.md')
       expect(content).toContain('docs/benchmarks/suite/')
-      expect(content).toContain('docs/benchmarks/2026-05-25-founder-command-center-auth-flow/')
+      expect(claims).toContain('docs/benchmarks/2026-05-25-founder-command-center-auth-flow/')
     })
 
     it('positions Madar as a context/evidence layer for review and security tools without overclaiming outcomes', () => {
@@ -181,43 +173,39 @@ describe('public marketing copy honesty', () => {
       expect(content).toContain('docs/claims-and-evidence.md')
     })
 
-    it('states who madar is for and not for explicitly', () => {
-      expect(lower).toContain('who madar is for')
-      expect(lower).toContain('who madar is not for')
-      expect(lower).toContain('medium-to-large typescript/node repos')
-      expect(lower).toContain('cost, latency, privacy, or wrong-file-edit risk')
-      expect(lower).toContain('tiny repos')
-      expect(lower).toContain('hosted-dashboard-first buyers')
+    it('frames fit and limitations directly in the shorter README', () => {
+      expect(lower).toContain('## fit')
+      expect(lower).toContain('most useful when')
+      expect(lower).toContain('your repo is medium or large')
+      expect(lower).toContain('token usage, latency, or local repo privacy matter')
+      expect(lower).toContain('it helps less when')
+      expect(lower).toContain('the repo is small')
     })
 
-    it('adds a bounded competitor positioning table backed by the claims-and-evidence map', () => {
-      expect(lower).toContain('madar vs repomix vs context7')
-      expect(content).toContain('| Tool | Best first use | Where it stops |')
-      expect(content).toContain('Repomix')
-      expect(content).toContain('Context7')
-      expect(content).toContain('Capability/scope summary only')
-      expect(content).toContain('docs/claims-and-evidence.md#competitive-positioning')
+    it('keeps competitor positioning in the claims-and-evidence doc instead of the shorter README', () => {
+      expect(content).toContain('docs/claims-and-evidence.md')
       expect(claims).toContain('## Competitive positioning')
       expect(claims).toContain('Repomix')
       expect(claims).toContain('Context7')
       expect(claims).toContain('scope summary, not a benchmark claim')
     })
 
-    it('frames the core promise as deterministic local context compilation that complements indexing', () => {
-      expect(lower).toContain('deterministic local context compilation')
-      expect(lower).toContain('complements agents and ide indexing')
-      expect(lower).toContain('not another generic codebase index')
+    it('keeps the deterministic local context compilation framing in the broader public docs', () => {
+      expect(publicLower).toContain('deterministic local context compilation')
+      expect(publicLower).toContain('complements agents and ide indexing')
+      expect(publicLower).toContain('not another generic codebase index')
     })
 
-    it('links a bounded team and enterprise offer instead of implying hosted packaging', () => {
-      expect(content).toContain('docs/team-enterprise-offer.md')
-      expect(lower).toContain('team and enterprise offer')
+    it('keeps team and enterprise positioning service-scoped in the evidence docs', () => {
+      expect(claims.toLowerCase()).toContain('team and enterprise offer')
+      expect(claims.toLowerCase()).toContain('service-scoped')
+      expect(content).toContain('docs/claims-and-evidence.md')
     })
 
-    it('keeps the README Python support claim conservative and current', () => {
+    it('keeps Python support claims conservative in the deeper public docs', () => {
       expect(publicDocs).toContain('FastAPI router composition')
       expect(publicDocs).toContain('Django URL-conf')
-      expect(publicLower).toContain('not near js/ts parity')
+      expect(languageMatrix.toLowerCase()).toContain('without claiming full framework parity')
     })
   })
 


### PR DESCRIPTION
## Summary
- rewrite the README into a shorter npm-facing landing page with clearer install, quick start, supported agent, fit, and docs sections
- keep telemetry controls and the telemetry docs link explicit so the public README matches the documented opt-in contract
- preserve the stable release changelog link and npm-facing main-branch documentation links

## Testing
- npm run test:run -- tests/unit/telemetry-doc.test.ts
- npm run release:verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote README into a concise npm-facing landing page with “Why / Install / Quick Start” flow
  * Added Supported Agents install matrix, “Use Without MCP”, and clearer “What It Builds / Fit” guidance
  * Documented freshness flags, telemetry controls, privacy, and CLI examples (madar try/doctor/status/pack/prompt/handoff)
  * Added “What’s New”, streamlined docs links, contributing instructions, and a single “Special thanks” contributor note
<!-- end of auto-generated comment: release notes by coderabbit.ai -->