### PR TITLE
fix: harden explain-runtime proof gates

### DIFF
--- a/docs/benchmarks/suite/runtime-proof.json
+++ b/docs/benchmarks/suite/runtime-proof.json
@@ -1,0 +1,164 @@
+{
+  "documenso-explain-runtime": {
+    "prompt": "How does Documenso move a document from send preparation through recipient creation, signing state, and notification delivery?",
+    "strict_runtime_proof": true,
+    "expected_spi": false,
+    "obligations": [
+      {
+        "id": "send_preparation",
+        "label": "send preparation",
+        "kind": "entrypoint",
+        "evidence_terms": ["send", "document", "prepare"]
+      },
+      {
+        "id": "recipient_creation",
+        "label": "recipient creation",
+        "kind": "handoff",
+        "evidence_terms": ["recipient", "create", "signer"]
+      },
+      {
+        "id": "signing_state",
+        "label": "signing state",
+        "kind": "handoff",
+        "evidence_terms": ["signing", "status", "signed"]
+      },
+      {
+        "id": "notification_delivery",
+        "label": "notification delivery",
+        "kind": "terminal",
+        "evidence_terms": ["notification", "email", "deliver"]
+      }
+    ]
+  },
+  "formbricks-explain-runtime": {
+    "prompt": "How does Formbricks process a survey response from request handling through persistence and analytics/event tracking?",
+    "strict_runtime_proof": true,
+    "expected_spi": false,
+    "obligations": [
+      {
+        "id": "request_handling",
+        "label": "request handling",
+        "kind": "entrypoint",
+        "evidence_terms": ["request", "route", "handler", "response"]
+      },
+      {
+        "id": "persistence",
+        "label": "persistence",
+        "kind": "terminal",
+        "evidence_terms": ["persist", "save", "store", "database"]
+      },
+      {
+        "id": "analytics_event_tracking",
+        "label": "analytics/event tracking",
+        "kind": "terminal",
+        "evidence_terms": ["analytics", "event", "track"]
+      }
+    ]
+  },
+  "dub-explain-runtime": {
+    "prompt": "How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?",
+    "strict_runtime_proof": true,
+    "expected_spi": false,
+    "obligations": [
+      {
+        "id": "request_handling",
+        "label": "request handling",
+        "kind": "entrypoint",
+        "evidence_terms": ["request", "route", "handler", "click"]
+      },
+      {
+        "id": "analytics_tracking",
+        "label": "analytics tracking",
+        "kind": "terminal",
+        "evidence_terms": ["analytics", "track", "click"]
+      },
+      {
+        "id": "destination_redirect",
+        "label": "destination redirect",
+        "kind": "terminal",
+        "evidence_terms": ["redirect", "destination", "location"]
+      }
+    ]
+  },
+  "twenty-explain-runtime": {
+    "prompt": "How does Twenty process a CRM record mutation from API handling through workspace services to persistence?",
+    "strict_runtime_proof": true,
+    "expected_spi": false,
+    "obligations": [
+      {
+        "id": "api_mutation_handling",
+        "label": "API mutation handling",
+        "kind": "entrypoint",
+        "evidence_terms": ["api", "mutation", "resolver", "controller"]
+      },
+      {
+        "id": "workspace_service_handoff",
+        "label": "workspace service handoff",
+        "kind": "handoff",
+        "evidence_terms": ["workspace", "service", "mutation"]
+      },
+      {
+        "id": "persistence",
+        "label": "persistence",
+        "kind": "terminal",
+        "evidence_terms": ["persist", "save", "repository", "database"]
+      }
+    ]
+  },
+  "cal-diy-explain-runtime": {
+    "prompt": "How does Cal.diy turn a booking request into availability validation, scheduled event persistence, and notification delivery?",
+    "strict_runtime_proof": true,
+    "expected_spi": false,
+    "obligations": [
+      {
+        "id": "booking_request",
+        "label": "booking request",
+        "kind": "entrypoint",
+        "evidence_terms": ["booking", "request", "route", "handler"]
+      },
+      {
+        "id": "availability_validation",
+        "label": "availability validation",
+        "kind": "handoff",
+        "evidence_terms": ["availability", "validate", "slot"]
+      },
+      {
+        "id": "scheduled_event_persistence",
+        "label": "scheduled event persistence",
+        "kind": "terminal",
+        "evidence_terms": ["event", "persist", "save", "schedule"]
+      },
+      {
+        "id": "notification_delivery",
+        "label": "notification delivery",
+        "kind": "terminal",
+        "evidence_terms": ["notification", "email", "deliver"]
+      }
+    ]
+  },
+  "novu-explain-runtime": {
+    "prompt": "How does Novu process a notification trigger from API entry through workflow orchestration to channel delivery?",
+    "strict_runtime_proof": true,
+    "expected_spi": false,
+    "obligations": [
+      {
+        "id": "api_entry",
+        "label": "API entry",
+        "kind": "entrypoint",
+        "evidence_terms": ["api", "trigger", "route", "controller"]
+      },
+      {
+        "id": "workflow_orchestration",
+        "label": "workflow orchestration",
+        "kind": "handoff",
+        "evidence_terms": ["workflow", "orchestrat", "trigger"]
+      },
+      {
+        "id": "channel_delivery",
+        "label": "channel delivery",
+        "kind": "terminal",
+        "evidence_terms": ["channel", "deliver", "notification", "send"]
+      }
+    ]
+  }
+}

--- a/src/contracts/context-pack.ts
+++ b/src/contracts/context-pack.ts
@@ -11,6 +11,7 @@ import type { ContextPackDiagnosticWarning } from './context-pack-diagnostics.js
 import type { SourceDomain } from '../shared/source-discovery.js'
 import type { TaskContextPlan } from './task-context-plan.js'
 import type { MadarResponseEvidence } from '../runtime/mcp-response-evidence.js'
+import type { RuntimeProofAssessment } from './runtime-proof.js'
 
 export type ContextPackTaskKind = 'explain' | 'implement' | 'review' | 'impact'
 export type ContextPackFormat = 'json' | 'text' | 'markdown' | 'claude' | 'copilot'
@@ -176,6 +177,7 @@ export interface ContextPackRuntimeGenerationAnswerContract {
   missing_phases: ContextPackExecutionPhase[]
   uncertainty_notes?: string[]
   confidence?: 'high' | 'medium' | 'low'
+  runtime_proof?: RuntimeProofAssessment
 }
 
 export interface ContextPackExplainAnswerReadySummary {

--- a/src/contracts/runtime-proof.ts
+++ b/src/contracts/runtime-proof.ts
@@ -1,0 +1,34 @@
+export type RuntimeProofObligationKind = 'entrypoint' | 'handoff' | 'terminal'
+
+export interface RuntimeProofProfileObligation {
+  id: string
+  label: string
+  kind: RuntimeProofObligationKind
+  evidence_terms: string[]
+}
+
+export interface RuntimeProofProfile {
+  prompt: string
+  strict_runtime_proof: boolean
+  expected_spi: boolean
+  obligations: RuntimeProofProfileObligation[]
+}
+
+export interface RuntimeProofObligationEvidence {
+  label: string
+  source_file: string
+  line_number: number
+}
+
+export interface RuntimeProofObligationAssessment {
+  id: string
+  label: string
+  kind: RuntimeProofObligationKind
+  required: true
+  evidence: RuntimeProofObligationEvidence[]
+}
+
+export interface RuntimeProofAssessment {
+  obligations: RuntimeProofObligationAssessment[]
+  missing_obligations: string[]
+}

--- a/src/infrastructure/benchmark/runtime-proof.ts
+++ b/src/infrastructure/benchmark/runtime-proof.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve, join } from 'node:path'
+
+import type { RuntimeProofObligationKind, RuntimeProofProfile } from '../../contracts/runtime-proof.js'
+
+function parseRuntimeProofStringArray(
+  profileName: string,
+  fieldName: string,
+  value: unknown,
+): string[] {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.some((entry) => typeof entry !== 'string' || entry.trim().length === 0)
+  ) {
+    throw new Error(`Malformed runtime proof profile "${profileName}": ${fieldName} must be a non-empty string array`)
+  }
+  return value.map((entry) => entry.trim())
+}
+
+function parseRuntimeProofKind(
+  profileName: string,
+  obligationId: string,
+  value: unknown,
+): RuntimeProofObligationKind {
+  if (value === 'entrypoint' || value === 'handoff' || value === 'terminal') {
+    return value
+  }
+  throw new Error(
+    `Malformed runtime proof profile "${profileName}" obligation "${obligationId}": kind must be entrypoint, handoff, or terminal`,
+  )
+}
+
+function parseRuntimeProofProfile(profileName: string, value: unknown): RuntimeProofProfile {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Malformed runtime proof profile "${profileName}": expected an object`)
+  }
+  const profile = value as Record<string, unknown>
+  if (typeof profile.prompt !== 'string' || profile.prompt.trim().length === 0) {
+    throw new Error(`Malformed runtime proof profile "${profileName}": prompt must be a non-empty string`)
+  }
+  if (typeof profile.strict_runtime_proof !== 'boolean') {
+    throw new Error(`Malformed runtime proof profile "${profileName}": strict_runtime_proof must be a boolean`)
+  }
+  if (typeof profile.expected_spi !== 'boolean') {
+    throw new Error(`Malformed runtime proof profile "${profileName}": expected_spi must be a boolean`)
+  }
+  if (!Array.isArray(profile.obligations) || profile.obligations.length === 0) {
+    throw new Error(`Malformed runtime proof profile "${profileName}": obligations must be a non-empty array`)
+  }
+
+  return {
+    prompt: profile.prompt.trim(),
+    strict_runtime_proof: profile.strict_runtime_proof,
+    expected_spi: profile.expected_spi,
+    obligations: profile.obligations.map((obligation, index) => {
+      if (obligation === null || typeof obligation !== 'object' || Array.isArray(obligation)) {
+        throw new Error(`Malformed runtime proof profile "${profileName}": obligation ${index + 1} must be an object`)
+      }
+      const entry = obligation as Record<string, unknown>
+      if (typeof entry.id !== 'string' || entry.id.trim().length === 0) {
+        throw new Error(`Malformed runtime proof profile "${profileName}": obligation ${index + 1} id must be a non-empty string`)
+      }
+      if (typeof entry.label !== 'string' || entry.label.trim().length === 0) {
+        throw new Error(`Malformed runtime proof profile "${profileName}" obligation "${entry.id}": label must be a non-empty string`)
+      }
+      return {
+        id: entry.id.trim(),
+        label: entry.label.trim(),
+        kind: parseRuntimeProofKind(profileName, entry.id.trim(), entry.kind),
+        evidence_terms: parseRuntimeProofStringArray(profileName, `obligations.${entry.id}.evidence_terms`, entry.evidence_terms),
+      }
+    }),
+  }
+}
+
+export function loadBenchmarkRuntimeProofProfiles(
+  questionsPath: string | null | undefined,
+): Map<string, RuntimeProofProfile> | null {
+  if (!questionsPath) {
+    return null
+  }
+  const configPath = join(dirname(resolve(questionsPath)), 'runtime-proof.json')
+  if (!existsSync(configPath)) {
+    return null
+  }
+  const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as unknown
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Malformed runtime proof config: expected a JSON object at ${configPath}`)
+  }
+
+  return new Map(
+    Object.entries(parsed).map(([profileName, profile]) => [profileName, parseRuntimeProofProfile(profileName, profile)]),
+  )
+}
+
+export function matchBenchmarkRuntimeProofProfile(
+  profiles: ReadonlyMap<string, RuntimeProofProfile> | null,
+  question: string,
+): RuntimeProofProfile | undefined {
+  if (profiles === null) {
+    return undefined
+  }
+  return [...profiles.values()].find((profile) => profile.prompt === question)
+}

--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -32,6 +32,11 @@ import { sanitizeShareSafeText, toShareSafeArtifactPath, type ShareSafePathRoots
 import { resolveShellCommand, shellEscape } from '../shared/shell.js'
 import { MAX_TEXT_BYTES, validateGraphOutputPath, validateGraphPath } from '../shared/security.js'
 import { copyWorkspaceForBenchmark } from '../shared/workspace-copy.js'
+import type { RuntimeProofAssessment, RuntimeProofProfile } from '../contracts/runtime-proof.js'
+import {
+  loadBenchmarkRuntimeProofProfiles,
+  matchBenchmarkRuntimeProofProfile,
+} from './benchmark/runtime-proof.js'
 
 export type CompareBaselineMode = 'full' | 'bounded' | 'pack_only' | 'native_agent'
 export type CompareRunMode = 'baseline' | 'madar'
@@ -121,6 +126,25 @@ export interface CompareMadarTraceTurnSummary {
   madar_tool_discovery_count?: number
   madar_tool_discovery_tool_indexes?: number[]
   agent_directive_seen?: string[]
+}
+
+const RAW_TRACE_TOOL_INPUTS = Symbol('rawTraceToolInputs')
+
+type CompareMadarTraceTurnSummaryWithInputs = CompareMadarTraceTurnSummary & {
+  [RAW_TRACE_TOOL_INPUTS]?: string[]
+}
+
+function rawTraceToolInputs(turn: CompareMadarTraceTurnSummary): string[] {
+  return (turn as CompareMadarTraceTurnSummaryWithInputs)[RAW_TRACE_TOOL_INPUTS] ?? []
+}
+
+function appendRawTraceToolInputs(turn: CompareMadarTraceTurnSummary, inputs: readonly string[]): void {
+  const current = rawTraceToolInputs(turn)
+  Object.defineProperty(turn, RAW_TRACE_TOOL_INPUTS, {
+    value: [...current, ...inputs],
+    enumerable: false,
+    configurable: true,
+  })
 }
 
 type CompareMadarTraceOutcome =
@@ -1240,6 +1264,38 @@ function extractTraceAgentDirectives(contentPart: Record<string, unknown>): stri
   return directives
 }
 
