### PR TITLE
ci(qualification): run #693 on fresh macOS 26 arm64 VMs

### DIFF
--- a/.github/workflows/issue-693-macos26-arm64.yml
+++ b/.github/workflows/issue-693-macos26-arm64.yml
@@ -406,7 +406,12 @@ jobs:
           set -uo pipefail
           for f in compare-native-agent watch stdio-server retrieve extract-frameworks; do
             set +e
-            npx vitest run "tests/unit/$f.test.ts" > "$EVIDENCE_DIR/isolated-$f.log" 2>&1
+            # Routed through the guarded runner rather than raw vitest: the repository's own
+            # policy test (tests/unit/vitest-guard-policy.test.ts) forbids a raw complete-suite
+            # invocation in any workflow, and it correctly flagged an earlier revision of this
+            # file. Forwarding a single path keeps the run isolated while still applying the
+            # canonical signature scan.
+            npm run test:run -- "tests/unit/$f.test.ts" > "$EVIDENCE_DIR/isolated-$f.log" 2>&1
             echo "isolated_${f}_status=$?" >> "$EVIDENCE_DIR/isolated.summary.txt"
             set -e
             {

--- a/.github/workflows/issue-693-macos26-arm64.yml
+++ b/.github/workflows/issue-693-macos26-arm64.yml
@@ -1,0 +1,303 @@
+# Diagnostics-only workflow for issue #693. Not part of normal CI and must not merge.
+# Runs the frozen qualification commit on fresh GitHub-hosted macOS 26 arm64 VMs to
+# determine whether the workstation's Vitest worker-start failures reproduce on the
+# same OS and architecture. Refs #693. Related parent: #654. #654 remains open.
+name: issue-693 macOS 26 arm64 qualification
+
+on:
+  push:
+    branches:
+      - roadmap/693-macos26-arm64-qualification
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-693-macos26-arm64-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FROZEN_COMMIT: b1300f8fcc2758404abc5e6064433c4d8b2ab40b
+  EXPECTED_LOCK_SHA256: 0144eb0ddf92f78c69f10089d0e0414485594966ff5be4f36f655c7aa5cff53e
+  EXPECTED_NODE: 22.22.3
+  EXPECTED_NPM: 12.0.2
+
+jobs:
+  qualify:
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        attempt: [1, 2, 3]
+    runs-on: macos-26
+    timeout-minutes: 180
+
+    steps:
+      - name: Record workflow-control versus tested identity
+        run: |
+          set -euo pipefail
+          echo "workflow-control commit: ${GITHUB_SHA}"
+          echo "tested source commit (expected): ${FROZEN_COMMIT}"
+
+      - name: Check out the frozen qualification commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: b1300f8fcc2758404abc5e6064433c4d8b2ab40b
+          persist-credentials: false
+
+      - name: Assert runner is Darwin 25 arm64 and freeze VM identity
+        id: identity
+        run: |
+          set -euo pipefail
+          EV="$RUNNER_TEMP/issue-693-evidence"
+          mkdir -p "$EV"
+          echo "EVIDENCE_DIR=$EV" >> "$GITHUB_ENV"
+
+          uname -a            | tee "$EV/uname.txt"
+          sw_vers             | tee "$EV/sw_vers.txt"
+          ulimit -a           | tee "$EV/ulimit.txt"
+          vm_stat             | tee "$EV/vm_stat.before.txt"
+          ps -axo pid,ppid,pcpu,pmem,command > "$EV/ps.start.txt"
+
+          ARCH="$(uname -m)"
+          DARWIN_MAJOR="$(sysctl -n kern.osrelease | cut -d. -f1)"
+          NCPU="$(sysctl -n hw.logicalcpu)"
+          MEM="$(sysctl -n hw.memsize)"
+          echo "arch=$ARCH darwin_major=$DARWIN_MAJOR logicalcpu=$NCPU memsize=$MEM" | tee "$EV/identity.txt"
+          echo "ncpu=$NCPU" >> "$GITHUB_OUTPUT"
+
+          if [ "$ARCH" != "arm64" ]; then
+            echo "::error::Runner architecture is $ARCH, expected arm64. Same-architecture comparison is required."
+            exit 1
+          fi
+          if [ "$DARWIN_MAJOR" != "25" ]; then
+            echo "::error::Runner Darwin major is $DARWIN_MAJOR, expected 25 (macOS 26). Same-OS comparison is required."
+            exit 1
+          fi
+
+          TESTED="$(git rev-parse HEAD)"
+          echo "tested source commit: $TESTED" | tee -a "$EV/identity.txt"
+          if [ "$TESTED" != "$FROZEN_COMMIT" ]; then
+            echo "::error::Tested commit $TESTED does not match the frozen qualification commit $FROZEN_COMMIT."
+            exit 1
+          fi
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.22.3
+
+      - name: Pin npm and install dependencies without cache
+        run: |
+          set -euo pipefail
+          npm install --global --ignore-scripts --no-audit --no-fund "npm@${EXPECTED_NPM}"
+          node --version | tee "$EVIDENCE_DIR/node-version.txt"
+          npm --version  | tee "$EVIDENCE_DIR/npm-version.txt"
+
+          ACTUAL_NODE="$(node --version | tr -d v)"
+          ACTUAL_NPM="$(npm --version)"
+          [ "$ACTUAL_NODE" = "$EXPECTED_NODE" ] || { echo "::error::Node $ACTUAL_NODE != $EXPECTED_NODE"; exit 1; }
+          [ "$ACTUAL_NPM"  = "$EXPECTED_NPM"  ] || { echo "::error::npm $ACTUAL_NPM != $EXPECTED_NPM"; exit 1; }
+
+          LOCK="$(shasum -a 256 package-lock.json | cut -d' ' -f1)"
+          echo "lock sha256: $LOCK" | tee "$EVIDENCE_DIR/lock.txt"
+          [ "$LOCK" = "$EXPECTED_LOCK_SHA256" ] || { echo "::error::lock checksum $LOCK != $EXPECTED_LOCK_SHA256"; exit 1; }
+
+          npm ci
+
+          LOCK_AFTER="$(shasum -a 256 package-lock.json | cut -d' ' -f1)"
+          [ "$LOCK_AFTER" = "$EXPECTED_LOCK_SHA256" ] || { echo "::error::npm ci mutated the lockfile"; exit 1; }
+          DIRTY="$(git status --short | wc -l | tr -d ' ')"
+          echo "git dirty files after npm ci: $DIRTY" | tee -a "$EVIDENCE_DIR/lock.txt"
+          [ "$DIRTY" = "0" ] || { echo "::error::npm ci mutated the checkout"; git status --short; exit 1; }
+
+      - name: Prove the raw-log scanner is active (positive control)
+        run: |
+          set -euo pipefail
+          CTL="$EVIDENCE_DIR/positive-control.log"
+          {
+            echo "stdout | tests/unit/fake.test.ts"
+            echo "Error: [vitest-pool]: Failed to start forks worker for test files fake.test.ts"
+            echo "Caused by: Error: [vitest-pool-runner]: Timeout waiting for worker to respond"
+            echo " Test Files  1 passed (1)"
+          } > "$CTL"
+
+          set +e
+          node .github/scripts/assert-clean-vitest-log.mjs "$CTL" > "$EVIDENCE_DIR/positive-control.result.txt" 2>&1
+          SCANNER_STATUS=$?
+          set -e
+          echo "scanner exit on poisoned log: $SCANNER_STATUS" | tee -a "$EVIDENCE_DIR/positive-control.result.txt"
+          [ "$SCANNER_STATUS" -ne 0 ] || { echo "::error::Positive control failed: scanner accepted a poisoned log"; exit 1; }
+
+          A="$(grep -c 'Failed to start forks worker' "$CTL")"
+          B="$(grep -c 'Timeout waiting for worker to respond' "$CTL")"
+          echo "control direct counts: forks=$A handshake=$B" | tee -a "$EVIDENCE_DIR/positive-control.result.txt"
+          [ "$A" -ge 1 ] && [ "$B" -ge 1 ] || { echo "::error::Positive control counting failed"; exit 1; }
+
+      - name: Write condition helpers
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/idle-load.mjs" <<'JS'
+          const seconds = Number(process.argv[2] || 3600)
+          const ballast = Buffer.alloc(1024 * 256, 1)
+          setTimeout(() => { void ballast; process.exit(0) }, seconds * 1000)
+          JS
+          cat > "$RUNNER_TEMP/busy-load.mjs" <<'JS'
+          const seconds = Number(process.argv[2] || 3600)
+          const end = Date.now() + seconds * 1000
+          while (Date.now() < end) { Math.sqrt(Math.random()) }
+          JS
+          cat > "$RUNNER_TEMP/run-condition.sh" <<'SH'
+          #!/bin/bash
+          # usage: run-condition.sh <label> <npm-script>
+          set -uo pipefail
+          LABEL="$1"; SCRIPT="$2"
+          EV="$EVIDENCE_DIR"
+          OUTER="$EV/${LABEL}.log"
+          GUARD="$EV/${LABEL}.guard.log"
+
+          {
+            echo "condition=$LABEL"
+            echo "script=$SCRIPT"
+            echo "start=$(date -u +%FT%TZ)"
+            echo "procs_total_before=$(ps ax | wc -l | tr -d ' ')"
+            echo "procs_node_before=$(ps -eo command | grep -ci '[n]ode')"
+            echo "procs_vitest_before=$(ps -eo command | grep -ci '[v]itest')"
+            echo "node_cpu_before=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')"
+          } > "$EV/${LABEL}.meta.txt"
+          vm_stat > "$EV/${LABEL}.vm_stat.before.txt"
+          ps -axo pid,ppid,pcpu,pmem,command > "$EV/${LABEL}.ps.before.txt"
+
+          S=$(date +%s)
+          VITEST_GUARD_LOG_PATH="$GUARD" npm run "$SCRIPT" 2>&1 | tee "$OUTER"
+          STATUS=${PIPESTATUS[0]}
+          E=$(date +%s)
+
+          FORKS=$(grep -c 'Failed to start forks worker' "$OUTER" || true)
+          HAND=$(grep -c 'Timeout waiting for worker to respond' "$OUTER" || true)
+          READABLE=$(grep -c 'Test Files' "$OUTER" || true)
+
+          {
+            echo "end=$(date -u +%FT%TZ)"
+            echo "duration_s=$((E-S))"
+            echo "command_status=$STATUS"
+            echo "forks_signatures=${FORKS:-0}"
+            echo "handshake_signatures=${HAND:-0}"
+            echo "readable_marker=${READABLE:-0}"
+            echo "procs_total_after=$(ps ax | wc -l | tr -d ' ')"
+            echo "procs_node_after=$(ps -eo command | grep -ci '[n]ode')"
+            echo "outer_log_sha256=$(shasum -a 256 "$OUTER" | cut -d' ' -f1)"
+          } >> "$EV/${LABEL}.meta.txt"
+          vm_stat > "$EV/${LABEL}.vm_stat.after.txt"
+          ps -axo pid,ppid,pcpu,pmem,command > "$EV/${LABEL}.ps.after.txt"
+
+          echo "::notice title=$LABEL::status=$STATUS forks=${FORKS:-0} handshake=${HAND:-0} duration=$((E-S))s"
+          cat "$EV/${LABEL}.meta.txt"
+          exit "$STATUS"
+          SH
+          chmod +x "$RUNNER_TEMP/run-condition.sh"
+
+      - name: Condition A — fresh quiet baseline (test:run)
+        id: cond_a_run
+        run: "$RUNNER_TEMP/run-condition.sh A-quiet-testrun test:run"
+
+      - name: Condition A — fresh quiet baseline (coverage, attempt 1 only)
+        if: matrix.attempt == 1
+        run: "$RUNNER_TEMP/run-condition.sh A-quiet-coverage test:coverage"
+
+      - name: Condition B1 — 64 idle Node processes
+        id: cond_b1
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          : > "$RUNNER_TEMP/b1.pids"
+          for i in $(seq 1 64); do
+            node "$RUNNER_TEMP/idle-load.mjs" 3600 &
+            echo $! >> "$RUNNER_TEMP/b1.pids"
+          done
+          sleep 5
+          LIVE=$(wc -l < "$RUNNER_TEMP/b1.pids" | tr -d ' ')
+          echo "b1_spawned=$LIVE" | tee "$EVIDENCE_DIR/B1.load.txt"
+          echo "node_cpu=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')" | tee -a "$EVIDENCE_DIR/B1.load.txt"
+          vm_stat | tee -a "$EVIDENCE_DIR/B1.load.txt"
+          set +e
+          "$RUNNER_TEMP/run-condition.sh" B1-idle64 test:run
+          echo "B1_STATUS=$?" | tee -a "$EVIDENCE_DIR/B1.load.txt"
+          set -e
+          while read -r p; do kill -9 "$p" 2>/dev/null || true; done < "$RUNNER_TEMP/b1.pids"
+          sleep 3
+          echo "b1_survivors=$(pgrep -f 'idle-load.mjs' | wc -l | tr -d ' ')" | tee -a "$EVIDENCE_DIR/B1.load.txt"
+
+      - name: Condition B2 — CPU-saturating Node load
+        id: cond_b2
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          N="${{ steps.identity.outputs.ncpu }}"
+          : > "$RUNNER_TEMP/b2.pids"
+          for i in $(seq 1 "$N"); do
+            node "$RUNNER_TEMP/busy-load.mjs" 3600 &
+            echo $! >> "$RUNNER_TEMP/b2.pids"
+          done
+          sleep 10
+          echo "b2_spawned=$(wc -l < "$RUNNER_TEMP/b2.pids" | tr -d ' ') ncpu=$N" | tee "$EVIDENCE_DIR/B2.load.txt"
+          echo "node_cpu=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')" | tee -a "$EVIDENCE_DIR/B2.load.txt"
+          uptime | tee -a "$EVIDENCE_DIR/B2.load.txt"
+          set +e
+          "$RUNNER_TEMP/run-condition.sh" B2-cpusat test:run
+          echo "B2_STATUS=$?" | tee -a "$EVIDENCE_DIR/B2.load.txt"
+          set -e
+          while read -r p; do kill -9 "$p" 2>/dev/null || true; done < "$RUNNER_TEMP/b2.pids"
+          sleep 3
+          echo "b2_survivors=$(pgrep -f 'busy-load.mjs' | wc -l | tr -d ' ')" | tee -a "$EVIDENCE_DIR/B2.load.txt"
+
+      - name: Verify load cleanup before recovery
+        run: |
+          set -euo pipefail
+          IDLE=$(pgrep -f 'idle-load.mjs' | wc -l | tr -d ' ')
+          BUSY=$(pgrep -f 'busy-load.mjs' | wc -l | tr -d ' ')
+          echo "surviving idle=$IDLE busy=$BUSY" | tee "$EVIDENCE_DIR/cleanup.txt"
+          uptime | tee -a "$EVIDENCE_DIR/cleanup.txt"
+          if [ "$IDLE" != "0" ] || [ "$BUSY" != "0" ]; then
+            echo "::error::Qualification load processes survived cleanup; recovery condition would be invalid."
+            exit 1
+          fi
+
+      - name: Condition D — recovery (test:run)
+        run: "$RUNNER_TEMP/run-condition.sh D-recovery-testrun test:run"
+
+      - name: Condition D — recovery (coverage, attempt 1 only)
+        if: matrix.attempt == 1
+        run: "$RUNNER_TEMP/run-condition.sh D-recovery-coverage test:coverage"
+
+      - name: Historical affected files, run alone
+        if: always()
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          for f in compare-native-agent watch stdio-server retrieve extract-frameworks; do
+            set +e
+            npx vitest run "tests/unit/$f.test.ts" > "$EVIDENCE_DIR/isolated-$f.log" 2>&1
+            echo "isolated_${f}_status=$?" >> "$EVIDENCE_DIR/isolated.summary.txt"
+            set -e
+            echo "isolated_${f}_forks=$(grep -c 'Failed to start forks worker' "$EVIDENCE_DIR/isolated-$f.log" || true)" >> "$EVIDENCE_DIR/isolated.summary.txt"
+          done
+          cat "$EVIDENCE_DIR/isolated.summary.txt"
+
+      - name: Checksum evidence
+        if: always()
+        run: |
+          set -uo pipefail
+          cd "$EVIDENCE_DIR"
+          shasum -a 256 ./* > SHA256SUMS.txt 2>/dev/null || true
+          ls -la
+          cat SHA256SUMS.txt || true
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: issue-693-macos26-arm64-run${{ github.run_id }}-attempt${{ github.run_attempt }}-m${{ matrix.attempt }}-darwin25-arm64-b1300f8f
+          path: ${{ runner.temp }}/issue-693-evidence
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/issue-693-macos26-arm64.yml
+++ b/.github/workflows/issue-693-macos26-arm64.yml
@@ -147,6 +147,54 @@ jobs:
           const end = Date.now() + seconds * 1000
           while (Date.now() < end) { Math.sqrt(Math.random()) }
           JS
+
+          # Shared helpers. Never use `pgrep ... | wc -l` in an assignment under
+          # `set -euo pipefail`: pgrep exits 1 when it correctly finds nothing, pipefail
+          # propagates that, and the assignment aborts the step precisely when cleanup
+          # SUCCEEDED. That defect made condition D unreachable in run 31718841614.
+          cat > "$RUNNER_TEMP/helpers.sh" <<'SH'
+          count_live_pids() {
+            local pid_file="$1"
+            local live_file="$2"
+            : > "$live_file"
+            if [ -f "$pid_file" ]; then
+              while read -r pid; do
+                if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                  echo "$pid" >> "$live_file"
+                fi
+              done < "$pid_file"
+            fi
+            wc -l < "$live_file" | tr -d ' '
+          }
+
+          cleanup_pid_file() {
+            local pid_file="$1"
+            [ -f "$pid_file" ] || return 0
+            while read -r pid; do
+              [ -n "$pid" ] || continue
+              kill "$pid" 2>/dev/null || true
+            done < "$pid_file"
+            sleep 1
+            while read -r pid; do
+              [ -n "$pid" ] || continue
+              if kill -0 "$pid" 2>/dev/null; then
+                kill -9 "$pid" 2>/dev/null || true
+              fi
+            done < "$pid_file"
+            while read -r pid; do
+              [ -n "$pid" ] || continue
+              wait "$pid" 2>/dev/null || true
+            done < "$pid_file"
+          }
+
+          count_pattern_survivors() {
+            local pattern="$1"
+            local out_file="$2"
+            pgrep -f "$pattern" > "$out_file" 2>/dev/null || true
+            wc -l < "$out_file" | tr -d ' '
+          }
+          SH
+
           cat > "$RUNNER_TEMP/run-condition.sh" <<'SH'
           #!/bin/bash
           # usage: run-condition.sh <label> <npm-script>
@@ -173,29 +221,54 @@ jobs:
           STATUS=${PIPESTATUS[0]}
           E=$(date +%s)
 
-          FORKS=$(grep -c 'Failed to start forks worker' "$OUTER" || true)
-          HAND=$(grep -c 'Timeout waiting for worker to respond' "$OUTER" || true)
+          # Signature counts come from the RAW guard log when it survives. On a dirty run the
+          # wrapper echoes matching lines into its own diagnostic report, so counting the outer
+          # transcript would double-count the underlying raw events. On a clean run the guard
+          # deletes its log, so the outer transcript is the only remaining source.
+          if [ -f "$GUARD" ]; then
+            SIG_SRC="guard_log"
+            FORKS=$(grep -c 'Failed to start forks worker' "$GUARD" || true)
+            HAND=$(grep -c 'Timeout waiting for worker to respond' "$GUARD" || true)
+            GUARD_SHA=$(shasum -a 256 "$GUARD" | cut -d' ' -f1)
+          else
+            SIG_SRC="outer_log"
+            FORKS=$(grep -c 'Failed to start forks worker' "$OUTER" || true)
+            HAND=$(grep -c 'Timeout waiting for worker to respond' "$OUTER" || true)
+            GUARD_SHA="absent"
+          fi
+          OUTER_FORKS=$(grep -c 'Failed to start forks worker' "$OUTER" || true)
+          OUTER_HAND=$(grep -c 'Timeout waiting for worker to respond' "$OUTER" || true)
           READABLE=$(grep -c 'Test Files' "$OUTER" || true)
 
           {
             echo "end=$(date -u +%FT%TZ)"
             echo "duration_s=$((E-S))"
             echo "command_status=$STATUS"
+            echo "signature_source=$SIG_SRC"
             echo "forks_signatures=${FORKS:-0}"
             echo "handshake_signatures=${HAND:-0}"
+            echo "outer_forks_signatures=${OUTER_FORKS:-0}"
+            echo "outer_handshake_signatures=${OUTER_HAND:-0}"
             echo "readable_marker=${READABLE:-0}"
             echo "procs_total_after=$(ps ax | wc -l | tr -d ' ')"
             echo "procs_node_after=$(ps -eo command | grep -ci '[n]ode')"
             echo "outer_log_sha256=$(shasum -a 256 "$OUTER" | cut -d' ' -f1)"
+            echo "guard_log_sha256=$GUARD_SHA"
           } >> "$EV/${LABEL}.meta.txt"
           vm_stat > "$EV/${LABEL}.vm_stat.after.txt"
           ps -axo pid,ppid,pcpu,pmem,command > "$EV/${LABEL}.ps.after.txt"
 
-          echo "::notice title=$LABEL::status=$STATUS forks=${FORKS:-0} handshake=${HAND:-0} duration=$((E-S))s"
+          echo "::notice title=$LABEL::status=$STATUS src=$SIG_SRC forks=${FORKS:-0} handshake=${HAND:-0} duration=$((E-S))s"
           cat "$EV/${LABEL}.meta.txt"
           exit "$STATUS"
           SH
           chmod +x "$RUNNER_TEMP/run-condition.sh"
+
+          bash -n "$RUNNER_TEMP/run-condition.sh"
+          bash -n "$RUNNER_TEMP/helpers.sh"
+          node --check "$RUNNER_TEMP/idle-load.mjs"
+          node --check "$RUNNER_TEMP/busy-load.mjs"
+          echo "all generated helpers pass syntax checks"
 
       - name: Condition A — fresh quiet baseline (test:run)
         id: cond_a_run
@@ -210,58 +283,114 @@ jobs:
         continue-on-error: true
         run: |
           set -uo pipefail
-          : > "$RUNNER_TEMP/b1.pids"
-          for i in $(seq 1 64); do
+          source "$RUNNER_TEMP/helpers.sh"
+          PIDF="$RUNNER_TEMP/b1.pids"
+          LIVEF="$RUNNER_TEMP/b1.live"
+          cleanup() { cleanup_pid_file "$PIDF"; }
+          trap cleanup EXIT INT TERM
+
+          EXPECTED=64
+          : > "$PIDF"
+          for i in $(seq 1 "$EXPECTED"); do
             node "$RUNNER_TEMP/idle-load.mjs" 3600 &
-            echo $! >> "$RUNNER_TEMP/b1.pids"
+            echo $! >> "$PIDF"
           done
           sleep 5
-          LIVE=$(wc -l < "$RUNNER_TEMP/b1.pids" | tr -d ' ')
-          echo "b1_spawned=$LIVE" | tee "$EVIDENCE_DIR/B1.load.txt"
-          echo "node_cpu=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')" | tee -a "$EVIDENCE_DIR/B1.load.txt"
-          vm_stat | tee -a "$EVIDENCE_DIR/B1.load.txt"
+
+          LIVE="$(count_live_pids "$PIDF" "$LIVEF")"
+          {
+            echo "b1_expected=$EXPECTED"
+            echo "b1_live=$LIVE"
+            echo "b1_live_pids=$(tr '\n' ' ' < "$LIVEF")"
+            echo "node_cpu=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')"
+            echo "procs_total=$(ps ax | wc -l | tr -d ' ')"
+          } | tee "$EVIDENCE_DIR/B1.load.txt"
+          vm_stat >> "$EVIDENCE_DIR/B1.load.txt"
+
+          if [ "$LIVE" != "$EXPECTED" ]; then
+            echo "b1_condition_valid=false" | tee -a "$EVIDENCE_DIR/B1.load.txt"
+            echo "::warning title=B1 invalid::intended $EXPECTED idle processes, only $LIVE live; not causal evidence"
+          else
+            echo "b1_condition_valid=true" | tee -a "$EVIDENCE_DIR/B1.load.txt"
+          fi
+
           set +e
           "$RUNNER_TEMP/run-condition.sh" B1-idle64 test:run
           echo "B1_STATUS=$?" | tee -a "$EVIDENCE_DIR/B1.load.txt"
           set -e
-          while read -r p; do kill -9 "$p" 2>/dev/null || true; done < "$RUNNER_TEMP/b1.pids"
-          sleep 3
-          echo "b1_survivors=$(pgrep -f 'idle-load.mjs' | wc -l | tr -d ' ')" | tee -a "$EVIDENCE_DIR/B1.load.txt"
+
+          cleanup
+          trap - EXIT INT TERM
+          AFTER="$(count_live_pids "$PIDF" "$LIVEF")"
+          echo "b1_live_after_cleanup=$AFTER" | tee -a "$EVIDENCE_DIR/B1.load.txt"
 
       - name: Condition B2 — CPU-saturating Node load
         id: cond_b2
         continue-on-error: true
         run: |
           set -uo pipefail
-          N="${{ steps.identity.outputs.ncpu }}"
-          : > "$RUNNER_TEMP/b2.pids"
-          for i in $(seq 1 "$N"); do
+          source "$RUNNER_TEMP/helpers.sh"
+          PIDF="$RUNNER_TEMP/b2.pids"
+          LIVEF="$RUNNER_TEMP/b2.live"
+          cleanup() { cleanup_pid_file "$PIDF"; }
+          trap cleanup EXIT INT TERM
+
+          EXPECTED="${{ steps.identity.outputs.ncpu }}"
+          : > "$PIDF"
+          for i in $(seq 1 "$EXPECTED"); do
             node "$RUNNER_TEMP/busy-load.mjs" 3600 &
-            echo $! >> "$RUNNER_TEMP/b2.pids"
+            echo $! >> "$PIDF"
           done
           sleep 10
-          echo "b2_spawned=$(wc -l < "$RUNNER_TEMP/b2.pids" | tr -d ' ') ncpu=$N" | tee "$EVIDENCE_DIR/B2.load.txt"
-          echo "node_cpu=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')" | tee -a "$EVIDENCE_DIR/B2.load.txt"
-          uptime | tee -a "$EVIDENCE_DIR/B2.load.txt"
+
+          LIVE="$(count_live_pids "$PIDF" "$LIVEF")"
+          {
+            echo "b2_expected=$EXPECTED"
+            echo "b2_live=$LIVE"
+            echo "b2_live_pids=$(tr '\n' ' ' < "$LIVEF")"
+            echo "node_cpu=$(ps -eo pcpu,command | grep -i '[n]ode' | awk '{s+=$1} END {printf "%.1f", s}')"
+            echo "uptime=$(uptime)"
+          } | tee "$EVIDENCE_DIR/B2.load.txt"
+
+          if [ "$LIVE" != "$EXPECTED" ]; then
+            echo "b2_condition_valid=false" | tee -a "$EVIDENCE_DIR/B2.load.txt"
+            echo "::warning title=B2 invalid::intended $EXPECTED busy processes, only $LIVE live; not causal evidence"
+          else
+            echo "b2_condition_valid=true" | tee -a "$EVIDENCE_DIR/B2.load.txt"
+          fi
+
           set +e
           "$RUNNER_TEMP/run-condition.sh" B2-cpusat test:run
           echo "B2_STATUS=$?" | tee -a "$EVIDENCE_DIR/B2.load.txt"
           set -e
-          while read -r p; do kill -9 "$p" 2>/dev/null || true; done < "$RUNNER_TEMP/b2.pids"
-          sleep 3
-          echo "b2_survivors=$(pgrep -f 'busy-load.mjs' | wc -l | tr -d ' ')" | tee -a "$EVIDENCE_DIR/B2.load.txt"
+
+          cleanup
+          trap - EXIT INT TERM
+          AFTER="$(count_live_pids "$PIDF" "$LIVEF")"
+          echo "b2_live_after_cleanup=$AFTER" | tee -a "$EVIDENCE_DIR/B2.load.txt"
 
       - name: Verify load cleanup before recovery
         run: |
           set -euo pipefail
-          IDLE=$(pgrep -f 'idle-load.mjs' | wc -l | tr -d ' ')
-          BUSY=$(pgrep -f 'busy-load.mjs' | wc -l | tr -d ' ')
-          echo "surviving idle=$IDLE busy=$BUSY" | tee "$EVIDENCE_DIR/cleanup.txt"
-          uptime | tee -a "$EVIDENCE_DIR/cleanup.txt"
+          source "$RUNNER_TEMP/helpers.sh"
+          # `count_pattern_survivors` redirects pgrep to a file and swallows its exit code, so a
+          # correct zero-survivor result cannot abort this step. The previous implementation used
+          # `pgrep ... | wc -l` inside an assignment, which under pipefail failed exactly when
+          # cleanup had succeeded and left condition D unreachable.
+          IDLE="$(count_pattern_survivors 'idle-load.mjs' "$RUNNER_TEMP/idle-survivors.txt")"
+          BUSY="$(count_pattern_survivors 'busy-load.mjs' "$RUNNER_TEMP/busy-survivors.txt")"
+          {
+            echo "surviving_idle=$IDLE"
+            echo "surviving_busy=$BUSY"
+            echo "uptime=$(uptime)"
+            echo "procs_total=$(ps ax | wc -l | tr -d ' ')"
+            echo "procs_node=$(ps -eo command | grep -ci '[n]ode')"
+          } | tee "$EVIDENCE_DIR/cleanup.txt"
           if [ "$IDLE" != "0" ] || [ "$BUSY" != "0" ]; then
-            echo "::error::Qualification load processes survived cleanup; recovery condition would be invalid."
+            echo "::error::Qualification load processes survived cleanup; condition D would be invalid."
             exit 1
           fi
+          echo "cleanup verified: no qualification load processes remain"
 
       - name: Condition D — recovery (test:run)
         run: "$RUNNER_TEMP/run-condition.sh D-recovery-testrun test:run"
@@ -280,7 +409,11 @@ jobs:
             npx vitest run "tests/unit/$f.test.ts" > "$EVIDENCE_DIR/isolated-$f.log" 2>&1
             echo "isolated_${f}_status=$?" >> "$EVIDENCE_DIR/isolated.summary.txt"
             set -e
-            echo "isolated_${f}_forks=$(grep -c 'Failed to start forks worker' "$EVIDENCE_DIR/isolated-$f.log" || true)" >> "$EVIDENCE_DIR/isolated.summary.txt"
+            {
+              echo "isolated_${f}_forks=$(grep -c 'Failed to start forks worker' "$EVIDENCE_DIR/isolated-$f.log" || true)"
+              echo "isolated_${f}_handshake=$(grep -c 'Timeout waiting for worker to respond' "$EVIDENCE_DIR/isolated-$f.log" || true)"
+              echo "isolated_${f}_readable=$(grep -c 'Test Files' "$EVIDENCE_DIR/isolated-$f.log" || true)"
+            } >> "$EVIDENCE_DIR/isolated.summary.txt"
           done
           cat "$EVIDENCE_DIR/isolated.summary.txt"
 


### PR DESCRIPTION
**Diagnostics only. This pull request must not merge.**

Adds one temporary workflow to run the frozen #693 qualification commit on fresh GitHub-hosted **macOS 26 arm64** VMs. It changes no product source, no package metadata, no dependencies, and no normal CI.

## Why

The workstation experiment already **rejected** the CPU-contention hypothesis on the same frozen commit:

| Run | Node CPU | Worker-start | Handshake |
| --- | ---: | ---: | ---: |
| A1 quiet | 47.8% | 16 | 16 |
| A2 quiet | **0.1%** | **20** | 20 |
| A3 quiet | 152.4% | 13 | 13 |
| B16 contended | **1471.7%** | **14** | 14 |

The quietest run produced the most signatures, and saturating 16 cores produced fewer. Counts stayed in a 13–20 band across four orders of magnitude of load. So contention is not the cause, and the remaining question is narrower: **does the frozen commit fail on a fresh machine of the same OS and architecture, or only on this workstation?**

## Design

- **Runner `macos-26`**, asserted at runtime to be `arm64` with Darwin major `25`. The job fails rather than silently substituting a different image.
- **Workflow-control commit and tested commit are separated.** Checkout pins `ref: b1300f8fcc2758404abc5e6064433c4d8b2ab40b` with `persist-credentials: false`, and the job fails if the tested `HEAD` is not that SHA. Branch code never enters the frozen checkout; helpers are generated in `$RUNNER_TEMP`.
- **Three attempts, `max-parallel: 1`**, each a newly provisioned VM.
- **Toolchain pinned**: Node 22.22.3, npm 12.0.2 installed with `--ignore-scripts`; lockfile checksum verified before and after `npm ci`; the job fails if `npm ci` mutates the checkout. No dependency cache.
- **Positive scanner control per attempt** — a deliberately poisoned log must make the canonical scanner exit non-zero. A zero signature count with no proven control is not accepted as evidence.
- **Authoritative commands only** — `npm run test:run` and `npm run test:coverage`. Raw `vitest run` is used only for the isolated historical-file diagnostic, never for accepted qualification evidence.
- Conditions per VM: **A** quiet baseline, **B1** 64 idle Node processes, **B2** one busy-loop process per logical CPU, **D** recovery after verified cleanup. B1/B2 use `continue-on-error` because either outcome is evidence; A and D must be clean.
- Evidence directory uploaded with `if: always()`, 30-day retention, artifact name carrying run id, attempt, matrix index, OS, architecture, and tested commit.

## Security

`permissions: contents: read`. No secrets, no environment, no OIDC, no cache, no publish. Branch-push trigger only — no `workflow_dispatch` (this workflow is not on the default branch), and none of `pull_request_target`, `repository_dispatch`, `workflow_run`, `schedule`, or tag push. All three actions pinned to full commit SHAs already verified in this repository.

## Disposition

This branch exists to produce evidence for #693. It will be closed as diagnostics-only once the issue comments link every run and artifact. If the capability proves worth keeping, that becomes its own issue after the #654 decision.

Refs #693.
Related parent: #654.
#654 remains open.


---

## Correction — initial run invalidated, workflow fixed

**Run `31718841614` is not counted toward final qualification.** The cleanup-verification step I wrote used `IDLE=$(pgrep -f 'idle-load.mjs' | wc -l)` under `set -euo pipefail`. `pgrep` exits `1` when it correctly finds nothing, `pipefail` propagates it, and the assignment aborted the step **precisely when cleanup had succeeded**. Both completed attempts failed there and skipped condition D, making the A → B → D contract unreachable.

That is a defect in this diagnostics workflow. **No Madar product source was affected**, and the frozen commit under test is unchanged at `b1300f8fcc2758404abc5e6064433c4d8b2ab40b` — zero non-workflow files differ from it on this branch.

The invalidated run did produce preliminary observations, recorded on #693 but **not counted**: on a fresh Darwin 25 arm64 VM (3 logical CPUs, 7 GiB), quiet `test:run`, quiet `test:coverage`, 64 idle Node processes, and CPU saturation at 293% aggregate each completed with **0/0** signatures.

### What changed

- Survivor counting redirects `pgrep` to a file and swallows its exit code, so zero survivors is a normal success.
- Load liveness proven with `kill -0` against the PID file; expected versus live counts and the live PID list recorded; a B condition explicitly marked invalid if the intended load never established.
- Cleanup traps on B1 and B2 so load is removed even when the guarded suite or metadata collection fails, with live PIDs re-counted afterwards.
- **Signature counts sourced from the raw guard log when it survives.** The wrapper echoes matching lines into its own report, so the outer transcript overcounts — demonstrated on a fixture where one event counts **1** in the guard log and **3** in the outer log. `signature_source`, both counts, and both checksums are recorded; a clean run whose guard log was deleted falls back to the outer log.
- Isolated historical files record handshake signatures and a readable marker too.
- Generated helpers are syntax-checked in-workflow.

Validated with ten deterministic local shell probes before pushing.

### A second defect, caught by the repository's own guard

The first corrected head failed all six CI lanes because `tests/unit/vitest-guard-policy.test.ts` — *"contains no raw vitest run invocation in any workflow"* — flagged this workflow's `npx vitest run` in the isolated-file step. The guard added by #690 caught a real violation in a file this branch introduced. **The test was not weakened**; the isolated runs now use `npm run test:run -- <path>`, keeping them single-file while applying the canonical scan.

### Current identity

| | |
| --- | --- |
| Invalidated run | `31718841614` |
| Corrected workflow-control head | `173bc6913a7e0538d8f352da7add5fd0a1aac843` |
| Replacement diagnostics run | `31722725288` |
| Frozen source under test | `b1300f8fcc2758404abc5e6064433c4d8b2ab40b` (unchanged) |

Still diagnostics-only. Still must not merge.
