### PR TITLE
Fix auto-refresh lease recovery and retry signaling

### DIFF
--- a/docs/auto-refresh.md
+++ b/docs/auto-refresh.md
@@ -36,11 +36,11 @@ The local `watcher-state.json` beside `graph.json` is written atomically and inc
 - pending/failure details; and
 - stored/current policy fingerprints and match state.
 
-`madar doctor` and `madar status` render those fields. During an auto-refresh MCP session, graph-backed prompts, resources, completions, and tool calls are refused while state is starting, pending, reconciling, failed, incomplete, or policy-mismatched. Retry after the state returns to `idle`; if it remains failed, run `madar generate . --update` and inspect `madar status`.
+`madar doctor` and `madar status` render those fields. During an auto-refresh MCP session, graph-backed prompts, resources, completions, and tool calls fail closed until the watcher is `idle` with matching published policy. Transient `starting`, `pending`, and `reconciling` responses use the structured MCP error type `madar_graph_not_ready` with `retryable: true`, `retry_after_ms: 1000`, and `suggested_action: "retry_same_request"`. Agents should retry the same Madar request; they do not need to bypass Madar or run generation while reconciliation is active. Terminal `failed`, incomplete, and policy-mismatched states return `retryable: false` with `suggested_action: "repair_graph"`; inspect `madar status`, then run `madar generate . --update` when repair is required.
 
 MCP initialization, ping, and list/discovery requests remain responsive during `starting` and `reconciling`. This lets an agent connect without waiting for a cold large-repository build while preserving the same freshness boundary for every graph answer.
 
-The refresh lease serializes multiple MCP processes that target the same workspace. Graph, source-manifest, indexing-manifest, report, and watcher-state publications use same-filesystem atomic renames. A post-build reconciliation detects edits made while generation was running and queues another rebuild before the state can return to `idle`.
+The refresh lease serializes multiple MCP processes that target the same workspace. If the recorded owner process is dead, Madar reclaims the lease immediately. If another live process owns it, auto-refresh remains in a retryable reconciliation state and waits with bounded backoff until the lease is released or the server shuts down; contention does not permanently fail the watcher. Graph, source-manifest, indexing-manifest, report, and watcher-state publications use same-filesystem atomic renames. A post-build reconciliation detects edits made while generation was running and queues another rebuild before the state can return to `idle`.
 
 ## Linked worktrees
 

--- a/docs/reference/cli-and-mcp.md
+++ b/docs/reference/cli-and-mcp.md
@@ -79,7 +79,7 @@ Cached `context_pack` explain responses still refresh the current freshness rece
 
 With `--auto-refresh`, filesystem events invalidate the graph immediately and adaptive authoritative reconciliations verify the full watched corpus. Graph-backed MCP requests fail closed while reconciliation is pending/failed or watcher coverage/policy is not trustworthy. Generation policy is versioned and fingerprinted in both `graph.json` and `manifest.json`, so automatic refresh reuses direction, SPI, Git-ignore, symlink, document/non-code, exclusion, extractor, and indexing-threshold settings. Policy drift forces a full rebuild. `madar doctor` and `madar status` expose the local `watcher-state.json` health record. Full behavior and legacy migration are documented in [Auto-refresh and generation policy](../auto-refresh.md).
 
-The stdio transport and MCP discovery stay responsive while initial reconciliation runs in a background worker. Until the watcher reaches `idle` with matching published policy, graph-backed calls return a bounded freshness error that tells the caller to wait or run `madar generate . --update`.
+The stdio transport and MCP discovery stay responsive while initial reconciliation runs in a background worker. Until the watcher reaches `idle` with matching published policy, graph-backed calls return the structured error type `madar_graph_not_ready`. For transient `starting`, `pending`, or `reconciling` states, `retryable` is `true`, `retry_after_ms` is `1000`, and the suggested action is to retry the same request without bypassing Madar. Terminal failures, incomplete graphs, and policy mismatches set `retryable` to `false` and suggest graph repair; inspect `madar status`, then run `madar generate . --update` when required.
 
 ## Common commands
 

--- a/src/infrastructure/background-auto-refresh.ts
+++ b/src/infrastructure/background-auto-refresh.ts
@@ -52,6 +52,12 @@ void (async () => {
       logger,
     },
   )
