### PR TITLE
chore(release): 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the TypeScript package will be documented in this file.
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-07-19
+
+### Added
+
+- **Capability-aware auto extraction is now the default**: `madar generate .` and programmatic generation combine SPI node and framework metadata with proven legacy relationship semantics for JavaScript/TypeScript, while using legacy fallback for SPI-unsupported languages. `--legacy` remains legacy-only and `--spi` remains strict SPI code extraction without legacy semantic augmentation or unsupported-language fallback. Addresses #570.
+- **Official MCP Registry publication is part of the release path**: the package now declares its canonical `mcpName`, ships an official Registry manifest for the local stdio server, and provides an OIDC-protected workflow that verifies the public npm package before publishing and checking the Registry entry.
+
 ## [0.31.4] - 2026-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Read the [benchmark suite and all dated receipts](https://github.com/mohanagy/ma
 
 Current version: `0.32.0`.
 
-`0.32.0` makes `madar generate .` capability-aware by default: SPI metadata and legacy relationship semantics work together for JavaScript/TypeScript, with legacy fallback for other supported languages. It also adds the official MCP Registry publication path for Madar's local stdio server.
+`0.32.0` makes `madar generate .` capability-aware by default: SPI metadata and legacy relationship semantics work together for JavaScript/TypeScript, with legacy fallback elsewhere. It adds an MCP Registry publishing path.
 
 `0.31.4` keeps receipts tied to visible context and hardens Claude/Codex hook handling.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ Read the [benchmark suite and all dated receipts](https://github.com/mohanagy/ma
 
 ## Current Release
 
-Current version: `0.31.4`.
+Current version: `0.32.0`.
+
+`0.32.0` makes `madar generate .` capability-aware by default: SPI metadata and legacy relationship semantics work together for JavaScript/TypeScript, with legacy fallback for other supported languages. It also adds the official MCP Registry publication path for Madar's local stdio server.
 
 `0.31.4` keeps receipts tied to visible context and hardens Claude/Codex hook handling.
 
@@ -203,7 +205,7 @@ Current version: `0.31.4`.
 
 `0.31.0` made code graphs directed by default, separated evidence strength from answer readiness, added bounded context recovery, made indexing completeness explicit, preserved generation policy during automatic refresh, isolated linked-worktree artifacts, and removed benchmark expectations from production retrieval.
 
-Read the full notes in the [0.31.4 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0314---2026-07-18).
+Read the full notes in the [0.32.0 changelog](https://github.com/mohanagy/madar/blob/main/CHANGELOG.md#0320---2026-07-19).
 
 ## Documentation
 

--- a/docs/mcp-registry/server.json
+++ b/docs/mcp-registry/server.json
@@ -9,13 +9,13 @@
         "source": "github",
         "url": "https://github.com/mohanagy/madar"
     },
-    "version": "0.31.4",
+    "version": "0.32.0",
     "packages": [
         {
             "registryType": "npm",
             "registryBaseUrl": "https://registry.npmjs.org",
             "identifier": "@lubab/madar",
-            "version": "0.31.4",
+            "version": "0.32.0",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lubab/madar",
-  "version": "0.31.4",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lubab/madar",
-      "version": "0.31.4",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/tree-sitter-wasm": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lubab/madar",
-    "version": "0.31.4",
+    "version": "0.32.0",
     "mcpName": "io.github.mohanagy/madar",
     "description": "Stop AI coding agents from rediscovering large TypeScript/Node repos. Madar compiles task-aware local context packs from what runs for this task.",
     "license": "MIT",


### PR DESCRIPTION
## Summary

- prepare the 0.32.0 release for capability-aware automatic extraction
- publish the official MCP Registry metadata path with matching package and manifest versions
- update the changelog and current-release README guidance

## Validation

- `npm run release:verify`
- `npm run registry:validate`
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run`
- `node dist/src/cli/bin.js --version`
- `npm sbom --sbom-format cyclonedx`

`npm run test:run` started locally but stalled in a Vitest worker and exited without a result; the required GitHub CI suite is the merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capability-aware extraction is now the default for `madar generate .` and programmatic generation.
  * Added `--legacy` for legacy-only extraction and `--spi` for strict SPI-only extraction.
  * Added an official MCP Registry publication step for the local stdio server, including an OIDC-protected publish flow.

* **Documentation**
  * Updated release notes and the “full notes” link for version `0.32.0`.
  * Refreshed registry and package metadata to reflect the new release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->