### PR TITLE
feat(cli): add --respect-gitignore option to exclude Git-ignored files

### DIFF
--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -82,6 +82,7 @@ Cached `context_pack` explain responses still refresh the current freshness rece
 ```bash
 madar generate .                          # build the graph
 madar generate . --spi                    # framework metadata + disk cache
+madar generate . --respect-gitignore      # exclude files ignored by Git
 madar watch .                             # rebuild on file change
 madar summary                             # bounded JSON overview
 madar pack "how does auth work?" --task explain --format text
@@ -112,3 +113,5 @@ On Windows, `compare`, `review-compare`, and benchmark `--exec` templates run un
 Tests, benchmarks, fixtures, mocks, and config files are not hard-ignored. They still get indexed so retrieval can use them when you ask for them, but production/runtime prompts soft-penalize them and honor prompt exclusions like "exclude tests, benchmarks, fixtures".
 
 `.madarignore` adds extra ignore rules, and negated entries such as `!vendor/**` or `!lib/**` can re-include a default hard-ignore when you intentionally want it indexed.
+
+Pass `--respect-gitignore` to additionally restrict generation to Git-tracked files and untracked files that are not ignored by Git. Outside a Git repository, Madar uses its normal discovery rules.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -464,6 +464,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --watch              keep watching after the initial build',
     '    --directed           preserve edge direction (source → target) in the built graph',
     '    --follow-symlinks    include in-root symlink targets',
+    '    --respect-gitignore  exclude files ignored by Git (falls back outside Git repositories)',
     '    --debounce S         watch debounce seconds (default 3)',
     '    --include-docs       include .md/.txt/.rst document files (excluded by default)',
     '    --docs               generate module documentation in out/docs/',
@@ -622,6 +623,7 @@ function isGenerateLikeArgument(argument: string): boolean {
     argument === '--watch' ||
     argument === '--directed' ||
     argument === '--follow-symlinks' ||
+    argument === '--respect-gitignore' ||
     argument === '--no-html' ||
     argument === '--wiki' ||
     argument === '--obsidian' ||
@@ -1007,6 +1009,7 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         clusterOnly: options.clusterOnly,
         directed: options.directed,
         followSymlinks: options.followSymlinks,
+        respectGitignore: options.respectGitignore,
         noHtml: options.noHtml,
         wiki: options.wiki,
         obsidian: options.obsidian,
@@ -1044,6 +1047,7 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (options.watch) {
         await dependencies.watchGraph(options.path, options.debounceSeconds, {
           followSymlinks: options.followSymlinks,
+          respectGitignore: options.respectGitignore,
           noHtml: options.noHtml,
           logger: io,
         })

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -163,6 +163,7 @@ export interface GenerateCliOptions {
   watch: boolean
   directed: boolean
   followSymlinks: boolean
+  respectGitignore: boolean
   debounceSeconds: number
   noHtml: boolean
   wiki: boolean
@@ -1694,6 +1695,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
   let watch = false
   let directed = false
   let followSymlinks = false
+  let respectGitignore = false
   let debounceSeconds = 3
   let noHtml = false
   let wiki = false
@@ -1724,7 +1726,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
     if (!argument.startsWith('--')) {
       if (path !== '.') {
         throw new UsageError(
-          'Usage: madar generate [path] [--update] [--cluster-only] [--watch] [--directed] [--follow-symlinks] [--debounce S] [--no-html] [--wiki] [--obsidian] [--obsidian-dir DIR] [--svg] [--graphml] [--neo4j] [--neo4j-push URI] [--neo4j-user USER] [--neo4j-password PW] [--neo4j-database DB] [--spi]',
+          'Usage: madar generate [path] [--update] [--cluster-only] [--watch] [--directed] [--follow-symlinks] [--respect-gitignore] [--debounce S] [--no-html] [--wiki] [--obsidian] [--obsidian-dir DIR] [--svg] [--graphml] [--neo4j] [--neo4j-push URI] [--neo4j-user USER] [--neo4j-password PW] [--neo4j-database DB] [--spi]',
         )
       }
       path = argument
@@ -1753,6 +1755,11 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
 
     if (argument === '--follow-symlinks') {
       followSymlinks = true
+      continue
+    }
+
+    if (argument === '--respect-gitignore') {
+      respectGitignore = true
       continue
     }
 
@@ -1884,6 +1891,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
     watch,
     directed,
     followSymlinks,
+    respectGitignore,
     debounceSeconds,
     noHtml,
     wiki,

--- a/src/infrastructure/generate.ts
+++ b/src/infrastructure/generate.ts
@@ -17,6 +17,7 @@ import { generate as generateReport } from '../pipeline/report.js'
 import { toWiki } from '../pipeline/wiki.js'
 import { loadGraph } from '../runtime/serve.js'
 import { buildGraphBuildFreshnessMetadata } from '../shared/graph-build-freshness.js'
+import { collectGitVisibleFiles } from '../shared/git.js'
 
 export type ProgressStep =
   | { step: 'detect'; message: string }
@@ -31,6 +32,8 @@ export interface GenerateGraphOptions {
   clusterOnly?: boolean
   directed?: boolean
   followSymlinks?: boolean
+  /** Restrict discovery to files that Git does not ignore. Falls back outside Git repositories. */
+  respectGitignore?: boolean
   noHtml?: boolean
   htmlMode?: 'auto' | 'inline' | 'overview'
   wiki?: boolean
