### PR TITLE
docs: close directed multigraph phase

### DIFF
--- a/docs/core-reset/removal-manifest.yml
+++ b/docs/core-reset/removal-manifest.yml
@@ -24,10 +24,12 @@ review:
   amendment: Source lists were completed and de-overlapped so every current production TypeScript file has exactly one existing disposition; no keep, rebuild, move, delete, or defer decision changed.
 
 current:
-  updated_at: 2026-07-20
-  completed_phase: scope-and-baseline
-  active_phase: directed-multigraph
+  updated_at: 2026-07-21
+  completed_phase: directed-multigraph
+  active_phase: null
+  ready_phase: canonical-typescript-index
   base_commit: 647c2912e9ff000b5d92cae3fc61395d9e556062
+  completed_phase_commit: 63c59049178e82bd6bd1c928f6666ef159365bbe
   production_typescript_files: 178
   production_typescript_loc: 93792
   production_loc_added: 1197
@@ -78,7 +80,7 @@ items:
 
   - id: directed-multigraph
     disposition: rebuild
-    status: in_progress
+    status: complete
     sources:
       - src/adapters/filesystem/graph-artifact.ts
       - src/application/build-graph.ts
@@ -95,17 +97,30 @@ items:
       - src/core/schema/normalize.ts
       - src/runtime/direction.ts
     destination: src/domain/graph/**
-    notes: The obsolete exporter helpers moved from the later non-core-products bucket to this phase because #582 deletes the entire legacy exporter surface; no later phase retains ownership of those files.
+    notes: 'The obsolete exporter helpers moved from the later non-core-products bucket to this phase because #582 deletes the entire legacy exporter surface; no later phase retains ownership of those files.'
     production_loc_budget:
       added_max: 1200
       removed_min: 2852
       net_max: -1500
+    completion:
+      issue: https://github.com/mohanagy/madar/issues/582
+      pull_request: https://github.com/mohanagy/madar/pull/583
+      commit: 63c59049178e82bd6bd1c928f6666ef159365bbe
+      production_typescript_files: 178
+      production_typescript_loc: 93792
+      production_loc_added: 1197
+      production_loc_removed: 4171
+      production_loc_net: -2974
+      dependencies_added: 0
+      ci_matrix_jobs_passed: 6
+      coderabbit: passed
+      unresolved_review_threads: 0
     remove_when: Schema-v2 invariant, serialization, migration-error, and deterministic-ID tests pass.
     exit_gate: Parallel relationship kinds and direction survive build, store, and load.
 
   - id: canonical-typescript-index
     disposition: rebuild
-    status: proposed
+    status: planned
     sources:
       - src/pipeline/spi/**
       - src/contracts/extraction.ts
@@ -115,6 +130,7 @@ items:
     preserve:
       - Generic TypeScript semantic-resolution algorithms
       - Framework detectors that satisfy the canonical adapter contract
+    notes: Ready after Directed multigraph passed. Implementation requires an accepted work item; legacy extraction and non-code/other-language ingestion remain blocked until this fixture gate passes.
     remove_when: Labelled language and framework fixtures pass without legacy augmentation.
     exit_gate: One canonical index schema writes the graph directly.
 

--- a/docs/core-reset/scorecard.md
+++ b/docs/core-reset/scorecard.md
@@ -2,7 +2,7 @@
 
 > **RFC:** [#577](https://github.com/mohanagy/madar/issues/577)
 > **Milestone:** [`v0.40.0 — Core Reset`](https://github.com/mohanagy/madar/milestone/7)
-> **Status:** accepted; Scope/Baseline passed; Directed multigraph is in verification; Canonical TypeScript index remains blocked
+> **Status:** accepted; Scope/Baseline and Directed multigraph passed; Canonical TypeScript index is Ready but not In progress
 
 This is the phase-gate evidence ledger. An issue or PR link is not evidence by itself; each gate needs a reproducible test, receipt, measurement, or external-user record.
 
@@ -31,8 +31,8 @@ The schema-validated, share-safe receipt was recorded at tooling checkout `250a6
 | Phase | Status | Exit gate | Evidence |
 | --- | --- | --- | --- |
 | Scope and baseline | **Passed** | Baseline script/receipt committed; held-out evaluation contract frozen; removal manifest reviewed | [#580](https://github.com/mohanagy/madar/issues/580), [receipt](evidence/baseline-v0.32.0.json), and [manifest](removal-manifest.yml) |
-| Directed multigraph | **In progress — verification** | Parallel types, direction, stable IDs, provenance, and serialization pass | [#582](https://github.com/mohanagy/madar/issues/582), branch invariant tests, and the phase evidence below; CI and review remain pending |
-| Canonical TypeScript index | **Blocked** | Labelled TS/framework gates pass without legacy augmentation | Becomes ready only after the Directed multigraph PR merges with all required checks and review threads resolved |
+| Directed multigraph | **Passed** | Parallel types, direction, stable IDs, provenance, and serialization pass | [#582](https://github.com/mohanagy/madar/issues/582), merged [PR #583](https://github.com/mohanagy/madar/pull/583), invariant tests, six green CI jobs, successful CodeRabbit review, and zero unresolved threads |
+| Canonical TypeScript index | **Ready — not In progress** | Labelled TS/framework gates pass without legacy augmentation | Work item contract and owner acceptance required before implementation starts |
 | Incremental index | Not started | Add/change/delete/rename output equals clean rebuild | Pending |
 | Evidence-path query | Not started | Held-out correctness and one-call completeness gates pass without repo-specific logic | Pending |
 | Delivery and package | Not started | Thin MCP/CLI, activation, startup, and package budgets pass | Pending |
@@ -42,14 +42,14 @@ The schema-validated, share-safe receipt was recorded at tooling checkout `250a6
 
 Only one technical phase may be `In progress` at a time.
 
-### Directed multigraph phase evidence (pre-merge)
+### Directed multigraph phase evidence (passed)
 
 - One always-directed `KnowledgeGraph` implementation now lives under `src/domain/graph/**`; there is no V1/V2 alias, mode, fallback loader, or second graph store.
 - The five owned predecessor files are deleted. Obsolete HTML, SVG, GraphML, Cypher, and Obsidian exporter code was not recreated.
-- Current working-branch production inventory: 178 TypeScript files / 93,792 LOC.
-- Working-branch delta from protected base `647c2912e9ff000b5d92cae3fc61395d9e556062`: `+1,197 / -4,171 / net -2,974`; five new production files; zero dependency changes.
-- Deterministic multigraph, build-adapter, serialization, schema rejection, provenance, collision, traversal, and consumer regressions are present as tests on the working branch. The baseline receipt remains unchanged.
-- Local pre-review gates ran on 2026-07-20. The phase does not pass until the final branch rerun, required CI, and review threads are all green.
+- Final protected-branch production inventory: 178 TypeScript files / 93,792 LOC.
+- Final delta from protected phase base `647c2912e9ff000b5d92cae3fc61395d9e556062`: `+1,197 / -4,171 / net -2,974`; five new production files; zero dependency changes.
+- Deterministic multigraph, build-adapter, serialization, schema rejection, provenance, collision, traversal, and consumer regressions are committed as tests. The baseline receipt remains unchanged.
+- PR #583 was squash-merged at `63c59049178e82bd6bd1c928f6666ef159365bbe` after all six CI matrix jobs passed, CodeRabbit completed successfully, and every review thread was resolved.
 
 ## Graph gates
 
@@ -57,7 +57,7 @@ Only one technical phase may be `In progress` at a time.
 - [x] Directed callers/callees and import/export relationships traverse correctly.
 - [x] Node and edge IDs are deterministic across unchanged rebuilds.
 - [x] Evidence locations and provenance survive serialization.
-- [ ] Deleted and renamed files leave no stale nodes or edges.
+- [ ] Deleted and renamed files leave no stale nodes or edges. (Deferred to the accepted incremental-equivalence phase.)
 
 ## Index gates
 
@@ -91,7 +91,7 @@ Labelled fixtures cover ESM, CJS, barrel exports, aliases, TypeScript paths, pro
 - [ ] `madar --version` is <100 ms and <80 MB RSS.
 - [ ] MCP handshake and tool listing is <1 second cold.
 - [ ] Warm retrieval p95 is <500 ms on an approximately 15,000-node graph.
-- [ ] All CI checks and review threads are green/resolved.
+- [x] All required CI checks and review threads are green/resolved at the current completed phase head.
 
 ## Business gates
 
@@ -148,3 +148,4 @@ Copy this into a comment on [#577](https://github.com/mohanagy/madar/issues/577)
 | 2026-07-19 | RFC accepted; scope-and-baseline phase authorized | Green governance PR and completed acceptance checklist | #577 and #579 |
 | 2026-07-19 | Scope/Baseline passed; Directed multigraph became ready | Schema-validated clean-checkout receipt, frozen comparator contract, and complete removal-manifest review | #580 |
 | 2026-07-20 | Obsolete exporter-helper deletion moved into the active Directed multigraph phase; successor phase remains blocked pending merge | Removal manifest and executable governance checks | #582 |
+| 2026-07-21 | Directed multigraph passed; Canonical TypeScript index became ready | Merged PR #583, final source delta, six green CI jobs, successful CodeRabbit review, and zero unresolved threads | #582 and #583 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,9 +11,9 @@ Madar is executing an accepted Core Reset. The roadmap is outcome-driven: work a
 - [Removal manifest](core-reset/removal-manifest.yml) — keep, rebuild, move, delete, and defer decisions
 - [Scorecard](core-reset/scorecard.md) — technical and business evidence gates
 
-The RFC is **accepted**. Scope and baseline has passed with a [committed evidence receipt](core-reset/evidence/baseline-v0.32.0.json). Directed multigraph is the only **In progress** phase and is still under merge verification. Canonical TypeScript/JavaScript index and every later replacement phase remain blocked until that PR merges with green checks and resolved review threads.
+The RFC is **accepted**. Scope and baseline has passed with a [committed evidence receipt](core-reset/evidence/baseline-v0.32.0.json), and Directed multigraph passed through [#582](https://github.com/mohanagy/madar/issues/582) and [PR #583](https://github.com/mohanagy/madar/pull/583). No technical phase is currently in progress. Canonical TypeScript/JavaScript index is the only **Ready** phase; every later replacement phase remains blocked.
 
-## In progress — directed multigraph
+## Passed — directed multigraph
 
 The `directed-multigraph` removal-manifest entry delivered:
 
@@ -22,21 +22,22 @@ The `directed-multigraph` removal-manifest entry delivered:
 3. Replace the owned graph path under the accepted destination rather than creating a permanent V1/V2 split.
 4. Delete the predecessor graph path when the phase gate passes, with net-negative production LOC.
 
-The five predecessor files and obsolete exporter surfaces are absent on the working branch. Current measurements are 178 production TypeScript files / 93,792 LOC with a `+1,197 / -4,171 / net -2,974` source delta and no dependency additions. Final CI and review gates are still open; the frozen baseline receipt remains unchanged.
+The five predecessor files and obsolete exporter surfaces are absent. PR #583 was squash-merged into the protected `core-reset` branch at `63c59049178e82bd6bd1c928f6666ef159365bbe`. Final measurements are 178 production TypeScript files / 93,792 LOC with a `+1,197 / -4,171 / net -2,974` source delta, five new production files, and no dependency additions. All six CI matrix jobs passed, CodeRabbit completed successfully, every review thread was resolved, and the frozen baseline receipt remains unchanged.
 
-## Blocked — canonical TypeScript/JavaScript index
+## Ready — canonical TypeScript/JavaScript index
 
-After the Directed multigraph PR merges, the next authorized work item is limited to the `canonical-typescript-index` removal-manifest entry. It must write canonical graph facts directly, satisfy the labelled language/framework fixtures, and make legacy augmentation removable. Until then, canonical indexing, incremental refresh, retrieval replacement, and delivery remain blocked.
+The next authorized work item is limited to the `canonical-typescript-index` removal-manifest entry. It must write canonical graph facts directly, satisfy the labelled language/framework fixtures, and make legacy augmentation removable. It remains Ready—not In progress—until its exact deletion contract is accepted and recorded. Legacy extraction and non-code/other-language ingestion become eligible for deletion only after this fixture gate passes; incremental refresh, retrieval replacement, and delivery remain blocked.
 
 ## Next — dependency-ordered replacement
 
-Only one technical phase may be active at a time. After Directed multigraph merges and passes, the remaining order is:
+Only one technical phase may be active at a time. After the Canonical TypeScript/JavaScript index passes, the remaining order is:
 
-1. Full-rebuild-equivalent incremental refresh.
-2. Generic evidence-path retrieval and deletion of the context/governance stack.
-3. Thin MCP, CLI, Claude Code, and Codex delivery.
-4. Move evaluation tooling outside runtime and reduce the npm package.
-5. Publish a beta under npm tag `next` for external validation.
+1. Delete legacy extraction and non-code/other-language ingestion after their blocker clears.
+2. Full-rebuild-equivalent incremental refresh.
+3. Generic evidence-path retrieval and deletion of the context/governance stack.
+4. Thin MCP, CLI, Claude Code, and Codex delivery.
+5. Move evaluation tooling outside runtime and reduce the npm package.
+6. Publish a beta under npm tag `next` for external validation.
 
 Every replacement issue has an exact deletion contract. New and old implementations may coexist only temporarily on the reset integration branch; the old path cannot survive the phase.
 

--- a/tests/unit/core-reset-governance.test.ts
+++ b/tests/unit/core-reset-governance.test.ts
@@ -82,16 +82,37 @@ describe('core reset governance', () => {
       status: string
       rules: string[]
       current: {
+        updated_at: string
         completed_phase: string
         active_phase: null
         ready_phase: string
+        base_commit: string
         completed_phase_commit: string
+        production_typescript_files: number
+        production_typescript_loc: number
+        production_loc_added: number
+        production_loc_removed: number
+        production_loc_net: number
       }
       items: Array<{
         id: string
         disposition: string
         status: string
         notes?: string
+        completion?: {
+          issue: string
+          pull_request: string
+          commit: string
+          production_typescript_files: number
+          production_typescript_loc: number
+          production_loc_added: number
+          production_loc_removed: number
+          production_loc_net: number
+          dependencies_added: number
+          ci_matrix_jobs_passed: number
+          coderabbit: string
+          unresolved_review_threads: number
+        }
         sources?: string[]
         removed_sources?: string[]
         exit_gate: string
@@ -102,10 +123,17 @@ describe('core reset governance', () => {
     expect(manifest.schema_version).toBe(1)
     expect(manifest.status).toBe('accepted')
     expect(manifest.current).toMatchObject({
+      updated_at: '2026-07-21',
       completed_phase: 'directed-multigraph',
       active_phase: null,
       ready_phase: 'canonical-typescript-index',
+      base_commit: '647c2912e9ff000b5d92cae3fc61395d9e556062',
       completed_phase_commit: '63c59049178e82bd6bd1c928f6666ef159365bbe',
+      production_typescript_files: 178,
+      production_typescript_loc: 93_792,
+      production_loc_added: 1_197,
+      production_loc_removed: 4_171,
+      production_loc_net: -2_974,
     })
     expect(manifest.rules.length).toBeGreaterThan(0)
     expect(manifest.items.length).toBeGreaterThan(10)
@@ -128,9 +156,27 @@ describe('core reset governance', () => {
         expect(item.remove_when?.trim().length).toBeGreaterThan(0)
       }
     }
-    expect(manifest.items.find((item) => item.id === 'directed-multigraph')?.status).toBe('complete')
-    expect(manifest.items.find((item) => item.id === 'directed-multigraph')?.notes).toContain('#582')
-    expect(manifest.items.find((item) => item.id === 'canonical-typescript-index')?.status).toBe('planned')
+    const directed = manifest.items.find((item) => item.id === 'directed-multigraph')
+    expect(directed?.status).toBe('complete')
+    expect(directed?.notes).toContain('#582')
+    expect(directed?.completion).toEqual({
+      issue: 'https://github.com/mohanagy/madar/issues/582',
+      pull_request: 'https://github.com/mohanagy/madar/pull/583',
+      commit: '63c59049178e82bd6bd1c928f6666ef159365bbe',
+      production_typescript_files: 178,
+      production_typescript_loc: 93_792,
+      production_loc_added: 1_197,
+      production_loc_removed: 4_171,
+      production_loc_net: -2_974,
+      dependencies_added: 0,
+      ci_matrix_jobs_passed: 6,
+      coderabbit: 'passed',
+      unresolved_review_threads: 0,
+    })
+    const canonical = manifest.items.find((item) => item.id === 'canonical-typescript-index')
+    expect(canonical?.status).toBe('planned')
+    expect(canonical?.notes).toContain('Implementation requires an accepted work item')
+    expect(canonical?.notes).toContain('remain blocked until this fixture gate passes')
     expect(manifest.items.filter((item) => item.status === 'in_progress')).toEqual([])
   })
 

--- a/tests/unit/core-reset-governance.test.ts
+++ b/tests/unit/core-reset-governance.test.ts
@@ -52,8 +52,8 @@ describe('core reset governance', () => {
     expect(roadmap).toContain('projects/8')
     expect(roadmap).toContain('removal-manifest.yml')
     expect(roadmap).toContain('scorecard.md')
-    expect(roadmap).toContain('## In progress')
-    expect(roadmap).toContain('## Blocked')
+    expect(roadmap).toContain('## Passed — directed multigraph')
+    expect(roadmap).toContain('## Ready — canonical TypeScript/JavaScript index')
     expect(roadmap).toContain('## Next')
     expect(roadmap).toContain('## Later')
     expect(roadmap).toContain('accepted Core Reset')
@@ -66,6 +66,9 @@ describe('core reset governance', () => {
     expect(design).toContain('not a permanent V1/V2 split')
     expect(design).toContain('Merging code alone is not completion')
     expect(scorecard).toContain('**Status:** accepted')
+    expect(scorecard).toContain('| Directed multigraph | **Passed**')
+    expect(scorecard).toContain('| Canonical TypeScript index | **Ready — not In progress**')
+    expect(scorecard).not.toContain('CI and review remain pending')
     expect(readme).toContain('docs/roadmap.md')
     expect(contributing).toContain('docs/roadmap.md')
   })
@@ -78,10 +81,17 @@ describe('core reset governance', () => {
       schema_version: number
       status: string
       rules: string[]
+      current: {
+        completed_phase: string
+        active_phase: null
+        ready_phase: string
+        completed_phase_commit: string
+      }
       items: Array<{
         id: string
         disposition: string
         status: string
+        notes?: string
         sources?: string[]
         removed_sources?: string[]
         exit_gate: string
@@ -91,6 +101,12 @@ describe('core reset governance', () => {
 
     expect(manifest.schema_version).toBe(1)
     expect(manifest.status).toBe('accepted')
+    expect(manifest.current).toMatchObject({
+      completed_phase: 'directed-multigraph',
+      active_phase: null,
+      ready_phase: 'canonical-typescript-index',
+      completed_phase_commit: '63c59049178e82bd6bd1c928f6666ef159365bbe',
+    })
     expect(manifest.rules.length).toBeGreaterThan(0)
     expect(manifest.items.length).toBeGreaterThan(10)
 
@@ -112,6 +128,10 @@ describe('core reset governance', () => {
         expect(item.remove_when?.trim().length).toBeGreaterThan(0)
       }
     }
+    expect(manifest.items.find((item) => item.id === 'directed-multigraph')?.status).toBe('complete')
+    expect(manifest.items.find((item) => item.id === 'directed-multigraph')?.notes).toContain('#582')
+    expect(manifest.items.find((item) => item.id === 'canonical-typescript-index')?.status).toBe('planned')
+    expect(manifest.items.filter((item) => item.status === 'in_progress')).toEqual([])
   })
 
   it('measures logical LOC independently from checkout line endings', () => {


### PR DESCRIPTION
## Summary

Closes the Directed multigraph phase in the versioned Core Reset governance after #582 was completed by #583, records its final evidence, and makes `canonical-typescript-index` the only Ready phase.

- Records merge `63c59049178e82bd6bd1c928f6666ef159365bbe`, final source metrics, six green CI lanes, successful CodeRabbit review, and zero unresolved threads.
- Marks `directed-multigraph` complete, leaves no active phase, and marks `canonical-typescript-index` planned/Ready.
- Keeps legacy deletion follow-ups, incremental refresh, retrieval, and delivery blocked.
- Adds executable assertions for the stable completion receipt and fixes the pre-existing YAML truncation caused by an unquoted `#582` note.

## Testing

- [x] `npm run test:run -- --maxWorkers=1` — 205 files passed; 2,820 tests passed; 2 skipped
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm pack --dry-run` — not applicable; package/install behavior is unchanged
- [x] `npm run release:verify`
- [x] `npm run registry:validate`
- [x] `npm run verify:pack-parity`
- [x] `node tools/eval/core-reset/verify-isolation.mjs`
- [x] `npm run test:run -- --maxWorkers=1 tests/unit/core-reset-governance.test.ts` — 7 passed after review follow-up
- [x] `git diff --check`

## Core Reset contract

- RFC requirement: Record a phase as complete only after its deletion and evidence gates pass; authorize only the immediate dependency successor.
- Parent issue: #582
- Removal-manifest IDs: `directed-multigraph` (complete), `canonical-typescript-index` (planned/Ready only)
- Exit gate: Versioned governance exactly records the passed graph receipt and no later implementation is active.
- Production LOC added: 0
- Production LOC removed: 0
- Net production LOC: 0
- Superseded paths deleted: None in this governance-only PR; #583 already deleted the directed-multigraph predecessor paths and obsolete exporter surfaces recorded here.

### Reset scope checks

- [x] This PR is governed by accepted RFC #577
- [x] This is the required phase-boundary evidence reconciliation; it adds no production path
- [x] No permanent fallback or parallel implementation was added
- [x] No evaluation-repository-specific production logic was added under `src/`
- [x] Production does not import development-only evaluation tooling
- [x] The removal manifest and scorecard were updated

## Checklist

- [x] I updated docs for the phase-state change
- [x] I updated tests for the governance contract
- [x] This PR does not include private corpora, secrets, credentials, proprietary prompts, sensitive raw logs, or accidental generated artifacts
- [x] I kept this PR focused on one phase-boundary reconciliation

## Related issues

- Governing RFC: #577
- Completed phase: #582
- Completion implementation: #583
- Successor work item will be created only after this PR merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the core reset roadmap and scorecard to show the Directed multigraph phase as passed.
  * Marked the Canonical TypeScript/JavaScript index as ready to begin.
  * Added completion evidence, sequencing details, and updated phase status information.

* **Tests**
  * Updated governance checks to validate the new phase statuses, completion records, and readiness gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->