### PR TITLE
ci: review dependency lockfile updates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,4 +3,8 @@ reviews:
   auto_review:
     enabled: true
     base_branches:
+      - "^main$"
       - "^next$"
+  # Explicitly override CodeRabbit's default exclusion so dependency-only PRs are reviewed.
+  path_filters:
+    - "**/package-lock.json"


### PR DESCRIPTION
## Summary

- enable CodeRabbit automatic reviews for `main` as well as `next`
- explicitly include `package-lock.json` so dependency-only pull requests receive an actual review instead of a skipped result

## Verification

- reviewed the current CodeRabbit path-filter configuration against CodeRabbit's documented include override
- will require GitHub Actions and a completed CodeRabbit review before merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated review coverage to include changes targeting both main development branches.
  * Ensured pull requests that only update lockfiles are included in automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->