+  if (stopRequested) {
+    controller.stop()
+  }
+  if (controller.startupSettled) {
+    await controller.startupSettled
+  }
   parentPort.postMessage({ type: 'started', initialRebuilt: controller.initialRebuilt })
   if (stopRequested) {
     controller.stop()

--- a/src/infrastructure/refresh-lease.ts
+++ b/src/infrastructure/refresh-lease.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'node:crypto'
+import { closeSync, mkdirSync, openSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const REFRESH_LOCK_FILENAME = '.madar-refresh.lock'
+const REFRESH_RECOVERY_LOCK_FILENAME = '.madar-refresh.recovery.lock'
+const DEFAULT_RETRY_MIN_MS = 50
+const DEFAULT_RETRY_MAX_MS = 1_000
+const DEFAULT_SYNC_TIMEOUT_MS = 30_000
+const INCOMPLETE_LEASE_GRACE_MS = 5_000
+
+export type ReleaseRefreshLease = () => void
+
+interface RefreshLeaseOwner {
+  pid: number
+  leaseId: string
+  acquiredAt: string
+}
+
+export interface RefreshLeaseOptions {
+  /** Internal test seam. Production uses process.kill(pid, 0). */
+  isProcessAlive?: (pid: number) => boolean
+  /** Internal test seam for retry timing. */
+  retryMinMs?: number
+  /** Internal test seam for retry timing. */
+  retryMaxMs?: number
+  /** Stops an asynchronous lease wait when its watcher is shutting down. */
+  signal?: AbortSignal
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error
+      ? (error as { code?: unknown }).code
+      : null
+    // EPERM means the process exists but belongs to another user.
+    return code === 'EPERM'
+  }
+}
+
+function parseRefreshLease(contents: string): RefreshLeaseOwner | null {
+  const [pidValue, leaseId, acquiredAt] = contents.trim().split(/\s+/, 3)
+  const pid = Number(pidValue)
+  if (
+    !Number.isSafeInteger(pid)
+    || pid <= 0
+    || !leaseId
+    || !acquiredAt
+    || !Number.isFinite(Date.parse(acquiredAt))
+  ) {
+    return null
+  }
+  return { pid, leaseId, acquiredAt }
+}
+
+function createExclusiveLease(lockPath: string): ReleaseRefreshLease | null {
+  let descriptor: number
+  try {
+    descriptor = openSync(lockPath, 'wx')
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error
+      ? (error as { code?: unknown }).code
+      : null
+    if (code === 'EEXIST') {
+      return null
+    }
+    throw error
+  }
+
+  const leaseId = randomUUID()
+  try {
+    writeFileSync(descriptor, `${process.pid} ${leaseId} ${new Date().toISOString()}\n`, 'utf8')
+  } finally {
+    closeSync(descriptor)
+  }
+
+  return () => {
+    try {
+      const contents = readFileSync(lockPath, 'utf8')
+      if (parseRefreshLease(contents)?.leaseId === leaseId) {
+        rmSync(lockPath, { force: true })
+      }
+    } catch {
+      // The owner may have crashed or the lease may already have been recovered.
+    }
+  }
+}
+
+function lockIsOldEnoughToRecoverIncompleteMetadata(lockPath: string): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs >= INCOMPLETE_LEASE_GRACE_MS
+  } catch {
+    return false
+  }
+}
+
+function tryAcquireRecoveryGuard(outputDir: string): ReleaseRefreshLease | null {
+  const recoveryPath = join(outputDir, REFRESH_RECOVERY_LOCK_FILENAME)
+  const release = createExclusiveLease(recoveryPath)
+  if (release) {
+    return release
+  }
+
+  // A crashed contender must not leave dead-lease recovery disabled forever.
+  try {
+    const contents = readFileSync(recoveryPath, 'utf8')
+    const owner = parseRefreshLease(contents)
+    if (
+      (owner && !processIsAlive(owner.pid))
+      || (!owner && lockIsOldEnoughToRecoverIncompleteMetadata(recoveryPath))
+    ) {
+      if (readFileSync(recoveryPath, 'utf8') === contents) {
+        rmSync(recoveryPath, { force: true })
+      }
+    }
+  } catch {
+    // Another contender may have completed recovery between reads.
+  }
+  return null
+}
+
+function recoverUnavailableLease(
+  outputDir: string,
+  lockPath: string,
+  isProcessAlive: (pid: number) => boolean,
+): boolean {
+  const releaseRecoveryGuard = tryAcquireRecoveryGuard(outputDir)
+  if (!releaseRecoveryGuard) {
+    return false
+  }
+
+  try {
+    const observedContents = readFileSync(lockPath, 'utf8')
+    const owner = parseRefreshLease(observedContents)
+    if (owner ? isProcessAlive(owner.pid) : !lockIsOldEnoughToRecoverIncompleteMetadata(lockPath)) {
+      return false
+    }
+
+    // Recheck the lease identity after acquiring the recovery guard. This keeps
+    // two Madar contenders from deleting a newly published owner record.
+    if (readFileSync(lockPath, 'utf8') !== observedContents) {
+      return false
+    }
+    rmSync(lockPath, { force: true })
+    return true
+  } catch {
+    return false
+  } finally {
+    releaseRecoveryGuard()
+  }
+}
+
+export function tryAcquireRefreshLease(
+  outputDir: string,
+  options: RefreshLeaseOptions = {},
+): ReleaseRefreshLease | null {
+  mkdirSync(outputDir, { recursive: true })
+  const lockPath = join(outputDir, REFRESH_LOCK_FILENAME)
+  const isProcessAlive = options.isProcessAlive ?? processIsAlive
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const release = createExclusiveLease(lockPath)
+    if (release) {
+      return release
+    }
+    if (!recoverUnavailableLease(outputDir, lockPath, isProcessAlive)) {
+      return null
+    }
+  }
+  return null
+}
+
+function pauseSynchronously(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+}
+
+function nextBackoff(current: number, maximum: number): number {
+  return Math.min(maximum, Math.max(current + 1, current * 2))
+}
+
+export function acquireRefreshLease(
+  outputDir: string,
+  options: RefreshLeaseOptions & { timeoutMs?: number } = {},
+): ReleaseRefreshLease {
+  const startedAt = Date.now()
+  const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_SYNC_TIMEOUT_MS)
+  const retryMaxMs = Math.max(1, options.retryMaxMs ?? DEFAULT_RETRY_MAX_MS)
+  let retryMs = Math.min(retryMaxMs, Math.max(1, options.retryMinMs ?? DEFAULT_RETRY_MIN_MS))
+
+  while (true) {
+    const release = tryAcquireRefreshLease(outputDir, options)
+    if (release) {
+      return release
+    }
+
+    const remaining = timeoutMs - (Date.now() - startedAt)
+    if (remaining <= 0) {
+      throw new Error(`Timed out waiting for another Madar refresh in ${outputDir}`)
+    }
+    pauseSynchronously(Math.min(retryMs, remaining))
+    retryMs = nextBackoff(retryMs, retryMaxMs)
+  }
+}
+
+function waitForRetry(milliseconds: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) {
+    return Promise.resolve(false)
+  }
+  return new Promise<boolean>((resolvePromise) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolvePromise(true)
+    }, milliseconds)
+    const onAbort = () => {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', onAbort)
+      resolvePromise(false)
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Waits for the active refresh owner without imposing a terminal contention
+ * timeout. The caller's AbortSignal remains the bounded shutdown mechanism.
+ */
+export async function acquireRefreshLeaseWithoutBlocking(
+  outputDir: string,
+  options: RefreshLeaseOptions = {},
+): Promise<ReleaseRefreshLease | null> {
+  const retryMaxMs = Math.max(1, options.retryMaxMs ?? DEFAULT_RETRY_MAX_MS)
+  let retryMs = Math.min(retryMaxMs, Math.max(1, options.retryMinMs ?? DEFAULT_RETRY_MIN_MS))
+
+  while (!options.signal?.aborted) {
+    const release = tryAcquireRefreshLease(outputDir, options)
+    if (release) {
+      return release
+    }
+    if (!await waitForRetry(retryMs, options.signal)) {
+      return null
+    }
+    retryMs = nextBackoff(retryMs, retryMaxMs)
+  }
+  return null
+}

--- a/src/infrastructure/watch.ts
+++ b/src/infrastructure/watch.ts
@@ -1,5 +1,5 @@
-import { createHash, randomUUID } from 'node:crypto'
-import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, unlinkSync, watch as createFileSystemWatcher, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, unlinkSync, watch as createFileSystemWatcher, writeFileSync } from 'node:fs'
 import { extname, join, resolve, sep } from 'node:path'
 
 import type { IndexingStrictThresholds } from '../contracts/indexing.js'
