### PR TITLE
fix(cli): include Git-aware discovery safely in 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ### Added
 
+- **Git-aware generation is available with `--respect-gitignore`**: `madar generate`, `madar generate --watch`, and `madar watch` can restrict discovery to tracked files plus non-ignored untracked files. The behavior covers legacy, SPI, incremental, and watch rebuilds while preserving normal discovery outside Git repositories. Closes #535.
 - **Codex CLI now gets a complete project-local integration**: `madar codex install` writes the Madar-owned AGENTS.md profile, a task-applicable `UserPromptSubmit` hook in `.codex/hooks.json`, its generated `.codex/madar-user-prompt-submit.cjs` script, and a marker-owned `[mcp_servers.madar]` block in `.codex/config.toml`. The hook supplies model-visible guidance only for local code tasks; it remains guidance rather than enforcement.
 - **Codex install safety and verification are explicit**: install and uninstall preserve unrelated hooks, TOML, and AGENTS content; `madar doctor` / `madar status` now validate the on-disk Codex hook, script, and MCP entry while documenting that live Codex trust and activation must be confirmed through Codex itself.
 

--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -82,6 +82,7 @@ Cached `context_pack` explain responses still refresh the current freshness rece
 ```bash
 madar generate .                          # build the graph
 madar generate . --spi                    # framework metadata + disk cache
+madar generate . --respect-gitignore      # exclude files ignored by Git
 madar watch .                             # rebuild on file change
 madar summary                             # bounded JSON overview
 madar pack "how does auth work?" --task explain --format text
@@ -112,3 +113,5 @@ On Windows, `compare`, `review-compare`, and benchmark `--exec` templates run un
 Tests, benchmarks, fixtures, mocks, and config files are not hard-ignored. They still get indexed so retrieval can use them when you ask for them, but production/runtime prompts soft-penalize them and honor prompt exclusions like "exclude tests, benchmarks, fixtures".
 
 `.madarignore` adds extra ignore rules, and negated entries such as `!vendor/**` or `!lib/**` can re-include a default hard-ignore when you intentionally want it indexed.
+
+Pass `--respect-gitignore` to additionally restrict generation to Git-tracked files and untracked files that are not ignored by Git. Outside a Git repository, Madar uses its normal discovery rules.

--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -84,6 +84,7 @@ madar generate .                          # build the graph
 madar generate . --spi                    # framework metadata + disk cache
 madar generate . --respect-gitignore      # exclude files ignored by Git
 madar watch .                             # rebuild on file change
+madar watch . --respect-gitignore         # watch only Git-visible source changes
 madar summary                             # bounded JSON overview
 madar pack "how does auth work?" --task explain --format text
 madar pack "add auth telemetry" --task implement --format json
@@ -114,4 +115,4 @@ Tests, benchmarks, fixtures, mocks, and config files are not hard-ignored. They 
 
 `.madarignore` adds extra ignore rules, and negated entries such as `!vendor/**` or `!lib/**` can re-include a default hard-ignore when you intentionally want it indexed.
 
-Pass `--respect-gitignore` to additionally restrict generation to Git-tracked files and untracked files that are not ignored by Git. Outside a Git repository, Madar uses its normal discovery rules.
+Pass `--respect-gitignore` to additionally restrict generation to Git-tracked files and untracked files that are not ignored by Git. The option applies to `generate --watch` and the standalone `watch` command too. Outside a Git repository, Madar uses its normal discovery rules.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -464,6 +464,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --watch              keep watching after the initial build',
     '    --directed           preserve edge direction (source → target) in the built graph',
     '    --follow-symlinks    include in-root symlink targets',
+    '    --respect-gitignore  exclude files ignored by Git (falls back outside Git repositories)',
     '    --debounce S         watch debounce seconds (default 3)',
     '    --include-docs       include .md/.txt/.rst document files (excluded by default)',
     '    --docs               generate module documentation in out/docs/',
@@ -622,6 +623,7 @@ function isGenerateLikeArgument(argument: string): boolean {
     argument === '--watch' ||
     argument === '--directed' ||
     argument === '--follow-symlinks' ||
+    argument === '--respect-gitignore' ||
     argument === '--no-html' ||
     argument === '--wiki' ||
     argument === '--obsidian' ||
@@ -1008,6 +1010,7 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
         clusterOnly: options.clusterOnly,
         directed: options.directed,
         followSymlinks: options.followSymlinks,
+        respectGitignore: options.respectGitignore,
         noHtml: options.noHtml,
         wiki: options.wiki,
         obsidian: options.obsidian,
@@ -1045,6 +1048,7 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       if (options.watch) {
         await dependencies.watchGraph(options.path, options.debounceSeconds, {
           followSymlinks: options.followSymlinks,
+          respectGitignore: options.respectGitignore,
           noHtml: options.noHtml,
           logger: io,
         })

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -483,6 +483,7 @@ export function formatHelp(binaryName = 'madar'): string {
     '    --output DIR         output directory (default out-federated)',
     '  watch [path]          build once, then watch for code/doc changes',
     '    --follow-symlinks    include in-root symlink targets',
+    '    --respect-gitignore  exclude files ignored by Git (falls back outside Git repositories)',
     '    --debounce S         watch debounce seconds (default 3)',
     '    --no-html            skip graph.html generation during the initial build',
     '  serve [graph.json]    serve graph artifacts over HTTP or stdio',
@@ -1060,12 +1061,14 @@ export async function executeCli(argv: string[], io: CliIO = console, dependenci
       const options = parseWatchArgs(args)
       const result = dependencies.generateGraph(options.path, {
         followSymlinks: options.followSymlinks,
+        respectGitignore: options.respectGitignore,
         noHtml: options.noHtml,
         onProgress: (step) => io.log(formatProgress(step)),
       })
       io.log(formatGenerateSummary(result))
       await dependencies.watchGraph(options.path, options.debounceSeconds, {
         followSymlinks: options.followSymlinks,
+        respectGitignore: options.respectGitignore,
         noHtml: options.noHtml,
         logger: io,
       })

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -163,6 +163,7 @@ export interface GenerateCliOptions {
   watch: boolean
   directed: boolean
   followSymlinks: boolean
+  respectGitignore: boolean
   debounceSeconds: number
   noHtml: boolean
   wiki: boolean
@@ -1694,6 +1695,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
   let watch = false
   let directed = false
   let followSymlinks = false
+  let respectGitignore = false
   let debounceSeconds = 3
   let noHtml = false
   let wiki = false
@@ -1724,7 +1726,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
     if (!argument.startsWith('--')) {
       if (path !== '.') {
         throw new UsageError(
-          'Usage: madar generate [path] [--update] [--cluster-only] [--watch] [--directed] [--follow-symlinks] [--debounce S] [--no-html] [--wiki] [--obsidian] [--obsidian-dir DIR] [--svg] [--graphml] [--neo4j] [--neo4j-push URI] [--neo4j-user USER] [--neo4j-password PW] [--neo4j-database DB] [--spi]',
+          'Usage: madar generate [path] [--update] [--cluster-only] [--watch] [--directed] [--follow-symlinks] [--respect-gitignore] [--debounce S] [--no-html] [--wiki] [--obsidian] [--obsidian-dir DIR] [--svg] [--graphml] [--neo4j] [--neo4j-push URI] [--neo4j-user USER] [--neo4j-password PW] [--neo4j-database DB] [--spi]',
         )
       }
       path = argument
@@ -1753,6 +1755,11 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
 
     if (argument === '--follow-symlinks') {
       followSymlinks = true
+      continue
+    }
+
+    if (argument === '--respect-gitignore') {
+      respectGitignore = true
       continue
     }
 
@@ -1884,6 +1891,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
     watch,
     directed,
     followSymlinks,
+    respectGitignore,
     debounceSeconds,
     noHtml,
     wiki,

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -188,6 +188,7 @@ export interface GenerateCliOptions {
 export interface WatchCliOptions {
   path: string
   followSymlinks: boolean
+  respectGitignore: boolean
   debounceSeconds: number
   noHtml: boolean
 }
@@ -1913,6 +1914,7 @@ export function parseGenerateArgs(args: string[]): GenerateCliOptions {
 export function parseWatchArgs(args: string[]): WatchCliOptions {
   let path = '.'
   let followSymlinks = false
+  let respectGitignore = false
   let debounceSeconds = 3
   let noHtml = false
 
@@ -1924,7 +1926,7 @@ export function parseWatchArgs(args: string[]): WatchCliOptions {
 
     if (!argument.startsWith('--')) {
       if (path !== '.') {
-        throw new UsageError('Usage: madar watch [path] [--follow-symlinks] [--debounce S] [--no-html]')
+        throw new UsageError('Usage: madar watch [path] [--follow-symlinks] [--respect-gitignore] [--debounce S] [--no-html]')
       }
       path = argument
       continue
@@ -1932,6 +1934,11 @@ export function parseWatchArgs(args: string[]): WatchCliOptions {
 
     if (argument === '--follow-symlinks') {
       followSymlinks = true
+      continue
+    }
+
+    if (argument === '--respect-gitignore') {
+      respectGitignore = true
       continue
     }
 
@@ -1955,7 +1962,7 @@ export function parseWatchArgs(args: string[]): WatchCliOptions {
     throw new UsageError(`error: unknown option for watch: ${argument}`)
   }
 
-  return { path, followSymlinks, debounceSeconds, noHtml }
+  return { path, followSymlinks, respectGitignore, debounceSeconds, noHtml }
 }
 
 export function parseServeArgs(args: string[]): ServeCliOptions {

--- a/src/infrastructure/generate.ts
+++ b/src/infrastructure/generate.ts
@@ -17,6 +17,7 @@ import { generate as generateReport } from '../pipeline/report.js'
 import { toWiki } from '../pipeline/wiki.js'
 import { loadGraph } from '../runtime/serve.js'
 import { buildGraphBuildFreshnessMetadata } from '../shared/graph-build-freshness.js'
+import { collectGitVisibleFiles } from '../shared/git.js'
 
 export type ProgressStep =
   | { step: 'detect'; message: string }
@@ -31,6 +32,8 @@ export interface GenerateGraphOptions {
   clusterOnly?: boolean
   directed?: boolean
   followSymlinks?: boolean
+  /** Restrict discovery to files that Git does not ignore. Falls back outside Git repositories. */
+  respectGitignore?: boolean
   noHtml?: boolean
   htmlMode?: 'auto' | 'inline' | 'overview'
   wiki?: boolean
