### PR TITLE
chore: prepare v0.31.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.31.4] - 2026-07-18
+
 ### Changed
 
 - **Cross-layer questions recover by query obligation instead of repeating the loudest vocabulary**: retrieval splits multi-stage flow questions into bounded obligations, reserves structurally connected anchors across distinct communities, and reports initial/final obligation coverage plus promoted communities in the retrieval plan. Explain packs can now treat a diverse cross-file set of direct workflow owners as supporting evidence instead of replacing stronger obligation anchors with weaker related candidates merely to satisfy a ranking label. Execution-owner questions such as “what runs the monthly close?” now receive behavior-slice retrieval, and exact file ownership remains available even when clustering separates a file node from its symbols. Addresses #565.
@@ -11,6 +13,8 @@ All notable changes to the TypeScript package will be documented in this file.
 ### Fixed
 
 - **A valid unchanged graph becomes usable without rebuilding at every MCP startup**: automatic refresh validates generation policy, graph freshness, indexing outcomes, the authoritative source snapshot, deletions, additions, ignored discovery paths, and control-file changes before reusing a graph. A graph-backed request waits through a bounded transient reconciliation window and completes as the same request once ready, while MCP initialization, discovery, and ping remain responsive. Changed, missing, incomplete, or policy-mismatched graphs still rebuild or fail closed. Addresses #564.
+- **Retrieval receipts now describe the snippets agents can actually inspect**: query-obligation totals and coverage are reconciled after recovery, compaction, serialization, context resolution, and delta filtering; historical coverage cannot exceed the visible total. This keeps answer-ready receipts truthful when the output surface trims evidence. Addresses #565.
+- **Claude and Codex installer lifecycle checks now fail closed around user-owned hook paths**: doctor, install, and uninstall distinguish managed hook scripts from directories, broken links, unreadable files, or custom replacements; workspace-scoped Codex MCP registrations continue to coexist and uninstall independently. Addresses #567.
 
 ## [0.31.3] - 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ Read the [benchmark suite and all dated receipts](https://github.com/mohanagy/ma
 
 Current version: `0.31.4`.
 
-`0.31.4` makes cross-layer context receipts match the snippets an agent can actually inspect after recovery and output compaction. It also makes Claude and Codex install, doctor, and uninstall flows safer around custom or invalid hook paths while preserving workspace-scoped Codex registrations.
+`0.31.4` keeps receipts tied to visible context and hardens Claude/Codex hook handling.
 
-`0.31.3` recovers refresh leases whose owner has exited, waits safely through live refresh contention, and gives agents a structured retry signal during temporary graph reconciliation instead of pushing them to bypass Madar.
+`0.31.3` recovers dead refresh owners, waits through live refresh contention, and returns a retry signal during temporary reconciliation instead of pushing agents to bypass Madar.
 
 `0.31.2` keeps the Codex MCP connection responsive while its initial automatic graph refresh runs, adds an explicit 180-second Codex startup window, and keeps graph-backed answers unavailable until the refreshed graph is ready.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Read the [benchmark suite and all dated receipts](https://github.com/mohanagy/ma
 
 ## Current Release
 
-Current version: `0.31.3`.
+Current version: `0.31.4`.
+
+`0.31.4` makes cross-layer context receipts match the snippets an agent can actually inspect after recovery and output compaction. It also makes Claude and Codex install, doctor, and uninstall flows safer around custom or invalid hook paths while preserving workspace-scoped Codex registrations.
 
 `0.31.3` recovers refresh leases whose owner has exited, waits safely through live refresh contention, and gives agents a structured retry signal during temporary graph reconciliation instead of pushing them to bypass Madar.
 
@@ -199,7 +201,7 @@ Current version: `0.31.3`.
 
 `0.31.0` made code graphs directed by default, separated evidence strength from answer readiness, added bounded context recovery, made indexing completeness explicit, preserved generation policy during automatic refresh, isolated linked-worktree artifacts, and removed benchmark expectations from production retrieval.
 
-Read the full notes in the [0.31.3 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0313---2026-07-17).
+Read the full notes in the [0.31.4 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0314---2026-07-18).
 
 ## Documentation
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.31.3",
+    "version": "0.31.4",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.31.3",
+            "version": "0.31.4",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lubab/madar",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lubab/madar",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "MIT",
       "dependencies": {
         "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.31.3",
+    "version": "0.31.4",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",
     "author": "mohanagy",


### PR DESCRIPTION
## Summary

- Bump `@lubab/madar` and MCP Registry metadata to 0.31.4.
- Document cross-layer receipt correctness and safer Claude/Codex lifecycle handling.
- Refresh README’s current-release link while preserving its marketing-copy guard.

## Validation

- `npm run release:verify`
- `npm run registry:validate`
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run`
- `npm sbom --sbom-format cyclonedx`
- `npx vitest run tests/unit/why-madar-doc.test.ts` (91 passed)

## Notes

The local full Vitest suite did not produce a conclusive summary; current-head CI is the release gate.

Refs #564
Refs #565
Refs #567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability by reusing valid, unchanged state and safely failing when state is invalid.
  - Made retrieval receipts match exactly what agents can inspect after recovery or compaction.
  - Hardened installer and diagnostics around user hook paths, failing safely for missing, broken, or unreadable paths.
  - Preserved workspace-scoped registrations during installation lifecycle checks.
- **Documentation**
  - Updated the current release to **0.31.4**, including changelog and registry metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->