@@ -26,6 +26,11 @@ import {
   readStoredGenerationPolicy,
 } from './generation-policy.js'
 import { createWatcherState, writeWatcherState } from './watcher-state.js'
+import {
+  acquireRefreshLease,
+  acquireRefreshLeaseWithoutBlocking,
+  tryAcquireRefreshLease,
+} from './refresh-lease.js'
 
 export const WATCHED_EXTENSIONS = new Set([
   ...CODE_EXTENSIONS,
@@ -45,10 +50,6 @@ const DEFAULT_EVENT_MAX_RECONCILIATION_INTERVAL_MS = 5 * 60_000
 const DEFAULT_POLL_RECONCILIATION_INTERVAL_MS = 1_000
 const DEFAULT_POLL_MAX_RECONCILIATION_INTERVAL_MS = 30_000
 const DEFAULT_RECONCILIATION_TIMEOUT_MS = 2 * 60_000
-const REFRESH_LOCK_RETRY_MS = 50
-const REFRESH_LOCK_TIMEOUT_MS = 30_000
-const REFRESH_LOCK_STALE_MS = 60 * 60 * 1000
-
 const WATCH_IGNORED_DIRECTORIES = new Set(['.git', 'out', 'node_modules', 'dist', 'build', 'target', 'venv', '.venv', 'env', '.env', '__pycache__'])
 // These files can change the discovered corpus or the extraction environment
 // even when no source file changes. Treat them as refresh triggers instead of
@@ -101,7 +102,7 @@ export interface WatchOptions extends RebuildCodeOptions {
   pollIntervalMs?: number
   maxPollIntervalMs?: number
   reconciliationTimeoutMs?: number
-  rebuildCode?: (watchPath: string, options?: RebuildCodeOptions) => boolean
+  rebuildCode?: (watchPath: string, options?: RebuildCodeOptions) => boolean | null | Promise<boolean | null>
   notifyOnly?: (watchPath: string, logger?: WatchLogger) => void
   onReconciliation?: (metrics: WatchReconciliationMetrics) => void
   /** Internal auto-refresh handshake: listener + snapshot are active before this rebuild starts. */
@@ -116,6 +117,8 @@ export interface GraphAutoRefreshController {
   startupComplete?(): boolean
   /** Returns a background startup/runtime failure that could not be read from watcher-state.json. */
   failureReason?(): string | null
+  /** Resolves after the initial reconciliation succeeds, fails, or is aborted. */
+  startupSettled?: Promise<void>
   /** Stops the watcher and releases its filesystem resources. */
   stop(): void
   /** Resolves once the watcher stops. */
@@ -241,103 +244,6 @@ function graphBelongsToWorkspace(graphPath: string, workspaceRoot: string): bool
       && sameFilesystemPath(parsed.root_path, workspaceRoot)
   } catch {
     return false
-  }
-}
-
-function pauseForRefreshLock(milliseconds: number): void {
-  // Rebuilds themselves are synchronous CPU/IO work. A short synchronous wait
-  // keeps the public `rebuildCode()` API synchronous while serializing two MCP
-  // servers that happen to attach to the same worktree.
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
-}
-
-function isRefreshLeaseOwnerAlive(lockPath: string): boolean {
-  try {
-    const [pidValue] = readFileSync(lockPath, 'utf8').trim().split(/\s+/, 1)
-    const pid = Number(pidValue)
-    if (!Number.isSafeInteger(pid) || pid <= 0) {
-      return false
-    }
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    const code = error && typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : null
-    // EPERM means the process exists but belongs to another user.
-    return code === 'EPERM'
-  }
-}
-
-function tryAcquireRefreshLease(outputDir: string): (() => void) | null {
-  mkdirSync(outputDir, { recursive: true })
-  const lockPath = join(outputDir, '.madar-refresh.lock')
-  try {
-    const descriptor = openSync(lockPath, 'wx')
-    const leaseId = randomUUID()
-    try {
-      writeFileSync(descriptor, `${process.pid} ${leaseId} ${new Date().toISOString()}\n`, 'utf8')
-    } finally {
-      closeSync(descriptor)
-    }
-    return () => {
-      try {
-        const contents = readFileSync(lockPath, 'utf8')
-        if (contents.split(/\s+/, 3)[1] === leaseId) {
-          rmSync(lockPath, { force: true })
-        }
-      } catch {
-        // The lease may have been recovered after a process crash.
-      }
-    }
-  } catch (error) {
-    const code = error && typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : null
-    if (code !== 'EEXIST') {
-      throw error
-    }
-  }
-
-  try {
-    if (Date.now() - statSync(lockPath).mtimeMs > REFRESH_LOCK_STALE_MS && !isRefreshLeaseOwnerAlive(lockPath)) {
-      rmSync(lockPath, { force: true })
-    }
-  } catch {
-    // Another process released the lease between the failed open and stat.
-  }
-  return null
-}
-
-function acquireRefreshLease(outputDir: string): () => void {
-  const startedAt = Date.now()
-
-  while (true) {
-    const releaseLease = tryAcquireRefreshLease(outputDir)
-    if (releaseLease) {
-      return releaseLease
-    }
-
-    const remaining = REFRESH_LOCK_TIMEOUT_MS - (Date.now() - startedAt)
-    if (remaining <= 0) {
-      throw new Error(`Timed out waiting for another Madar refresh in ${outputDir}`)
-    }
-    pauseForRefreshLock(Math.min(REFRESH_LOCK_RETRY_MS, remaining))
-  }
-}
-
-async function acquireRefreshLeaseWithoutBlocking(outputDir: string): Promise<() => void> {
-  const startedAt = Date.now()
-
-  while (true) {
-    const releaseLease = tryAcquireRefreshLease(outputDir)
-    if (releaseLease) {
-      return releaseLease
-    }
-
-    const remaining = REFRESH_LOCK_TIMEOUT_MS - (Date.now() - startedAt)
-    if (remaining <= 0) {
-      throw new Error(`Timed out waiting for another Madar refresh in ${outputDir}`)
-    }
-    await new Promise<void>((resolvePromise) => {
-      setTimeout(resolvePromise, Math.min(REFRESH_LOCK_RETRY_MS, remaining))
-    })
   }
 }
 
@@ -624,17 +530,29 @@ export function rebuildCode(watchPath: string, options: RebuildCodeOptions = {})
   }
 }
 
