### PR TITLE
fix: harden partial runtime proof guidance

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -346,10 +346,7 @@ function answerContractInstructions(retrieval: RetrieveResult): string[] {
     instructions.push('Do not collapse producer-to-worker handoffs into direct calls when the evidence is an enqueues_job boundary.')
   }
 
-  if (
-    answerContract.uncertainty_notes?.includes('mention missing or uncertain phases when the execution slice is partial')
-    || answerContract.do_not_claim.includes('full_runtime_certainty_when_slice_is_partial')
-  ) {
+  if (answerContract.do_not_claim.includes('full_runtime_certainty_when_slice_is_partial')) {
     instructions.push('Mention missing or uncertain phases when the execution slice is partial.')
   }
 
@@ -1851,14 +1848,16 @@ function strictRuntimeProofPromptOptions(
   missingPhases?: string[]
   rescopedTo?: string | null
 } | undefined {
-  if (!strictRuntimeProofModeApplies(retrieval)) {
-    return undefined
-  }
-
   const missingPhases = [...new Set([
     ...(retrieval.answer_contract?.missing_phases ?? []),
     ...(retrieval.execution_slice?.phase_coverage?.missing ?? []),
   ])]
+  const forceForDegradedReadiness = benchmarkReadiness.status !== 'ready'
+    && missingPhases.length > 0
+
+  if (!strictRuntimeProofModeApplies(retrieval) && !forceForDegradedReadiness) {
+    return undefined
+  }
 
   return {
     ...(missingPhases.length > 0 ? { missingPhases } : {}),

--- a/src/runtime/context-pack.ts
+++ b/src/runtime/context-pack.ts
@@ -1374,7 +1374,13 @@ export function generateAnswerReadyFromExecutionSlice(
   executionSlice: ContextPackExecutionSlice | undefined,
   taskKind: ContextPackTaskKind,
 ): ContextPackExplainAnswerReadySummary | undefined {
-  if (taskKind !== 'explain' || !executionSlice || executionSlice.confidence !== 'high') {
+  const partialExplainBarrier = executionSlice?.status === 'partial' && executionSlice.confidence === 'medium'
+
+  if (
+    taskKind !== 'explain'
+    || !executionSlice
+    || (executionSlice.confidence !== 'high' && !partialExplainBarrier)
+  ) {
     return undefined
   }
 
@@ -1406,12 +1412,27 @@ export function generateAnswerReadyFromExecutionSlice(
     }
   }
 
+  const missingPhases = executionSlice.phase_coverage?.missing ?? []
+  const stop_condition = partialExplainBarrier
+    ? (
+        missingPhases.length > 0
+          ? `answer from observed steps only; if the full flow is requested, answer: not enough evidence; missing ${missingPhases.join(', ')}; do not raw-search unless missing_context is non-empty`
+          : 'answer from observed steps only; if the full flow is requested, answer: not enough evidence; do not raw-search unless missing_context is non-empty'
+      )
+    : 'answer now; do not raw-search unless missing_context is non-empty'
+  const allowed_followups = [
+    ...(partialExplainBarrier && missingPhases.length > 0
+      ? [`Use at most one focused follow-up to surface missing phases: ${missingPhases.join(', ')}`]
+      : []),
+    ...(executionSlice.confidence_reasons
+      ? [`Review confidence reasons: ${executionSlice.confidence_reasons.join(', ')}`]
+      : []),
+  ]
+
   return {
     answer_outline: answer_outline.length > 0 ? answer_outline : ['Flow execution traced'],
     must_cite,
-    stop_condition: 'answer now; do not raw-search unless missing_context is non-empty',
-    allowed_followups: executionSlice.confidence_reasons
-      ? [`Review confidence reasons: ${executionSlice.confidence_reasons.join(', ')}`]
-      : [],
+    stop_condition,
+    allowed_followups,
   }
 }

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -3245,7 +3245,9 @@ function buildRuntimeGenerationAnswerContract(
 
   if (executionSlice.status === 'partial' || missingPhases.length > 0) {
     answerContract.uncertainty_notes = [
-      'mention missing or uncertain phases when the execution slice is partial',
+      missingPhases.length > 0
+        ? `Do not infer unobserved runtime phases; if the full flow is requested, answer: not enough evidence; missing ${missingPhases.join(', ')}`
+        : 'Do not infer unobserved runtime phases; if the full flow is requested, answer: not enough evidence.',
     ]
   }
 

--- a/tests/unit/answer-ready-explain-pack.test.ts
+++ b/tests/unit/answer-ready-explain-pack.test.ts
@@ -223,6 +223,34 @@ describe('answer-ready explain pack', () => {
     expect(result).toBeUndefined()
   })
 
+  test('generateAnswerReadyFromExecutionSlice adds a partial-slice barrier for medium-confidence explain slices', () => {
+    const executionSlice: ContextPackExecutionSlice = {
+      status: 'partial',
+      confidence: 'medium',
+      confidence_reasons: ['missing_phase:persistence'],
+      steps: [
+        { label: 'Controller.handle()', source_file: 'src/controller.ts', line_number: 10 },
+        { label: 'Service.process()', source_file: 'src/service.ts', line_number: 25 },
+        { label: 'Worker.perform()', source_file: 'src/worker.ts', line_number: 40 },
+      ],
+      phase_coverage: {
+        expected: ['controller', 'service', 'worker', 'persistence'],
+        observed: ['controller', 'service', 'worker'],
+        missing: ['persistence'],
+      },
+    }
+
+    const result = generateAnswerReadyFromExecutionSlice(executionSlice, 'explain')
+
+    expect(result).toBeDefined()
+    expect(result?.answer_outline.length).toBeGreaterThan(0)
+    expect(result?.must_cite.length).toBeGreaterThan(0)
+    expect(result?.stop_condition).toContain('not enough evidence; missing persistence')
+    expect(result?.allowed_followups).toEqual(expect.arrayContaining([
+      expect.stringContaining('missing_phase:persistence'),
+    ]))
+  })
+
   test('generateAnswerReadyFromExecutionSlice returns undefined when no execution_slice', () => {
     const result = generateAnswerReadyFromExecutionSlice(undefined, 'explain')
     expect(result).toBeUndefined()

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -1892,6 +1892,81 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
+  it('passes strict missing-phase proof guidance for degraded backend runtime prompts even when the retrieval gate is not flow-proof-shaped', async () => {
+    const { projectDir, graphPath, outputDir } = makeRescopedReadinessFixtureProjectWithOptions({
+      includePersistenceStep: false,
+    })
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'Explain runtime pipeline for `POST /login` persistence',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_FULL_WIN_PAYLOAD,
+            madar: VERBOSE_MADAR_FULL_WIN_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-27T00:46:00Z'),
+          assessBenchmarkReadiness: () => ({
+            status: 'degraded',
+            reasons: ['missing downstream runtime phases: persistence'],
+            suggested_graph_scope: null,
+          }),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const madarPrompt = readFileSync(report.paths.madar_prompt, 'utf8')
+
+      expect(madarPrompt).toContain('This question requires strict runtime proof.')
+      expect(madarPrompt).toContain('Use at most one focused follow-up to surface the missing persistence phase.')
+      expect(madarPrompt).toContain('If the flow still cannot be proven, answer: not enough evidence; missing persistence')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not pass strict missing-phase proof guidance for ready backend runtime prompts when the retrieval gate is not flow-proof-shaped', async () => {
+    const { projectDir, graphPath, outputDir } = makeRescopedReadinessFixtureProjectWithOptions({
+      includePersistenceStep: false,
+    })
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question: 'Explain runtime pipeline for `POST /login` persistence',
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_FULL_WIN_PAYLOAD,
+            madar: VERBOSE_MADAR_FULL_WIN_PAYLOAD,
+          }),
+          now: () => new Date('2026-05-27T00:47:00Z'),
+          assessBenchmarkReadiness: () => ({
+            status: 'ready',
+            reasons: [],
+            suggested_graph_scope: null,
+          }),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const madarPrompt = readFileSync(report.paths.madar_prompt, 'utf8')
+
+      expect(madarPrompt).not.toContain('This question requires strict runtime proof.')
+      expect(madarPrompt).not.toContain('If the flow still cannot be proven, answer: not enough evidence; missing persistence')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('does not claim auto-rescope when the suggested scoped graph is unavailable', async () => {
     const { projectDir, graphPath, outputDir } = makeRescopedReadinessFixtureProjectWithOptions({
       includeScopedGraph: false,

--- a/tests/unit/retrieve-production-correctness.test.ts
+++ b/tests/unit/retrieve-production-correctness.test.ts
@@ -489,6 +489,9 @@ describe('retrieveContext production retrieval regressions', () => {
       do_not_claim: expect.arrayContaining([
         'full_runtime_certainty_when_slice_is_partial',
       ]),
+      uncertainty_notes: expect.arrayContaining([
+        expect.stringMatching(/not enough evidence; missing .*persistence/),
+      ]),
     }))
   })
 


### PR DESCRIPTION
## Summary
- harden partial runtime answer contracts so partial slices explicitly say not enough evidence and name missing phases
- emit answer_ready barriers for medium-confidence partial explain slices instead of dropping guidance entirely
- inject strict missing-phase proof guidance only for degraded/not-ready backend runtime packs, with regression coverage for degraded vs ready prompt behavior

## Testing
- npm run test:run -- tests/unit/compare-native-agent.test.ts tests/unit/answer-ready-explain-pack.test.ts tests/unit/retrieve-production-correctness.test.ts tests/unit/compare.test.ts
- npm run typecheck
- npm run build
- CI=1 npm run test:run

## Benchmark note
- A fresh non-isolated local diagnostic rerun still does not get the public six-repo runtime suite to 6/6 full wins. `formbricks` remains the strongest row, while `documenso`, `twenty`, and `novu` still hit readiness blockers and `dub` / `cal-diy` still need separate prompt-contract work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of missing execution phases during partial runtime analysis
  * Enhanced uncertainty messaging to include specific missing phase details when available
  * Refined handling of degraded readiness states with better phase visibility

* **New Features**
  * Extended medium-confidence explanation support with appropriate uncertainty caveats
  * Added targeted follow-up prompts to guide users toward addressing execution gaps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->