### PR TITLE
Release v0.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the TypeScript package will be documented in this file.
 
+## [0.31.3] - 2026-07-17
+
+### Fixed
+
+- **Automatic refresh no longer becomes permanently unavailable after refresh-lease contention**: leases whose recorded owner is definitely dead are reclaimed immediately, while a live owner is awaited with bounded, abortable backoff instead of turning a 30-second contention window into a terminal watcher failure. Shutdown requested during contended startup is honored promptly. Closes #561.
+- **Agents can distinguish temporary graph reconciliation from graph repair**: graph-backed MCP calls now return structured `madar_graph_not_ready` error data with `retryable`, `retry_after_ms`, and `suggested_action`. `starting`, `pending`, and `reconciling` ask the agent to retry the same Madar request; failed, incomplete, or policy-mismatched graphs remain fail-closed and ask for repair.
+
+### Notes
+
+- Restart or reconnect the agent's MCP session after upgrading so it launches the `0.31.3` runtime. No installer-profile migration or manual graph generation is required when the graph is only reconciling.
+
 ## [0.31.2] - 2026-07-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ After upgrading Madar, rerun your agent's install command so its managed profile
 
 Starting with `0.31.2`, Codex installs set `startup_timeout_sec = 180`. Madar makes the MCP transport available while the initial graph reconciliation runs in a background worker. Graph-backed calls resume only after startup completes, watcher health is non-blocking with complete coverage, and the idle watcher's policy matches the published graph and manifest; `idle` alone is not a readiness guarantee.
 
+Starting with `0.31.3`, a graph-backed call made while Madar is `starting`, `pending`, or `reconciling` returns a structured retryable response. The agent should retry the same Madar request after the suggested delay instead of bypassing Madar or running generation manually. A dead refresh owner is recovered automatically; only failed, incomplete, or policy-mismatched graph states ask for repair.
+
 ## What Changes for the Agent
 
 Without Madar, a coding agent often begins with broad filename searches, repeated reads, and guesses about which route, service, or handler owns the task.
@@ -187,7 +189,9 @@ Read the [benchmark suite and all dated receipts](https://github.com/mohanagy/ma
 
 ## Current Release
 
-Current version: `0.31.2`.
+Current version: `0.31.3`.
+
+`0.31.3` recovers refresh leases whose owner has exited, waits safely through live refresh contention, and gives agents a structured retry signal during temporary graph reconciliation instead of pushing them to bypass Madar.
 
 `0.31.2` keeps the Codex MCP connection responsive while its initial automatic graph refresh runs, adds an explicit 180-second Codex startup window, and keeps graph-backed answers unavailable until the refreshed graph is ready.
 
@@ -195,7 +199,7 @@ Current version: `0.31.2`.
 
 `0.31.0` made code graphs directed by default, separated evidence strength from answer readiness, added bounded context recovery, made indexing completeness explicit, preserved generation policy during automatic refresh, isolated linked-worktree artifacts, and removed benchmark expectations from production retrieval.
 
-Read the full notes in the [0.31.2 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0312---2026-07-16).
+Read the full notes in the [0.31.3 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0313---2026-07-17).
 
 ## Documentation
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.31.2",
+    "version": "0.31.3",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.31.2",
+            "version": "0.31.3",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lubab/madar",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lubab/madar",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "license": "MIT",
       "dependencies": {
         "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.31.2",
+    "version": "0.31.3",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Release

Prepare `@lubab/madar@0.31.3` after the refresh-lease recovery fix merged in #562.

## Changes

- bump `package.json` and `package-lock.json` to `0.31.3`
- add the `0.31.3` changelog entry for #561
- update the README current-release and transient-reconciliation guidance

## Verification

- `npm run release:verify`
- `npm run typecheck`
- `npm pack --dry-run --json`
- tarball reports `0.31.3`, 398 files, and includes the new lease runtime and declarations

After merge, the merge commit will be tagged `v0.31.3`, published as a GitHub release, and published to npm with the `latest` tag.