@@ -102,8 +105,12 @@ export class GenerateUnsupportedCorpusError extends Error {
 
 type IncrementalDetectResult = ReturnType<typeof detectIncremental>
 
-function detectOptions(options: GenerateGraphOptions): { followSymlinks?: boolean } {
-  return options.followSymlinks ? { followSymlinks: true } : {}
+function detectOptions(options: GenerateGraphOptions, gitVisibleFiles: string[] | null): { followSymlinks?: boolean; includedFiles?: ReadonlySet<string> } {
+  const includedFiles = gitVisibleFiles ? new Set(gitVisibleFiles.map((filePath) => resolve(filePath))) : undefined
+  return {
+    ...(options.followSymlinks ? { followSymlinks: true } : {}),
+    ...(includedFiles ? { includedFiles } : {}),
+  }
 }
 
 function countNonCodeFiles(files: DetectResult['files']): number {
@@ -272,7 +279,9 @@ export function generateGraph(rootPath = '.', options: GenerateGraphOptions = {}
   const progress = options.onProgress
 
   progress?.({ step: 'detect', message: 'Scanning files...' })
-  const detected = options.update ? detectIncremental(resolvedRootPath, manifestPath, detectOptions(options)) : detect(resolvedRootPath, detectOptions(options))
+  const gitVisibleFiles = options.respectGitignore ? collectGitVisibleFiles(resolvedRootPath) : null
+  const detectionOptions = detectOptions(options, gitVisibleFiles)
+  const detected = options.update ? detectIncremental(resolvedRootPath, manifestPath, detectionOptions) : detect(resolvedRootPath, detectionOptions)
 
   if (options.includeDocs === false) {
     detected.files[FileType.DOCUMENT] = []
@@ -344,6 +353,7 @@ export function generateGraph(rootPath = '.', options: GenerateGraphOptions = {}
             root: resolvedRootPath,
             madarVersion: `spi-extractor-${EXTRACTOR_CACHE_VERSION}`,
             extractorVersion: spiExtractorVersion,
+            ...(gitVisibleFiles ? { includedFiles: new Set(gitVisibleFiles.map((filePath) => resolve(filePath))) } : {}),
           })
         : null
     const spiExtraction = built ? projectSpiToExtraction(built.spi, { root: resolvedRootPath }) : emptyExtraction()

--- a/src/infrastructure/watch.ts
+++ b/src/infrastructure/watch.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, statSync, unlinkSync, watch as createFileSystemWatcher, writeFileSync } from 'node:fs'
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, unlinkSync, watch as createFileSystemWatcher, writeFileSync } from 'node:fs'
 import { extname, join, resolve, sep } from 'node:path'
 
 import { AUDIO_EXTENSIONS, CODE_EXTENSIONS, DOC_EXTENSIONS, IMAGE_EXTENSIONS, OFFICE_EXTENSIONS, PAPER_EXTENSIONS, VIDEO_EXTENSIONS } from '../pipeline/detect.js'
@@ -116,6 +116,14 @@ function isWithinRoot(rootRealPath: string, candidateRealPath: string): boolean 
   return candidateRealPath === rootRealPath || candidateRealPath.startsWith(rootPrefix)
 }
 
+function gitignoreFingerprint(filePath: string, modifiedAt: number): string {
+  try {
+    return createHash('sha256').update(readFileSync(filePath)).digest('hex')
+  } catch {
+    return String(Math.round(modifiedAt))
+  }
+}
+
 function collectWatchedFiles(
   directory: string,
   followSymlinks: boolean,
@@ -123,6 +131,7 @@ function collectWatchedFiles(
   ancestorRealPaths: string[],
   snapshots: Map<string, number | string>,
   includedFiles?: ReadonlySet<string>,
+  watchGitignore = false,
   depth = 0,
 ): void {
   if (depth > MAX_SYMLINK_DEPTH || snapshots.size >= MAX_WATCHED_FILES) {
@@ -137,7 +146,8 @@ function collectWatchedFiles(
   }
 
   for (const entry of entries) {
-    if (entry.startsWith('.')) {
+    const isGitignore = watchGitignore && entry === '.gitignore'
+    if (entry.startsWith('.') && !isGitignore) {
       continue
     }
     if (WATCH_IGNORED_DIRECTORIES.has(entry)) {
@@ -153,7 +163,12 @@ function collectWatchedFiles(
     }
 
     if (stats.isDirectory()) {
-      collectWatchedFiles(entryPath, followSymlinks, rootRealPath, ancestorRealPaths, snapshots, includedFiles, depth + 1)
+      collectWatchedFiles(entryPath, followSymlinks, rootRealPath, ancestorRealPaths, snapshots, includedFiles, watchGitignore, depth + 1)
+      continue
+    }
+
+    if (isGitignore && stats.isFile()) {
+      snapshots.set(entryPath, gitignoreFingerprint(entryPath, stats.mtimeMs))
       continue
     }
 
@@ -181,7 +196,7 @@ function collectWatchedFiles(
       }
 
       if (targetStats.isDirectory()) {
-        collectWatchedFiles(entryPath, followSymlinks, rootRealPath, [...ancestorRealPaths, realTarget], snapshots, includedFiles, depth + 1)
+        collectWatchedFiles(entryPath, followSymlinks, rootRealPath, [...ancestorRealPaths, realTarget], snapshots, includedFiles, watchGitignore, depth + 1)
         continue
       }
 
@@ -220,9 +235,9 @@ function snapshotWatchedFiles(watchPath: string, followSymlinks: boolean, respec
 
   const visibleFiles = respectGitignore ? collectGitVisibleFiles(resolvedWatchPath) : null
   const includedFiles = visibleFiles === null ? undefined : new Set(visibleFiles)
-  collectWatchedFiles(resolvedWatchPath, followSymlinks, rootRealPath, [rootRealPath], snapshots, includedFiles)
+  collectWatchedFiles(resolvedWatchPath, followSymlinks, rootRealPath, [rootRealPath], snapshots, includedFiles, visibleFiles !== null)
   if (visibleFiles !== null) {
-    const visibilityFingerprint = createHash('sha256').update(visibleFiles.sort().join('\0')).digest('hex')
+    const visibilityFingerprint = createHash('sha256').update([...visibleFiles].sort().join('\0')).digest('hex')
     snapshots.set(GIT_VISIBILITY_SNAPSHOT_KEY, visibilityFingerprint)
   }
   return snapshots

--- a/src/infrastructure/watch.ts
+++ b/src/infrastructure/watch.ts
@@ -1,13 +1,16 @@
+import { createHash } from 'node:crypto'
 import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, statSync, unlinkSync, watch as createFileSystemWatcher, writeFileSync } from 'node:fs'
 import { extname, join, resolve, sep } from 'node:path'
 
 import { AUDIO_EXTENSIONS, CODE_EXTENSIONS, DOC_EXTENSIONS, IMAGE_EXTENSIONS, OFFICE_EXTENSIONS, PAPER_EXTENSIONS, VIDEO_EXTENSIONS } from '../pipeline/detect.js'
 import { sidecarAwareFileFingerprint } from '../shared/binary-ingest-sidecar.js'
+import { collectGitVisibleFiles } from '../shared/git.js'
 import { generateGraph } from './generate.js'
 
 export const WATCHED_EXTENSIONS = new Set([...CODE_EXTENSIONS, ...DOC_EXTENSIONS, ...PAPER_EXTENSIONS, ...IMAGE_EXTENSIONS, ...AUDIO_EXTENSIONS, ...VIDEO_EXTENSIONS, ...OFFICE_EXTENSIONS])
 const MAX_SYMLINK_DEPTH = 40
 const MAX_WATCHED_FILES = 10_000
+const GIT_VISIBILITY_SNAPSHOT_KEY = '\0madar:git-visible-files'
 
 const WATCH_IGNORED_DIRECTORIES = new Set(['.git', 'out', 'node_modules', 'dist', 'build', 'target', 'venv', '.venv', 'env', '.env', '__pycache__'])
 
@@ -118,7 +121,8 @@ function collectWatchedFiles(
   followSymlinks: boolean,
   rootRealPath: string,
   ancestorRealPaths: string[],
-  snapshots: Map<string, number>,
+  snapshots: Map<string, number | string>,
+  includedFiles?: ReadonlySet<string>,
   depth = 0,
 ): void {
   if (depth > MAX_SYMLINK_DEPTH || snapshots.size >= MAX_WATCHED_FILES) {
@@ -149,7 +153,7 @@ function collectWatchedFiles(
     }
 
     if (stats.isDirectory()) {
-      collectWatchedFiles(entryPath, followSymlinks, rootRealPath, ancestorRealPaths, snapshots, depth + 1)
+      collectWatchedFiles(entryPath, followSymlinks, rootRealPath, ancestorRealPaths, snapshots, includedFiles, depth + 1)
       continue
     }
 
@@ -177,7 +181,7 @@ function collectWatchedFiles(
       }
 
       if (targetStats.isDirectory()) {
-        collectWatchedFiles(entryPath, followSymlinks, rootRealPath, [...ancestorRealPaths, realTarget], snapshots, depth + 1)
+        collectWatchedFiles(entryPath, followSymlinks, rootRealPath, [...ancestorRealPaths, realTarget], snapshots, includedFiles, depth + 1)
         continue
       }
 
@@ -186,7 +190,7 @@ function collectWatchedFiles(
       }
 
       const extension = extname(entryPath).toLowerCase()
-      if (WATCHED_EXTENSIONS.has(extension)) {
+      if (WATCHED_EXTENSIONS.has(extension) && (!includedFiles || includedFiles.has(entryPath))) {
         snapshots.set(entryPath, sidecarAwareFileFingerprint(entryPath, targetStats.mtimeMs))
       }
       continue
@@ -197,15 +201,15 @@ function collectWatchedFiles(
     }
 
     const extension = extname(entryPath).toLowerCase()
-    if (WATCHED_EXTENSIONS.has(extension)) {
+    if (WATCHED_EXTENSIONS.has(extension) && (!includedFiles || includedFiles.has(entryPath))) {
       snapshots.set(entryPath, sidecarAwareFileFingerprint(entryPath, stats.mtimeMs))
     }
   }
 }
 
-function snapshotWatchedFiles(watchPath: string, followSymlinks: boolean): Map<string, number> {
+function snapshotWatchedFiles(watchPath: string, followSymlinks: boolean, respectGitignore = false): Map<string, number | string> {
   const resolvedWatchPath = resolveWatchPath(watchPath)
-  const snapshots = new Map<string, number>()
+  const snapshots = new Map<string, number | string>()
 
   let rootRealPath = resolvedWatchPath
   try {
@@ -214,11 +218,17 @@ function snapshotWatchedFiles(watchPath: string, followSymlinks: boolean): Map<s
     rootRealPath = resolvedWatchPath
   }
 
-  collectWatchedFiles(resolvedWatchPath, followSymlinks, rootRealPath, [rootRealPath], snapshots)
+  const visibleFiles = respectGitignore ? collectGitVisibleFiles(resolvedWatchPath) : null
+  const includedFiles = visibleFiles === null ? undefined : new Set(visibleFiles)
+  collectWatchedFiles(resolvedWatchPath, followSymlinks, rootRealPath, [rootRealPath], snapshots, includedFiles)
+  if (visibleFiles !== null) {
+    const visibilityFingerprint = createHash('sha256').update(visibleFiles.sort().join('\0')).digest('hex')
+    snapshots.set(GIT_VISIBILITY_SNAPSHOT_KEY, visibilityFingerprint)
+  }
   return snapshots
 }
 
-function diffSnapshots(previous: Map<string, number>, next: Map<string, number>): string[] {
+function diffSnapshots(previous: Map<string, number | string>, next: Map<string, number | string>): string[] {
   const changed = new Set<string>()
 
   for (const [filePath, modifiedAt] of next.entries()) {
@@ -299,7 +309,7 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
     loopSignal.wake()
   })
 
-  let previousSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false)
+  let previousSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false, options.respectGitignore ?? false)
   let pending = false
   let lastTriggerAt = 0
   const changed = new Set<string>()
@@ -320,7 +330,7 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
         break
       }
 
-      const nextSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false)
+      const nextSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false, options.respectGitignore ?? false)
       const changedBatch = diffSnapshots(previousSnapshot, nextSnapshot)
       previousSnapshot = nextSnapshot
 

--- a/src/infrastructure/watch.ts
+++ b/src/infrastructure/watch.ts
@@ -11,6 +11,7 @@ export const WATCHED_EXTENSIONS = new Set([...CODE_EXTENSIONS, ...DOC_EXTENSIONS
 const MAX_SYMLINK_DEPTH = 40
 const MAX_WATCHED_FILES = 10_000
 const GIT_VISIBILITY_SNAPSHOT_KEY = '\0madar:git-visible-files'
+const GIT_VISIBILITY_CACHE_DURATION_MS = 500
 
 const WATCH_IGNORED_DIRECTORIES = new Set(['.git', 'out', 'node_modules', 'dist', 'build', 'target', 'venv', '.venv', 'env', '.env', '__pycache__'])
 
@@ -36,6 +37,11 @@ export interface WatchOptions extends RebuildCodeOptions {
 interface WatchLoopSignal {
   wait(signal?: AbortSignal): Promise<void>
   wake(): void
+}
+
+interface GitVisibilityCache {
+  visibleFiles: string[] | null
+  expiresAt: number
 }
 
 function defaultLogger(logger?: WatchLogger): WatchLogger {
@@ -222,7 +228,25 @@ function collectWatchedFiles(
   }
 }
 
-function snapshotWatchedFiles(watchPath: string, followSymlinks: boolean, respectGitignore = false): Map<string, number | string> {
+function readGitVisibleFiles(watchPath: string, cache?: GitVisibilityCache): string[] | null {
+  if (cache && cache.expiresAt > Date.now()) {
+    return cache.visibleFiles
+  }
+
+  const visibleFiles = collectGitVisibleFiles(watchPath)
+  if (cache) {
+    cache.visibleFiles = visibleFiles
+    cache.expiresAt = Date.now() + GIT_VISIBILITY_CACHE_DURATION_MS
+  }
+  return visibleFiles
+}
+
+function snapshotWatchedFiles(
+  watchPath: string,
+  followSymlinks: boolean,
+  respectGitignore = false,
+  gitVisibilityCache?: GitVisibilityCache,
+): Map<string, number | string> {
   const resolvedWatchPath = resolveWatchPath(watchPath)
   const snapshots = new Map<string, number | string>()
 
@@ -233,7 +257,7 @@ function snapshotWatchedFiles(watchPath: string, followSymlinks: boolean, respec
     rootRealPath = resolvedWatchPath
   }
 
-  const visibleFiles = respectGitignore ? collectGitVisibleFiles(resolvedWatchPath) : null
+  const visibleFiles = respectGitignore ? readGitVisibleFiles(resolvedWatchPath, gitVisibilityCache) : null
   const includedFiles = visibleFiles === null ? undefined : new Set(visibleFiles)
   collectWatchedFiles(resolvedWatchPath, followSymlinks, rootRealPath, [rootRealPath], snapshots, includedFiles, visibleFiles !== null)
   if (visibleFiles !== null) {
@@ -320,32 +344,37 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
   const runRebuild = options.rebuildCode ?? rebuildCode
   const runNotify = options.notifyOnly ?? notifyOnly
   const loopSignal = createWatchLoopSignal(pollIntervalMs)
+  const respectGitignore = options.respectGitignore ?? false
+  const gitVisibilityCache = respectGitignore ? { visibleFiles: null, expiresAt: 0 } : undefined
   const eventWatcher = startEventWatcher(resolvedWatchPath, () => {
+    if (gitVisibilityCache) {
+      gitVisibilityCache.expiresAt = 0
+    }
     loopSignal.wake()
   })
 
-  let previousSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false, options.respectGitignore ?? false)
-  let pending = false
-  let lastTriggerAt = 0
-  const changed = new Set<string>()
-
-  output.log(`[madar watch] Watching ${resolvedWatchPath} - abort the process to stop`)
-  output.log(
-    '[madar watch] Supported code, docs, papers, images, local audio/video, and office documents rebuild automatically; manual refresh is only needed for unsupported future formats.',
-  )
-  output.log(`[madar watch] Debounce: ${debounce}s`)
-  if (eventWatcher) {
-    output.log('[madar watch] Filesystem events enabled with polling fallback.')
-  }
-
   try {
+    let previousSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false, respectGitignore, gitVisibilityCache)
+    let pending = false
+    let lastTriggerAt = 0
+    const changed = new Set<string>()
+
+    output.log(`[madar watch] Watching ${resolvedWatchPath} - abort the process to stop`)
+    output.log(
+      '[madar watch] Supported code, docs, papers, images, local audio/video, and office documents rebuild automatically; manual refresh is only needed for unsupported future formats.',
+    )
+    output.log(`[madar watch] Debounce: ${debounce}s`)
+    if (eventWatcher) {
+      output.log('[madar watch] Filesystem events enabled with polling fallback.')
+    }
+
     while (!options.signal?.aborted) {
       await loopSignal.wait(options.signal)
       if (options.signal?.aborted) {
         break
       }
 
-      const nextSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false, options.respectGitignore ?? false)
+      const nextSnapshot = snapshotWatchedFiles(resolvedWatchPath, options.followSymlinks ?? false, respectGitignore, gitVisibilityCache)
       const changedBatch = diffSnapshots(previousSnapshot, nextSnapshot)
       previousSnapshot = nextSnapshot
 
@@ -375,6 +404,9 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
         }
       }
     }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    output.error(`[madar watch] Watch stopped: ${message}`)
   } finally {
     try {
       eventWatcher?.close()

--- a/src/infrastructure/watch.ts
+++ b/src/infrastructure/watch.ts
@@ -18,6 +18,7 @@ export interface WatchLogger {
 
 export interface RebuildCodeOptions {
   followSymlinks?: boolean
+  respectGitignore?: boolean
   noHtml?: boolean
   logger?: WatchLogger
 }
@@ -262,6 +263,7 @@ export function rebuildCode(watchPath: string, options: RebuildCodeOptions = {})
     const result = generateGraph(resolvedWatchPath, {
       ...(existsSync(manifestPath) && existsSync(graphPath) ? { update: true } : {}),
       ...(options.followSymlinks !== undefined ? { followSymlinks: options.followSymlinks } : {}),
+      ...(options.respectGitignore !== undefined ? { respectGitignore: options.respectGitignore } : {}),
       ...(options.noHtml !== undefined ? { noHtml: options.noHtml } : {}),
     })
 
@@ -339,6 +341,7 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
         const rebuildOptions: RebuildCodeOptions = {
           logger: output,
           ...(options.followSymlinks !== undefined ? { followSymlinks: options.followSymlinks } : {}),
+          ...(options.respectGitignore !== undefined ? { respectGitignore: options.respectGitignore } : {}),
           ...(options.noHtml !== undefined ? { noHtml: options.noHtml } : {}),
         }
         const rebuilt = runRebuild(resolvedWatchPath, rebuildOptions)

--- a/src/pipeline/detect.ts
+++ b/src/pipeline/detect.ts
@@ -21,6 +21,8 @@ export type FileTypeValue = (typeof FileType)[keyof typeof FileType]
 
 export interface DetectOptions {
   followSymlinks?: boolean
+  /** Restrict discovery to these absolute paths after Madar's own filters. */
+  includedFiles?: ReadonlySet<string>
 }
 
 export interface DetectResult {
@@ -365,6 +367,9 @@ export function detect(root: string, options: DetectOptions = {}): DetectResult 
   const skippedSensitive: string[] = []
 
   for (const filePath of collectFiles(root, followSymlinks, ignorePatterns)) {
+    if (options.includedFiles && !options.includedFiles.has(resolve(filePath))) {
+      continue
+    }
     if (isSensitive(filePath, root)) {
       skippedSensitive.push(filePath)
       continue

--- a/src/pipeline/spi/build.ts
+++ b/src/pipeline/spi/build.ts
@@ -81,6 +81,8 @@ export type BuildSpiOptions = {
   root: string
   madarVersion: string
   extractorVersion?: string
+  /** Restrict source discovery to these absolute paths. */
+  includedFiles?: ReadonlySet<string>
   // Override the wall-clock used in `generated_at`. Test-only escape hatch
   // so snapshot tests can assert deterministic output.
   now?: () => Date
@@ -120,7 +122,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
 
   const absPaths: string[] = []
   const ignorePatterns = loadMadarignorePatterns(root)
-  collectFiles(root, root, ignorePatterns, absPaths)
+  collectFiles(root, root, ignorePatterns, absPaths, opts.includedFiles)
 
   const pathToFileId = new Map<string, string>()
   for (const abs of absPaths) {
@@ -192,7 +194,7 @@ export function buildSpi(opts: BuildSpiOptions): SemanticProgramIndex {
 // buildSpi directly.
 export const buildSpiFileLayer = buildSpi
 
-function collectFiles(root: string, dir: string, ignorePatterns: readonly string[], out: string[]): void {
+function collectFiles(root: string, dir: string, ignorePatterns: readonly string[], out: string[], includedFiles?: ReadonlySet<string>): void {
   let entries: import('node:fs').Dirent<string>[]
   try {
     entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' })
@@ -204,9 +206,9 @@ function collectFiles(root: string, dir: string, ignorePatterns: readonly string
     const full = join(dir, entry.name)
     if (isDiscoveryPathIgnored(full, root, ignorePatterns)) continue
     if (entry.isDirectory()) {
-      collectFiles(root, full, ignorePatterns, out)
+      collectFiles(root, full, ignorePatterns, out, includedFiles)
     } else if (entry.isFile()) {
-      out.push(full)
+      if (!includedFiles || includedFiles.has(resolve(full))) out.push(full)
     }
   }
 }

--- a/src/pipeline/spi/cache.ts
+++ b/src/pipeline/spi/cache.ts
@@ -218,7 +218,7 @@ interface WorkspaceFingerprint {
 
 function computeWorkspaceFingerprint(root: string, opts: BuildSpiCachedOptions): WorkspaceFingerprint {
   const entries: string[] = []
-  collectIndexableFiles(root, root, entries)
+  collectIndexableFiles(root, root, entries, opts.includedFiles)
   entries.sort()
 
   const hasher = createHash('sha256')
@@ -276,7 +276,7 @@ function collectProjectConfigPaths(root: string, entries: readonly string[]): st
   return [...projectConfigPaths].sort()
 }
 
-function collectIndexableFiles(root: string, dir: string, out: string[]): void {
+function collectIndexableFiles(root: string, dir: string, out: string[], includedFiles?: ReadonlySet<string>): void {
   let entries: import('node:fs').Dirent<string>[]
   try {
     entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' })
@@ -288,11 +288,13 @@ function collectIndexableFiles(root: string, dir: string, out: string[]): void {
     if (entry.isSymbolicLink()) continue
     const full = join(dir, entry.name)
     if (entry.isDirectory()) {
-      collectIndexableFiles(root, full, out)
+      collectIndexableFiles(root, full, out, includedFiles)
     } else if (entry.isFile()) {
       const ext = extname(entry.name).toLowerCase()
       if (CACHE_INDEXABLE_EXTS.has(ext)) {
-        out.push(relative(root, full).split('\\').join('/'))
+        if (!includedFiles || includedFiles.has(resolve(full))) {
+          out.push(relative(root, full).split('\\').join('/'))
+        }
       }
     }
   }

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -16,6 +16,38 @@ export function findGitRoot(path: string): string | null {
   }
 }
 
+/**
+ * Lists tracked files plus untracked files that are not excluded by Git's
+ * standard ignore rules. `null` means Git is unavailable or the path is not
+ * inside a repository; an empty array is a valid empty worktree result.
+ */
+export function collectGitVisibleFiles(rootDir: string): string[] | null {
+  const root = resolve(rootDir)
+
+  try {
+    const repoRoot = execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    }).trim()
+    const relativeRoot = relative(repoRoot, root)
+    if (relativeRoot === '..' || relativeRoot.startsWith(`..${sep}`) || isAbsolute(relativeRoot)) {
+      return null
+    }
+    const output = execFileSync(
+      'git',
+      ['-C', repoRoot, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', relativeRoot || '.'],
+      { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, windowsHide: true },
+    )
+
+    return output
+      .split('\0')
+      .filter(Boolean)
+      .map((relativePath) => resolve(repoRoot, relativePath))
+  } catch {
+    return null
+  }
+}
+
 function gitOutput(rootDir: string, args: string[], trim = true): string {
   const output = execFileSync('git', ['-c', 'core.quotePath=false', ...args], {
     cwd: rootDir,

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, realpathSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 export function findGitRoot(path: string): string | null {
@@ -24,12 +24,11 @@ export function findGitRoot(path: string): string | null {
 export function collectGitVisibleFiles(rootDir: string): string[] | null {
   const root = resolve(rootDir)
 
-  let repoRoot: string
   try {
-    repoRoot = execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
+    execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
       encoding: 'utf8',
       windowsHide: true,
-    }).trim()
+    })
   } catch {
     if (findGitRoot(root) !== null) {
       throw new Error(`Unable to determine the Git root for --respect-gitignore: ${root}`)
@@ -38,18 +37,11 @@ export function collectGitVisibleFiles(rootDir: string): string[] | null {
   }
 
   try {
-    const canonicalRoot = realpathSync(root)
-    const canonicalRepoRoot = realpathSync(repoRoot)
-    const relativeRoot = relative(canonicalRepoRoot, canonicalRoot)
-    if (relativeRoot === '..' || relativeRoot.startsWith(`..${sep}`) || isAbsolute(relativeRoot)) {
-      return null
-    }
-
     let output: string
     try {
       output = execFileSync(
         'git',
-        ['-C', canonicalRepoRoot, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', `:(literal)${relativeRoot || '.'}`],
+        ['-C', root, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', '.'],
         { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, windowsHide: true },
       )
     } catch {
@@ -59,13 +51,13 @@ export function collectGitVisibleFiles(rootDir: string): string[] | null {
     return output
       .split('\0')
       .filter(Boolean)
-      .map((repoRelativePath) => {
-        const canonicalFilePath = resolve(canonicalRepoRoot, repoRelativePath)
-        const rootRelativePath = relative(canonicalRoot, canonicalFilePath)
-        if (rootRelativePath === '..' || rootRelativePath.startsWith(`..${sep}`) || isAbsolute(rootRelativePath)) {
+      .map((rootRelativePath) => {
+        const filePath = resolve(root, rootRelativePath)
+        const relativePath = relative(root, filePath)
+        if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
           throw new Error(`Git returned a path outside the requested root for --respect-gitignore: ${root}`)
         }
-        return resolve(root, rootRelativePath)
+        return filePath
       })
   } catch (error) {
     if (error instanceof Error) {

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 export function findGitRoot(path: string): string | null {
@@ -24,27 +24,54 @@ export function findGitRoot(path: string): string | null {
 export function collectGitVisibleFiles(rootDir: string): string[] | null {
   const root = resolve(rootDir)
 
+  let repoRoot: string
   try {
-    const repoRoot = execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
+    repoRoot = execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
       encoding: 'utf8',
       windowsHide: true,
     }).trim()
-    const relativeRoot = relative(repoRoot, root)
+  } catch {
+    if (findGitRoot(root) !== null) {
+      throw new Error(`Unable to determine the Git root for --respect-gitignore: ${root}`)
+    }
+    return null
+  }
+
+  try {
+    const canonicalRoot = realpathSync(root)
+    const canonicalRepoRoot = realpathSync(repoRoot)
+    const relativeRoot = relative(canonicalRepoRoot, canonicalRoot)
     if (relativeRoot === '..' || relativeRoot.startsWith(`..${sep}`) || isAbsolute(relativeRoot)) {
       return null
     }
-    const output = execFileSync(
-      'git',
-      ['-C', repoRoot, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', relativeRoot || '.'],
-      { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, windowsHide: true },
-    )
+
+    let output: string
+    try {
+      output = execFileSync(
+        'git',
+        ['-C', canonicalRepoRoot, 'ls-files', '--cached', '--others', '--exclude-standard', '-z', '--', `:(literal)${relativeRoot || '.'}`],
+        { encoding: 'utf8', maxBuffer: 100 * 1024 * 1024, windowsHide: true },
+      )
+    } catch {
+      throw new Error(`Unable to list Git-visible files for --respect-gitignore: ${root}`)
+    }
 
     return output
       .split('\0')
       .filter(Boolean)
-      .map((relativePath) => resolve(repoRoot, relativePath))
-  } catch {
-    return null
+      .map((repoRelativePath) => {
+        const canonicalFilePath = resolve(canonicalRepoRoot, repoRelativePath)
+        const rootRelativePath = relative(canonicalRoot, canonicalFilePath)
+        if (rootRelativePath === '..' || rootRelativePath.startsWith(`..${sep}`) || isAbsolute(rootRelativePath)) {
+          throw new Error(`Git returned a path outside the requested root for --respect-gitignore: ${root}`)
+        }
+        return resolve(root, rootRelativePath)
+      })
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error
+    }
+    throw new Error(`Unable to resolve Git-visible files for --respect-gitignore: ${root}`)
   }
 }
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -975,9 +975,10 @@ describe('cli parser', () => {
   })
 
   it('parses watch args', () => {
-    expect(parseWatchArgs(['src', '--follow-symlinks', '--debounce=2', '--no-html'])).toEqual({
+    expect(parseWatchArgs(['src', '--follow-symlinks', '--respect-gitignore', '--debounce=2', '--no-html'])).toEqual({
       path: 'src',
       followSymlinks: true,
+      respectGitignore: true,
       debounceSeconds: 2,
       noHtml: true,
     })
@@ -2891,7 +2892,7 @@ describe('cli main', () => {
       servedOverStdio = true
     }
 
-    const watchExitCode = await executeCli(['watch', 'src', '--debounce', '1', '--no-html'], io, dependencies)
+    const watchExitCode = await executeCli(['watch', 'src', '--respect-gitignore', '--debounce', '1', '--no-html'], io, dependencies)
     const serveExitCode = await executeCli(['serve', 'out/graph.json', '--port', '0'], io, dependencies)
     const stdioExitCode = await executeCli(['serve', 'out/graph.json', '--mcp'], io, dependencies)
 
@@ -2902,6 +2903,7 @@ describe('cli main', () => {
     expect(served).toBe(true)
     expect(servedOverStdio).toBe(true)
     expect(lastWatchOptions?.noHtml).toBe(true)
+    expect(lastWatchOptions?.respectGitignore).toBe(true)
     expect(logs[0]).toContain('[madar generate]')
   })
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -2879,8 +2879,14 @@ describe('cli main', () => {
     let watched = false
     let served = false
     let servedOverStdio = false
+    let lastGenerateOptions: Record<string, unknown> | undefined
     let lastWatchOptions: Record<string, unknown> | undefined
     const dependencies = createDependencies()
+    const generateGraph = dependencies.generateGraph
+    dependencies.generateGraph = (path, options) => {
+      lastGenerateOptions = options as Record<string, unknown>
+      return generateGraph(path, options)
+    }
     dependencies.watchGraph = async (_path, _debounce, options) => {
       watched = true
       lastWatchOptions = options as Record<string, unknown>
@@ -2902,6 +2908,8 @@ describe('cli main', () => {
     expect(watched).toBe(true)
     expect(served).toBe(true)
     expect(servedOverStdio).toBe(true)
+    expect(lastGenerateOptions?.noHtml).toBe(true)
+    expect(lastGenerateOptions?.respectGitignore).toBe(true)
     expect(lastWatchOptions?.noHtml).toBe(true)
     expect(lastWatchOptions?.respectGitignore).toBe(true)
     expect(logs[0]).toContain('[madar generate]')

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -900,6 +900,7 @@ describe('cli parser', () => {
       watch: false,
       directed: false,
       followSymlinks: false,
+      respectGitignore: false,
       debounceSeconds: 3,
       noHtml: false,
       wiki: false,
@@ -924,6 +925,7 @@ describe('cli parser', () => {
         '--watch',
         '--directed',
         '--follow-symlinks',
+        '--respect-gitignore',
         '--debounce',
         '1.5',
         '--no-html',
@@ -950,6 +952,7 @@ describe('cli parser', () => {
       watch: true,
       directed: true,
       followSymlinks: true,
+      respectGitignore: true,
       debounceSeconds: 1.5,
       noHtml: true,
       wiki: true,
@@ -1212,6 +1215,7 @@ describe('cli main', () => {
     expect(help).toContain('watch [path]')
     expect(help).toContain('serve [graph.json]')
     expect(help).toContain('--directed')
+    expect(help).toContain('--respect-gitignore')
     expect(help).toContain('--wiki')
     expect(help).toContain('--obsidian')
     expect(help).toContain('--svg')

--- a/tests/unit/generate.test.ts
+++ b/tests/unit/generate.test.ts
@@ -1012,6 +1012,32 @@ describe('generateGraph', () => {
     })
   }, generateGraphIntegrationTimeoutMs)
 
+  test.runIf(process.platform !== 'win32')('excludes Git-ignored files through a symlinked generation root', () => {
+    withTempDir((realRoot) => {
+      withTempDir((aliasParent) => {
+        writeFileSync(join(realRoot, '.gitignore'), 'ignored.ts\n', 'utf8')
+        writeFileSync(join(realRoot, 'tracked.ts'), 'export const tracked = true\n', 'utf8')
+        writeFileSync(join(realRoot, 'untracked.ts'), 'export const untracked = true\n', 'utf8')
+        writeFileSync(join(realRoot, 'ignored.ts'), 'export const ignored = true\n', 'utf8')
+        execFileSync('git', ['init'], { cwd: realRoot, stdio: 'pipe' })
+        execFileSync('git', ['add', '.gitignore', 'tracked.ts'], { cwd: realRoot, stdio: 'pipe' })
+
+        const aliasedRoot = join(aliasParent, 'workspace')
+        symlinkSync(realRoot, aliasedRoot, 'dir')
+        generateGraph(aliasedRoot, { noHtml: true, respectGitignore: true })
+
+        const graphData = JSON.parse(readFileSync(join(aliasedRoot, 'out', 'graph.json'), 'utf8')) as {
+          nodes: Array<{ source_file?: string }>
+        }
+        const sourceFiles = new Set(graphData.nodes.map((node) => node.source_file))
+
+        expect(sourceFiles).toContain(join(aliasedRoot, 'tracked.ts'))
+        expect(sourceFiles).toContain(join(aliasedRoot, 'untracked.ts'))
+        expect(sourceFiles).not.toContain(join(aliasedRoot, 'ignored.ts'))
+      })
+    })
+  }, generateGraphIntegrationTimeoutMs)
+
   test('builds graph artifacts for a code corpus', () => {
     withTempDir((tempDir) => {
       writeFileSync(join(tempDir, 'main.py'), 'class Greeter:\n    def hello(self):\n        return 1\n', 'utf8')

--- a/tests/unit/generate.test.ts
+++ b/tests/unit/generate.test.ts
@@ -1,4 +1,5 @@
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -988,6 +989,28 @@ describe('generateGraph', () => {
       }
     })
   })
+
+  test('excludes Git-ignored files when respectGitignore is enabled', () => {
+    withTempDir((tempDir) => {
+      writeFileSync(join(tempDir, '.gitignore'), 'ignored.ts\n', 'utf8')
+      writeFileSync(join(tempDir, 'tracked.ts'), 'export const tracked = true\n', 'utf8')
+      writeFileSync(join(tempDir, 'untracked.ts'), 'export const untracked = true\n', 'utf8')
+      writeFileSync(join(tempDir, 'ignored.ts'), 'export const ignored = true\n', 'utf8')
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' })
+      execFileSync('git', ['add', '.gitignore', 'tracked.ts'], { cwd: tempDir, stdio: 'pipe' })
+
+      generateGraph(tempDir, { noHtml: true, respectGitignore: true })
+
+      const graphData = JSON.parse(readFileSync(join(tempDir, 'out', 'graph.json'), 'utf8')) as {
+        nodes: Array<{ source_file?: string }>
+      }
+      const sourceFiles = new Set(graphData.nodes.map((node) => node.source_file))
+
+      expect(sourceFiles).toContain(join(tempDir, 'tracked.ts'))
+      expect(sourceFiles).toContain(join(tempDir, 'untracked.ts'))
+      expect(sourceFiles).not.toContain(join(tempDir, 'ignored.ts'))
+    })
+  }, generateGraphIntegrationTimeoutMs)
 
   test('builds graph artifacts for a code corpus', () => {
     withTempDir((tempDir) => {

--- a/tests/unit/generate.test.ts
+++ b/tests/unit/generate.test.ts
@@ -1014,6 +1014,32 @@ describe('generateGraph', () => {
     })
   }, generateGraphIntegrationTimeoutMs)
 
+  test('excludes Git-ignored files from a nested generation root', () => {
+    withTempDir((repoRoot) => {
+      const nestedRoot = join(repoRoot, 'workspace')
+      mkdirSync(nestedRoot)
+      writeFileSync(join(repoRoot, '.gitignore'), 'workspace/ignored.ts\n', 'utf8')
+      writeFileSync(join(nestedRoot, 'tracked.ts'), 'export const tracked = true\n', 'utf8')
+      writeFileSync(join(nestedRoot, 'untracked.ts'), 'export const untracked = true\n', 'utf8')
+      writeFileSync(join(nestedRoot, 'ignored.ts'), 'export const ignored = true\n', 'utf8')
+      execFileSync('git', ['init'], { cwd: repoRoot, stdio: 'pipe' })
+      execFileSync('git', ['add', '.gitignore', 'workspace/tracked.ts'], { cwd: repoRoot, stdio: 'pipe' })
+
+      generateGraph(nestedRoot, { noHtml: true, respectGitignore: true })
+
+      const graphData = JSON.parse(readFileSync(join(nestedRoot, 'out', 'graph.json'), 'utf8')) as {
+        nodes: Array<{ source_file?: string }>
+      }
+      const sourceFiles = new Set(
+        graphData.nodes.flatMap((node) => (typeof node.source_file === 'string' ? [normalizeAssertionPath(realpathSync(node.source_file))] : [])),
+      )
+
+      expect(sourceFiles).toContain(normalizeAssertionPath(realpathSync(join(nestedRoot, 'tracked.ts'))))
+      expect(sourceFiles).toContain(normalizeAssertionPath(realpathSync(join(nestedRoot, 'untracked.ts'))))
+      expect(sourceFiles).not.toContain(normalizeAssertionPath(realpathSync(join(nestedRoot, 'ignored.ts'))))
+    })
+  }, generateGraphIntegrationTimeoutMs)
+
   test.runIf(process.platform !== 'win32')('excludes Git-ignored files through a symlinked generation root', () => {
     withTempDir((realRoot) => {
       withTempDir((aliasParent) => {

--- a/tests/unit/generate.test.ts
+++ b/tests/unit/generate.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -1004,11 +1004,13 @@ describe('generateGraph', () => {
       const graphData = JSON.parse(readFileSync(join(tempDir, 'out', 'graph.json'), 'utf8')) as {
         nodes: Array<{ source_file?: string }>
       }
-      const sourceFiles = new Set(graphData.nodes.map((node) => node.source_file))
+      const sourceFiles = new Set(
+        graphData.nodes.flatMap((node) => (typeof node.source_file === 'string' ? [normalizeAssertionPath(realpathSync(node.source_file))] : [])),
+      )
 
-      expect(sourceFiles).toContain(join(tempDir, 'tracked.ts'))
-      expect(sourceFiles).toContain(join(tempDir, 'untracked.ts'))
-      expect(sourceFiles).not.toContain(join(tempDir, 'ignored.ts'))
+      expect(sourceFiles).toContain(normalizeAssertionPath(realpathSync(join(tempDir, 'tracked.ts'))))
+      expect(sourceFiles).toContain(normalizeAssertionPath(realpathSync(join(tempDir, 'untracked.ts'))))
+      expect(sourceFiles).not.toContain(normalizeAssertionPath(realpathSync(join(tempDir, 'ignored.ts'))))
     })
   }, generateGraphIntegrationTimeoutMs)
 

--- a/tests/unit/watch.test.ts
+++ b/tests/unit/watch.test.ts
@@ -200,6 +200,107 @@ describe('watch', () => {
     })
   }, 10_000)
 
+  test('caches Git visibility between watch polls', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      writeFileSync(join(tempDir, 'main.ts'), 'export const visible = true\n', 'utf8')
+      const collectGitVisibleFiles = vi.fn(() => [join(tempDir, 'main.ts')])
+
+      vi.resetModules()
+      const actualGitModule = await vi.importActual<typeof import('../../src/shared/git.js')>('../../src/shared/git.js')
+      vi.doMock('../../src/shared/git.js', () => ({ ...actualGitModule, collectGitVisibleFiles }))
+
+      try {
+        const { watch: watchWithMockedGit } = await import('../../src/infrastructure/watch.js')
+        const controller = new AbortController()
+        const watcher = watchWithMockedGit(tempDir, 0.02, {
+          signal: controller.signal,
+          pollIntervalMs: 10,
+          respectGitignore: true,
+          logger: { log() {}, error() {} },
+        })
+
+        await delay(100)
+        controller.abort()
+        await watcher
+
+        expect(collectGitVisibleFiles).toHaveBeenCalledTimes(1)
+      } finally {
+        vi.doUnmock('../../src/shared/git.js')
+        vi.resetModules()
+      }
+    })
+  })
+
+  test('stops cleanly when the initial Git visibility snapshot fails', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      const collectGitVisibleFiles = vi.fn(() => {
+        throw new Error('Git inspection failed')
+      })
+
+      vi.resetModules()
+      const actualGitModule = await vi.importActual<typeof import('../../src/shared/git.js')>('../../src/shared/git.js')
+      vi.doMock('../../src/shared/git.js', () => ({ ...actualGitModule, collectGitVisibleFiles }))
+
+      try {
+        const { watch: watchWithMockedGit } = await import('../../src/infrastructure/watch.js')
+        const logger = { log: vi.fn(), error: vi.fn() }
+
+        await expect(
+          watchWithMockedGit(tempDir, 0.02, {
+            respectGitignore: true,
+            logger,
+          }),
+        ).resolves.toBeUndefined()
+
+        expect(collectGitVisibleFiles).toHaveBeenCalledTimes(1)
+        expect(logger.error).toHaveBeenCalledWith('[madar watch] Watch stopped: Git inspection failed')
+      } finally {
+        vi.doUnmock('../../src/shared/git.js')
+        vi.resetModules()
+      }
+    })
+  })
+
+  test('stops cleanly when a later Git visibility snapshot fails', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      writeFileSync(join(tempDir, 'main.ts'), 'export const visible = true\n', 'utf8')
+      let calls = 0
+      const collectGitVisibleFiles = vi.fn(() => {
+        calls += 1
+        if (calls > 1) {
+          throw new Error('Git inspection failed after startup')
+        }
+        return [join(tempDir, 'main.ts')]
+      })
+
+      vi.resetModules()
+      const actualGitModule = await vi.importActual<typeof import('../../src/shared/git.js')>('../../src/shared/git.js')
+      vi.doMock('../../src/shared/git.js', () => ({ ...actualGitModule, collectGitVisibleFiles }))
+
+      try {
+        const { watch: watchWithMockedGit } = await import('../../src/infrastructure/watch.js')
+        const controller = new AbortController()
+        const logger = { log: vi.fn(), error: vi.fn() }
+        const watcher = watchWithMockedGit(tempDir, 0.02, {
+          signal: controller.signal,
+          pollIntervalMs: 10,
+          respectGitignore: true,
+          logger,
+        })
+        const timeout = setTimeout(() => controller.abort(), 2_000)
+
+        await watcher
+        clearTimeout(timeout)
+
+        expect(collectGitVisibleFiles).toHaveBeenCalledTimes(2)
+        expect(logger.error).toHaveBeenCalledWith('[madar watch] Watch stopped: Git inspection failed after startup')
+      } finally {
+        vi.doUnmock('../../src/shared/git.js')
+        vi.resetModules()
+      }
+    })
+  }, 5_000)
+
   test('triggers rebuild for code-only changes', async () => {
     await withTempDirAsync(async (tempDir) => {
       const controller = new AbortController()

--- a/tests/unit/watch.test.ts
+++ b/tests/unit/watch.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -110,6 +111,63 @@ describe('rebuildCode', () => {
 })
 
 describe('watch', () => {
+  test('triggers a Git-visible rebuild when .gitignore changes', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      writeFileSync(join(tempDir, 'main.ts'), 'export const visible = true\n', 'utf8')
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' })
+
+      const controller = new AbortController()
+      const rebuild = vi.fn((_watchPath: string, _options?: unknown) => {
+        controller.abort()
+        return true
+      })
+      const watcher = watch(tempDir, 0.02, {
+        signal: controller.signal,
+        pollIntervalMs: 10,
+        respectGitignore: true,
+        rebuildCode: rebuild,
+        logger: { log() {}, error() {} },
+      })
+      const timeout = setTimeout(() => controller.abort(), 2_000)
+
+      await delay(30)
+      writeFileSync(join(tempDir, '.gitignore'), 'main.ts\n', 'utf8')
+
+      await watcher
+      clearTimeout(timeout)
+
+      expect(rebuild).toHaveBeenCalledTimes(1)
+      expect(rebuild.mock.calls[0]?.[1]).toMatchObject({ respectGitignore: true })
+    })
+  })
+
+  test('ignores changes to Git-ignored source files when respectGitignore is enabled', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      writeFileSync(join(tempDir, '.gitignore'), 'ignored.ts\n', 'utf8')
+      writeFileSync(join(tempDir, 'main.ts'), 'export const visible = true\n', 'utf8')
+      writeFileSync(join(tempDir, 'ignored.ts'), 'export const ignored = true\n', 'utf8')
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' })
+
+      const controller = new AbortController()
+      const rebuild = vi.fn(() => true)
+      const watcher = watch(tempDir, 0.02, {
+        signal: controller.signal,
+        pollIntervalMs: 10,
+        respectGitignore: true,
+        rebuildCode: rebuild,
+        logger: { log() {}, error() {} },
+      })
+
+      await delay(30)
+      writeFileSync(join(tempDir, 'ignored.ts'), 'export const ignored = false\n', 'utf8')
+      await delay(150)
+      controller.abort()
+      await watcher
+
+      expect(rebuild).not.toHaveBeenCalled()
+    })
+  })
+
   test('triggers rebuild for code-only changes', async () => {
     await withTempDirAsync(async (tempDir) => {
       const controller = new AbortController()

--- a/tests/unit/watch.test.ts
+++ b/tests/unit/watch.test.ts
@@ -128,9 +128,9 @@ describe('watch', () => {
         rebuildCode: rebuild,
         logger: { log() {}, error() {} },
       })
-      const timeout = setTimeout(() => controller.abort(), 2_000)
+      const timeout = setTimeout(() => controller.abort(), 5_000)
 
-      await delay(30)
+      await delay(100)
       writeFileSync(join(tempDir, '.gitignore'), 'main.ts\n', 'utf8')
 
       await watcher
@@ -139,7 +139,7 @@ describe('watch', () => {
       expect(rebuild).toHaveBeenCalledTimes(1)
       expect(rebuild.mock.calls[0]?.[1]).toMatchObject({ respectGitignore: true })
     })
-  })
+  }, 10_000)
 
   test('ignores changes to Git-ignored source files when respectGitignore is enabled', async () => {
     await withTempDirAsync(async (tempDir) => {
@@ -158,15 +158,47 @@ describe('watch', () => {
         logger: { log() {}, error() {} },
       })
 
-      await delay(30)
+      await delay(100)
       writeFileSync(join(tempDir, 'ignored.ts'), 'export const ignored = false\n', 'utf8')
-      await delay(150)
+      await delay(250)
       controller.abort()
       await watcher
 
       expect(rebuild).not.toHaveBeenCalled()
     })
-  })
+  }, 10_000)
+
+  test.runIf(process.platform !== 'win32')('triggers a rebuild when Git excludes a followed symlink alias', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      writeFileSync(join(tempDir, 'target.ts'), 'export const target = true\n', 'utf8')
+      symlinkSync(join(tempDir, 'target.ts'), join(tempDir, 'alias.ts'))
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' })
+
+      const controller = new AbortController()
+      const rebuild = vi.fn((_watchPath: string, _options?: unknown) => {
+        controller.abort()
+        return true
+      })
+      const watcher = watch(tempDir, 0.02, {
+        signal: controller.signal,
+        pollIntervalMs: 10,
+        followSymlinks: true,
+        respectGitignore: true,
+        rebuildCode: rebuild,
+        logger: { log() {}, error() {} },
+      })
+      const timeout = setTimeout(() => controller.abort(), 5_000)
+
+      await delay(100)
+      writeFileSync(join(tempDir, '.git', 'info', 'exclude'), 'alias.ts\n', 'utf8')
+
+      await watcher
+      clearTimeout(timeout)
+
+      expect(rebuild).toHaveBeenCalledTimes(1)
+      expect(rebuild.mock.calls[0]?.[1]).toMatchObject({ followSymlinks: true, respectGitignore: true })
+    })
+  }, 10_000)
 
   test('triggers rebuild for code-only changes', async () => {
     await withTempDirAsync(async (tempDir) => {


### PR DESCRIPTION
## Summary

- carry the contributor implementation from #536 into a base-owned release branch, preserving its original commit attribution
- fix cross-platform Git root canonicalization so `--respect-gitignore` works through macOS `/var` aliases and symlinked roots
- make Git discovery fail closed when a Git workspace cannot be inspected, rather than accidentally scanning ignored files
- make both `madar generate --watch` and standalone `madar watch` honor Git-visible files, including .gitignore membership changes
- document the feature under the existing `0.29.0` changelog section

## Validation

- `npm run test:run` — 189 files, 2,571 passed, 2 skipped
- `npm run typecheck`
- `npm run release:verify`
- `npm run registry:validate`
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`

Closes #535.

Supersedes #536: its contributor-owned branch cannot be amended and fails macOS/Windows CI; this PR includes the original feature plus the required corrective coverage. No npm publish has run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--respect-gitignore` to `generate` and `watch`.
  * Generation and watching can now limit discovery to Git-tracked files plus non-ignored untracked files (including regular, incremental, SPI, and watch workflows).
  * Outside a Git repository, discovery falls back to the default behavior.
* **Documentation**
  * Updated CLI docs with examples and clarified default discovery behavior with the new option.
* **Bug Fixes**
  * Watch now triggers rebuilds when Git visibility changes (including `.gitignore` updates) and avoids rebuilds for files that are Git-ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->