@@ -102,8 +105,12 @@ export class GenerateUnsupportedCorpusError extends Error {
 
 type IncrementalDetectResult = ReturnType<typeof detectIncremental>
 
-function detectOptions(options: GenerateGraphOptions): { followSymlinks?: boolean } {
-  return options.followSymlinks ? { followSymlinks: true } : {}
+function detectOptions(options: GenerateGraphOptions, gitVisibleFiles: string[] | null): { followSymlinks?: boolean; includedFiles?: ReadonlySet<string> } {
+  const includedFiles = gitVisibleFiles ? new Set(gitVisibleFiles.map((filePath) => resolve(filePath))) : undefined
+  return {
+    ...(options.followSymlinks ? { followSymlinks: true } : {}),
+    ...(includedFiles ? { includedFiles } : {}),
+  }
 }
 
 function countNonCodeFiles(files: DetectResult['files']): number {
@@ -272,7 +279,9 @@ export function generateGraph(rootPath = '.', options: GenerateGraphOptions = {}
   const progress = options.onProgress
 
   progress?.({ step: 'detect', message: 'Scanning files...' })
-  const detected = options.update ? detectIncremental(resolvedRootPath, manifestPath, detectOptions(options)) : detect(resolvedRootPath, detectOptions(options))
+  const gitVisibleFiles = options.respectGitignore ? collectGitVisibleFiles(resolvedRootPath) : null
+  const detectionOptions = detectOptions(options, gitVisibleFiles)
+  const detected = options.update ? detectIncremental(resolvedRootPath, manifestPath, detectionOptions) : detect(resolvedRootPath, detectionOptions)
 
   if (options.includeDocs === false) {
     detected.files[FileType.DOCUMENT] = []
@@ -344,6 +353,7 @@ export function generateGraph(rootPath = '.', options: GenerateGraphOptions = {}
             root: resolvedRootPath,
             madarVersion: `spi-extractor-${EXTRACTOR_CACHE_VERSION}`,
             extractorVersion: spiExtractorVersion,
+            ...(gitVisibleFiles ? { includedFiles: new Set(gitVisibleFiles.map((filePath) => resolve(filePath))) } : {}),
           })
         : null
     const spiExtraction = built ? projectSpiToExtraction(built.spi, { root: resolvedRootPath }) : emptyExtraction()

--- a/src/infrastructure/watch.ts
+++ b/src/infrastructure/watch.ts
@@ -18,6 +18,7 @@ export interface WatchLogger {
 
 export interface RebuildCodeOptions {
   followSymlinks?: boolean
+  respectGitignore?: boolean
   noHtml?: boolean
   logger?: WatchLogger
 }
@@ -262,6 +263,7 @@ export function rebuildCode(watchPath: string, options: RebuildCodeOptions = {})
     const result = generateGraph(resolvedWatchPath, {
       ...(existsSync(manifestPath) && existsSync(graphPath) ? { update: true } : {}),
       ...(options.followSymlinks !== undefined ? { followSymlinks: options.followSymlinks } : {}),
+      ...(options.respectGitignore !== undefined ? { respectGitignore: options.respectGitignore } : {}),
       ...(options.noHtml !== undefined ? { noHtml: options.noHtml } : {}),
     })
 
@@ -339,6 +341,7 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
         const rebuildOptions: RebuildCodeOptions = {
           logger: output,
           ...(options.followSymlinks !== undefined ? { followSymlinks: options.followSymlinks } : {}),
+          ...(options.respectGitignore !== undefined ? { respectGitignore: options.respectGitignore } : {}),
           ...(options.noHtml !== undefined ? { noHtml: options.noHtml } : {}),
         }
         const rebuilt = runRebuild(resolvedWatchPath, rebuildOptions)

--- a/src/pipeline/detect.ts
+++ b/src/pipeline/detect.ts
@@ -21,6 +21,8 @@ export type FileTypeValue = (typeof FileType)[keyof typeof FileType]
 
 export interface DetectOptions {
   followSymlinks?: boolean
+  /** Restrict discovery to these absolute paths after Madar's own filters. */
+  includedFiles?: ReadonlySet<string>
 }
 
 export interface DetectResult {
@@ -365,6 +367,9 @@ export function detect(root: string, options: DetectOptions = {}): DetectResult 
   const skippedSensitive: string[] = []
 
   for (const filePath of collectFiles(root, followSymlinks, ignorePatterns)) {
+    if (options.includedFiles && !options.includedFiles.has(resolve(filePath))) {
+      continue
+    }
     if (isSensitive(filePath, root)) {
       skippedSensitive.push(filePath)
       continue

--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -81,6 +81,8 @@ export type BuildSpiOptions = {
   root: string
   madarVersion: string
   extractorVersion?: string
+  /** Restrict source discovery to these absolute paths. */
+  includedFiles?: ReadonlySet<string>
   // Override the wall-clock used in `generated_at`. Test-only escape hatch
   // so snapshot tests can assert deterministic output.
   now?: () => Date
@@ -120,7 +122,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
 
   const absPaths: string[] = []
   const ignorePatterns = loadMadarignorePatterns(root)
-  collectFiles(root, root, ignorePatterns, absPaths)
+  collectFiles(root, root, ignorePatterns, absPaths, opts.includedFiles)
 
   const pathToFileId = new Map<string, string>()
   for (const abs of absPaths) {
@@ -192,7 +194,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
 // buildSpi directly.
 export const buildSpiFileLayer = buildSpi
 
-function collectFiles(root: string, dir: string, ignorePatterns: readonly string[], out: string[]): void {
+function collectFiles(root: string, dir: string, ignorePatterns: readonly string[], out: string[], includedFiles?: ReadonlySet<string>): void {
   let entries: import('node:fs').Dirent<string>[]
   try {
     entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' })
@@ -204,9 +206,9 @@ function collectFiles(root: string, dir: string, ignorePatterns: readonly string
     const full = join(dir, entry.name)
     if (isDiscoveryPathIgnored(full, root, ignorePatterns)) continue
     if (entry.isDirectory()) {
-      collectFiles(root, full, ignorePatterns, out)
+      collectFiles(root, full, ignorePatterns, out, includedFiles)
     } else if (entry.isFile()) {
-      out.push(full)
+      if (!includedFiles || includedFiles.has(resolve(full))) out.push(full)
     }
   }
 }

--- a/src/pipeline/spi/cache.ts
+++ b/src/pipeline/spi/cache.ts
@@ -218,7 +218,7 @@ interface WorkspaceFingerprint {
 
 function computeWorkspaceFingerprint(root: string, opts: BuildSpiCachedOptions): WorkspaceFingerprint {
   const entries: string[] = []
-  collectIndexableFiles(root, root, entries)
+  collectIndexableFiles(root, root, entries, opts.includedFiles)
   entries.sort()
 
   const hasher = createHash('sha256')
@@ -276,7 +276,7 @@ function collectProjectConfigPaths(root: string, entries: readonly string[]): st
   return [...projectConfigPaths].sort()
 }
 
-function collectIndexableFiles(root: string, dir: string, out: string[]): void {
+function collectIndexableFiles(root: string, dir: string, out: string[], includedFiles?: ReadonlySet<string>): void {
   let entries: import('node:fs').Dirent<string>[]
   try {
     entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' })
@@ -288,11 +288,13 @@ function collectIndexableFiles(root: string, dir: string, out: string[]): void {
     if (entry.isSymbolicLink()) continue
     const full = join(dir, entry.name)
     if (entry.isDirectory()) {
-      collectIndexableFiles(root, full, out)
+      collectIndexableFiles(root, full, out, includedFiles)
     } else if (entry.isFile()) {
       const ext = extname(entry.name).toLowerCase()
       if (CACHE_INDEXABLE_EXTS.has(ext)) {
-        out.push(relative(root, full).split('\\').join('/'))
+        if (!includedFiles || includedFiles.has(resolve(full))) {
+          out.push(relative(root, full).split('\\').join('/'))
+        }
       }
     }
   }

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -16,6 +16,38 @@ export function findGitRoot(path: string): string | null {
   }
 }
 
+/**
+ * Lists tracked files plus untracked files that are not excluded by Git's
+ * standard ignore rules. `null` means Git is unavailable or the path is not
+ * inside a repository; an empty array is a valid empty worktree result.
+ */
+export function collectGitVisibleFiles(rootDir: string): string[] | null {
+  const root = resolve(rootDir)
+
+  try {
+    const repoRoot = execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    }).trim()
+    const relativeRoot = relative(repoRoot, root)
+    if (relativeRoot === '..' || relativeRoot.startsWith(`..${sep}`) || isAbsolute(relativeRoot)) {
+      return null
+    }
+    const output = execFileSync(
+      'git',
+      ['-C', repoRoot, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', relativeRoot || '.'],
+      { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, windowsHide: true },
+    )
+
+    return output
+      .split('\0')
+      .filter(Boolean)
+      .map((relativePath) => resolve(repoRoot, relativePath))
+  } catch {
+    return null
+  }
+}
+
 function gitOutput(rootDir: string, args: string[], trim = true): string {
   const output = execFileSync('git', ['-c', 'core.quotePath=false', ...args], {
     cwd: rootDir,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -900,6 +900,7 @@ describe('cli parser', () => {
       watch: false,
       directed: false,
       followSymlinks: false,
+      respectGitignore: false,
       debounceSeconds: 3,
       noHtml: false,
       wiki: false,
@@ -924,6 +925,7 @@ describe('cli parser', () => {
         '--watch',
         '--directed',
         '--follow-symlinks',
+        '--respect-gitignore',
         '--debounce',
         '1.5',
         '--no-html',
@@ -950,6 +952,7 @@ describe('cli parser', () => {
       watch: true,
       directed: true,
       followSymlinks: true,
+      respectGitignore: true,
       debounceSeconds: 1.5,
       noHtml: true,
       wiki: true,
@@ -1212,6 +1215,7 @@ describe('cli main', () => {
     expect(help).toContain('watch [path]')
     expect(help).toContain('serve [graph.json]')
     expect(help).toContain('--directed')
+    expect(help).toContain('--respect-gitignore')
     expect(help).toContain('--wiki')
     expect(help).toContain('--obsidian')
     expect(help).toContain('--svg')

--- a/tests/unit/generate.test.ts
+++ b/tests/unit/generate.test.ts
@@ -1,4 +1,5 @@
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -988,6 +989,28 @@ describe('generateGraph', () => {
       }
     })
   })
+
+  test('excludes Git-ignored files when respectGitignore is enabled', () => {
+    withTempDir((tempDir) => {
+      writeFileSync(join(tempDir, '.gitignore'), 'ignored.ts\n', 'utf8')
+      writeFileSync(join(tempDir, 'tracked.ts'), 'export const tracked = true\n', 'utf8')
+      writeFileSync(join(tempDir, 'untracked.ts'), 'export const untracked = true\n', 'utf8')
+      writeFileSync(join(tempDir, 'ignored.ts'), 'export const ignored = true\n', 'utf8')
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' })
+      execFileSync('git', ['add', '.gitignore', 'tracked.ts'], { cwd: tempDir, stdio: 'pipe' })
+
+      generateGraph(tempDir, { noHtml: true, respectGitignore: true })
+
+      const graphData = JSON.parse(readFileSync(join(tempDir, 'out', 'graph.json'), 'utf8')) as {
+        nodes: Array<{ source_file?: string }>
+      }
+      const sourceFiles = new Set(graphData.nodes.map((node) => node.source_file))
+
+      expect(sourceFiles).toContain(join(tempDir, 'tracked.ts'))
+      expect(sourceFiles).toContain(join(tempDir, 'untracked.ts'))
+      expect(sourceFiles).not.toContain(join(tempDir, 'ignored.ts'))
+    })
+  }, generateGraphIntegrationTimeoutMs)
 
   test('builds graph artifacts for a code corpus', () => {
     withTempDir((tempDir) => {


### PR DESCRIPTION
#535

## Summary

Added opt-in Git-aware discovery for generation.

Users can now run:

```ts
generate(repoPath, { respectGitignore: true });
```

or:

```bash
madar generate . --respect-gitignore
```

This includes tracked files and non-ignored untracked files while excluding Git-ignored files. It applies to legacy extraction, SPI extraction, incremental updates, and watch rebuilds. Non-Git repositories retain the existing discovery behavior.

## Testing

- [ ] `npm run test:run` — unable to run; local Vitest installation is incomplete.
- [ ] `npm run typecheck` — unable to run; local TypeScript installation is incomplete.
- [ ] `npm run build` — not run for the same dependency issue.
- [ ] `npm pack --dry-run` — not applicable.

Manual verification:

- `git diff --check` passed.
- Added generation coverage for tracked, untracked, and ignored files.
- Added CLI parser/help coverage.

## Checklist

- [x] Updated docs for the user-visible `--respect-gitignore` option.
- [x] Added tests for the changed behavior.
- [x] No private corpora, secrets, credentials, proprietary prompts, sensitive logs, or generated artifacts included.
- [x] Change is focused on Git-aware file discovery.

## Related issues

Closes #535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--respect-gitignore` option to `madar generate`.
  * Generation now limits source discovery to Git-tracked and non-ignored untracked files when enabled.
  * The option is supported in watch mode and applies consistently to generated graphs and caches.

* **Documentation**
  * Updated CLI help and reference documentation with usage details.

* **Tests**
  * Added coverage for CLI parsing, help text, and Git-ignored file exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->