-async function rebuildCodeWithoutBlockingLease(watchPath: string, options: RebuildCodeOptions = {}): Promise<boolean> {
+function rebuildCodeWithRecoverableLease(
+  watchPath: string,
+  options: RebuildCodeOptions = {},
+  signal?: AbortSignal,
+): boolean | Promise<boolean | null> {
   const resolvedWatchPath = resolveWatchPath(watchPath)
   const output = defaultLogger(options.logger)
   const graphOutputDir = resolveMadarOutputDirectory(resolvedWatchPath)
-  try {
-    const releaseLease = await acquireRefreshLeaseWithoutBlocking(graphOutputDir)
-    return rebuildCodeUnderLease(resolvedWatchPath, options, releaseLease)
-  } catch (error) {
-    output.error(`[madar watch] Rebuild failed: ${error instanceof Error ? error.message : String(error)}`)
-    return false
+  const immediateLease = tryAcquireRefreshLease(graphOutputDir)
+  if (immediateLease) {
+    return rebuildCodeUnderLease(resolvedWatchPath, options, immediateLease)
   }
+
+  return acquireRefreshLeaseWithoutBlocking(graphOutputDir, {
+    ...(signal ? { signal } : {}),
+  })
+    .then((releaseLease) => releaseLease
+      ? rebuildCodeUnderLease(resolvedWatchPath, options, releaseLease)
+      : null)
+    .catch((error: unknown) => {
+      output.error(`[madar watch] Rebuild failed: ${error instanceof Error ? error.message : String(error)}`)
+      return false
+    })
 }
 
 /**
@@ -649,18 +567,36 @@ export function startGraphAutoRefresh(
 ): GraphAutoRefreshController {
   const controller = new AbortController()
   let initialRebuilt = false
+  let startupComplete = false
+  let resolveStartupSettled!: () => void
+  const startupSettled = new Promise<void>((resolvePromise) => {
+    resolveStartupSettled = resolvePromise
+  })
+  function settleStartup(): void {
+    if (startupComplete) {
+      return
+    }
+    startupComplete = true
+    resolveStartupSettled()
+  }
   const completed = watch(watchPath, debounceSeconds, {
     ...options,
     signal: controller.signal,
     rebuildOnStart: true,
     onInitialRebuild: (rebuilt) => {
       initialRebuilt = rebuilt
+      settleStartup()
       options.onInitialRebuild?.(rebuilt)
     },
   })
+  void completed.then(settleStartup, settleStartup)
 
   return {
-    initialRebuilt,
+    get initialRebuilt() {
+      return initialRebuilt
+    },
+    startupComplete: () => startupComplete,
+    startupSettled,
     stop: () => controller.abort(),
     completed,
   }
@@ -732,8 +668,9 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
   const outputDir = resolveMadarOutputDirectory(resolvedWatchPath)
   const output = defaultLogger(options.logger)
   const debounceMs = Math.max(0, Math.round(debounce * 1000))
-  const runInitialRebuild = options.rebuildCode ?? rebuildCode
-  const runWatchedRebuild = options.rebuildCode ?? rebuildCodeWithoutBlockingLease
+  const runInitialRebuild = options.rebuildCode
+    ?? ((target: string, rebuildOptions?: RebuildCodeOptions) => rebuildCodeWithRecoverableLease(target, rebuildOptions, options.signal))
+  const runWatchedRebuild = runInitialRebuild
   const runNotify = options.notifyOnly ?? notifyOnly
   const loopSignal = createWatchLoopSignal()
   const initialStoredPolicy = readStoredGenerationPolicy(
@@ -885,7 +822,16 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
     if (options.rebuildOnStart) {
       state.status = 'reconciling'
       persistState()
-      const rebuilt = runInitialRebuild(resolvedWatchPath, rebuildOptionsFromWatch(options, output))
+      const initialRebuild = runInitialRebuild(resolvedWatchPath, rebuildOptionsFromWatch(options, output))
+      const rebuilt = typeof initialRebuild === 'boolean' || initialRebuild === null
+        ? initialRebuild
+        : await initialRebuild
+      if (rebuilt === null) {
+        if (!options.signal?.aborted) {
+          throw new Error('Initial refresh lease wait ended without an abort signal.')
+        }
+        return
+      }
       options.onInitialRebuild?.(rebuilt)
       if (!rebuilt) {
         state.status = 'failed'
@@ -1007,7 +953,13 @@ export async function watch(watchPath: string, debounce = 3, options: WatchOptio
         output.log(`\n[madar watch] ${batch.length} file(s) changed`)
         state.status = 'reconciling'
         persistState()
-        const rebuilt = await runWatchedRebuild(resolvedWatchPath, rebuildOptionsFromWatch(options, output))
+        const watchedRebuild = runWatchedRebuild(resolvedWatchPath, rebuildOptionsFromWatch(options, output))
+        const rebuilt = typeof watchedRebuild === 'boolean' || watchedRebuild === null
+          ? watchedRebuild
+          : await watchedRebuild
+        if (rebuilt === null && options.signal?.aborted) {
+          break
+        }
         if (!rebuilt) {
           state.status = 'failed'
           state.failure_reason = 'Automatic graph rebuild failed; the graph must not be treated as fresh.'

--- a/src/runtime/stdio-server.ts
+++ b/src/runtime/stdio-server.ts
@@ -149,6 +149,7 @@ interface StdioResponse {
   error?: {
     code: number
     message: string
+    data?: Record<string, unknown>
   }
 }
 
@@ -192,7 +193,7 @@ function graphRootPath(graphPath: string): string | null {
 function autoRefreshGraphReadiness(
   controller: GraphAutoRefreshController,
   graphPath: string,
-): { ready: boolean; detail: string } {
+): { ready: boolean; detail: string; state: string; retryable: boolean; retryAfterMs?: number } {
   const startupComplete = controller.startupComplete?.() ?? true
   const backgroundFailure = controller.failureReason?.() ?? null
   const watcherState = readWatcherStateForGraph(graphPath)
@@ -209,16 +210,31 @@ function autoRefreshGraphReadiness(
     && watcherState.status === 'idle'
     && !watcherStateBlocksGraphReads(watcherState)
     && watcherMatchesPublishedPolicy
+  const state = watcherState?.status ?? (startupComplete ? 'unavailable' : 'starting')
+  const retryable = !ready
+    && backgroundFailure === null
+    && (
+      !startupComplete
+      || watcherState?.status === 'starting'
+      || watcherState?.status === 'pending'
+      || watcherState?.status === 'reconciling'
+    )
 
   if (watcherState) {
     return {
       ready,
+      state,
+      retryable,
+      ...(retryable ? { retryAfterMs: 1_000 } : {}),
       detail: `status=${watcherState.status}, coverage=${watcherState.coverage}, policy=${watcherState.policy_match === null ? 'unknown' : watcherState.policy_match ? 'match' : 'mismatch'}, published_policy=${watcherMatchesPublishedPolicy ? 'match' : 'mismatch'}${watcherState.failure_reason ? `, failure=${watcherState.failure_reason}` : ''}${backgroundFailure ? `, background_failure=${backgroundFailure}` : ''}`,
     }
   }
 
   return {
     ready,
+    state,
+    retryable,
+    ...(retryable ? { retryAfterMs: 1_000 } : {}),
     detail: backgroundFailure
       ? `background startup failed: ${backgroundFailure}`
       : startupComplete
@@ -231,11 +247,16 @@ function ok(id: string | number | null, result: unknown): StdioResponse {
   return { jsonrpc: '2.0', id, result }
 }
 
-function failure(id: string | number | null, code: number, message: string): StdioResponse {
+function failure(
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: Record<string, unknown>,
+): StdioResponse {
   return {
     jsonrpc: '2.0',
     id,
-    error: { code, message },
+    error: { code, message, ...(data ? { data } : {}) },
   }
 }
 
@@ -1037,10 +1058,22 @@ export async function serveGraphStdio(options: ServeGraphStdioOptions): Promise<
         } else if (refreshReadiness && !refreshReadiness.ready && requestMethod === 'resources/list') {
           response = ok(requestId(request), { resources: [] })
         } else if (refreshReadiness && !refreshReadiness.ready && requestMethod !== null && !AUTO_REFRESH_CONTROL_METHODS.has(requestMethod)) {
+          const readinessData = {
+            type: 'madar_graph_not_ready',
+            state: refreshReadiness.state,
+            retryable: refreshReadiness.retryable,
+            ...(refreshReadiness.retryAfterMs !== undefined
+              ? { retry_after_ms: refreshReadiness.retryAfterMs }
+              : {}),
+            suggested_action: refreshReadiness.retryable ? 'retry_same_request' : 'repair_graph',
+          }
           response = failure(
             requestId(request),
             JSONRPC_SERVER_ERROR,
-            `Madar auto-refresh cannot guarantee a fresh graph (${refreshReadiness.detail}). Wait for reconciliation or run \`madar generate . --update\` before retrying.`,
+            refreshReadiness.retryable
+              ? `Madar graph is temporarily ${refreshReadiness.state} (${refreshReadiness.detail}). Retry the same request after ${refreshReadiness.retryAfterMs ?? 1_000}ms; no manual graph generation is needed while reconciliation is active.`
+              : `Madar auto-refresh cannot guarantee a fresh graph (${refreshReadiness.detail}). Run \`madar status\`, then \`madar generate . --update\` if repair is required before retrying.`,
+            readinessData,
           )
         } else {
           emitResourceNotifications(output, options.graphPath, sessionState)

--- a/tests/unit/background-auto-refresh.test.ts
+++ b/tests/unit/background-auto-refresh.test.ts
@@ -54,6 +54,30 @@ export function startGraphAutoRefresh() {
 }
 `
 
+const DELAYED_IMPORT_WAITING_WATCH_MODULE = `
+await new Promise((resolve) => setTimeout(resolve, 250))
+
+export function startGraphAutoRefresh() {
+  let resolveStartup
+  const startupSettled = new Promise((resolve) => {
+    resolveStartup = resolve
+  })
+  let resolveCompleted
+  const completed = new Promise((resolve) => {
+    resolveCompleted = resolve
+  })
+  return {
+    initialRebuilt: false,
+    startupSettled,
+    stop() {
+      resolveStartup()
+      resolveCompleted()
+    },
+    completed,
+  }
+}
+`
+
 async function waitFor(condition: () => boolean, timeoutMs = 2_000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -82,6 +106,31 @@ function publishReadyWatcherState(root: string, graphPath: string): void {
 }
 
 describe('background auto-refresh', () => {
+  it('honors shutdown requested before the worker finishes importing its watcher', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-background-early-stop-'))
+    const watchModulePath = join(root, 'delayed-import-watch.mjs')
+    writeFileSync(watchModulePath, DELAYED_IMPORT_WAITING_WATCH_MODULE, 'utf8')
+
+    try {
+      const refresh = startGraphAutoRefreshInBackground(
+        root,
+        0.02,
+        { noHtml: true, logger: { log() {}, error() {} } },
+        { watchModuleUrl: pathToFileURL(watchModulePath) },
+      )
+      refresh.stop()
+
+      await Promise.race([
+        refresh.completed,
+        delay(2_000).then(() => {
+          throw new Error('Background auto-refresh did not stop during startup')
+        }),
+      ])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('returns immediately while a slow initial reconciliation runs in a worker', async () => {
     const root = mkdtempSync(join(tmpdir(), 'madar-background-refresh-'))
     const graphPath = join(root, 'out', 'graph.json')
@@ -172,7 +221,7 @@ describe('background auto-refresh', () => {
         .map((line) => JSON.parse(line) as {
           id?: number
           result?: Record<string, unknown>
-          error?: { message?: string }
+          error?: { message?: string; data?: Record<string, unknown> }
         })
 
       expect(responses.find((response) => response.id === 1)?.result).toMatchObject({
@@ -181,9 +230,15 @@ describe('background auto-refresh', () => {
       expect(responses.find((response) => response.id === 2)?.result).toMatchObject({ prompts: expect.any(Array) })
       expect(responses.find((response) => response.id === 3)?.result).toEqual({ resources: [] })
       expect(responses.find((response) => response.id === 4)?.result).toMatchObject({ tools: expect.any(Array) })
-      expect(responses.find((response) => response.id === 5)?.error?.message).toContain(
-        'auto-refresh cannot guarantee a fresh graph',
-      )
+      expect(responses.find((response) => response.id === 5)?.error).toMatchObject({
+        message: expect.stringContaining('temporarily starting'),
+        data: {
+          state: 'starting',
+          retryable: true,
+          retry_after_ms: 1_000,
+          suggested_action: 'retry_same_request',
+        },
+      })
 
       await waitFor(() => refreshController?.startupComplete?.() === true)
       expect(existsSync(completionMarker)).toBe(true)

--- a/tests/unit/refresh-lease.test.ts
+++ b/tests/unit/refresh-lease.test.ts
@@ -1,0 +1,132 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  acquireRefreshLeaseWithoutBlocking,
+  tryAcquireRefreshLease,
+} from '../../src/infrastructure/refresh-lease.js'
+
+function withTempDir(callback: (tempDir: string) => void): void {
+  const tempDir = mkdtempSync(join(tmpdir(), 'madar-refresh-lease-'))
+  try {
+    callback(tempDir)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+describe('refresh lease coordination', () => {
+  it('reclaims a young lease whose recorded owner is dead', () => {
+    withTempDir((tempDir) => {
+      const outputDir = join(tempDir, 'out')
+      const lockPath = join(outputDir, '.madar-refresh.lock')
+      mkdirSync(outputDir, { recursive: true })
+      writeFileSync(lockPath, `999999999 abandoned ${new Date().toISOString()}\n`, 'utf8')
+
+      const release = tryAcquireRefreshLease(outputDir, {
+        isProcessAlive: () => false,
+      })
+
+      expect(release).toBeTypeOf('function')
+      release?.()
+      expect(existsSync(lockPath)).toBe(false)
+    })
+  })
+
+  it('does not reclaim an old lease while its recorded PID is alive', () => {
+    withTempDir((tempDir) => {
+      const outputDir = join(tempDir, 'out')
+      const lockPath = join(outputDir, '.madar-refresh.lock')
+      mkdirSync(outputDir, { recursive: true })
+      const contents = `12345 active-owner ${new Date().toISOString()}\n`
+      writeFileSync(lockPath, contents, 'utf8')
+      const old = new Date(Date.now() - (2 * 60 * 60 * 1000))
+      utimesSync(lockPath, old, old)
+
+      expect(tryAcquireRefreshLease(outputDir, { isProcessAlive: () => true })).toBeNull()
+      expect(readFileSync(lockPath, 'utf8')).toBe(contents)
+    })
+  })
+
+  it('gives an in-progress owner time to finish writing lease metadata', () => {
+    withTempDir((tempDir) => {
+      const outputDir = join(tempDir, 'out')
+      const lockPath = join(outputDir, '.madar-refresh.lock')
+      mkdirSync(outputDir, { recursive: true })
+      writeFileSync(lockPath, '', 'utf8')
+
+      expect(tryAcquireRefreshLease(outputDir, { isProcessAlive: () => false })).toBeNull()
+      expect(existsSync(lockPath)).toBe(true)
+    })
+  })
+
+  it('recovers incomplete lease metadata after the write grace period', () => {
+    withTempDir((tempDir) => {
+      const outputDir = join(tempDir, 'out')
+      const lockPath = join(outputDir, '.madar-refresh.lock')
+      mkdirSync(outputDir, { recursive: true })
+      writeFileSync(lockPath, '', 'utf8')
+      const old = new Date(Date.now() - 10_000)
+      utimesSync(lockPath, old, old)
+
+      const release = tryAcquireRefreshLease(outputDir, { isProcessAlive: () => false })
+      expect(release).toBeTypeOf('function')
+      release?.()
+      expect(existsSync(lockPath)).toBe(false)
+    })
+  })
+
+  it('waits through live contention and acquires after the owner releases', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'madar-refresh-lease-'))
+    const outputDir = join(tempDir, 'out')
+    const ownerRelease = tryAcquireRefreshLease(outputDir)
+    expect(ownerRelease).toBeTypeOf('function')
+
+    let settled = false
+    const waiter = acquireRefreshLeaseWithoutBlocking(outputDir, {
+      retryMinMs: 5,
+      retryMaxMs: 20,
+    }).then((release) => {
+      settled = true
+      return release
+    })
+
+    try {
+      await delay(75)
+      expect(settled).toBe(false)
+      ownerRelease?.()
+
+      const waiterRelease = await waiter
+      expect(waiterRelease).toBeTypeOf('function')
+      waiterRelease?.()
+      expect(existsSync(join(outputDir, '.madar-refresh.lock'))).toBe(false)
+    } finally {
+      ownerRelease?.()
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('stops waiting promptly when the watcher is aborted', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'madar-refresh-lease-'))
+    const outputDir = join(tempDir, 'out')
+    const ownerRelease = tryAcquireRefreshLease(outputDir)
+    const controller = new AbortController()
+
+    try {
+      const waiter = acquireRefreshLeaseWithoutBlocking(outputDir, {
+        signal: controller.signal,
+        retryMinMs: 5,
+        retryMaxMs: 20,
+      })
+      controller.abort()
+      await expect(waiter).resolves.toBeNull()
+    } finally {
+      ownerRelease?.()
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/stdio-server.test.ts
+++ b/tests/unit/stdio-server.test.ts
@@ -2768,10 +2768,21 @@ describe('stdio runtime', () => {
         .trim()
         .split('\n')
         .filter(Boolean)
-        .map((line) => JSON.parse(line)) as Array<{ id?: number; result?: string; error?: { message?: string } }>
-      expect(responses.find((response) => response.id === 31)?.error?.message).toContain(
-        'auto-refresh cannot guarantee a fresh graph',
-      )
+        .map((line) => JSON.parse(line)) as Array<{
+          id?: number
+          result?: string
+          error?: { message?: string; data?: Record<string, unknown> }
+        }>
+      expect(responses.find((response) => response.id === 31)?.error).toMatchObject({
+        message: expect.stringContaining('temporarily pending'),
+        data: {
+          type: 'madar_graph_not_ready',
+          state: 'pending',
+          retryable: true,
+          retry_after_ms: 1_000,
+          suggested_action: 'retry_same_request',
+        },
+      })
       expect(responses.find((response) => response.id === 32)?.result).toContain('Nodes:')
     } finally {
       input.destroy()
@@ -2838,12 +2849,29 @@ describe('stdio runtime', () => {
         .trim()
         .split('\n')
         .filter(Boolean)
-        .map((line) => JSON.parse(line)) as Array<{ id?: number; result?: string; error?: { message?: string } }>
-      for (const id of [41, 42, 43, 44, 46]) {
+        .map((line) => JSON.parse(line)) as Array<{
+          id?: number
+          result?: string
+          error?: { message?: string; data?: Record<string, unknown> }
+        }>
+      for (const id of [41, 42, 44, 46]) {
         expect(responses.find((response) => response.id === id)?.error?.message).toContain(
           'auto-refresh cannot guarantee a fresh graph',
         )
+        expect(responses.find((response) => response.id === id)?.error?.data).toMatchObject({
+          retryable: false,
+          suggested_action: 'repair_graph',
+        })
       }
+      expect(responses.find((response) => response.id === 43)?.error).toMatchObject({
+        message: expect.stringContaining('temporarily reconciling'),
+        data: {
+          state: 'reconciling',
+          retryable: true,
+          retry_after_ms: 1_000,
+          suggested_action: 'retry_same_request',
+        },
+      })
       expect(responses.find((response) => response.id === 45)?.result).toContain('Nodes:')
     } finally {
       input.destroy()
@@ -2880,20 +2908,43 @@ describe('stdio runtime', () => {
       writeFileSync(join(root, 'main.ts'), 'export const value = 2\n', 'utf8')
       await waitFor(() => readWatcherStateForGraph(graphPath)?.status === 'reconciling')
 
+      input.write(`${JSON.stringify({ id: 52, method: 'stats' })}\n`)
       input.write(`${JSON.stringify({ id: 51, method: 'ping' })}\n`)
+      await waitFor(() => outputText.includes('"id":52'), 1_000)
       await waitFor(() => outputText.includes('"id":51'), 1_000)
       rmSync(lockPath, { force: true })
       await waitFor(() => readWatcherStateForGraph(graphPath)?.status === 'idle')
-      input.end()
+      input.end(`${JSON.stringify({ id: 53, method: 'stats' })}\n`)
       await serverPromise
 
-      const ping = outputText
+      const responses = outputText
         .trim()
         .split('\n')
         .filter(Boolean)
-        .map((line) => JSON.parse(line) as { id?: number; result?: unknown })
-        .find((response) => response.id === 51)
-      expect(ping?.result).toEqual({ ok: true })
+        .map((line) => JSON.parse(line) as {
+          id?: number
+          result?: unknown
+          error?: {
+            message?: string
+            data?: {
+              state?: string
+              retryable?: boolean
+              retry_after_ms?: number
+              suggested_action?: string
+            }
+          }
+        })
+      expect(responses.find((response) => response.id === 51)?.result).toEqual({ ok: true })
+      expect(responses.find((response) => response.id === 52)?.error).toMatchObject({
+        message: expect.stringContaining('temporarily reconciling'),
+        data: {
+          state: 'reconciling',
+          retryable: true,
+          retry_after_ms: 1_000,
+          suggested_action: 'retry_same_request',
+        },
+      })
+      expect(responses.find((response) => response.id === 53)?.result).toEqual(expect.any(String))
     } finally {
       rmSync(lockPath, { force: true })
       input.destroy()

--- a/tests/unit/watch.test.ts
+++ b/tests/unit/watch.test.ts
@@ -10,6 +10,7 @@ import { WATCHED_EXTENSIONS, hasNonCode, notifyOnly, rebuildCode, startGraphAuto
 import { generateGraph } from '../../src/infrastructure/generate.js'
 import { parseGenerationPolicy } from '../../src/contracts/generation-policy.js'
 import { readWatcherStateForGraph } from '../../src/infrastructure/watcher-state.js'
+import { tryAcquireRefreshLease } from '../../src/infrastructure/refresh-lease.js'
 import { resolveMadarWorkspace } from '../../src/shared/workspace.js'
 import { binaryIngestSidecarPath } from '../../src/shared/binary-ingest-sidecar.js'
 
@@ -164,15 +165,13 @@ describe('rebuildCode', () => {
     })
   })
 
-  test('recovers a stale refresh lease left by a dead process', () => {
+  test('recovers a young refresh lease left by a dead process', () => {
     withTempDir((tempDir) => {
       writeFileSync(join(tempDir, 'main.ts'), 'export const refreshed = true\n', 'utf8')
       const outputDir = join(tempDir, 'out')
       mkdirSync(outputDir, { recursive: true })
       const lockPath = join(outputDir, '.madar-refresh.lock')
-      writeFileSync(lockPath, '999999999 stale-lease 1970-01-01T00:00:00.000Z\n', 'utf8')
-      const staleAt = new Date(Date.now() - (2 * 60 * 60 * 1000))
-      utimesSync(lockPath, staleAt, staleAt)
+      writeFileSync(lockPath, `999999999 abandoned-lease ${new Date().toISOString()}\n`, 'utf8')
 
       expect(rebuildCode(tempDir, { noHtml: true })).toBe(true)
       expect(existsSync(lockPath)).toBe(false)
@@ -181,6 +180,36 @@ describe('rebuildCode', () => {
 })
 
 describe('watch', () => {
+  test('keeps startup unsettled during live lease contention and recovers after release', async () => {
+    await withTempDirAsync(async (tempDir) => {
+      writeFileSync(join(tempDir, 'main.ts'), 'export const value = 1\n', 'utf8')
+      const generated = generateGraph(tempDir, { noHtml: true })
+      const releaseOwner = tryAcquireRefreshLease(generated.outputDir)
+      expect(releaseOwner).toBeTypeOf('function')
+
+      const refresh = startGraphAutoRefresh(tempDir, 0.02, {
+        pollIntervalMs: 20,
+        noHtml: true,
+        logger: { log() {}, error() {} },
+      })
+      try {
+        expect(refresh.initialRebuilt).toBe(false)
+        expect(refresh.startupComplete?.()).toBe(false)
+        await waitFor(() => readWatcherStateForGraph(generated.graphPath)?.status === 'reconciling')
+
+        releaseOwner?.()
+        await refresh.startupSettled
+        expect(refresh.startupComplete?.()).toBe(true)
+        expect(refresh.initialRebuilt).toBe(true)
+        expect(readWatcherStateForGraph(generated.graphPath)?.status).toBe('idle')
+      } finally {
+        releaseOwner?.()
+        refresh.stop()
+        await refresh.completed
+      }
+    })
+  })
+
   test('keeps auto-refresh graph and watcher state outside a linked worktree', async () => {
     await withTempDirAsync(async (tempDir) => {
       const primary = join(tempDir, 'primary')


### PR DESCRIPTION
## Summary

- recover refresh leases immediately when their recorded owner is definitely dead
- keep live-owner contention non-terminal with bounded, abortable backoff
- return structured retryable MCP readiness errors so agents retry Madar instead of falling back to broad file reads
- preserve fail-closed behavior for genuine graph, coverage, and generation-policy failures
- document the transient-versus-terminal readiness contract

## Root cause

A contender stopped after 30 seconds, while a dead owner lease was only reclaimed after one hour. That mismatch could leave the watcher permanently failed for the rest of an MCP session even though the lease owner no longer existed.

## Verification

- 203 test files accounted for; 2,672 tests passed and 1 skipped across the serial aggregate plus isolated reruns
- focused lease/watcher/stdio/background suite passed
- `npm run typecheck`
- `npm run build`
- `npm run release:verify`
- `npm pack --dry-run --json` (398 files; new lease JS and declarations included)

The serial aggregate had four local Vitest fork-start timeouts with zero assertion failures. Each affected file passed in isolation; thread-compatible files also passed through the thread pool. The concurrency regression files passed in the main aggregate.

Closes #561