+function summarizeTraceToolInput(input: unknown): string {
+  if (typeof input === 'string') {
+    return input.trim()
+  }
+  if (Array.isArray(input)) {
+    return input.map((entry) => summarizeTraceToolInput(entry)).filter((value) => value.length > 0).join(' ')
+  }
+  if (!isRecord(input)) {
+    return ''
+  }
+
+  const prioritizedKeys = ['question', 'query', 'prompt', 'path', 'paths', 'label', 'source', 'target', 'description']
+  const collected: string[] = []
+  for (const key of prioritizedKeys) {
+    const value = input[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      collected.push(value.trim())
+      continue
+    }
+    if (Array.isArray(value)) {
+      const summarized = value.map((entry) => summarizeTraceToolInput(entry)).filter((entry) => entry.length > 0).join(' ')
+      if (summarized.length > 0) {
+        collected.push(summarized)
+      }
+    }
+  }
+  if (collected.length > 0) {
+    return collected.join(' ')
+  }
+  return ''
+}
+
 function emptyNativeAgentToolCallCountsEntry(): NativeAgentToolCallCountsEntry {
   return {
     total: 0,
@@ -1340,6 +1396,7 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
     fallbackTurn = Math.max(fallbackTurn, turn + 1)
     const existingTurn = perTurnIndex.get(turn)
     const tools: string[] = []
+    const toolInputs: string[] = []
     const directives: string[] = []
     let madarToolDiscoveryCount = 0
     const madarToolDiscoveryToolIndexes: number[] = []
@@ -1356,6 +1413,7 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
 
         const toolIndex = tools.length
         tools.push(toolName)
+        toolInputs.push(summarizeTraceToolInput(contentPart.input))
         toolCallsByName[toolName] = (toolCallsByName[toolName] ?? 0) + 1
         totalToolCalls += 1
         if (isMadarToolDiscoveryToolUse(toolName, contentPart.input)) {
@@ -1375,6 +1433,7 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
       const existingToolCount = existingTurn.tools.length
       existingTurn.tool_call_count += tools.length
       existingTurn.tools.push(...tools)
+      appendRawTraceToolInputs(existingTurn, toolInputs)
       if (madarToolDiscoveryCount > 0) {
         existingTurn.madar_tool_discovery_count = (existingTurn.madar_tool_discovery_count ?? 0) + madarToolDiscoveryCount
         existingTurn.madar_tool_discovery_tool_indexes = [
@@ -1391,7 +1450,7 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
       continue
     }
 
-    perTurnIndex.set(turn, {
+    const turnSummary: CompareMadarTraceTurnSummary = {
       turn,
       tool_call_count: tools.length,
       tools,
@@ -1400,7 +1459,9 @@ function extractMadarTrace(stdout: string): CompareMadarTrace | undefined {
         ? { madar_tool_discovery_tool_indexes: madarToolDiscoveryToolIndexes }
         : {}),
       ...(directives.length > 0 ? { agent_directive_seen: directives } : {}),
-    })
+    }
+    appendRawTraceToolInputs(turnSummary, toolInputs)
+    perTurnIndex.set(turn, turnSummary)
   }
 
   if (totalToolCalls === 0) {
@@ -1683,6 +1744,7 @@ function retrieveCompareContext(
   budget: number,
   projectRoot: string,
   taskKind: ContextPackTaskKind = 'explain',
+  runtimeProofProfile?: RuntimeProofProfile,
 ): RetrieveResult {
   const { graph: retrievalGraph, originalSourceFiles } = createCompareRetrievalGraph(graph, projectRoot)
   const originalCwd = process.cwd()
@@ -1693,7 +1755,12 @@ function retrieveCompareContext(
       question,
       budget: Math.max(budget, 200),
       taskKind,
-      ...(gate.signals.generation_intent === 'runtime_generation' ? { retrievalStrategy: 'slice-v1' as const } : {}),
+      ...(
+        gate.signals.generation_intent === 'runtime_generation' || runtimeProofProfile?.strict_runtime_proof === true
+          ? { retrievalStrategy: 'slice-v1' as const }
+          : {}
+      ),
+      ...(runtimeProofProfile ? { runtimeProofProfile } : {}),
     })
     for (const matchedNode of retrieval.matched_nodes) {
       matchedNode.source_file = originalSourceFiles.get(matchedNode.source_file) ?? matchedNode.source_file
@@ -1778,9 +1845,10 @@ function benchmarkReadinessSeverity(current: BenchmarkReadinessStatus, next: Ben
 export function assessBenchmarkReadinessFromRetrieveResult(input: {
   graphPath: string
   retrieval: RetrieveResult
+  runtimeProofProfile?: RuntimeProofProfile
 }): BenchmarkReadiness {
-  const { graphPath, retrieval } = input
-  if (!strictRuntimeProofModeApplies(retrieval)) {
+  const { graphPath, retrieval, runtimeProofProfile } = input
+  if (!strictRuntimeProofModeApplies(retrieval, runtimeProofProfile)) {
     return {
       status: 'ready',
       reasons: [],
@@ -1792,10 +1860,22 @@ export function assessBenchmarkReadinessFromRetrieveResult(input: {
   const reasons: string[] = []
   const sourceFiles = collectBenchmarkReadinessSourceFiles(retrieval)
   const suggestedGraphScope = suggestBenchmarkGraphScope(graphPath, sourceFiles)
+  const runtimeProof = runtimeProofAssessment(retrieval)
+  const missingObligations = runtimeProofMissingObligationLabels(runtimeProofProfile, runtimeProof)
   const missingPhases = [...new Set([
     ...(retrieval.answer_contract?.missing_phases ?? []),
     ...(retrieval.execution_slice?.phase_coverage?.missing ?? []),
   ])].filter((phase) => BENCHMARK_READINESS_CRITICAL_PHASES.has(phase))
+
+  if (runtimeProofProfile?.strict_runtime_proof && !runtimeProof) {
+    status = benchmarkReadinessSeverity(status, 'not_ready')
+    reasons.push('runtime proof obligations were not assessed')
+  }
+
+  if (missingObligations.length > 0) {
+    status = benchmarkReadinessSeverity(status, 'not_ready')
+    reasons.push(`missing runtime proof obligations: ${missingObligations.join(', ')}`)
+  }
 
   if (missingPhases.length >= 3) {
     status = benchmarkReadinessSeverity(status, 'not_ready')
@@ -1814,7 +1894,7 @@ export function assessBenchmarkReadinessFromRetrieveResult(input: {
     reasons.push('runtime slice confidence is medium')
   }
 
-  if (!graphPathHasSpiMode(graphPath)) {
+  if ((runtimeProofProfile?.expected_spi ?? true) && !graphPathHasSpiMode(graphPath)) {
     status = benchmarkReadinessSeverity(status, suggestedGraphScope ? 'not_ready' : 'degraded')
     reasons.push(
       suggestedGraphScope
@@ -1835,32 +1915,64 @@ export function assessBenchmarkReadinessFromRetrieveResult(input: {
   }
 }
 
-function strictRuntimeProofModeApplies(retrieval: RetrieveResult): boolean {
-  return retrieval.retrieval_gate?.signals.generation_intent === 'runtime_generation'
+function runtimeProofAssessment(retrieval: RetrieveResult): RuntimeProofAssessment | undefined {
+  return retrieval.answer_contract?.runtime_proof
+}
+
+function runtimeProofMissingObligationLabels(
+  runtimeProofProfile: RuntimeProofProfile | undefined,
+  runtimeProof: RuntimeProofAssessment | undefined,
+): string[] {
+  if (!runtimeProofProfile || !runtimeProof) {
+    return []
+  }
+  return runtimeProof.missing_obligations.map((id) =>
+    runtimeProofProfile.obligations.find((obligation) => obligation.id === id)?.label
+      ?? id.replaceAll('_', ' '),
+  )
+}
+
+function strictRuntimeProofModeApplies(
+  retrieval: RetrieveResult,
+  runtimeProofProfile?: RuntimeProofProfile,
+): boolean {
+  return runtimeProofProfile?.strict_runtime_proof === true
+    || (
+      retrieval.retrieval_gate?.signals.generation_intent === 'runtime_generation'
     && retrieval.retrieval_gate?.signals.target_domain_hint === 'backend_runtime'
     && retrieval.retrieval_gate?.signals.generation_debug?.flow_proof_shaped === true
+    )
 }
 
 function strictRuntimeProofPromptOptions(
   retrieval: RetrieveResult,
   benchmarkReadiness: BenchmarkReadiness,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): {
   missingPhases?: string[]
+  missingObligations?: string[]
+  requiredObligations?: string[]
   rescopedTo?: string | null
 } | undefined {
   const missingPhases = [...new Set([
     ...(retrieval.answer_contract?.missing_phases ?? []),
     ...(retrieval.execution_slice?.phase_coverage?.missing ?? []),
   ])]
+  const missingObligations = runtimeProofMissingObligationLabels(runtimeProofProfile, runtimeProofAssessment(retrieval))
   const forceForDegradedReadiness = benchmarkReadiness.status !== 'ready'
-    && missingPhases.length > 0
+    && (missingPhases.length > 0 || missingObligations.length > 0)
+  const forceForRuntimeProofProfile = runtimeProofProfile?.strict_runtime_proof === true
 
-  if (!strictRuntimeProofModeApplies(retrieval) && !forceForDegradedReadiness) {
+  if (!strictRuntimeProofModeApplies(retrieval, runtimeProofProfile) && !forceForDegradedReadiness && !forceForRuntimeProofProfile) {
     return undefined
   }
 
   return {
     ...(missingPhases.length > 0 ? { missingPhases } : {}),
+    ...(missingObligations.length > 0 ? { missingObligations } : {}),
+    ...(runtimeProofProfile?.obligations.length
+      ? { requiredObligations: runtimeProofProfile.obligations.map((obligation) => obligation.label) }
+      : {}),
     ...(benchmarkReadiness.rescoped_to ? { rescopedTo: benchmarkReadiness.rescoped_to } : {}),
   }
 }
@@ -1874,6 +1986,7 @@ function prepareNativeAgentBenchmarkReadiness(input: {
   taskKind: ContextPackTaskKind
   graphCache: Map<string, KnowledgeGraph>
   assessBenchmarkReadiness?: (input: BenchmarkReadinessInput) => BenchmarkReadiness
+  runtimeProofProfile?: RuntimeProofProfile
 }): {
   retrieval: RetrieveResult
   benchmarkReadiness: BenchmarkReadiness
@@ -1885,13 +1998,24 @@ function prepareNativeAgentBenchmarkReadiness(input: {
           projectRoot: input.projectRoot,
           question: input.question,
         })
-      : assessBenchmarkReadinessFromRetrieveResult({ graphPath, retrieval })
+      : assessBenchmarkReadinessFromRetrieveResult({
+          graphPath,
+          retrieval,
+          ...(input.runtimeProofProfile ? { runtimeProofProfile: input.runtimeProofProfile } : {}),
+        })
 
-  const retrieval = retrieveCompareContext(input.graph, input.question, input.budget, input.projectRoot, input.taskKind)
+  const retrieval = retrieveCompareContext(
+    input.graph,
+    input.question,
+    input.budget,
+    input.projectRoot,
+    input.taskKind,
+    input.runtimeProofProfile,
+  )
   const benchmarkReadiness = assessReadiness(input.graphPath, retrieval)
   if (
     input.assessBenchmarkReadiness
-    || !strictRuntimeProofModeApplies(retrieval)
+    || !strictRuntimeProofModeApplies(retrieval, input.runtimeProofProfile)
     || !benchmarkReadiness.suggested_graph_scope
   ) {
     return { retrieval, benchmarkReadiness }
@@ -1919,10 +2043,12 @@ function prepareNativeAgentBenchmarkReadiness(input: {
     input.budget,
     rescopedProjectRoot,
     input.taskKind,
+    input.runtimeProofProfile,
   )
   const rescopedReadiness = assessBenchmarkReadinessFromRetrieveResult({
     graphPath: rescopedGraphPath,
     retrieval: rescopedRetrieval,
+    ...(input.runtimeProofProfile ? { runtimeProofProfile: input.runtimeProofProfile } : {}),
   })
 
   return {
@@ -2100,6 +2226,8 @@ export function buildNativeAgentPrompt(
       implementation?: ImplementationPackGuidance
       strictRuntimeProof?: {
         missingPhases?: string[]
+        missingObligations?: string[]
+        requiredObligations?: string[]
         rescopedTo?: string | null
       }
     } = 'core',
@@ -2151,8 +2279,21 @@ export function buildNativeAgentPrompt(
   const strictRuntimeProofInstructions = options.strictRuntimeProof
     ? [
         'This question requires strict runtime proof.',
+        ...(options.strictRuntimeProof.requiredObligations && options.strictRuntimeProof.requiredObligations.length > 0
+          ? [
+              'Required proof checklist:',
+              ...options.strictRuntimeProof.requiredObligations.map((obligation) => `- ${obligation}`),
+              'Answer only if every required obligation has direct evidence.',
+              'If one required obligation is still missing after one focused follow-up, answer exactly: not enough evidence; missing <obligation>',
+            ]
+          : []),
         ...(options.strictRuntimeProof.rescopedTo
           ? [`Start from the auto-rescoped graph scope: ${options.strictRuntimeProof.rescopedTo}.`]
+          : []),
+        ...(options.strictRuntimeProof.missingObligations && options.strictRuntimeProof.missingObligations.length > 0
+          ? [
+              `Use at most one focused follow-up to surface the missing ${options.strictRuntimeProof.missingObligations.join(', ')} obligation${options.strictRuntimeProof.missingObligations.length === 1 ? '' : 's'}.`,
+            ]
           : []),
         ...(options.strictRuntimeProof.missingPhases && options.strictRuntimeProof.missingPhases.length > 0
           ? [
@@ -3549,11 +3690,74 @@ function evaluateNativeAgentAnswerQualityRun(
   }
 }
 
+function obligationCitationTerms(
+  obligation: RuntimeProofAssessment['obligations'][number],
+  uniqueBasenames: ReadonlySet<string>,
+): string[] {
+  return [...new Set(
+    obligation.evidence.flatMap((evidence) => {
+      const terms = [normalizeAnswerQualityText(evidence.label)]
+      const normalizedBasename = normalizeAnswerQualityText(basename(evidence.source_file))
+      if (normalizedBasename.length > 0 && uniqueBasenames.has(normalizedBasename)) {
+        terms.push(normalizedBasename)
+      }
+      return terms
+    }).filter((value) => value.length > 0),
+  )]
+}
+
+function missingRuntimeProofCitations(
+  answerText: string,
+  pack: CompareReportPack | undefined,
+  runtimeProofProfile: RuntimeProofProfile | undefined,
+): string[] {
+  if (runtimeProofProfile?.strict_runtime_proof !== true) {
+    return []
+  }
+  const runtimeProof = pack?.answer_contract?.runtime_proof
+  if (!runtimeProof) {
+    return []
+  }
+  const normalizedAnswer = normalizeAnswerQualityText(answerText)
+  const basenameCounts = new Map<string, number>()
+  for (const obligation of runtimeProof.obligations) {
+    if (!obligation.required || obligation.evidence.length === 0) {
+      continue
+    }
+    const obligationBasenames = new Set(
+      obligation.evidence
+        .map((evidence) => normalizeAnswerQualityText(basename(evidence.source_file)))
+        .filter((value) => value.length > 0),
+    )
+    for (const normalizedBasename of obligationBasenames) {
+      basenameCounts.set(normalizedBasename, (basenameCounts.get(normalizedBasename) ?? 0) + 1)
+    }
+  }
+  const uniqueBasenames = new Set(
+    [...basenameCounts.entries()]
+      .filter(([, count]) => count === 1)
+      .map(([normalizedBasename]) => normalizedBasename),
+  )
+  return runtimeProof.obligations.flatMap((obligation) => {
+    if (!obligation.required || obligation.evidence.length === 0) {
+      return []
+    }
+    const citationTerms = obligationCitationTerms(obligation, uniqueBasenames)
+    return citationTerms.some((term) => normalizedAnswer.includes(term))
+      ? []
+      : [`direct evidence citation: ${obligation.label}`]
+  })
+}
+
 function evaluateNativeAgentAnswerQualityReport(
   gates: ReadonlyMap<string, NativeAgentAnswerQualityGate> | null,
   question: string,
   baselineAnswerPath: string,
   madarAnswerPath: string,
+  options: {
+    pack?: CompareReportPack | undefined
+    runtimeProofProfile?: RuntimeProofProfile | undefined
+  } = {},
 ): NativeAgentCompareReport['answer_quality'] | undefined {
   if (gates === null) {
     return undefined
@@ -3569,11 +3773,20 @@ function evaluateNativeAgentAnswerQualityReport(
   const [gateName, gate] = match
   const baselineAnswer = readFileSync(baselineAnswerPath, 'utf8')
   const madarAnswer = readFileSync(madarAnswerPath, 'utf8')
+  const baseline = evaluateNativeAgentAnswerQualityRun(gate, baselineAnswer)
+  const madar = evaluateNativeAgentAnswerQualityRun(gate, madarAnswer)
+  const missingCitations = gate.require_direct_evidence
+    ? missingRuntimeProofCitations(madarAnswer, options.pack, options.runtimeProofProfile)
+    : []
   return {
     gate: gateName,
     prompt: gate.prompt,
-    baseline: evaluateNativeAgentAnswerQualityRun(gate, baselineAnswer),
-    madar: evaluateNativeAgentAnswerQualityRun(gate, madarAnswer),
+    baseline,
+    madar: {
+      passed: madar.passed && missingCitations.length === 0,
+      missing_required_terms: [...madar.missing_required_terms, ...missingCitations],
+      forbidden_terms_present: madar.forbidden_terms_present,
+    },
     required_concepts: gate.required_concepts,
     answer_quality_notes: gate.answer_quality_notes,
     manual_review_notes: gate.manual_review_notes,
@@ -4226,8 +4439,9 @@ function nativeAgentAttributionGapEvidence(report: NativeAgentCompareReport): st
 }
 
 function assessNativeAgentPromptContract(
-  report: Pick<NativeAgentCompareReport, 'trace_status' | 'madar_trace'>,
+  report: Pick<NativeAgentCompareReport, 'trace_status' | 'madar_trace' | 'benchmark_readiness'>,
   toolProfile: McpToolProfile,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): NativeAgentPromptContractAssessment {
   if (report.trace_status !== 'trace_available' || report.madar_trace === undefined) {
     return {
@@ -4268,6 +4482,50 @@ function assessNativeAgentPromptContract(
     && (directives.has('verify_one_targeted_file') || directives.has('explore_with_caution'))
   ) {
     evidence.push('more than one focused Madar follow-up was used')
+  }
+  const missingRuntimeTargets = (() => {
+    const labels = report.benchmark_readiness?.reasons.flatMap((reason) => {
+      if (reason.startsWith('missing runtime proof obligations:')) {
+        return reason.slice('missing runtime proof obligations:'.length).split(',').map((value) => value.trim()).filter((value) => value.length > 0)
+      }
+      if (reason.startsWith('missing downstream runtime phases:')) {
+        return reason.slice('missing downstream runtime phases:'.length).split(',').map((value) => value.trim()).filter((value) => value.length > 0)
+      }
+      return []
+    }) ?? []
+    if (labels.length > 0) {
+      return labels
+    }
+    return runtimeProofProfile?.strict_runtime_proof ? runtimeProofProfile.obligations.map((obligation) => obligation.label) : []
+  })()
+  if (runtimeProofProfile?.strict_runtime_proof && report.madar_trace.focused_follow_up_tool_call_count > 0) {
+    const targetedObligations = runtimeProofProfile.obligations.filter((obligation) =>
+      missingRuntimeTargets.some((label) => {
+        const normalizedLabel = normalizeAnswerQualityText(label)
+        return normalizeAnswerQualityText(obligation.label) === normalizedLabel
+          || normalizeAnswerQualityText(obligation.id) === normalizedLabel
+          || obligation.evidence_terms.some((term) => normalizeAnswerQualityText(term) === normalizedLabel)
+      })
+    )
+    const obligations = targetedObligations.length > 0 ? targetedObligations : runtimeProofProfile.obligations
+    const targetTerms = [...new Set(
+      obligations.flatMap((obligation) => [obligation.label, ...obligation.evidence_terms]).map((value) => normalizeAnswerQualityText(value)).filter((value) => value.length > 0),
+    )]
+    const firstMadarTurn = report.madar_trace.first_madar_turn ?? 0
+    const followUpInputs = report.madar_trace.per_turn
+      .filter((turn) => turn.turn > firstMadarTurn)
+      .flatMap((turn) =>
+        turn.tools.flatMap((toolName, index) => {
+          if (!isMadarTraceToolName(toolName) && !isFocusedFollowUpTraceToolName(toolName)) {
+            return []
+          }
+          const input = normalizeAnswerQualityText(rawTraceToolInputs(turn)[index] ?? '')
+          return input.length > 0 ? [input] : []
+        }),
+      )
+    if (followUpInputs.length > 0 && !followUpInputs.some((input) => targetTerms.some((term) => input.includes(term)))) {
+      evidence.push(`focused follow-up did not target missing runtime obligation: ${missingRuntimeTargets[0] ?? runtimeProofProfile.obligations[0]?.label ?? 'runtime proof'}`)
+    }
   }
 
   if (evidence.length > 0) {
@@ -4439,6 +4697,7 @@ export async function executeNativeAgentCompare(
   const graphCache = new Map<string, KnowledgeGraph>([[graphPath, graph]])
   const reports: NativeAgentCompareReport[] = []
   const answerQualityGates = loadNativeAgentAnswerQualityGates(input.questionsPath)
+  const runtimeProofProfiles = loadBenchmarkRuntimeProofProfiles(input.questionsPath)
   const reviewerVisibleGates = task === 'implement' ? loadImplementationReviewerVisibleGates(input.questionsPath) : new Map()
   const environment = await captureBenchmarkEnvironment({ projectRoot })
   const isolation = benchmarkIsolationEnabled()
@@ -4448,6 +4707,7 @@ export async function executeNativeAgentCompare(
   }
 
   const preparedQuestions = questions.map((question, index) => {
+    const runtimeProofProfile = matchBenchmarkRuntimeProofProfile(runtimeProofProfiles, question)
     const questionDir = questions.length === 1 ? outputRoot : join(outputRoot, `question-${String(index + 1).padStart(3, '0')}`)
     mkdirSync(questionDir, { recursive: true })
     const { retrieval, benchmarkReadiness } = prepareNativeAgentBenchmarkReadiness({
@@ -4458,8 +4718,10 @@ export async function executeNativeAgentCompare(
       projectRoot,
       taskKind: task,
       graphCache,
+      ...(runtimeProofProfile ? { runtimeProofProfile } : {}),
       ...(assessBenchmarkReadiness ? { assessBenchmarkReadiness } : {}),
     })
+    const comparePack = compareReportPackFromRetrieveResult(retrieval)
     const implementationGuidance =
       task === 'implement'
         ? buildImplementationPackGuidance(graph, retrieval, {
@@ -4473,7 +4735,7 @@ export async function executeNativeAgentCompare(
     const legacyPromptFile = join(questionDir, 'native_agent-prompt.txt')
     const baselinePrompt = buildNativeAgentBaselinePrompt(question, { task })
     const strictRuntimeProof = benchmarkReadiness
-      ? strictRuntimeProofPromptOptions(retrieval, benchmarkReadiness)
+      ? strictRuntimeProofPromptOptions(retrieval, benchmarkReadiness, runtimeProofProfile)
       : undefined
     const madarPrompt = buildNativeAgentPrompt(question, {
       profile: installCheck.tool_profile,
@@ -4559,6 +4821,8 @@ export async function executeNativeAgentCompare(
       reportShell,
       implementationGuidance,
       reviewerVisibleGate: reviewerVisibleGates.get(question),
+      comparePack,
+      runtimeProofProfile,
     }
   })
 
@@ -4584,6 +4848,8 @@ export async function executeNativeAgentCompare(
       reportShell,
       implementationGuidance,
       reviewerVisibleGate,
+      comparePack,
+      runtimeProofProfile,
     } = entry
     const baselineWorkspace = task === 'implement' ? prepareImplementationWorkspace(projectRoot, graphPath) : null
     const madarWorkspace = task === 'implement' ? prepareImplementationWorkspace(projectRoot, graphPath) : null
@@ -4908,16 +5174,20 @@ export async function executeNativeAgentCompare(
       madarTrace: reportShell.madar_trace,
       strictMadarFirst: input.strictMadarFirst,
     })
-    reportShell.prompt_contract = assessNativeAgentPromptContract(reportShell, installCheck.tool_profile)
     const answerQuality = evaluateNativeAgentAnswerQualityReport(
       answerQualityGates,
       question,
       baselineAnswerPath,
       madarAnswerPath,
+      {
+        pack: comparePack,
+        runtimeProofProfile,
+      },
     )
     if (answerQuality !== undefined) {
       reportShell.answer_quality = answerQuality
     }
+    reportShell.prompt_contract = assessNativeAgentPromptContract(reportShell, installCheck.tool_profile, runtimeProofProfile)
     const claimAssessment = assessNativeAgentClaims(reportShell)
     if (claimAssessment !== undefined) {
       reportShell.claim_assessment = claimAssessment

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -27,6 +27,7 @@ import type {
 } from '../contracts/context-pack.js'
 import type { TaskIntentKind } from '../contracts/task-intent.js'
 import { KnowledgeGraph } from '../contracts/graph.js'
+import type { RuntimeProofProfile } from '../contracts/runtime-proof.js'
 import { godNodes, workspaceBridges } from '../pipeline/analyze.js'
 import { type Communities } from '../pipeline/cluster.js'
 import { buildCommunityLabels } from '../pipeline/community-naming.js'
@@ -56,6 +57,12 @@ import {
   relationIsPrimaryForPolicy,
 } from './retrieve/expansion.js'
 import { sliceCandidatesForRetrieve } from './retrieve/slicing.js'
+import {
+  buildRuntimeProofAssessment,
+  runtimeProofAnchorBonus,
+  runtimeProofObligationMatchScore,
+  type RuntimeProofCandidate,
+} from './runtime-proof.js'
 import { communitiesFromGraph, estimateQueryTokens } from './serve.js'
 
 const SNIPPET_HALF_WINDOW = 7
@@ -100,6 +107,7 @@ export interface RetrieveOptions {
   /** Internal additive override for benchmarks/tests. */
   selectionStrategy?: ContextPackSelectionStrategy
   retrievalStrategy?: ContextPackRetrievalStrategy
+  runtimeProofProfile?: RuntimeProofProfile
   snippetBudget?: number
   topNWithSnippet?: number
 }
@@ -2142,8 +2150,9 @@ function augmentSliceCandidateIdsForRuntimeExplain(
   metadata: ContextPackSliceMetadata,
   retrievalGate: RetrievalGateDecision,
   question: string,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): string[] {
-  if (!runtimeGenerationSliceCandidatePromotionApplies(retrievalGate, metadata)) {
+  if (!runtimeGenerationSliceCandidatePromotionApplies(retrievalGate, metadata) && runtimeProofProfile?.strict_runtime_proof !== true) {
     return [...orderedIds]
   }
 
@@ -2167,7 +2176,7 @@ function augmentSliceCandidateIdsForRuntimeExplain(
   const anchorIds = metadata.anchors
     .map((anchor) => resolveNodeId(anchor.node_id, anchor.label))
     .filter((nodeId): nodeId is string => typeof nodeId === 'string')
-  const executionScope = collectExecutionSliceScope(graph, metadata, anchorIds, question, resolveNodeId)
+  const executionScope = collectExecutionSliceScope(graph, metadata, anchorIds, question, resolveNodeId, runtimeProofProfile)
 
   for (const nodeId of executionScope.orderedIds) {
     if (!seen.has(nodeId)) {
@@ -2183,7 +2192,11 @@ function runtimeGenerationExecutionSliceApplies(
   taskContract: ContextPackTaskContract,
   retrievalGate: RetrievalGateDecision,
   sliceMetadata: ContextPackSliceMetadata | undefined,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): boolean {
+  if (runtimeProofProfile?.strict_runtime_proof === true) {
+    return taskContract.task_kind === 'explain' && sliceMetadata !== undefined
+  }
   return retrievalGate.signals.generation_intent === 'runtime_generation'
     && retrievalGate.signals.target_domain_hint === 'backend_runtime'
     && taskContract.task_kind === 'explain'
@@ -2294,12 +2307,161 @@ interface ExecutionPathCandidate {
   edges: ExecutionFlowEdge[]
 }
 
+function runtimeProofCandidateFromGraph(
+  graph: KnowledgeGraph,
+  nodeId: string,
+): RuntimeProofCandidate {
+  const attributes = graph.nodeAttributes(nodeId)
+  return {
+    label: String(attributes.label ?? nodeId),
+    source_file: String(attributes.source_file ?? ''),
+    line_number: lineNumberFromSourceLocation(String(attributes.source_location ?? '')) ?? 0,
+    ...(typeof attributes.node_kind === 'string' ? { node_kind: attributes.node_kind } : {}),
+    ...(typeof attributes.framework_role === 'string' ? { framework_role: attributes.framework_role } : {}),
+  }
+}
+
+function runtimeProofCandidateFromExecutionStep(
+  step: Pick<ContextPackExecutionSliceStep, 'label' | 'source_file' | 'line_number' | 'node_kind' | 'framework_role'>,
+): RuntimeProofCandidate {
+  return {
+    label: step.label,
+    source_file: step.source_file,
+    line_number: step.line_number,
+    ...(step.node_kind ? { node_kind: step.node_kind } : {}),
+    ...(step.framework_role ? { framework_role: step.framework_role } : {}),
+  }
+}
+
+function augmentExecutionScopeForRuntimeProof(
+  graph: KnowledgeGraph,
+  orderedIds: string[],
+  idSet: Set<string>,
+  anchorIds: readonly string[],
+  runtimeProofProfile: RuntimeProofProfile,
+): void {
+  const addPath = (path: readonly string[]): void => {
+    for (const nodeId of path) {
+      if (graph.hasNode(nodeId) && !idSet.has(nodeId)) {
+        idSet.add(nodeId)
+        orderedIds.push(nodeId)
+      }
+    }
+  }
+
+  const findTargetedPath = (obligationId: string): string[] | undefined => {
+    const obligation = runtimeProofProfile.obligations.find((entry) => entry.id === obligationId)
+    if (!obligation) {
+      return undefined
+    }
+    const sourceIds = orderedIds.length > 0 ? [...orderedIds] : [...anchorIds]
+    const queue = sourceIds.map((nodeId) => ({ nodeId, path: [nodeId], depth: 0 }))
+    const bestDepth = new Map(sourceIds.map((nodeId) => [nodeId, 0]))
+    let bestPath: string[] | undefined
+    let bestScore = 0
+
+    while (queue.length > 0) {
+      const current = queue.shift()!
+      const candidate = runtimeProofCandidateFromGraph(graph, current.nodeId)
+      const matchScore = runtimeProofObligationMatchScore(candidate, obligation)
+      if (
+        matchScore > bestScore
+        || (matchScore === bestScore && matchScore > 0 && bestPath !== undefined && current.path.length < bestPath.length)
+      ) {
+        bestScore = matchScore
+        bestPath = current.path
+      }
+      if (current.depth >= 6) {
+        continue
+      }
+
+      const neighbors = [
+        ...graph.predecessors(current.nodeId).map((nodeId) => ({ nodeId, relation: String(graph.edgeAttributes(nodeId, current.nodeId).relation ?? 'related_to') })),
+        ...graph.successors(current.nodeId).map((nodeId) => ({ nodeId, relation: String(graph.edgeAttributes(current.nodeId, nodeId).relation ?? 'related_to') })),
+      ]
+        .filter((neighbor) => executionSliceFlowRelation(neighbor.relation))
+        .sort((left, right) => {
+          const leftScore = runtimeProofObligationMatchScore(runtimeProofCandidateFromGraph(graph, left.nodeId), obligation)
+          const rightScore = runtimeProofObligationMatchScore(runtimeProofCandidateFromGraph(graph, right.nodeId), obligation)
+          return rightScore - leftScore || executionSliceEdgePriority(right.relation) - executionSliceEdgePriority(left.relation)
+        })
+
+      for (const neighbor of neighbors) {
+        const nextDepth = current.depth + 1
+        const previousBest = bestDepth.get(neighbor.nodeId)
+        if (previousBest !== undefined && previousBest <= nextDepth) {
+          continue
+        }
+        bestDepth.set(neighbor.nodeId, nextDepth)
+        queue.push({
+          nodeId: neighbor.nodeId,
+          path: [...current.path, neighbor.nodeId],
+          depth: nextDepth,
+        })
+      }
+    }
+
+    return bestScore > 0 ? bestPath : undefined
+  }
+
+  for (const obligationId of buildRuntimeProofAssessment(
+    runtimeProofProfile,
+    orderedIds.map((nodeId) => runtimeProofCandidateFromGraph(graph, nodeId)),
+  )?.missing_obligations ?? []) {
+    const targetedPath = findTargetedPath(obligationId)
+    if (targetedPath) {
+      addPath(targetedPath)
+    }
+  }
+
+  const entrypointObligations = runtimeProofProfile.obligations.filter((obligation) => obligation.kind === 'entrypoint')
+  if (entrypointObligations.length === 0) {
+    return
+  }
+
+  const queue = [...orderedIds]
+  const seen = new Set(queue)
+  while (queue.length > 0) {
+    const nodeId = queue.shift()!
+    for (const predecessorId of graph.predecessors(nodeId)) {
+      if (seen.has(predecessorId)) {
+        continue
+      }
+      const relation = String(graph.edgeAttributes(predecessorId, nodeId).relation ?? 'related_to')
+      if (!executionSliceFlowRelation(relation)) {
+        continue
+      }
+      seen.add(predecessorId)
+      const predecessorStep = runtimeProofCandidateFromGraph(graph, predecessorId)
+      const entrypointScore = Math.max(0, ...entrypointObligations.map((obligation) =>
+        runtimeProofObligationMatchScore(predecessorStep, obligation)
+      ))
+      if (
+        entrypointScore > 0
+        || controllerLikeExecutionStep({
+          label: predecessorStep.label,
+          source_file: predecessorStep.source_file,
+          ...(predecessorStep.node_kind ? { node_kind: predecessorStep.node_kind } : {}),
+          ...(predecessorStep.framework_role ? { framework_role: predecessorStep.framework_role } : {}),
+        })
+      ) {
+        if (!idSet.has(predecessorId)) {
+          idSet.add(predecessorId)
+          orderedIds.unshift(predecessorId)
+        }
+        queue.push(predecessorId)
+      }
+    }
+  }
+}
+
 function collectExecutionSliceScope(
   graph: KnowledgeGraph,
   sliceMetadata: ContextPackSliceMetadata,
   anchorIds: readonly string[],
   question: string,
   resolveNodeId: (nodeId: string | undefined, label: string) => string | undefined,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): { orderedIds: string[]; idSet: ReadonlySet<string> } {
   const orderedIds: string[] = []
   const idSet = new Set<string>()
@@ -2358,6 +2520,10 @@ function collectExecutionSliceScope(
     }
   }
 
+  if (runtimeProofProfile?.strict_runtime_proof === true) {
+    augmentExecutionScopeForRuntimeProof(graph, orderedIds, idSet, anchorIds, runtimeProofProfile)
+  }
+
   if (addedSelectedFlowPath) {
     return { orderedIds, idSet }
   }
@@ -2389,6 +2555,10 @@ function collectExecutionSliceScope(
         enqueueNeighbor(successorId, depth + 1)
       }
     }
+  }
+
+  if (runtimeProofProfile?.strict_runtime_proof === true) {
+    augmentExecutionScopeForRuntimeProof(graph, orderedIds, idSet, anchorIds, runtimeProofProfile)
   }
 
   return { orderedIds, idSet }
@@ -2790,6 +2960,7 @@ function executionPathScore(
   path: ExecutionPathCandidate,
   nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
   question: string,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): number {
   const steps = path.nodeIds
     .map((nodeId) => nodeById.get(nodeId))
@@ -2833,6 +3004,42 @@ function executionPathScore(
   }
   if (lastStep && lowValueExecutionStepForQuestion(lastStep, question)) {
     score -= 40
+  }
+
+  if (runtimeProofProfile) {
+    const runtimeProof = buildRuntimeProofAssessment(
+      runtimeProofProfile,
+      steps.map((step) => runtimeProofCandidateFromExecutionStep(step)),
+    )
+    if (runtimeProof) {
+      const coveredCount = runtimeProof.obligations.length - runtimeProof.missing_obligations.length
+      score += coveredCount * 140
+      score -= runtimeProof.missing_obligations.length * 220
+      if (runtimeProof.missing_obligations.some((obligationId) =>
+        runtimeProofProfile.obligations.find((obligation) => obligation.id === obligationId)?.kind === 'terminal'
+      )) {
+        score -= 120
+      }
+    }
+    const firstStep = steps[0]
+    if (firstStep) {
+      const entrypointBonus = Math.max(0, ...runtimeProofProfile.obligations
+        .filter((obligation) => obligation.kind === 'entrypoint')
+        .map((obligation) => runtimeProofObligationMatchScore(runtimeProofCandidateFromExecutionStep(firstStep), obligation)))
+      score += entrypointBonus * 20
+      if (controllerLikeExecutionStep(firstStep)) {
+        score += 35
+      }
+    }
+    if (lastStep) {
+      const terminalBonus = Math.max(0, ...runtimeProofProfile.obligations
+        .filter((obligation) => obligation.kind === 'terminal')
+        .map((obligation) => runtimeProofObligationMatchScore(runtimeProofCandidateFromExecutionStep(lastStep), obligation)))
+      score += terminalBonus * 18
+      if (!serviceLikeExecutionStep(lastStep)) {
+        score += 15
+      }
+    }
   }
 
   return score + path.edges.length
@@ -2994,7 +3201,35 @@ function pickExecutionSliceStart(
   idSet: ReadonlySet<string>,
   nodeById: ReadonlyMap<string, ContextPackExecutionSliceStep>,
   question: string,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): string | undefined {
+  if (runtimeProofProfile?.strict_runtime_proof === true) {
+    const roots = orderedIds.filter((nodeId) =>
+      [...graph.predecessors(nodeId)].every((predecessorId) =>
+        !idSet.has(predecessorId)
+        || !executionSliceFlowRelation(String(graph.edgeAttributes(predecessorId, nodeId).relation ?? 'related_to')),
+      ),
+    )
+    const candidates = roots.length > 0 ? roots : orderedIds
+    return [...candidates].sort((left, right) => {
+      const leftStep = nodeById.get(left)
+      const rightStep = nodeById.get(right)
+      const leftEntry = leftStep
+        ? Math.max(0, ...runtimeProofProfile.obligations
+          .filter((obligation) => obligation.kind === 'entrypoint')
+          .map((obligation) => runtimeProofObligationMatchScore(runtimeProofCandidateFromExecutionStep(leftStep), obligation)))
+        : 0
+      const rightEntry = rightStep
+        ? Math.max(0, ...runtimeProofProfile.obligations
+          .filter((obligation) => obligation.kind === 'entrypoint')
+          .map((obligation) => runtimeProofObligationMatchScore(runtimeProofCandidateFromExecutionStep(rightStep), obligation)))
+        : 0
+      return rightEntry - leftEntry
+        || (rightStep && controllerLikeExecutionStep(rightStep) ? 1 : 0) - (leftStep && controllerLikeExecutionStep(leftStep) ? 1 : 0)
+        || (rightStep ? executionSliceStepPriority(rightStep, question) : 0) - (leftStep ? executionSliceStepPriority(leftStep, question) : 0)
+    })[0]
+  }
+
   const anchoredStart = anchorIds.find((nodeId) => idSet.has(nodeId))
   if (anchoredStart) {
     return anchoredStart
@@ -3219,8 +3454,9 @@ function buildRuntimeGenerationAnswerContract(
   matchedNodes: readonly Pick<RetrieveMatchedNode, 'label' | 'source_file' | 'node_kind' | 'framework_role'>[],
   executionSlice: ContextPackExecutionSlice | undefined,
   sliceMetadata: ContextPackSliceMetadata | undefined,
+  runtimeProofProfile?: RuntimeProofProfile,
 ): ContextPackRuntimeGenerationAnswerContract | undefined {
-  if (!runtimeGenerationExecutionSliceApplies(taskContract, retrievalGate, sliceMetadata) || !executionSlice) {
+  if (!runtimeGenerationExecutionSliceApplies(taskContract, retrievalGate, sliceMetadata, runtimeProofProfile) || !executionSlice) {
     return undefined
   }
 
@@ -3243,9 +3479,26 @@ function buildRuntimeGenerationAnswerContract(
     missing_phases: missingPhases,
   }
 
-  if (executionSlice.status === 'partial' || missingPhases.length > 0) {
+  const runtimeProof = buildRuntimeProofAssessment(
+    runtimeProofProfile,
+    [
+      ...executionSlice.steps.map((step) => runtimeProofCandidateFromExecutionStep(step)),
+      ...(executionSlice.side_effects ?? []).flatMap((branch) => branch.steps.map((step) => runtimeProofCandidateFromExecutionStep(step))),
+      ...(executionSlice.terminal_boundaries ?? []).flatMap((branch) => branch.steps.map((step) => runtimeProofCandidateFromExecutionStep(step))),
+    ],
+  )
+  if (runtimeProof) {
+    answerContract.runtime_proof = runtimeProof
+  }
+
+  const missingRuntimeObligations = runtimeProof?.missing_obligations
+    .map((obligationId) => runtimeProofProfile?.obligations.find((obligation) => obligation.id === obligationId)?.label ?? obligationId)
+    ?? []
+  if (executionSlice.status === 'partial' || missingPhases.length > 0 || missingRuntimeObligations.length > 0) {
     answerContract.uncertainty_notes = [
-      missingPhases.length > 0
+      missingRuntimeObligations.length > 0
+        ? `Do not infer unobserved runtime obligations; if the full flow is requested, answer: not enough evidence; missing ${missingRuntimeObligations.join(', ')}`
+        : missingPhases.length > 0
         ? `Do not infer unobserved runtime phases; if the full flow is requested, answer: not enough evidence; missing ${missingPhases.join(', ')}`
         : 'Do not infer unobserved runtime phases; if the full flow is requested, answer: not enough evidence.',
     ]
@@ -3265,9 +3518,10 @@ function buildExecutionSlice(
   retrievalGate: RetrievalGateDecision,
   question: string,
   sliceMetadata: ContextPackSliceMetadata | undefined,
+  runtimeProofProfile?: RuntimeProofProfile,
   rootPath?: string,
 ): ContextPackExecutionSlice | undefined {
-  if (!runtimeGenerationExecutionSliceApplies(taskContract, retrievalGate, sliceMetadata) || !sliceMetadata) {
+  if (!runtimeGenerationExecutionSliceApplies(taskContract, retrievalGate, sliceMetadata, runtimeProofProfile) || !sliceMetadata) {
     return undefined
   }
 
@@ -3289,7 +3543,7 @@ function buildExecutionSlice(
   const anchorIds = sliceMetadata.anchors
     .map((anchor) => resolveNodeId(anchor.node_id, anchor.label))
     .filter((nodeId): nodeId is string => typeof nodeId === 'string')
-  const { orderedIds, idSet } = collectExecutionSliceScope(graph, sliceMetadata, anchorIds, question, resolveNodeId)
+  const { orderedIds, idSet } = collectExecutionSliceScope(graph, sliceMetadata, anchorIds, question, resolveNodeId, runtimeProofProfile)
   if (orderedIds.length === 0) {
     return {
       status: 'partial',
@@ -3304,7 +3558,7 @@ function buildExecutionSlice(
     orderedIds
       .map((nodeId) => [nodeId, executionSliceStepFromGraph(graph, nodeId, rootPath)] as const),
   )
-  const startId = pickExecutionSliceStart(graph, anchorIds, orderedIds, idSet, nodeById, question)
+  const startId = pickExecutionSliceStart(graph, anchorIds, orderedIds, idSet, nodeById, question, runtimeProofProfile)
   if (!startId) {
     return {
       status: 'partial',
@@ -3322,7 +3576,7 @@ function buildExecutionSlice(
     edges: [] as ExecutionFlowEdge[],
   }]
   const primaryPath = primaryPathCandidates.sort((left, right) =>
-    executionPathScore(right, nodeById, question) - executionPathScore(left, nodeById, question)
+    executionPathScore(right, nodeById, question, runtimeProofProfile) - executionPathScore(left, nodeById, question, runtimeProofProfile)
   )[0]!
 
   const steps = primaryPath.nodeIds
@@ -3340,7 +3594,14 @@ function buildExecutionSlice(
     ...branches.omittedEvidenceSteps,
   ]
   const phaseCoverage = phaseCoverageForPath(steps, boundaries, question, scopeSteps, tracedSteps)
-  const missingPhase = phaseCoverage.missing[0]
+  const runtimeProof = buildRuntimeProofAssessment(
+    runtimeProofProfile,
+    tracedSteps.map((step) => runtimeProofCandidateFromExecutionStep(step)),
+  )
+  const runtimeProofComplete = runtimeProofProfile?.strict_runtime_proof === true
+    && runtimeProof !== undefined
+    && runtimeProof.missing_obligations.length === 0
+  const missingPhase = runtimeProofComplete ? undefined : phaseCoverage.missing[0]
   const boundaryReason = missingPhase ? missingExecutionPhaseBoundaryReason(missingPhase) : undefined
   const executionSlice: ContextPackExecutionSlice = {
     status: missingPhase ? 'partial' : 'complete',
@@ -3974,7 +4235,15 @@ function buildRetrieveResultFromOrderedCandidates(
     bridge_nodes: [...new Set(orderedCandidates.map((node) => node.label).filter((label) => retrieveGraphSignals.bridgeNodeLabels.has(label)))],
   }
   const structuralIds = structuralSliceNodeIds(sliceMetadata, orderedCandidates, options.question)
-  const executionSlice = buildExecutionSlice(graph, taskContract, retrievalGate, options.question, sliceMetadata, rootPath)
+  const executionSlice = buildExecutionSlice(
+    graph,
+    taskContract,
+    retrievalGate,
+    options.question,
+    sliceMetadata,
+    options.runtimeProofProfile,
+    rootPath,
+  )
   const nodeCandidates: Array<ContextPackNodeCandidate<ContextPackNode>> = orderedCandidates.map((node) => {
     let builtEntry: RetrieveMatchedNode | undefined
     let tokenCost: number | undefined
@@ -4084,6 +4353,7 @@ function buildRetrieveResultFromOrderedCandidates(
     matchedNodes,
     executionSlice,
     sliceMetadata,
+    options.runtimeProofProfile,
   )
 
   return {
@@ -4637,6 +4907,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
     : frameworkOrderedCandidates.filter((node) => node.relevanceBand !== 'peripheral')
 
   if (options.retrievalStrategy === 'slice-v1') {
+    const strictRuntimeProof = options.runtimeProofProfile?.strict_runtime_proof === true
     const sliced = sliceCandidatesForRetrieve(
       graph,
       scored.map((node) => ({
@@ -4653,8 +4924,9 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
       retrievalGate.intent,
       {
         prompt: question,
-        generationIntent: retrievalGate.signals.generation_intent,
-        targetDomainHint: retrievalGate.signals.target_domain_hint,
+        generationIntent: strictRuntimeProof ? 'runtime_generation' : retrievalGate.signals.generation_intent,
+        targetDomainHint: strictRuntimeProof ? 'backend_runtime' : retrievalGate.signals.target_domain_hint,
+        runtimeProofProfile: options.runtimeProofProfile,
         mentionedSymbols: retrievalGate.signals.mentioned_symbols,
         excludedDomains: retrievalGate.signals.excluded_domains,
         excludedTerms: retrievalGate.signals.excluded_terms,
@@ -4671,6 +4943,7 @@ export function retrieveContext(graph: KnowledgeGraph, options: RetrieveOptions)
         sliced.metadata,
         retrievalGate,
         options.question,
+        options.runtimeProofProfile,
       )
       const orderedSliceIds = augmentSliceCandidateIdsForDebug(graph, runtimeExpandedSliceIds, sliced.metadata)
       const sliceCandidates = orderedSliceIds.map((nodeId, index) => (

--- a/src/runtime/retrieve/slicing.ts
+++ b/src/runtime/retrieve/slicing.ts
@@ -9,8 +9,10 @@ import type {
   RetrievalIntent,
   RetrievalTargetDomainHint,
 } from '../../contracts/retrieval-gate.js'
+import type { RuntimeProofProfile } from '../../contracts/runtime-proof.js'
 import { classifySourceDomain, isPollutedSourcePath } from '../../shared/source-discovery.js'
 import { relativizeSourceFile } from '../../shared/source-path.js'
+import { runtimeProofAnchorBonus } from '../runtime-proof.js'
 
 export interface SliceScoredNode {
   id: string
@@ -28,6 +30,7 @@ interface SliceOptions {
   prompt?: string | undefined
   generationIntent?: RetrievalGenerationIntent | undefined
   targetDomainHint?: RetrievalTargetDomainHint | undefined
+  runtimeProofProfile?: RuntimeProofProfile | undefined
   mentionedSymbols?: readonly string[] | undefined
   excludedDomains?: readonly string[] | undefined
   excludedTerms?: readonly string[] | undefined
@@ -440,6 +443,22 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
       .sort((left, right) => right.value - left.value || right.node.score - left.node.score)
       .map((entry) => entry.node)
     : []
+  const runtimeProofAnchors = options.runtimeProofProfile?.strict_runtime_proof
+    ? scored
+      .filter((node) => !isBarrelLike(node.label, node.sourceFile) && !frontendDisplayLikeNode(node))
+      .map((node) => ({
+        node,
+        value: runtimeProofAnchorBonus({
+          label: node.label,
+          source_file: node.sourceFile,
+          node_kind: node.nodeKind,
+          framework_role: node.frameworkRole,
+        }, options.runtimeProofProfile) + runtimeGenerationAnchorValue(node),
+      }))
+      .filter((entry) => entry.value > 0)
+      .sort((left, right) => right.value - left.value || right.node.score - left.node.score)
+      .map((entry) => entry.node)
+    : []
   const intentAnchors = (() => {
     if (options.generationIntent === 'runtime_generation' && options.targetDomainHint === 'backend_runtime') {
       return matchedAnchors
@@ -467,6 +486,8 @@ function buildAnchors(scored: readonly SliceScoredNode[], options: SliceOptions)
     anchorPool = exactMethodAnchors.slice(0, 1)
   } else if (explicitPathAnchor) {
     anchorPool = [explicitPathAnchor]
+  } else if (runtimeProofAnchors.length > 0) {
+    anchorPool = runtimeProofAnchors.slice(0, broadRuntimeGeneration ? 2 : 1)
   } else if (broadRuntimeGeneration && reportGenerationPrompt && semanticCoreAnchors.length > 0) {
     const primaryRuntimeAnchor = routePromptAnchors[0]
       ?? intentAnchors[0]

--- a/src/runtime/runtime-proof.ts
+++ b/src/runtime/runtime-proof.ts
@@ -1,0 +1,137 @@
+import type {
+  RuntimeProofAssessment,
+  RuntimeProofObligationAssessment,
+  RuntimeProofProfile,
+  RuntimeProofProfileObligation,
+} from '../contracts/runtime-proof.js'
+
+export interface RuntimeProofCandidate {
+  label: string
+  source_file: string
+  line_number: number
+  node_kind?: string | undefined
+  framework_role?: string | undefined
+}
+
+function normalizeRuntimeProofText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function runtimeProofCandidateText(candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>): string {
+  return normalizeRuntimeProofText(
+    `${candidate.label} ${candidate.source_file} ${candidate.node_kind ?? ''} ${candidate.framework_role ?? ''}`,
+  )
+}
+
+function runtimeProofKindBonus(
+  candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+  obligation: RuntimeProofProfileObligation,
+): number {
+  const text = runtimeProofCandidateText(candidate)
+  switch (obligation.kind) {
+    case 'entrypoint':
+      return /\b(?:route|controller|handler|resolver|endpoint|api)\b/.test(text) ? 4 : 0
+    case 'handoff':
+      return /\b(?:service|workspace|orchestr|dispatch|process|apply|pipeline)\b/.test(text) ? 3 : 0
+    case 'terminal':
+      return /\b(?:persist|save|repository|redirect|deliver|notification|analytics|track|event|send)\b/.test(text) ? 4 : 0
+  }
+}
+
+function runtimeProofMatchedTermCount(
+  candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+  obligation: RuntimeProofProfileObligation,
+): number {
+  const text = runtimeProofCandidateText(candidate)
+  return obligation.evidence_terms.filter((term) => {
+    const normalized = normalizeRuntimeProofText(term)
+    return normalized.length > 0 && text.includes(normalized)
+  }).length
+}
+
+export function runtimeProofObligationMatchScore(
+  candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+  obligation: RuntimeProofProfileObligation,
+): number {
+  return (runtimeProofMatchedTermCount(candidate, obligation) * 3) + runtimeProofKindBonus(candidate, obligation)
+}
+
+function runtimeProofHasDirectTerminalSignal(
+  candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+): boolean {
+  const text = runtimeProofCandidateText(candidate)
+  return /\b(?:persist|save|write|store|record|track|emit|event|publish|send|deliver|redirect|notification|webhook|repository|database|render|synthesis)\b/.test(text)
+}
+
+export function runtimeProofProvidesDirectEvidence(
+  candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+  obligation: RuntimeProofProfileObligation,
+): boolean {
+  const matchedTerms = runtimeProofMatchedTermCount(candidate, obligation)
+  if (matchedTerms === 0) {
+    return false
+  }
+  switch (obligation.kind) {
+    case 'entrypoint':
+      return matchedTerms >= 1
+    case 'handoff':
+      return matchedTerms >= 1 && runtimeProofObligationMatchScore(candidate, obligation) >= 4
+    case 'terminal':
+      return matchedTerms >= 2 && runtimeProofHasDirectTerminalSignal(candidate)
+  }
+}
+
+export function runtimeProofAnchorBonus(
+  candidate: Pick<RuntimeProofCandidate, 'label' | 'source_file' | 'node_kind' | 'framework_role'>,
+  profile: RuntimeProofProfile | undefined,
+): number {
+  if (!profile) {
+    return 0
+  }
+  return Math.max(0, ...profile.obligations.map((obligation) => runtimeProofObligationMatchScore(candidate, obligation)))
+}
+
+function dedupeRuntimeProofEvidence(
+  evidence: RuntimeProofCandidate[],
+): RuntimeProofObligationAssessment['evidence'] {
+  const seen = new Set<string>()
+  const deduped: RuntimeProofObligationAssessment['evidence'] = []
+  for (const entry of evidence) {
+    const key = `${entry.source_file}:${entry.line_number}:${entry.label}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    deduped.push({
+      label: entry.label,
+      source_file: entry.source_file,
+      line_number: entry.line_number,
+    })
+  }
+  return deduped
+}
+
+export function buildRuntimeProofAssessment(
+  profile: RuntimeProofProfile | undefined,
+  candidates: readonly RuntimeProofCandidate[],
+): RuntimeProofAssessment | undefined {
+  if (!profile) {
+    return undefined
+  }
+  const obligations = profile.obligations.map<RuntimeProofObligationAssessment>((obligation) => {
+    const evidence = dedupeRuntimeProofEvidence(
+      candidates.filter((candidate) => runtimeProofProvidesDirectEvidence(candidate, obligation)),
+    )
+    return {
+      id: obligation.id,
+      label: obligation.label,
+      kind: obligation.kind,
+      required: true,
+      evidence,
+    }
+  })
+  return {
+    obligations,
+    missing_obligations: obligations.filter((obligation) => obligation.evidence.length === 0).map((obligation) => obligation.id),
+  }
+}

--- a/tests/unit/benchmark-suite.test.ts
+++ b/tests/unit/benchmark-suite.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest'
 import type { GenerateGraphResult } from '../../src/infrastructure/generate.js'
 import type { NativeAgentCompareResult, NativeAgentCompareReport } from '../../src/infrastructure/compare.js'
 import type { BenchmarkEnvironment, BenchmarkExpectedEnvironment } from '../../src/infrastructure/benchmark/environment.js'
+import { loadBenchmarkRuntimeProofProfiles } from '../../src/infrastructure/benchmark/runtime-proof.js'
 import { claudeInstall } from '../../src/infrastructure/install.js'
 import {
   loadBenchmarkSuiteRepos,
@@ -540,6 +541,84 @@ describe('benchmark suite manifests', () => {
       'partly inferred',
       'did not surface the top-level handler that wires them together',
     ]))
+  })
+
+  it('ships deterministic runtime-proof profiles for the public explain-runtime rows', () => {
+    const profiles = JSON.parse(readFileSync(resolve('docs/benchmarks/suite/runtime-proof.json'), 'utf8')) as Record<string, {
+      prompt: string
+      strict_runtime_proof: boolean
+      expected_spi: boolean
+      obligations: Array<{
+        id: string
+        label: string
+        kind: string
+        evidence_terms: string[]
+      }>
+    }>
+
+    expect(Object.values(profiles).map((profile) => profile.prompt)).toEqual(expect.arrayContaining([
+      'How does Documenso move a document from send preparation through recipient creation, signing state, and notification delivery?',
+      'How does Formbricks process a survey response from request handling through persistence and analytics/event tracking?',
+      'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?',
+      'How does Twenty process a CRM record mutation from API handling through workspace services to persistence?',
+      'How does Cal.diy turn a booking request into availability validation, scheduled event persistence, and notification delivery?',
+      'How does Novu process a notification trigger from API entry through workflow orchestration to channel delivery?',
+    ]))
+
+    for (const profile of Object.values(profiles)) {
+      expect(profile.strict_runtime_proof).toBe(true)
+      expect(profile.expected_spi).toBe(false)
+      expect(profile.obligations.length).toBeGreaterThanOrEqual(3)
+      for (const obligation of profile.obligations) {
+        expect(obligation.id).toEqual(expect.any(String))
+        expect(obligation.label).toEqual(expect.any(String))
+        expect(['entrypoint', 'handoff', 'terminal']).toContain(obligation.kind)
+        expect(obligation.evidence_terms.length).toBeGreaterThan(0)
+      }
+    }
+
+    expect(profiles['dub-explain-runtime']?.obligations.map((obligation) => obligation.id)).toEqual(expect.arrayContaining([
+      'request_handling',
+      'analytics_tracking',
+      'destination_redirect',
+    ]))
+    expect(profiles['twenty-explain-runtime']?.obligations.map((obligation) => obligation.id)).toEqual(expect.arrayContaining([
+      'api_mutation_handling',
+      'workspace_service_handoff',
+      'persistence',
+    ]))
+  })
+
+  it('rejects runtime-proof profiles with empty evidence term arrays', async () => {
+    await withTempDir(async (tempDir) => {
+      const benchmarkDir = join(tempDir, 'benchmarks', 'explain')
+      mkdirSync(benchmarkDir, { recursive: true })
+      const questionsPath = join(benchmarkDir, 'questions.json')
+      writeFileSync(questionsPath, JSON.stringify([{ question: 'How does login create a session?' }], null, 2), 'utf8')
+      writeFileSync(
+        join(benchmarkDir, 'runtime-proof.json'),
+        JSON.stringify({
+          'login-runtime': {
+            prompt: 'How does login create a session?',
+            strict_runtime_proof: true,
+            expected_spi: false,
+            obligations: [
+              {
+                id: 'request_handling',
+                label: 'request handling',
+                kind: 'entrypoint',
+                evidence_terms: [],
+              },
+            ],
+          },
+        }, null, 2),
+        'utf8',
+      )
+
+      expect(() => loadBenchmarkRuntimeProofProfiles(questionsPath)).toThrow(
+        'Malformed runtime proof profile "login-runtime": obligations.request_handling.evidence_terms must be a non-empty string array',
+      )
+    })
   })
 
   it('rejects repo ids with unsafe path characters', async () => {

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -244,6 +244,36 @@ function makeExplainQualityFixtureProject(): {
   return { projectDir, graphPath, outputDir, questionsPath }
 }
 
+function writeRuntimeProofFixture(
+  projectDir: string,
+  profileId: string,
+  question: string,
+  obligations: Array<{
+    id: string
+    label: string
+    kind: 'entrypoint' | 'handoff' | 'terminal'
+    evidence_terms: string[]
+  }>,
+): string {
+  const benchmarkDir = join(projectDir, 'benchmarks', 'explain')
+  mkdirSync(benchmarkDir, { recursive: true })
+  const questionsPath = join(benchmarkDir, 'questions.json')
+  writeFileSync(questionsPath, JSON.stringify([{ question }], null, 2), 'utf8')
+  writeFileSync(
+    join(benchmarkDir, 'runtime-proof.json'),
+    JSON.stringify({
+      [profileId]: {
+        prompt: question,
+        strict_runtime_proof: true,
+        expected_spi: false,
+        obligations,
+      },
+    }, null, 2),
+    'utf8',
+  )
+  return questionsPath
+}
+
 function makeRescopedReadinessFixtureProject(): {
   projectDir: string
   graphPath: string
@@ -1019,6 +1049,52 @@ const VERBOSE_MADAR_FIRST_LOW_CONFIDENCE_THEN_READY_PAYLOAD = [
               agent_directive: 'answer_from_pack',
             },
           }),
+        },
+      ],
+    },
+  },
+  MADAR_USAGE_PAYLOAD,
+] as const
+
+const VERBOSE_MADAR_RUNTIME_PROOF_UNTARGETED_FOLLOWUP_PAYLOAD = [
+  { type: 'system', subtype: 'init' },
+  {
+    type: 'assistant',
+    turn: 1,
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name: 'mcp__madar__retrieve',
+          input: {
+            question: 'How does login create a session from request handling through persistence?',
+          },
+        },
+        {
+          type: 'tool_result',
+          tool_name: 'mcp__madar__retrieve',
+          content: JSON.stringify({
+            evidence: {
+              pack_confidence: 'medium',
+              agent_directive: 'verify_one_targeted_file',
+            },
+            missing_context: ['primary'],
+          }),
+        },
+      ],
+    },
+  },
+  {
+    type: 'assistant',
+    turn: 2,
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name: 'mcp__madar__retrieve',
+          input: {
+            question: 'Explain auth config wiring',
+          },
         },
       ],
     },
@@ -1925,6 +2001,69 @@ describe('executeNativeAgentCompare', () => {
       expect(madarPrompt).toContain('This question requires strict runtime proof.')
       expect(madarPrompt).toContain('Use at most one focused follow-up to surface the missing persistence phase.')
       expect(madarPrompt).toContain('If the flow still cannot be proven, answer: not enough evidence; missing persistence')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    {
+      profileId: 'dub-explain-runtime',
+      question: 'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?',
+      checklist: ['request handling', 'analytics tracking', 'destination redirect'],
+    },
+    {
+      profileId: 'formbricks-explain-runtime',
+      question: 'How does Formbricks process a survey response from request handling through persistence and analytics/event tracking?',
+      checklist: ['request handling', 'persistence', 'analytics/event tracking'],
+    },
+    {
+      profileId: 'cal-diy-explain-runtime',
+      question: 'How does Cal.diy turn a booking request into availability validation, scheduled event persistence, and notification delivery?',
+      checklist: ['booking request', 'availability validation', 'notification delivery'],
+    },
+  ])('injects the required proof checklist for $profileId benchmark rows', async ({ profileId, question, checklist }) => {
+    const { projectDir, graphPath, outputDir } = makeFixtureProject()
+    try {
+      const questionsPath = writeRuntimeProofFixture(
+        projectDir,
+        profileId,
+        question,
+        checklist.map((label, index) => ({
+          id: label.replace(/[^a-z]+/gi, '_').replace(/^_+|_+$/g, '').toLowerCase(),
+          label,
+          kind: index === 0 ? 'entrypoint' : 'terminal',
+          evidence_terms: label.split(/[\s/]+/).filter((term) => term.length > 0),
+        })),
+      )
+
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          question,
+          questionsPath,
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_FULL_WIN_PAYLOAD,
+            madar: VERBOSE_MADAR_FULL_WIN_PAYLOAD,
+          }),
+          now: () => new Date('2026-06-08T12:00:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      const madarPrompt = readFileSync(report.paths.madar_prompt, 'utf8')
+
+      expect(madarPrompt).toContain('This question requires strict runtime proof.')
+      expect(madarPrompt).toContain('Required proof checklist:')
+      for (const obligation of checklist) {
+        expect(madarPrompt).toContain(`- ${obligation}`)
+      }
+      expect(madarPrompt).toContain('If one required obligation is still missing after one focused follow-up, answer exactly: not enough evidence; missing <obligation>')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -2863,6 +3002,199 @@ describe('executeNativeAgentCompare', () => {
     }
   })
 
+  it('fails strict runtime-proof answer quality when the Madar answer does not cite direct obligation evidence', async () => {
+    const { projectDir, outputDir } = makeRescopedReadinessFixtureProjectWithOptions({
+      includeScopedGraph: true,
+      scopedGraphUsesScopedRoot: true,
+    })
+    writeClaudeInstallArtifacts(join(projectDir, 'backend'))
+    const graphPath = join(projectDir, 'backend', 'out', 'graph.json')
+    const question = 'How does login create a session from request handling through persistence?'
+    const questionsPath = writeRuntimeProofFixture(
+      projectDir,
+      'login-runtime',
+      question,
+      [
+        { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['login', 'request', 'route', 'controller'] },
+        { id: 'persistence', label: 'persistence', kind: 'terminal', evidence_terms: ['session', 'persist', 'save', 'store'] },
+      ],
+    )
+    writeFileSync(
+      join(projectDir, 'benchmarks', 'explain', 'quality-gates.json'),
+      JSON.stringify({
+        'login-runtime': {
+          prompt: question,
+          required_answer_terms: ['session'],
+          forbidden_answer_terms: [],
+          required_concepts: ['directly cite the request and persistence flow'],
+          answer_quality_notes: ['Strict runtime-proof rows require answer citations grounded in the retrieved evidence.'],
+          manual_review_notes: ['Confirm every required runtime obligation cites direct evidence.'],
+          require_direct_evidence: true,
+        },
+      }, null, 2),
+      'utf8',
+    )
+
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          questionsPath,
+          outputDir,
+          execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+          baselineMode: 'native_agent',
+        },
+        {
+          now: () => new Date('2026-06-08T15:00:00Z'),
+          runner: async (execution) => ({
+            exitCode: 0,
+            stdout: `${JSON.stringify({
+              type: 'result',
+              subtype: 'success',
+              is_error: false,
+              duration_ms: execution.mode === 'baseline' ? 11 : 7,
+              num_turns: 1,
+              result: execution.mode === 'baseline'
+                ? 'AuthController.login in src/auth/controller.ts hands off to SessionStore.createSession in src/session/store.ts.'
+                : 'The login request reaches the session persistence path and creates a session.',
+              usage: {
+                input_tokens: execution.mode === 'baseline' ? 120 : 90,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                output_tokens: 30,
+              },
+            })}\n`,
+            stderr: '',
+            elapsedMs: execution.mode === 'baseline' ? 11 : 7,
+          }),
+        },
+      )
+
+      expect(result.reports[0]?.answer_quality).toEqual(
+        expect.objectContaining({
+          madar: expect.objectContaining({
+            passed: false,
+            missing_required_terms: expect.arrayContaining([
+              'direct evidence citation: request handling',
+              'direct evidence citation: persistence',
+            ]),
+          }),
+        }),
+      )
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not treat a shared basename as satisfying multiple runtime-proof citations', async () => {
+    const { projectDir, outputDir } = makeRescopedReadinessFixtureProjectWithOptions({
+      includeScopedGraph: true,
+      scopedGraphUsesScopedRoot: true,
+    })
+    writeClaudeInstallArtifacts(join(projectDir, 'backend'))
+    const graphPath = join(projectDir, 'backend', 'out', 'graph.json')
+    const scopedRoot = join(projectDir, 'backend')
+    writeLineAnchoredSourceFile(join(scopedRoot, 'src', 'request', 'index.ts'), 10, 'export const requestIndex = "request-index-proof"')
+    writeLineAnchoredSourceFile(join(scopedRoot, 'src', 'session', 'index.ts'), 60, 'export const sessionIndex = "session-index-proof"')
+    const scopedGraph = JSON.parse(readFileSync(graphPath, 'utf8')) as {
+      nodes?: Array<Record<string, unknown>>
+      links?: Array<Record<string, unknown>>
+    }
+    for (const node of scopedGraph.nodes ?? []) {
+      if (node.id === 'login_route') {
+        node.source_file = 'src/request/index.ts'
+      }
+      if (node.id === 'session_store') {
+        node.source_file = 'src/session/index.ts'
+      }
+    }
+    for (const link of scopedGraph.links ?? []) {
+      if (link.source === 'login_route') {
+        link.source_file = 'src/request/index.ts'
+      }
+      if (link.source === 'login_worker' && link.target === 'session_store') {
+        link.source_file = 'src/session/index.ts'
+      }
+    }
+    writeFileSync(graphPath, `${JSON.stringify(scopedGraph, null, 2)}\n`, 'utf8')
+
+    const question = 'How does login create a session from request handling through persistence?'
+    const questionsPath = writeRuntimeProofFixture(
+      projectDir,
+      'login-runtime',
+      question,
+      [
+        { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['login', 'request', 'route', 'controller'] },
+        { id: 'persistence', label: 'persistence', kind: 'terminal', evidence_terms: ['session', 'persist', 'save', 'store'] },
+      ],
+    )
+    writeFileSync(
+      join(projectDir, 'benchmarks', 'explain', 'quality-gates.json'),
+      JSON.stringify({
+        'login-runtime': {
+          prompt: question,
+          required_answer_terms: ['session'],
+          forbidden_answer_terms: [],
+          required_concepts: ['directly cite the request and persistence flow'],
+          answer_quality_notes: ['Strict runtime-proof rows require answer citations grounded in the retrieved evidence.'],
+          manual_review_notes: ['Confirm every required runtime obligation cites direct evidence.'],
+          require_direct_evidence: true,
+        },
+      }, null, 2),
+      'utf8',
+    )
+
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          questionsPath,
+          outputDir,
+          execTemplate: 'runner --prompt {prompt_file} --mode {mode} --out {output_file}',
+          baselineMode: 'native_agent',
+        },
+        {
+          now: () => new Date('2026-06-08T15:05:00Z'),
+          runner: async (execution) => ({
+            exitCode: 0,
+            stdout: `${JSON.stringify({
+              type: 'result',
+              subtype: 'success',
+              is_error: false,
+              duration_ms: execution.mode === 'baseline' ? 11 : 7,
+              num_turns: 1,
+              result: execution.mode === 'baseline'
+                ? 'POST /login in src/request/index.ts hands off to SessionStore.createSession in src/session/index.ts.'
+                : 'The session flow is evidenced in index.ts and creates a session.',
+              usage: {
+                input_tokens: execution.mode === 'baseline' ? 120 : 90,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                output_tokens: 30,
+              },
+            })}\n`,
+            stderr: '',
+            elapsedMs: execution.mode === 'baseline' ? 11 : 7,
+          }),
+        },
+      )
+
+      expect(result.reports[0]?.answer_quality).toEqual(
+        expect.objectContaining({
+          madar: expect.objectContaining({
+            passed: false,
+            missing_required_terms: expect.arrayContaining([
+              'direct evidence citation: request handling',
+              'direct evidence citation: persistence',
+            ]),
+          }),
+        }),
+      )
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('suppresses runtime benchmark wins when the prompt contract is violated', async () => {
     const { projectDir, graphPath, outputDir } = makeFixtureProject({ profile: 'full' })
     try {
@@ -2904,6 +3236,54 @@ describe('executeNativeAgentCompare', () => {
       }))
       expect(summary).toContain('prompt_contract: violated')
       expect(summary).toContain('benchmark_outcome: not_measured')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('flags strict runtime-proof follow-ups that do not target the missing obligation', async () => {
+    const { projectDir, outputDir } = makeRescopedReadinessFixtureProjectWithOptions({
+      includePersistenceStep: false,
+      includeScopedGraph: true,
+      scopedGraphUsesScopedRoot: true,
+    })
+    claudeInstall(join(projectDir, 'backend'), { profile: 'core' })
+    const graphPath = join(projectDir, 'backend', 'out', 'graph.json')
+    const question = 'How does login create a session from request handling through persistence?'
+    const questionsPath = writeRuntimeProofFixture(
+      projectDir,
+      'login-runtime',
+      question,
+      [
+        { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['login', 'request', 'route', 'controller'] },
+        { id: 'persistence', label: 'persistence', kind: 'terminal', evidence_terms: ['session', 'persist', 'save', 'store'] },
+      ],
+    )
+
+    try {
+      const result = await executeNativeAgentCompare(
+        {
+          graphPath,
+          questionsPath,
+          outputDir,
+          execTemplate: 'mock-runner',
+          baselineMode: 'native_agent',
+        },
+        {
+          runner: scriptedRunner({
+            baseline: VERBOSE_BASELINE_PAYLOAD,
+            madar: VERBOSE_MADAR_RUNTIME_PROOF_UNTARGETED_FOLLOWUP_PAYLOAD,
+          }),
+          now: () => new Date('2026-06-08T15:10:00Z'),
+        },
+      )
+
+      const report = result.reports[0] as NativeAgentCompareReport
+      expect(report.benchmark_readiness?.status).toBe('not_ready')
+      expect(report.prompt_contract).toEqual({
+        status: 'violated',
+        evidence: ['focused follow-up did not target missing runtime obligation: persistence'],
+      })
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/tests/unit/compare-native-agent.test.ts
+++ b/tests/unit/compare-native-agent.test.ts
@@ -1614,7 +1614,7 @@ describe('executeNativeAgentCompare', () => {
         task: 'implement',
         validationTimeoutSeconds: 0.01,
       } as Parameters<typeof executeNativeAgentCompare>[0] & { validationTimeoutSeconds: number }
-      const hangBudgetMs = 2000
+      const hangBudgetMs = 10000
 
       const outcome = await Promise.race([
         executeNativeAgentCompare(

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -4985,6 +4985,216 @@ describe('assessBenchmarkReadinessFromRetrieveResult', () => {
     })
   })
 
+  it('treats complete non-SPI runtime-proof benchmark rows as ready when every obligation has direct evidence', () => {
+    const readiness = (assessBenchmarkReadinessFromRetrieveResult as (input: any) => ReturnType<typeof assessBenchmarkReadinessFromRetrieveResult>)({
+      graphPath: '/repo/out/graph.json',
+      runtimeProofProfile: {
+        prompt: 'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?',
+        strict_runtime_proof: true,
+        expected_spi: false,
+        obligations: [
+          { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['route', 'handler'] },
+          { id: 'analytics_tracking', label: 'analytics tracking', kind: 'terminal', evidence_terms: ['analytics', 'track'] },
+          { id: 'destination_redirect', label: 'destination redirect', kind: 'terminal', evidence_terms: ['redirect', 'destination'] },
+        ],
+      },
+      retrieval: makeRuntimeGenerationRetrieval({
+        question: 'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?',
+        matched_nodes: [
+          {
+            label: 'GET /:domain/:key',
+            source_file: 'apps/web/links/route.ts',
+            line_number: 10,
+            file_type: 'code',
+            snippet: null,
+            match_score: 18,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+          {
+            label: 'recordLinkAnalytics',
+            source_file: 'lib/analytics/clicks.ts',
+            line_number: 42,
+            file_type: 'code',
+            snippet: null,
+            match_score: 17,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+          {
+            label: 'destinationRedirect',
+            source_file: 'apps/web/links/redirect.ts',
+            line_number: 78,
+            file_type: 'code',
+            snippet: null,
+            match_score: 16,
+            relevance_band: 'direct',
+            community: null,
+            community_label: null,
+          },
+        ],
+        execution_slice: {
+          status: 'complete',
+          confidence: 'high',
+          confidence_reasons: ['expected_obligations_covered'],
+          steps: [
+            {
+              label: 'GET /:domain/:key',
+              source_file: 'apps/web/links/route.ts',
+              line_number: 10,
+              node_kind: 'route',
+            },
+            {
+              label: 'recordLinkAnalytics',
+              source_file: 'lib/analytics/clicks.ts',
+              line_number: 42,
+              node_kind: 'method',
+            },
+            {
+              label: 'destinationRedirect',
+              source_file: 'apps/web/links/redirect.ts',
+              line_number: 78,
+              node_kind: 'method',
+            },
+          ],
+          phase_coverage: {
+            expected: ['controller', 'service', 'notification_or_event'],
+            observed: ['controller', 'service', 'notification_or_event'],
+            missing: [],
+          },
+        },
+        answer_contract: {
+          version: 1,
+          answer_focus: 'runtime_generation',
+          entrypoint_scope: 'setup_context',
+          required_elements: ['main_pipeline_phases'],
+          do_not_claim: [],
+          observed_phases: ['controller', 'service', 'notification_or_event'],
+          missing_phases: [],
+          confidence: 'high',
+          runtime_proof: {
+            obligations: [
+              {
+                id: 'request_handling',
+                label: 'request handling',
+                kind: 'entrypoint',
+                required: true,
+                evidence: [{ label: 'GET /:domain/:key', source_file: 'apps/web/links/route.ts', line_number: 10 }],
+              },
+              {
+                id: 'analytics_tracking',
+                label: 'analytics tracking',
+                kind: 'terminal',
+                required: true,
+                evidence: [{ label: 'recordLinkAnalytics', source_file: 'lib/analytics/clicks.ts', line_number: 42 }],
+              },
+              {
+                id: 'destination_redirect',
+                label: 'destination redirect',
+                kind: 'terminal',
+                required: true,
+                evidence: [{ label: 'destinationRedirect', source_file: 'apps/web/links/redirect.ts', line_number: 78 }],
+              },
+            ],
+            missing_obligations: [],
+          },
+        } as any,
+      } as any),
+    })
+
+    expect(readiness).toEqual({
+      status: 'ready',
+      reasons: [],
+      suggested_graph_scope: null,
+    })
+  })
+
+  it('fails non-SPI runtime-proof benchmark rows closed when a required terminal obligation is still missing', () => {
+    const readiness = (assessBenchmarkReadinessFromRetrieveResult as (input: any) => ReturnType<typeof assessBenchmarkReadinessFromRetrieveResult>)({
+      graphPath: '/repo/out/graph.json',
+      runtimeProofProfile: {
+        prompt: 'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?',
+        strict_runtime_proof: true,
+        expected_spi: false,
+        obligations: [
+          { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['route', 'handler'] },
+          { id: 'analytics_tracking', label: 'analytics tracking', kind: 'terminal', evidence_terms: ['analytics', 'track'] },
+          { id: 'destination_redirect', label: 'destination redirect', kind: 'terminal', evidence_terms: ['redirect', 'destination'] },
+        ],
+      },
+      retrieval: makeRuntimeGenerationRetrieval({
+        question: 'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?',
+        execution_slice: {
+          status: 'complete',
+          confidence: 'high',
+          confidence_reasons: ['entrypoint_and_analytics_found'],
+          steps: [
+            {
+              label: 'GET /:domain/:key',
+              source_file: 'apps/web/links/route.ts',
+              line_number: 10,
+              node_kind: 'route',
+            },
+            {
+              label: 'recordLinkAnalytics',
+              source_file: 'lib/analytics/clicks.ts',
+              line_number: 42,
+              node_kind: 'method',
+            },
+          ],
+          phase_coverage: {
+            expected: ['controller', 'service'],
+            observed: ['controller', 'service'],
+            missing: [],
+          },
+        },
+        answer_contract: {
+          version: 1,
+          answer_focus: 'runtime_generation',
+          entrypoint_scope: 'setup_context',
+          required_elements: ['main_pipeline_phases'],
+          do_not_claim: [],
+          observed_phases: ['controller', 'service'],
+          missing_phases: [],
+          confidence: 'high',
+          runtime_proof: {
+            obligations: [
+              {
+                id: 'request_handling',
+                label: 'request handling',
+                kind: 'entrypoint',
+                required: true,
+                evidence: [{ label: 'GET /:domain/:key', source_file: 'apps/web/links/route.ts', line_number: 10 }],
+              },
+              {
+                id: 'analytics_tracking',
+                label: 'analytics tracking',
+                kind: 'terminal',
+                required: true,
+                evidence: [{ label: 'recordLinkAnalytics', source_file: 'lib/analytics/clicks.ts', line_number: 42 }],
+              },
+              {
+                id: 'destination_redirect',
+                label: 'destination redirect',
+                kind: 'terminal',
+                required: true,
+                evidence: [],
+              },
+            ],
+            missing_obligations: ['destination_redirect'],
+          },
+        } as any,
+      } as any),
+    })
+
+    expect(readiness.status).toBe('not_ready')
+    expect(readiness.reasons).toEqual(expect.arrayContaining([
+      'missing runtime proof obligations: destination redirect',
+    ]))
+  })
+
   it('keeps non-SPI app-file runtime packs flagged as missing SPI evidence', () => {
     const graphPath = writeReadinessGraphFixture({
       graphFixtureRoot: join(PROJECT_FIXTURE_ROOT, 'backend', 'out'),

--- a/tests/unit/retrieve-slice-v1.test.ts
+++ b/tests/unit/retrieve-slice-v1.test.ts
@@ -171,6 +171,78 @@ function buildDirectPersistenceGraph() {
   )
 }
 
+function buildDubRuntimeProofGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'click_route', label: 'GET /:domain/:key', file_type: 'code', source_file: '/apps/web/links/route.ts', source_location: 'L10', node_kind: 'route', framework_role: 'nextjs_route', community: 0 },
+          { id: 'redirect_controller', label: 'LinkRedirectController.handleClick', file_type: 'code', source_file: '/apps/web/links/controller.ts', source_location: 'L20', node_kind: 'method', framework_role: 'controller', community: 0 },
+          { id: 'redirect_service', label: 'LinkRedirectService.resolveDestination', file_type: 'code', source_file: '/apps/web/links/service.ts', source_location: 'L30', node_kind: 'method', framework_role: 'service', community: 0 },
+          { id: 'analytics_tracker', label: 'ClickAnalytics.record', file_type: 'code', source_file: '/lib/analytics/clicks.ts', source_location: 'L40', node_kind: 'method', framework_role: 'service', community: 1 },
+          { id: 'destination_redirect', label: 'DestinationRedirect.send', file_type: 'code', source_file: '/apps/web/links/redirect.ts', source_location: 'L50', node_kind: 'method', framework_role: 'handler', community: 1 },
+        ],
+        edges: [
+          { source: 'click_route', target: 'redirect_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: '/apps/web/links/route.ts' },
+          { source: 'redirect_controller', target: 'redirect_service', relation: 'calls', confidence: 'EXTRACTED', source_file: '/apps/web/links/controller.ts' },
+          { source: 'redirect_service', target: 'analytics_tracker', relation: 'calls', confidence: 'EXTRACTED', source_file: '/apps/web/links/service.ts' },
+          { source: 'redirect_service', target: 'destination_redirect', relation: 'calls', confidence: 'EXTRACTED', source_file: '/apps/web/links/service.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
+function buildFormbricksRuntimeProofGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'survey_route', label: 'POST /api/surveys/:surveyId/responses', file_type: 'code', source_file: '/apps/web/surveys/route.ts', source_location: 'L10', node_kind: 'route', framework_role: 'nextjs_route', community: 0 },
+          { id: 'response_controller', label: 'SurveyResponseController.submit', file_type: 'code', source_file: '/apps/web/surveys/controller.ts', source_location: 'L20', node_kind: 'method', framework_role: 'controller', community: 0 },
+          { id: 'response_service', label: 'SurveyResponseService.process', file_type: 'code', source_file: '/packages/responses/service.ts', source_location: 'L30', node_kind: 'method', framework_role: 'service', community: 0 },
+          { id: 'response_store', label: 'SurveyResponseStore.persist', file_type: 'code', source_file: '/packages/responses/store.ts', source_location: 'L40', node_kind: 'method', framework_role: 'repository', community: 1 },
+          { id: 'analytics_tracker', label: 'ResponseAnalytics.trackEvent', file_type: 'code', source_file: '/packages/analytics/track.ts', source_location: 'L50', node_kind: 'method', framework_role: 'service', community: 1 },
+        ],
+        edges: [
+          { source: 'survey_route', target: 'response_controller', relation: 'controller_route', confidence: 'EXTRACTED', source_file: '/apps/web/surveys/route.ts' },
+          { source: 'response_controller', target: 'response_service', relation: 'calls', confidence: 'EXTRACTED', source_file: '/apps/web/surveys/controller.ts' },
+          { source: 'response_service', target: 'response_store', relation: 'calls', confidence: 'EXTRACTED', source_file: '/packages/responses/service.ts' },
+          { source: 'response_service', target: 'analytics_tracker', relation: 'calls', confidence: 'EXTRACTED', source_file: '/packages/responses/service.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
+function buildTwentyRuntimeProofGraph() {
+  return build(
+    [
+      {
+        schema_version: 1,
+        nodes: [
+          { id: 'mutation_route', label: 'POST /crm/records/:id', file_type: 'code', source_file: '/packages/twenty-server/src/modules/records/route.ts', source_location: 'L10', node_kind: 'route', framework_role: 'express_route', community: 0 },
+          { id: 'mutation_resolver', label: 'RecordMutationResolver.updateRecord', file_type: 'code', source_file: '/packages/twenty-server/src/modules/records/resolver.ts', source_location: 'L20', node_kind: 'method', framework_role: 'resolver', community: 0 },
+          { id: 'workspace_scope', label: 'WorkspaceScope.apply', file_type: 'code', source_file: '/packages/twenty-server/src/modules/workspace/workspace-scope.ts', source_location: 'L30', node_kind: 'method', framework_role: 'service', community: 1 },
+          { id: 'activity_emitter', label: 'WorkspaceActivityEmitter.publish', file_type: 'code', source_file: '/packages/twenty-server/src/modules/workspace/activity.ts', source_location: 'L40', node_kind: 'method', framework_role: 'service', community: 1 },
+          { id: 'record_repository', label: 'RecordRepository.save', file_type: 'code', source_file: '/packages/twenty-server/src/modules/records/repository.ts', source_location: 'L50', node_kind: 'method', framework_role: 'repository', community: 1 },
+        ],
+        edges: [
+          { source: 'mutation_route', target: 'mutation_resolver', relation: 'controller_route', confidence: 'EXTRACTED', source_file: '/packages/twenty-server/src/modules/records/route.ts' },
+          { source: 'mutation_resolver', target: 'workspace_scope', relation: 'calls', confidence: 'EXTRACTED', source_file: '/packages/twenty-server/src/modules/records/resolver.ts' },
+          { source: 'workspace_scope', target: 'activity_emitter', relation: 'calls', confidence: 'EXTRACTED', source_file: '/packages/twenty-server/src/modules/workspace/workspace-scope.ts' },
+          { source: 'workspace_scope', target: 'record_repository', relation: 'calls', confidence: 'EXTRACTED', source_file: '/packages/twenty-server/src/modules/workspace/workspace-scope.ts' },
+        ],
+      },
+    ],
+    { directed: true },
+  )
+}
+
 function compactFor(prompt: string, graph = buildSliceGraph()) {
   const retrieval = retrieveContext(graph, {
     question: prompt,
@@ -181,6 +253,35 @@ function compactFor(prompt: string, graph = buildSliceGraph()) {
 
   return compactRetrieveResult(retrieval) as ReturnType<typeof compactRetrieveResult> & {
     execution_slice?: ExecutionSliceExpectation
+  }
+}
+
+function compactForWithRuntimeProof(prompt: string, graph: ReturnType<typeof build>, runtimeProofProfile: Record<string, unknown>) {
+  const retrieval = retrieveContext(graph, {
+    question: prompt,
+    budget: 3000,
+    retrievalLevel: 4,
+    retrievalStrategy: 'slice-v1',
+    runtimeProofProfile,
+  } as never)
+
+  return compactRetrieveResult(retrieval) as ReturnType<typeof compactRetrieveResult> & {
+    execution_slice?: ExecutionSliceExpectation
+    answer_contract?: {
+      runtime_proof?: {
+        obligations: Array<{
+          id: string
+          label: string
+          kind: string
+          evidence: Array<{
+            label: string
+            source_file: string
+            line_number: number
+          }>
+        }>
+        missing_obligations: string[]
+      }
+    }
   }
 }
 
@@ -309,6 +410,120 @@ describe('retrieveContext retrievalStrategy=slice-v1', () => {
       secondaryBranchTargets.has('AuthController.getStatusMessage')
       || secondaryBranchTargets.has('Logger.info'),
     ).toBe(true)
+  })
+
+  it('surfaces runtime-proof obligation coverage for Dub-style explain-runtime prompts', () => {
+    const prompt = 'How does Dub resolve a short-link click from request handling through analytics tracking and destination redirect?'
+    const compact = compactForWithRuntimeProof(
+      prompt,
+      buildDubRuntimeProofGraph(),
+      {
+        prompt,
+        strict_runtime_proof: true,
+        expected_spi: false,
+        obligations: [
+          { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['request', 'route', 'handler', 'click'] },
+          { id: 'analytics_tracking', label: 'analytics tracking', kind: 'terminal', evidence_terms: ['analytics', 'track', 'click'] },
+          { id: 'destination_redirect', label: 'destination redirect', kind: 'terminal', evidence_terms: ['redirect', 'destination', 'location'] },
+        ],
+      },
+    )
+
+    expect(compact.execution_slice?.steps.map((step) => step.label)).toEqual(expect.arrayContaining([
+      'GET /:domain/:key',
+      'LinkRedirectController.handleClick',
+      'LinkRedirectService.resolveDestination',
+      'DestinationRedirect.send',
+    ]))
+    expect(compact.execution_slice?.side_effects).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({ label: 'ClickAnalytics.record' }),
+        ]),
+      }),
+    ]))
+    expect(compact.answer_contract?.runtime_proof).toEqual(expect.objectContaining({
+      missing_obligations: [],
+      obligations: expect.arrayContaining([
+        expect.objectContaining({
+          id: 'request_handling',
+          evidence: expect.arrayContaining([expect.objectContaining({ label: 'GET /:domain/:key' })]),
+        }),
+        expect.objectContaining({
+          id: 'analytics_tracking',
+          evidence: expect.arrayContaining([expect.objectContaining({ label: 'ClickAnalytics.record' })]),
+        }),
+        expect.objectContaining({
+          id: 'destination_redirect',
+          evidence: expect.arrayContaining([expect.objectContaining({ label: 'DestinationRedirect.send' })]),
+        }),
+      ]),
+    }))
+  })
+
+  it('keeps Formbricks-style complete runtime proofs covered when request, persistence, and analytics are all present', () => {
+    const prompt = 'How does Formbricks process a survey response from request handling through persistence and analytics/event tracking?'
+    const compact = compactForWithRuntimeProof(
+      prompt,
+      buildFormbricksRuntimeProofGraph(),
+      {
+        prompt,
+        strict_runtime_proof: true,
+        expected_spi: false,
+        obligations: [
+          { id: 'request_handling', label: 'request handling', kind: 'entrypoint', evidence_terms: ['request', 'route', 'handler', 'response'] },
+          { id: 'persistence', label: 'persistence', kind: 'terminal', evidence_terms: ['persist', 'save', 'store', 'database'] },
+          { id: 'analytics_event_tracking', label: 'analytics/event tracking', kind: 'terminal', evidence_terms: ['analytics', 'event', 'track'] },
+        ],
+      },
+    )
+
+    expect(compact.execution_slice?.status).toBe('complete')
+    expect(compact.answer_contract?.runtime_proof?.missing_obligations).toEqual([])
+    expect(compact.answer_contract?.runtime_proof?.obligations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'persistence',
+        evidence: expect.arrayContaining([expect.objectContaining({ label: 'SurveyResponseStore.persist' })]),
+      }),
+      expect.objectContaining({
+        id: 'analytics_event_tracking',
+        evidence: expect.arrayContaining([expect.objectContaining({ label: 'ResponseAnalytics.trackEvent' })]),
+      }),
+    ]))
+  })
+
+  it('prioritizes complete Twenty-style runtime proofs so persistence stays in the selected slice', () => {
+    const prompt = 'How does Twenty process a CRM record mutation from API handling through workspace services to persistence?'
+    const compact = compactForWithRuntimeProof(
+      prompt,
+      buildTwentyRuntimeProofGraph(),
+      {
+        prompt,
+        strict_runtime_proof: true,
+        expected_spi: false,
+        obligations: [
+          { id: 'api_mutation_handling', label: 'API mutation handling', kind: 'entrypoint', evidence_terms: ['api', 'mutation', 'resolver', 'controller'] },
+          { id: 'workspace_service_handoff', label: 'workspace service handoff', kind: 'handoff', evidence_terms: ['workspace', 'service', 'mutation'] },
+          { id: 'persistence', label: 'persistence', kind: 'terminal', evidence_terms: ['persist', 'save', 'repository', 'database'] },
+        ],
+      },
+    )
+
+    expect(compact.execution_slice?.steps.map((step) => step.label)).toEqual(expect.arrayContaining([
+      'POST /crm/records/:id',
+      'RecordMutationResolver.updateRecord',
+      'WorkspaceScope.apply',
+      'RecordRepository.save',
+    ]))
+    expect(compact.answer_contract?.runtime_proof).toEqual(expect.objectContaining({
+      missing_obligations: [],
+      obligations: expect.arrayContaining([
+        expect.objectContaining({
+          id: 'persistence',
+          evidence: expect.arrayContaining([expect.objectContaining({ label: 'RecordRepository.save' })]),
+        }),
+      ]),
+    }))
   })
 
   it('anchors route-shaped backend runtime prompts on the route path', () => {


### PR DESCRIPTION
## Summary
- add deterministic runtime-proof profiles for the public explain-runtime benchmark rows
- harden compare-time readiness, prompt-contract, and answer-quality checks around strict runtime-proof obligations
- make retrieval slice-v1 completeness-first for strict runtime-proof rows and add regression coverage for the new fail-closed cases

## Verification
- npm run typecheck
- npm run build
- CI=1 npm run test:run

## Benchmark status
- Local non-isolated warm receipts for the six public explain-runtime rows remain fail-closed rather than tuned wins:
  - dub: not_measured
  - twenty: not_measured
  - formbricks: not_measured
  - documenso: not_measured
  - cal-diy: not_measured
  - novu: not_measured
- Common pattern: readiness stays not_ready because required runtime-proof obligations are still missing from retrieval evidence, and answer quality also fails when the answer does not cite direct evidence for at least one required obligation.
- This PR does not weaken gates, does not turn not_measured into wins, and does not hide failed rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-proof benchmark suite and per-question runtime-proof profiles to enforce execution-obligation checks.
  * Prompts now include a "Required proof checklist" and targeted follow-up guidance when obligations are missing.
  * Retrieval/answers surface a runtime_proof assessment and readiness gating that can mark a question "not_ready" if obligations lack evidence.
  * Answer-quality now requires direct-evidence citations for missing runtime obligations.

* **Tests**
  * Expanded unit tests to cover runtime-proof loading, readiness behavior, prompt checklist inclusion, and answer-quality enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->