### PR TITLE
test(workspace): replace aggregate worktree timeout with phase-aware assertions

### DIFF
--- a/tests/unit/helpers/phase-run.ts
+++ b/tests/unit/helpers/phase-run.ts
@@ -3,6 +3,8 @@
  * cannot interrupt a synchronous test body when its per-test timeout expires.
  */
 
+import { onTestFinished } from 'vitest'
+
 export interface PhaseRecord {
   readonly name: string
   readonly kind: 'work' | 'cleanup'
@@ -26,7 +28,7 @@ export interface PhaseRun {
   timeline(): readonly PhaseRecord[]
   cleanupErrors(): readonly PhaseFailure[]
   format(): string
-  emit(): void
+  emit(testFailed?: boolean): void
 }
 
 export class PhaseFailure extends Error {
@@ -54,12 +56,35 @@ export class PhaseFailure extends Error {
   }
 }
 
+export class PhaseDeadlock extends PhaseFailure {
+  constructor(
+    message: string,
+    options: {
+      cause: unknown
+      phase: string
+      kind: 'work' | 'cleanup'
+      durationMs: number
+      timeline: readonly PhaseRecord[]
+    },
+  ) {
+    super(message, options)
+    this.name = 'PhaseDeadlock'
+  }
+}
+
 function causeMessage(failure: PhaseFailure): string {
   const { cause } = failure
   if (typeof cause === 'object' && cause !== null && 'message' in cause && typeof cause.message === 'string') {
     return cause.message
   }
   return failure.message
+}
+
+function isDeadlock(error: unknown): boolean {
+  if ((typeof error !== 'object' || error === null) && typeof error !== 'function') {
+    return false
+  }
+  return ('isDeadlock' in error && Boolean(error.isDeadlock)) || ('code' in error && error.code === 'ETIMEDOUT')
 }
 
 export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
@@ -91,7 +116,11 @@ export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
       if (error instanceof PhaseFailure) {
         throw error
       }
-      throw new PhaseFailure(`${options.label}: phase "${name}" failed after ${durationMs} ms`, {
+      const Failure = isDeadlock(error) ? PhaseDeadlock : PhaseFailure
+      const message = isDeadlock(error)
+        ? `${options.label}: phase "${name}" exceeded its deadlock limit after ${durationMs} ms`
+        : `${options.label}: phase "${name}" failed after ${durationMs} ms`
+      throw new Failure(message, {
         cause: error,
         phase: name,
         kind: 'work',
@@ -110,7 +139,11 @@ export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
     } catch (error) {
       const durationMs = durationSince(startedAtMs)
       records.push({ name, kind: 'cleanup', status: 'failed', startedAtMs, durationMs, error })
-      failures.push(new PhaseFailure(`${options.label}: cleanup phase "${name}" failed after ${durationMs} ms`, {
+      const Failure = isDeadlock(error) ? PhaseDeadlock : PhaseFailure
+      const message = isDeadlock(error)
+        ? `${options.label}: cleanup phase "${name}" exceeded its deadlock limit after ${durationMs} ms`
+        : `${options.label}: cleanup phase "${name}" failed after ${durationMs} ms`
+      failures.push(new Failure(message, {
         cause: error,
         phase: name,
         kind: 'cleanup',
@@ -140,6 +173,18 @@ export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
     timeline,
     cleanupErrors,
     format,
-    emit: () => report(format()),
+    emit: (testFailed = false) => {
+      if (testFailed || records.some((record) => record.status === 'failed') || failures.length > 0) {
+        report(format())
+      }
+    },
   }
+}
+
+export function usePhaseRun(label: string): PhaseRun {
+  const phases = createPhaseRun({ label })
+  onTestFinished((context) => {
+    phases.emit(context.task.result?.state === 'fail')
+  })
+  return phases
 }

--- a/tests/unit/helpers/phase-run.ts
+++ b/tests/unit/helpers/phase-run.ts
@@ -140,7 +140,18 @@ export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
   }
 
   const cleanup = (name: string, run: () => void): void => {
-    reserveName(name)
+    if (names.has(name)) {
+      const error = new Error(`${options.label}: duplicate phase name "${name}"`)
+      failures.push(new PhaseFailure(`${options.label}: cleanup duplicate phase name "${name}"`, {
+        cause: error,
+        phase: name,
+        kind: 'cleanup',
+        durationMs: 0,
+        timeline: records,
+      }))
+      return
+    }
+    names.add(name)
     const startedAtMs = now()
     try {
       run()
@@ -165,6 +176,7 @@ export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
   const timeline = (): readonly PhaseRecord[] => records.slice()
   const cleanupErrors = (): readonly PhaseFailure[] => failures.slice()
   const format = (): string => {
+    // Nested phase durations overlap, so their sum can exceed wall-clock elapsed time.
     const totalMs = records.reduce((total, record) => total + record.durationMs, 0)
     const lines = [`[phase-run] ${options.label} total=${totalMs}ms`]
     records.forEach((record, index) => {

--- a/tests/unit/helpers/phase-run.ts
+++ b/tests/unit/helpers/phase-run.ts
@@ -35,6 +35,15 @@ export class PhaseFailure extends Error {
   readonly phase: string
   readonly kind: 'work' | 'cleanup'
   readonly durationMs: number
+  /**
+   * Live reference to the run's records, deliberately not a snapshot. The
+   * asymmetry with `timeline()`, which copies, is intentional: a failure needs
+   * to carry the cleanup phases that ran *after* it, since whether cleanup
+   * succeeded is part of diagnosing the failure. Snapshotting at throw time
+   * would discard exactly the evidence a post-hoc timeout verdict already
+   * fails to produce. `timeline()` copies because its callers are reading a
+   * finished run rather than holding a handle to one still in progress.
+   */
   readonly timeline: readonly PhaseRecord[]
 
   constructor(

--- a/tests/unit/helpers/phase-run.ts
+++ b/tests/unit/helpers/phase-run.ts
@@ -1,0 +1,145 @@
+/**
+ * Aggregate wall-clock timeouts cannot identify the slow phase, and Vitest
+ * cannot interrupt a synchronous test body when its per-test timeout expires.
+ */
+
+export interface PhaseRecord {
+  readonly name: string
+  readonly kind: 'work' | 'cleanup'
+  readonly status: 'ok' | 'failed'
+  readonly startedAtMs: number
+  readonly durationMs: number
+  readonly error?: unknown
+}
+
+export interface PhaseRunOptions {
+  readonly label: string
+  /** Injected monotonic clock in milliseconds. Defaults to a real monotonic source. */
+  readonly now?: () => number
+  /** Optional sink for the report. Defaults to console output. */
+  readonly report?: (text: string) => void
+}
+
+export interface PhaseRun {
+  phase<T>(name: string, run: () => T): T
+  cleanup(name: string, run: () => void): void
+  timeline(): readonly PhaseRecord[]
+  cleanupErrors(): readonly PhaseFailure[]
+  format(): string
+  emit(): void
+}
+
+export class PhaseFailure extends Error {
+  readonly phase: string
+  readonly kind: 'work' | 'cleanup'
+  readonly durationMs: number
+  readonly timeline: readonly PhaseRecord[]
+
+  constructor(
+    message: string,
+    options: {
+      cause: unknown
+      phase: string
+      kind: 'work' | 'cleanup'
+      durationMs: number
+      timeline: readonly PhaseRecord[]
+    },
+  ) {
+    super(message, { cause: options.cause })
+    this.name = 'PhaseFailure'
+    this.phase = options.phase
+    this.kind = options.kind
+    this.durationMs = options.durationMs
+    this.timeline = options.timeline
+  }
+}
+
+function causeMessage(failure: PhaseFailure): string {
+  const { cause } = failure
+  if (typeof cause === 'object' && cause !== null && 'message' in cause && typeof cause.message === 'string') {
+    return cause.message
+  }
+  return failure.message
+}
+
+export function createPhaseRun(options: PhaseRunOptions): PhaseRun {
+  const now = options.now ?? (() => performance.now())
+  const report = options.report ?? ((text: string) => console.log(text))
+  const records: PhaseRecord[] = []
+  const failures: PhaseFailure[] = []
+  const names = new Set<string>()
+
+  const reserveName = (name: string): void => {
+    if (names.has(name)) {
+      throw new Error(`${options.label}: duplicate phase name "${name}"`)
+    }
+    names.add(name)
+  }
+
+  const durationSince = (startedAtMs: number): number => Math.round(now() - startedAtMs)
+
+  const phase = <T>(name: string, run: () => T): T => {
+    reserveName(name)
+    const startedAtMs = now()
+    try {
+      const value = run()
+      records.push({ name, kind: 'work', status: 'ok', startedAtMs, durationMs: durationSince(startedAtMs) })
+      return value
+    } catch (error) {
+      const durationMs = durationSince(startedAtMs)
+      records.push({ name, kind: 'work', status: 'failed', startedAtMs, durationMs, error })
+      if (error instanceof PhaseFailure) {
+        throw error
+      }
+      throw new PhaseFailure(`${options.label}: phase "${name}" failed after ${durationMs} ms`, {
+        cause: error,
+        phase: name,
+        kind: 'work',
+        durationMs,
+        timeline: records,
+      })
+    }
+  }
+
+  const cleanup = (name: string, run: () => void): void => {
+    reserveName(name)
+    const startedAtMs = now()
+    try {
+      run()
+      records.push({ name, kind: 'cleanup', status: 'ok', startedAtMs, durationMs: durationSince(startedAtMs) })
+    } catch (error) {
+      const durationMs = durationSince(startedAtMs)
+      records.push({ name, kind: 'cleanup', status: 'failed', startedAtMs, durationMs, error })
+      failures.push(new PhaseFailure(`${options.label}: cleanup phase "${name}" failed after ${durationMs} ms`, {
+        cause: error,
+        phase: name,
+        kind: 'cleanup',
+        durationMs,
+        timeline: records,
+      }))
+    }
+  }
+
+  const timeline = (): readonly PhaseRecord[] => records.slice()
+  const cleanupErrors = (): readonly PhaseFailure[] => failures.slice()
+  const format = (): string => {
+    const totalMs = records.reduce((total, record) => total + record.durationMs, 0)
+    const lines = [`[phase-run] ${options.label} total=${totalMs}ms`]
+    records.forEach((record, index) => {
+      lines.push(`[phase-run] ${options.label} ${index + 1}. ${record.kind} ${record.name} ${record.status} ${record.durationMs}ms`)
+    })
+    failures.forEach((failure) => {
+      lines.push(`[phase-run] ${options.label} cleanup-error ${failure.phase}: ${causeMessage(failure)}`)
+    })
+    return lines.join('\n')
+  }
+
+  return {
+    phase,
+    cleanup,
+    timeline,
+    cleanupErrors,
+    format,
+    emit: () => report(format()),
+  }
+}

--- a/tests/unit/workspace-phase-run.test.ts
+++ b/tests/unit/workspace-phase-run.test.ts
@@ -123,6 +123,21 @@ describe('workspace phase runs', () => {
     expect(phases.timeline().map((record) => record.name)).toEqual(['work', 'cleanup'])
   })
 
+  test('carries cleanup records that ran after the failure was thrown', () => {
+    const phases = createPhaseRun({ label: 'live-failure-timeline', now: injectedClock(0, 7, 7, 11) })
+    const caught = captureThrown(() => phases.phase('work', () => {
+      throw new Error('work failed')
+    }))
+
+    expect(caught).toBeInstanceOf(PhaseFailure)
+    phases.cleanup('remove-temp-root', () => undefined)
+
+    expect((caught as PhaseFailure).timeline.map(({ name, kind, durationMs }) => ({ name, kind, durationMs }))).toEqual([
+      { name: 'work', kind: 'work', durationMs: 7 },
+      { name: 'remove-temp-root', kind: 'cleanup', durationMs: 4 },
+    ])
+  })
+
   test('runs cleanup after a simulated graph-generation failure', () => {
     const generatorError = new Error('graph generator failed')
     const generateGraphStub = (): never => {

--- a/tests/unit/workspace-phase-run.test.ts
+++ b/tests/unit/workspace-phase-run.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from 'vitest'
+import { afterAll, describe, expect, onTestFinished, test, vi } from 'vitest'
 
-import { createPhaseRun, PhaseDeadlock, PhaseFailure } from './helpers/phase-run.js'
+import { createPhaseRun, PhaseDeadlock, PhaseFailure, usePhaseRun } from './helpers/phase-run.js'
 
 function injectedClock(...values: number[]): () => number {
   let index = 0
@@ -218,16 +218,126 @@ describe('workspace phase runs', () => {
     expect((markedCaught as PhaseDeadlock).phase).toBe('worktree-add')
   })
 
-  test('rejects duplicate phase names before running them again', () => {
+  test('records duplicate cleanup names but still rejects duplicate work phases', () => {
     const phases = createPhaseRun({ label: 'duplicates', now: injectedClock(0, 1) })
-    let ranAgain = false
+    let cleanupRan = false
+    let phaseRan = false
 
     phases.phase('same-name', () => undefined)
 
     expect(() => phases.cleanup('same-name', () => {
-      ranAgain = true
+      cleanupRan = true
+    })).not.toThrow()
+    expect(cleanupRan).toBe(false)
+    expect(phases.cleanupErrors()).toHaveLength(1)
+    expect(phases.cleanupErrors()[0]).toMatchObject({
+      phase: 'same-name',
+      kind: 'cleanup',
+      durationMs: 0,
+    })
+    expect(phases.cleanupErrors()[0]?.message).toContain('duplicate phase name "same-name"')
+    expect(phases.timeline()).toHaveLength(1)
+
+    expect(() => phases.phase('same-name', () => {
+      phaseRan = true
     })).toThrow('duplicates: duplicate phase name "same-name"')
-    expect(ranAgain).toBe(false)
+    expect(phaseRan).toBe(false)
+  })
+
+  test('preserves an in-flight work failure when cleanup reuses its phase name', () => {
+    const original = new Error('original work failure')
+    const phases = createPhaseRun({ label: 'duplicate-cleanup-finally', now: injectedClock(0, 4) })
+    let workFailure: unknown
+    let cleanupRan = false
+
+    const propagated = captureThrown(() => {
+      try {
+        try {
+          phases.phase('work', () => {
+            throw original
+          })
+        } catch (error) {
+          workFailure = error
+          throw error
+        }
+      } finally {
+        phases.cleanup('work', () => {
+          cleanupRan = true
+        })
+      }
+    })
+
+    expect(propagated).toBe(workFailure)
+    expect(propagated).toBeInstanceOf(PhaseFailure)
+    expect((propagated as PhaseFailure).cause).toBe(original)
+    expect(cleanupRan).toBe(false)
+    expect(phases.cleanupErrors()).toHaveLength(1)
+    expect(phases.cleanupErrors()[0]?.message).toContain('duplicate phase name "work"')
+  })
+
+  test('emits a passing timeline when the enclosing test failed', () => {
+    const reports: string[] = []
+    const phases = createPhaseRun({
+      label: 'failed-test',
+      now: injectedClock(0, 8),
+      report: (text) => reports.push(text),
+    })
+
+    phases.phase('passing-phase', () => undefined)
+    phases.emit(true)
+
+    expect(reports).toEqual([phases.format()])
+    expect(reports[0]).toContain('[phase-run] failed-test 1. work passing-phase ok 8ms')
+  })
+
+  test('emits a cleanup-only failure with its cleanup-error line', () => {
+    const reports: string[] = []
+    const phases = createPhaseRun({
+      label: 'cleanup-only-failure',
+      now: injectedClock(0, 6),
+      report: (text) => reports.push(text),
+    })
+
+    phases.cleanup('remove-temp-root', () => {
+      throw new Error('cleanup exploded')
+    })
+    phases.emit()
+
+    expect(reports).toEqual([phases.format()])
+    expect(reports[0]).toContain('[phase-run] cleanup-only-failure cleanup-error remove-temp-root: cleanup exploded')
+  })
+
+  describe('usePhaseRun failure lifecycle', () => {
+    let observation: { readonly state: string | undefined, readonly reports: readonly unknown[][] } | undefined
+
+    afterAll(() => {
+      expect(observation?.state).toBe('fail')
+      expect(observation?.reports).toHaveLength(1)
+      expect(observation?.reports[0]?.[0]).toContain('[phase-run] lifecycle-failure')
+      expect(observation?.reports[0]?.[0]).toContain('work passing-phase ok')
+    })
+
+    // `usePhaseRun` only emits when its test fails, so the sole way to observe
+    // that path is to let a test genuinely fail. `test.fails` alone would be a
+    // weak assertion -- it passes on any throw -- so the observation is captured
+    // here and asserted in `afterAll`, where a lost emission fails the file.
+    // The observer is registered *before* `usePhaseRun` because Vitest runs
+    // `onTestFinished` callbacks in reverse order, so this one runs last and
+    // sees the emission. That ordering was verified empirically, not assumed.
+    test.fails('usePhaseRun emits through console.log when its test fails', () => {
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+      onTestFinished((context) => {
+        observation = {
+          state: context.task.result?.state,
+          reports: consoleLog.mock.calls.map((call) => [...call]),
+        }
+        consoleLog.mockRestore()
+      })
+
+      const phases = usePhaseRun('lifecycle-failure')
+      phases.phase('passing-phase', () => undefined)
+      expect(true).toBe(false)
+    })
   })
 
   test('formats deterministically and emits nothing for a successful run', () => {

--- a/tests/unit/workspace-phase-run.test.ts
+++ b/tests/unit/workspace-phase-run.test.ts
@@ -172,10 +172,11 @@ describe('workspace phase runs', () => {
     expect(phases.cleanupErrors()[0]?.cause).toBe(cleanupError)
   })
 
-  test('classifies a timed-out phase as a deadlock', () => {
+  test('classifies a timed-out phase as a deadlock and retains its diagnostics', () => {
     const timedOut = Object.assign(new Error('spawn timed out'), { code: 'ETIMEDOUT' })
-    const phases = createPhaseRun({ label: 'deadlock', now: injectedClock(0, 30_000) })
+    const phases = createPhaseRun({ label: 'deadlock', now: injectedClock(0, 120, 120, 30_120) })
 
+    phases.phase('git-init', () => undefined)
     const caught = captureThrown(() => phases.phase('git-commit', () => {
       throw timedOut
     }))
@@ -184,6 +185,14 @@ describe('workspace phase runs', () => {
     expect((caught as PhaseDeadlock).phase).toBe('git-commit')
     expect((caught as PhaseDeadlock).message).toBe('deadlock: phase "git-commit" exceeded its deadlock limit after 30000 ms')
     expect((caught as PhaseDeadlock).cause).toBe(timedOut)
+
+    // The failure must carry the diagnostics, not merely the phase name: every
+    // completed phase and its duration travels with the thrown error, so a
+    // reader of the failure alone can see what ran and how long it took.
+    expect((caught as PhaseDeadlock).timeline.map(({ name, status, durationMs }) => ({ name, status, durationMs }))).toEqual([
+      { name: 'git-init', status: 'ok', durationMs: 120 },
+      { name: 'git-commit', status: 'failed', durationMs: 30_000 },
+    ])
 
     const markedDeadlock = Object.assign(new Error('child received a signal'), { isDeadlock: true })
     const markedPhases = createPhaseRun({ label: 'marked-deadlock', now: injectedClock(0, 1) })

--- a/tests/unit/workspace-phase-run.test.ts
+++ b/tests/unit/workspace-phase-run.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from 'vitest'
+
+import { createPhaseRun, PhaseDeadlock, PhaseFailure } from './helpers/phase-run.js'
+
+function injectedClock(...values: number[]): () => number {
+  let index = 0
+  return () => {
+    const value = values[index]
+    if (value === undefined) {
+      throw new Error(`Injected clock exhausted at call ${index + 1}`)
+    }
+    index += 1
+    return value
+  }
+}
+
+function captureThrown(run: () => void): unknown {
+  try {
+    run()
+  } catch (error) {
+    return error
+  }
+  throw new Error('Expected callback to throw')
+}
+
+describe('workspace phase runs', () => {
+  test('allows logical work durations well beyond 20 seconds', () => {
+    const phases = createPhaseRun({ label: 'long-logical-run', now: injectedClock(0, 25_000, 25_000, 45_000) })
+
+    expect(phases.phase('first', () => 'first-result')).toBe('first-result')
+    expect(phases.phase('second', () => 'second-result')).toBe('second-result')
+
+    expect(phases.timeline().map((record) => record.durationMs)).toEqual([25_000, 20_000])
+    expect(phases.timeline().every((record) => record.status === 'ok')).toBe(true)
+    expect(phases.format()).toContain('total=45000ms')
+  })
+
+  test('preserves phase ordering in the timeline', () => {
+    const phases = createPhaseRun({ label: 'ordered', now: injectedClock(0, 1, 2, 3, 4, 5) })
+
+    phases.phase('alpha', () => undefined)
+    phases.phase('beta', () => undefined)
+    phases.cleanup('gamma', () => undefined)
+
+    expect(phases.timeline().map((record) => record.name)).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  test('names the exact failing phase and preserves the original cause', () => {
+    const reports: string[] = []
+    const original = new Error('work exploded')
+    const phases = createPhaseRun({
+      label: 'failure',
+      now: injectedClock(100, 140),
+      report: (text) => reports.push(text),
+    })
+
+    const caught = captureThrown(() => phases.phase('resolve-workspace', () => {
+      throw original
+    }))
+
+    expect(caught).toBeInstanceOf(PhaseFailure)
+    expect(caught).not.toBeInstanceOf(PhaseDeadlock)
+    expect((caught as PhaseFailure).phase).toBe('resolve-workspace')
+    expect((caught as PhaseFailure).message).toBe('failure: phase "resolve-workspace" failed after 40 ms')
+    expect((caught as PhaseFailure).cause).toBe(original)
+    phases.emit()
+    expect(reports).toHaveLength(1)
+  })
+
+  test('retains completed durations before a later failure', () => {
+    const phases = createPhaseRun({ label: 'partial', now: injectedClock(0, 10, 10, 35) })
+
+    phases.phase('completed', () => undefined)
+    captureThrown(() => phases.phase('failed', () => {
+      throw new Error('later failure')
+    }))
+
+    expect(phases.timeline().map(({ name, status, durationMs }) => ({ name, status, durationMs }))).toEqual([
+      { name: 'completed', status: 'ok', durationMs: 10 },
+      { name: 'failed', status: 'failed', durationMs: 25 },
+    ])
+  })
+
+  test('does not re-wrap a nested PhaseFailure', () => {
+    const phases = createPhaseRun({ label: 'nested', now: injectedClock(0, 1, 3, 5) })
+    let innerFailure: unknown
+
+    const caught = captureThrown(() => phases.phase('outer', () => {
+      try {
+        phases.phase('inner', () => {
+          throw new Error('inner failure')
+        })
+      } catch (error) {
+        innerFailure = error
+        throw error
+      }
+    }))
+
+    expect(caught).toBe(innerFailure)
+    expect(caught).toBeInstanceOf(PhaseFailure)
+    expect((caught as PhaseFailure).phase).toBe('inner')
+  })
+
+  test('runs cleanup after a work failure', () => {
+    const events: string[] = []
+    const phases = createPhaseRun({ label: 'cleanup-after-work', now: injectedClock(0, 5, 5, 6) })
+
+    const caught = captureThrown(() => {
+      try {
+        phases.phase('work', () => {
+          events.push('work')
+          throw new Error('work failed')
+        })
+      } finally {
+        phases.cleanup('cleanup', () => {
+          events.push('cleanup')
+        })
+      }
+    })
+
+    expect(caught).toBeInstanceOf(PhaseFailure)
+    expect(events).toEqual(['work', 'cleanup'])
+    expect(phases.timeline().map((record) => record.name)).toEqual(['work', 'cleanup'])
+  })
+
+  test('runs cleanup after a simulated graph-generation failure', () => {
+    const generatorError = new Error('graph generator failed')
+    const generateGraphStub = (): never => {
+      throw generatorError
+    }
+    let cleaned = false
+    const phases = createPhaseRun({ label: 'graph-failure', now: injectedClock(0, 8, 8, 10) })
+
+    const caught = captureThrown(() => {
+      try {
+        phases.phase('generate-graph', generateGraphStub)
+      } finally {
+        phases.cleanup('remove-temp-root', () => {
+          cleaned = true
+        })
+      }
+    })
+
+    expect(caught).toBeInstanceOf(PhaseFailure)
+    expect((caught as PhaseFailure).phase).toBe('generate-graph')
+    expect((caught as PhaseFailure).cause).toBe(generatorError)
+    expect(cleaned).toBe(true)
+  })
+
+  test('records cleanup failure without replacing the work failure', () => {
+    const workError = new Error('original work failure')
+    const cleanupError = new Error('cleanup failure')
+    const phases = createPhaseRun({ label: 'dual-failure', now: injectedClock(0, 4, 4, 7) })
+
+    const caught = captureThrown(() => {
+      try {
+        phases.phase('work', () => {
+          throw workError
+        })
+      } finally {
+        phases.cleanup('cleanup', () => {
+          throw cleanupError
+        })
+      }
+    })
+
+    expect(caught).toBeInstanceOf(PhaseFailure)
+    expect((caught as PhaseFailure).phase).toBe('work')
+    expect((caught as PhaseFailure).cause).toBe(workError)
+    expect(phases.cleanupErrors()).toHaveLength(1)
+    expect(phases.cleanupErrors()[0]?.phase).toBe('cleanup')
+    expect(phases.cleanupErrors()[0]?.cause).toBe(cleanupError)
+  })
+
+  test('classifies a timed-out phase as a deadlock', () => {
+    const timedOut = Object.assign(new Error('spawn timed out'), { code: 'ETIMEDOUT' })
+    const phases = createPhaseRun({ label: 'deadlock', now: injectedClock(0, 30_000) })
+
+    const caught = captureThrown(() => phases.phase('git-commit', () => {
+      throw timedOut
+    }))
+
+    expect(caught).toBeInstanceOf(PhaseDeadlock)
+    expect((caught as PhaseDeadlock).phase).toBe('git-commit')
+    expect((caught as PhaseDeadlock).message).toBe('deadlock: phase "git-commit" exceeded its deadlock limit after 30000 ms')
+    expect((caught as PhaseDeadlock).cause).toBe(timedOut)
+
+    const markedDeadlock = Object.assign(new Error('child received a signal'), { isDeadlock: true })
+    const markedPhases = createPhaseRun({ label: 'marked-deadlock', now: injectedClock(0, 1) })
+    const markedCaught = captureThrown(() => markedPhases.phase('worktree-add', () => {
+      throw markedDeadlock
+    }))
+    expect(markedCaught).toBeInstanceOf(PhaseDeadlock)
+    expect((markedCaught as PhaseDeadlock).phase).toBe('worktree-add')
+  })
+
+  test('rejects duplicate phase names before running them again', () => {
+    const phases = createPhaseRun({ label: 'duplicates', now: injectedClock(0, 1) })
+    let ranAgain = false
+
+    phases.phase('same-name', () => undefined)
+
+    expect(() => phases.cleanup('same-name', () => {
+      ranAgain = true
+    })).toThrow('duplicates: duplicate phase name "same-name"')
+    expect(ranAgain).toBe(false)
+  })
+
+  test('formats deterministically and emits nothing for a successful run', () => {
+    const reports: string[] = []
+    const phases = createPhaseRun({
+      label: 'deterministic',
+      now: injectedClock(100, 112, 200, 205),
+      report: (text) => reports.push(text),
+    })
+
+    phases.phase('work', () => undefined)
+    phases.cleanup('cleanup', () => undefined)
+
+    expect(phases.format()).toBe([
+      '[phase-run] deterministic total=17ms',
+      '[phase-run] deterministic 1. work work ok 12ms',
+      '[phase-run] deterministic 2. cleanup cleanup ok 5ms',
+    ].join('\n'))
+    phases.emit()
+    expect(reports).toEqual([])
+  })
+})

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -3,16 +3,57 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
 
-import { describe, expect, onTestFinished, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { generateGraph } from '../../src/infrastructure/generate.js'
 import { validateGraphOutputPath } from '../../src/shared/security.js'
 import { resolveMadarWorkspace, resolveWorkspaceGraphPath, resolveWorkspaceOutputPath } from '../../src/shared/workspace.js'
 
-import { createPhaseRun } from './helpers/phase-run.js'
+import { createPhaseRun, PhaseFailure, usePhaseRun } from './helpers/phase-run.js'
 
-function git(directory: string, args: string[]): void {
-  execFileSync('git', args, { cwd: directory, stdio: 'pipe' })
+// The slowest Git command in the six-lane matrix was 177 ms. This 30 s limit
+// is roughly 170x that value and is deadlock protection, not a correctness bound.
+const GIT_DEADLOCK_LIMIT_MS = 30_000
+
+// The slowest measured phase was 4,102 ms and the slowest healthy total was
+// 8,707 ms. This 60 s timeout is only a deadlock alarm (Git hangs are interrupted
+// above); elapsed time is never asserted as a correctness criterion.
+const TEST_DEADLOCK_LIMIT_MS = 60_000
+
+interface GitProcessError {
+  readonly code?: unknown
+  readonly signal?: unknown
+  readonly stderr?: unknown
+}
+
+function git(directory: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: directory,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: GIT_DEADLOCK_LIMIT_MS,
+      windowsHide: true,
+    })
+  } catch (error) {
+    const processError = (typeof error === 'object' && error !== null ? error : {}) as GitProcessError
+    const stderr = typeof processError.stderr === 'string'
+      ? processError.stderr.trim()
+      : Buffer.isBuffer(processError.stderr)
+        ? processError.stderr.toString('utf8').trim()
+        : ''
+    const deadlock = processError.code === 'ETIMEDOUT'
+      || (processError.signal !== null && processError.signal !== undefined)
+    const argv = JSON.stringify(['git', ...args])
+    const message = deadlock
+      ? `Git deadlock after ${GIT_DEADLOCK_LIMIT_MS} ms: argv=${argv}; stderr=${stderr || '<empty>'}`
+      : `Git command failed: argv=${argv}; stderr=${stderr || '<empty>'}`
+    const failure = new Error(message, { cause: error }) as Error & { isDeadlock?: boolean }
+    if (deadlock) {
+      failure.isDeadlock = true
+    }
+    throw failure
+  }
 }
 
 function isInside(candidate: string, root: string): boolean {
@@ -25,20 +66,40 @@ function canonicalPhysicalPath(path: string): string {
   return process.platform === 'win32' ? canonical.toLowerCase() : canonical
 }
 
-function reportPhases(text: string): void {
-  process.stdout.write(`${text}\n`)
+function normalizedWorktreePath(path: string): string {
+  const normalized = resolve(path).replaceAll('\\', '/').normalize('NFC')
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function hasWorktreeRegistration(porcelain: string, linked: string): boolean {
+  const expected = normalizedWorktreePath(linked)
+  return porcelain.split(/\r?\n/)
+    .filter((line) => line.startsWith('worktree '))
+    .some((line) => normalizedWorktreePath(line.slice('worktree '.length).trim()) === expected)
+}
+
+function assertNoWorktreeRegistration(porcelain: string, linked: string): void {
+  if (hasWorktreeRegistration(porcelain, linked)) {
+    throw new Error(`Git still registers removed worktree path: ${linked}`)
+  }
+}
+
+function throwCleanupErrors(label: string, phases: ReturnType<typeof createPhaseRun>): void {
+  const failures = phases.cleanupErrors()
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `${label} cleanup failed`)
+  }
 }
 
 describe('worktree artifact routing', () => {
   test('keeps a nested source root in a primary checkout local', () => {
-    const phases = createPhaseRun({ label: 'primary-workspace', report: reportPhases })
-    onTestFinished(() => phases.emit())
+    const phases = usePhaseRun('primary-workspace')
     const tempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar-primary-workspace-')))
     const primary = join(tempDir, 'primary')
     const nested = join(primary, 'packages', 'api')
     let workSucceeded = false
     try {
-      phases.phase('git-init', () => execFileSync('git', ['init', primary], { stdio: 'pipe' }))
+      phases.phase('git-init', () => git(tempDir, ['init', primary]))
       phases.phase('mkdir-nested', () => mkdirSync(nested, { recursive: true }))
 
       const workspace = phases.phase('resolve-workspace', () => resolveMadarWorkspace(nested))
@@ -52,83 +113,242 @@ describe('worktree artifact routing', () => {
       workSucceeded = true
     } finally {
       phases.cleanup('remove-temp-root', () => rmSync(tempDir, { recursive: true, force: true }))
-      if (workSucceeded && phases.cleanupErrors().length > 0) {
-        throw new AggregateError(phases.cleanupErrors(), 'primary-workspace cleanup failed')
+      if (workSucceeded) {
+        throwCleanupErrors('primary-workspace', phases)
       }
     }
   })
+})
 
-  test('keeps a linked worktree graph outside the source checkout and isolated from the primary checkout', () => {
-    const phases = createPhaseRun({ label: 'linked-worktree', report: reportPhases })
-    onTestFinished(() => phases.emit())
-    const tempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar-worktree-')))
-    const primary = join(tempDir, 'primary')
-    const linked = join(tempDir, 'linked')
-    let workSucceeded = false
+describe('linked worktree artifact routing', () => {
+  type Workspace = ReturnType<typeof resolveMadarWorkspace>
+
+  let tempDir: string | undefined
+  let primary: string | undefined
+  let linked: string | undefined
+  let primaryWorkspace: Workspace | undefined
+  let linkedWorkspace: Workspace | undefined
+  let scopedWorkspace: Workspace | undefined
+
+  const fixturePaths = (): { tempDir: string; primary: string; linked: string } => {
+    if (!tempDir || !primary || !linked) {
+      throw new Error('Linked worktree fixture was not initialized')
+    }
+    return { tempDir, primary, linked }
+  }
+
+  const resolvedWorkspaces = (): { primary: Workspace; linked: Workspace; scoped: Workspace } => {
+    if (!primaryWorkspace || !linkedWorkspace || !scopedWorkspace) {
+      throw new Error('Linked worktree fixture was not resolved')
+    }
+    return { primary: primaryWorkspace, linked: linkedWorkspace, scoped: scopedWorkspace }
+  }
+
+  beforeAll(() => {
+    const phases = createPhaseRun({ label: 'linked-worktree-setup' })
     try {
-      phases.phase('git-init', () => execFileSync('git', ['init', primary], { stdio: 'pipe' }))
-      phases.phase('git-config-email', () => git(primary, ['config', 'user.email', 'madar-tests@example.com']))
-      phases.phase('git-config-name', () => git(primary, ['config', 'user.name', 'Madar Tests']))
-      phases.phase('write-main', () => writeFileSync(join(primary, 'main.ts'), 'export const primaryValue = 1\n', 'utf8'))
-      phases.phase('git-add', () => git(primary, ['add', '.']))
-      phases.phase('git-commit', () => git(primary, ['commit', '-m', 'initial']))
-      phases.phase('worktree-add', () => git(primary, ['worktree', 'add', '-b', 'feature/worktree-routing', linked]))
-      phases.phase('mkdir-linked-src', () => mkdirSync(join(linked, 'src')))
-
-      const primaryWorkspace = phases.phase('resolve-primary-workspace', () => resolveMadarWorkspace(primary))
-      const linkedWorkspace = phases.phase('resolve-linked-workspace', () => resolveMadarWorkspace(linked))
-      const scopedWorkspace = phases.phase('resolve-scoped-workspace', () => resolveMadarWorkspace(join(linked, 'src')))
-
-      phases.phase('assert-routing', () => {
-        expect(primaryWorkspace.isLinkedWorktree).toBe(false)
-        expect(primaryWorkspace.graphPath).toBe(join(resolve(primary), 'out', 'graph.json'))
-        expect(linkedWorkspace.isLinkedWorktree).toBe(true)
-        expect(canonicalPhysicalPath(linkedWorkspace.gitCommonDir ?? '')).toBe(canonicalPhysicalPath(join(primary, '.git')))
-        expect(linkedWorkspace.graphPath).not.toBe(primaryWorkspace.graphPath)
-        expect(isInside(linkedWorkspace.graphPath, linked)).toBe(false)
-        expect(scopedWorkspace.graphPath).not.toBe(linkedWorkspace.graphPath)
-        expect(resolveWorkspaceGraphPath('out/graph.json', linked)).toBe(linkedWorkspace.graphPath)
-        expect(resolveWorkspaceGraphPath('./out/graph.json', linked)).toBe(linkedWorkspace.graphPath)
-        expect(resolveWorkspaceOutputPath('out/compare', linked)).toBe(join(linkedWorkspace.outputDir, 'compare'))
-        expect(validateGraphOutputPath('out/compare', 'out', linked)).toBe(join(linkedWorkspace.outputDir, 'compare'))
-      })
-
-      phases.phase('write-feature', () => writeFileSync(join(linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 2 }\n', 'utf8'))
-      const result = phases.phase('generate-graph', () => generateGraph(linked, { noHtml: true }))
-      const graph = phases.phase('read-graph', () => JSON.parse(readFileSync(result.graphPath, 'utf8')) as { root_path?: string; nodes?: Array<{ source_file?: string }> })
-
-      phases.phase('assert-graph-artifacts', () => {
-        expect(result.outputDir).toBe(linkedWorkspace.outputDir)
-        expect(result.graphPath).toBe(linkedWorkspace.graphPath)
-        expect(existsSync(join(linked, 'out'))).toBe(false)
-        expect(graph.root_path).toBe(resolve(linked))
-        expect(graph.nodes?.some((node) => node.source_file?.endsWith('feature.ts'))).toBe(true)
-      })
-
-      phases.phase('write-feature-update', () => writeFileSync(join(linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 3 }\n', 'utf8'))
-      const update = phases.phase('generate-update', () => generateGraph(linked, { update: true, noHtml: true }))
-      phases.phase('assert-update', () => {
-        expect(update.outputDir).toBe(linkedWorkspace.outputDir)
-      })
-
-      const spi = phases.phase('generate-spi', () => generateGraph(linked, { useSpi: true, noHtml: true }))
-      phases.phase('assert-spi', () => {
-        expect(spi.outputDir).toBe(linkedWorkspace.outputDir)
-        expect(existsSync(join(linked, 'out'))).toBe(false)
-        expect(existsSync(join(linkedWorkspace.outputDir, '.spi-cache'))).toBe(true)
-      })
-      workSucceeded = true
+      const createdTempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar worktree ünïcode ')))
+      const createdPrimary = join(createdTempDir, 'primary')
+      const createdLinked = join(createdTempDir, 'linked')
+      tempDir = createdTempDir
+      primary = createdPrimary
+      linked = createdLinked
+      phases.phase('git-init', () => git(createdTempDir, ['init', createdPrimary]))
+      phases.phase('git-config-email', () => git(createdPrimary, ['config', 'user.email', 'madar-tests@example.com']))
+      phases.phase('git-config-name', () => git(createdPrimary, ['config', 'user.name', 'Madar Tests']))
+      phases.phase('write-main', () => writeFileSync(join(createdPrimary, 'main.ts'), 'export const primaryValue = 1\n', 'utf8'))
+      phases.phase('git-add', () => git(createdPrimary, ['add', '.']))
+      phases.phase('git-commit', () => git(createdPrimary, ['commit', '-m', 'initial']))
+      phases.phase('worktree-add', () => git(createdPrimary, ['worktree', 'add', '-b', 'feature/worktree-routing', createdLinked]))
+      phases.phase('mkdir-linked-src', () => mkdirSync(join(createdLinked, 'src')))
     } finally {
-      phases.cleanup('worktree-remove', () => {
-        if (existsSync(primary)) {
+      phases.emit()
+    }
+  }, TEST_DEADLOCK_LIMIT_MS)
+
+  test('resolves the linked worktree to the primary Git common directory', () => {
+    const phases = usePhaseRun('linked-worktree-resolve')
+    const paths = fixturePaths()
+
+    const resolvedPrimary = phases.phase('resolve-primary-workspace', () => resolveMadarWorkspace(paths.primary))
+    const resolvedLinked = phases.phase('resolve-linked-workspace', () => resolveMadarWorkspace(paths.linked))
+    const resolvedScoped = phases.phase('resolve-scoped-workspace', () => resolveMadarWorkspace(join(paths.linked, 'src')))
+    primaryWorkspace = resolvedPrimary
+    linkedWorkspace = resolvedLinked
+    scopedWorkspace = resolvedScoped
+
+    phases.phase('assert-routing', () => {
+      expect(resolvedPrimary.isLinkedWorktree).toBe(false)
+      expect(resolvedPrimary.graphPath).toBe(join(resolve(paths.primary), 'out', 'graph.json'))
+      expect(resolvedLinked.isLinkedWorktree).toBe(true)
+      expect(canonicalPhysicalPath(resolvedLinked.gitCommonDir ?? '')).toBe(canonicalPhysicalPath(join(paths.primary, '.git')))
+      expect(resolvedLinked.graphPath).not.toBe(resolvedPrimary.graphPath)
+      expect(isInside(resolvedLinked.graphPath, paths.linked)).toBe(false)
+      expect(resolvedScoped.graphPath).not.toBe(resolvedLinked.graphPath)
+    })
+  }, TEST_DEADLOCK_LIMIT_MS)
+
+  test('routes conventional out paths outside the linked source checkout', () => {
+    const phases = usePhaseRun('linked-worktree-conventional-paths')
+    const paths = fixturePaths()
+    const workspace = resolvedWorkspaces().linked
+
+    phases.phase('assert-routing', () => {
+      expect(resolveWorkspaceGraphPath('out/graph.json', paths.linked)).toBe(workspace.graphPath)
+      expect(resolveWorkspaceGraphPath('./out/graph.json', paths.linked)).toBe(workspace.graphPath)
+      expect(resolveWorkspaceOutputPath('out/compare', paths.linked)).toBe(join(workspace.outputDir, 'compare'))
+      expect(validateGraphOutputPath('out/compare', 'out', paths.linked)).toBe(join(workspace.outputDir, 'compare'))
+      expect(resolveWorkspaceGraphPath('out\\graph.json', paths.linked)).toBe(workspace.graphPath)
+      expect(resolveWorkspaceGraphPath('.\\out\\graph.json', paths.linked)).toBe(workspace.graphPath)
+      expect(resolveWorkspaceOutputPath('out\\compare', paths.linked)).toBe(join(workspace.outputDir, 'compare'))
+      expect(validateGraphOutputPath('out\\compare', 'out', paths.linked)).toBe(join(workspace.outputDir, 'compare'))
+    })
+  }, TEST_DEADLOCK_LIMIT_MS)
+
+  test('writes generated graph artifacts outside the linked source checkout', () => {
+    const phases = usePhaseRun('linked-worktree-graph')
+    const paths = fixturePaths()
+    const workspace = resolvedWorkspaces().linked
+
+    phases.phase('write-feature', () => writeFileSync(join(paths.linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 2 }\n', 'utf8'))
+    const result = phases.phase('generate-graph', () => generateGraph(paths.linked, { noHtml: true }))
+    const graph = phases.phase('read-graph', () => JSON.parse(readFileSync(result.graphPath, 'utf8')) as { root_path?: string; nodes?: Array<{ source_file?: string }> })
+
+    phases.phase('assert-graph-artifacts', () => {
+      expect(result.outputDir).toBe(workspace.outputDir)
+      expect(result.graphPath).toBe(workspace.graphPath)
+      expect(existsSync(join(paths.linked, 'out'))).toBe(false)
+      expect(graph.root_path).toBe(resolve(paths.linked))
+      expect(graph.nodes?.some((node) => node.source_file?.endsWith('feature.ts'))).toBe(true)
+    })
+  }, TEST_DEADLOCK_LIMIT_MS)
+
+  test('keeps an incremental update routed to the linked artifact directory', () => {
+    const phases = usePhaseRun('linked-worktree-update')
+    const paths = fixturePaths()
+    const workspace = resolvedWorkspaces().linked
+
+    phases.phase('write-feature-update', () => writeFileSync(join(paths.linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 3 }\n', 'utf8'))
+    const update = phases.phase('generate-update', () => generateGraph(paths.linked, { update: true, noHtml: true }))
+    phases.phase('assert-update', () => {
+      expect(update.outputDir).toBe(workspace.outputDir)
+    })
+  }, TEST_DEADLOCK_LIMIT_MS)
+
+  test('keeps the SPI cache outside the linked source checkout', () => {
+    const phases = usePhaseRun('linked-worktree-spi')
+    const paths = fixturePaths()
+    const workspace = resolvedWorkspaces().linked
+
+    const spi = phases.phase('generate-spi', () => generateGraph(paths.linked, { useSpi: true, noHtml: true }))
+    phases.phase('assert-spi', () => {
+      expect(spi.outputDir).toBe(workspace.outputDir)
+      expect(existsSync(join(paths.linked, 'out'))).toBe(false)
+      expect(existsSync(join(workspace.outputDir, '.spi-cache'))).toBe(true)
+    })
+  }, TEST_DEADLOCK_LIMIT_MS)
+
+  afterAll(() => {
+    const phases = createPhaseRun({ label: 'linked-worktree-cleanup' })
+    phases.cleanup('worktree-remove', () => {
+      if (primary && linked && existsSync(primary) && existsSync(linked)) {
+        git(primary, ['worktree', 'remove', '--force', linked])
+      }
+    })
+    phases.cleanup('verify-no-stale-registration', () => {
+      if (primary && linked && existsSync(primary)) {
+        const porcelain = git(primary, ['-c', 'core.quotePath=false', 'worktree', 'list', '--porcelain'])
+        assertNoWorktreeRegistration(porcelain, linked)
+      }
+    })
+    phases.cleanup('remove-temp-root', () => {
+      if (tempDir) {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    })
+    phases.emit()
+    throwCleanupErrors('linked-worktree', phases)
+  }, TEST_DEADLOCK_LIMIT_MS)
+})
+
+test('names the worktree-add phase when linked worktree creation fails', () => {
+  const phases = createPhaseRun({ label: 'worktree-add-failure', report: () => undefined })
+  const tempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar-worktree-add-failure-')))
+  const primary = join(tempDir, 'primary')
+  const linked = join(tempDir, 'non-empty-linked')
+  let workSucceeded = false
+  try {
+    phases.phase('git-init', () => git(tempDir, ['init', primary]))
+    phases.phase('git-config-email', () => git(primary, ['config', 'user.email', 'madar-tests@example.com']))
+    phases.phase('git-config-name', () => git(primary, ['config', 'user.name', 'Madar Tests']))
+    phases.phase('write-main', () => writeFileSync(join(primary, 'main.ts'), 'export const primaryValue = 1\n', 'utf8'))
+    phases.phase('git-add', () => git(primary, ['add', '.']))
+    phases.phase('git-commit', () => git(primary, ['commit', '-m', 'initial']))
+    phases.phase('mkdir-non-empty-target', () => mkdirSync(linked))
+    phases.phase('write-target-blocker', () => writeFileSync(join(linked, 'occupied.txt'), 'occupied\n', 'utf8'))
+
+    let caught: unknown
+    try {
+      phases.phase('worktree-add', () => git(primary, ['worktree', 'add', '-b', 'feature/worktree-add-failure', linked]))
+    } catch (error) {
+      caught = error
+    }
+
+    phases.phase('assert-worktree-add-failure', () => {
+      expect(caught).toBeInstanceOf(PhaseFailure)
+      expect((caught as PhaseFailure).phase).toBe('worktree-add')
+      expect((caught as PhaseFailure).message).toContain('phase "worktree-add" failed')
+      expect((caught as PhaseFailure).cause).toBeInstanceOf(Error)
+      expect(((caught as PhaseFailure).cause as Error).message).toContain('argv=["git","worktree","add"')
+      expect(((caught as PhaseFailure).cause as Error).message).toContain('stderr=')
+    })
+    workSucceeded = true
+  } finally {
+    phases.cleanup('worktree-remove', () => {
+      if (existsSync(primary) && existsSync(linked)) {
+        const porcelain = git(primary, ['-c', 'core.quotePath=false', 'worktree', 'list', '--porcelain'])
+        if (hasWorktreeRegistration(porcelain, linked)) {
           git(primary, ['worktree', 'remove', '--force', linked])
         }
-        // The temp directory cleanup below is still safe if setup failed.
-      })
-      phases.cleanup('remove-temp-root', () => rmSync(tempDir, { recursive: true, force: true }))
-      if (workSucceeded && phases.cleanupErrors().length > 0) {
-        throw new AggregateError(phases.cleanupErrors(), 'linked-worktree cleanup failed')
       }
+    })
+    phases.cleanup('remove-temp-root', () => rmSync(tempDir, { recursive: true, force: true }))
+    phases.emit()
+    if (workSucceeded) {
+      throwCleanupErrors('worktree-add-failure', phases)
     }
-  }, 20_000)
-})
+  }
+}, TEST_DEADLOCK_LIMIT_MS)
+
+test('leaves no stale linked worktree registration after removal', () => {
+  const phases = usePhaseRun('worktree-registration-removal')
+  const tempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar-worktree-registration-')))
+  const primary = join(tempDir, 'primary')
+  const linked = join(tempDir, 'linked')
+  let workSucceeded = false
+  try {
+    phases.phase('git-init', () => git(tempDir, ['init', primary]))
+    phases.phase('git-config-email', () => git(primary, ['config', 'user.email', 'madar-tests@example.com']))
+    phases.phase('git-config-name', () => git(primary, ['config', 'user.name', 'Madar Tests']))
+    phases.phase('write-main', () => writeFileSync(join(primary, 'main.ts'), 'export const primaryValue = 1\n', 'utf8'))
+    phases.phase('git-add', () => git(primary, ['add', '.']))
+    phases.phase('git-commit', () => git(primary, ['commit', '-m', 'initial']))
+    phases.phase('worktree-add', () => git(primary, ['worktree', 'add', '-b', 'feature/worktree-registration', linked]))
+    phases.phase('worktree-remove', () => git(primary, ['worktree', 'remove', '--force', linked]))
+    const porcelain = phases.phase('worktree-list', () => git(primary, ['-c', 'core.quotePath=false', 'worktree', 'list', '--porcelain']))
+    phases.phase('assert-no-stale-registration', () => {
+      expect(hasWorktreeRegistration(porcelain, linked)).toBe(false)
+    })
+    workSucceeded = true
+  } finally {
+    phases.cleanup('ensure-worktree-remove', () => {
+      if (existsSync(primary) && existsSync(linked)) {
+        git(primary, ['worktree', 'remove', '--force', linked])
+      }
+    })
+    phases.cleanup('remove-temp-root', () => rmSync(tempDir, { recursive: true, force: true }))
+    if (workSucceeded) {
+      throwCleanupErrors('worktree-registration-removal', phases)
+    }
+  }
+}, TEST_DEADLOCK_LIMIT_MS)

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -11,14 +11,21 @@ import { resolveMadarWorkspace, resolveWorkspaceGraphPath, resolveWorkspaceOutpu
 
 import { createPhaseRun, PhaseFailure, usePhaseRun } from './helpers/phase-run.js'
 
-// The slowest Git command in the six-lane matrix was 177 ms. This 30 s limit
-// is roughly 170x that value and is deadlock protection, not a correctness bound.
+// The only real hang protection available here. `execFileSync`'s `timeout`
+// kills the child and returns control; Vitest cannot interrupt a synchronous
+// test body, so no per-test bound can ever rescue a wedged Git process. The
+// slowest Git command across the six-lane matrix was 177 ms, so 30 s is ~170x
+// that value and can only fire on a genuine hang, never on ordinary slowness.
 const GIT_DEADLOCK_LIMIT_MS = 30_000
 
-// The slowest measured phase was 4,102 ms and the slowest healthy total was
-// 8,707 ms. This 60 s timeout is only a deadlock alarm (Git hangs are interrupted
-// above); elapsed time is never asserted as a correctness criterion.
-const TEST_DEADLOCK_LIMIT_MS = 60_000
+// Vitest requires a per-test bound. This is neither a correctness criterion nor
+// the deadlock mechanism -- the Git limit above is the mechanism. It is parked
+// far outside the measured envelope so it cannot act as a gate. The slowest unit
+// across six lanes was 3,617 ms and the same unit varies 2.9x between lanes, so
+// 60 s leaves ~17x. The override is kept rather than dropped because the config
+// default off Windows is 15 s, which would leave only ~4x on the coverage lane --
+// close to the ~2.3x margin that already failed once.
+const NON_GATING_ELAPSED_CEILING_MS = 60_000
 
 interface GitProcessError {
   readonly code?: unknown
@@ -164,7 +171,7 @@ describe('linked worktree artifact routing', () => {
     } finally {
       phases.emit()
     }
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('resolves the linked worktree to the primary Git common directory', () => {
     const phases = usePhaseRun('linked-worktree-resolve')
@@ -186,7 +193,7 @@ describe('linked worktree artifact routing', () => {
       expect(isInside(resolvedLinked.graphPath, paths.linked)).toBe(false)
       expect(resolvedScoped.graphPath).not.toBe(resolvedLinked.graphPath)
     })
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('routes conventional out paths outside the linked source checkout', () => {
     const phases = usePhaseRun('linked-worktree-conventional-paths')
@@ -203,7 +210,7 @@ describe('linked worktree artifact routing', () => {
       expect(resolveWorkspaceOutputPath('out\\compare', paths.linked)).toBe(join(workspace.outputDir, 'compare'))
       expect(validateGraphOutputPath('out\\compare', 'out', paths.linked)).toBe(join(workspace.outputDir, 'compare'))
     })
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('writes generated graph artifacts outside the linked source checkout', () => {
     const phases = usePhaseRun('linked-worktree-graph')
@@ -221,7 +228,7 @@ describe('linked worktree artifact routing', () => {
       expect(graph.root_path).toBe(resolve(paths.linked))
       expect(graph.nodes?.some((node) => node.source_file?.endsWith('feature.ts'))).toBe(true)
     })
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('keeps an incremental update routed to the linked artifact directory', () => {
     const phases = usePhaseRun('linked-worktree-update')
@@ -233,7 +240,7 @@ describe('linked worktree artifact routing', () => {
     phases.phase('assert-update', () => {
       expect(update.outputDir).toBe(workspace.outputDir)
     })
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('keeps the SPI cache outside the linked source checkout', () => {
     const phases = usePhaseRun('linked-worktree-spi')
@@ -246,7 +253,7 @@ describe('linked worktree artifact routing', () => {
       expect(existsSync(join(paths.linked, 'out'))).toBe(false)
       expect(existsSync(join(workspace.outputDir, '.spi-cache'))).toBe(true)
     })
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 
   afterAll(() => {
     const phases = createPhaseRun({ label: 'linked-worktree-cleanup' })
@@ -268,7 +275,7 @@ describe('linked worktree artifact routing', () => {
     })
     phases.emit()
     throwCleanupErrors('linked-worktree', phases)
-  }, TEST_DEADLOCK_LIMIT_MS)
+  }, NON_GATING_ELAPSED_CEILING_MS)
 })
 
 test('names the worktree-add phase when linked worktree creation fails', () => {
@@ -318,7 +325,7 @@ test('names the worktree-add phase when linked worktree creation fails', () => {
       throwCleanupErrors('worktree-add-failure', phases)
     }
   }
-}, TEST_DEADLOCK_LIMIT_MS)
+}, NON_GATING_ELAPSED_CEILING_MS)
 
 test('leaves no stale linked worktree registration after removal', () => {
   const phases = usePhaseRun('worktree-registration-removal')
@@ -351,4 +358,4 @@ test('leaves no stale linked worktree registration after removal', () => {
       throwCleanupErrors('worktree-registration-removal', phases)
     }
   }
-}, TEST_DEADLOCK_LIMIT_MS)
+}, NON_GATING_ELAPSED_CEILING_MS)

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -16,6 +16,17 @@ import { createPhaseRun, PhaseFailure, usePhaseRun } from './helpers/phase-run.j
 // test body, so no per-test bound can ever rescue a wedged Git process. The
 // slowest Git command across the six-lane matrix was 177 ms, so 30 s is ~170x
 // that value and can only fire on a genuine hang, never on ordinary slowness.
+//
+// Scope, stated precisely because the difference matters: this bounds only the
+// Git commands the fixture invokes directly through `git()` below. Git reached
+// *indirectly* is NOT bounded -- `gitPath()` in `src/shared/workspace.ts` sets
+// no `timeout`, so the three spawns behind every `resolveMadarWorkspace()` call,
+// and everything `generateGraph()` resolves through it, can still hang the
+// synchronous worker. For those paths the elapsed ceiling below is a post-hoc
+// report, not protection. That is a pre-existing production gap, not one this
+// test introduced, and closing it would change production behavior (a wedged
+// Git would start returning `null` instead of hanging), so it is deliberately
+// out of scope for #695.
 const GIT_DEADLOCK_LIMIT_MS = 30_000
 
 // Vitest requires a per-test bound. This is neither a correctness criterion nor

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -3,11 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
 
-import { describe, expect, test } from 'vitest'
+import { describe, expect, onTestFinished, test } from 'vitest'
 
 import { generateGraph } from '../../src/infrastructure/generate.js'
 import { validateGraphOutputPath } from '../../src/shared/security.js'
 import { resolveMadarWorkspace, resolveWorkspaceGraphPath, resolveWorkspaceOutputPath } from '../../src/shared/workspace.js'
+
+import { createPhaseRun } from './helpers/phase-run.js'
 
 function git(directory: string, args: string[]): void {
   execFileSync('git', args, { cwd: directory, stdio: 'pipe' })
@@ -23,83 +25,110 @@ function canonicalPhysicalPath(path: string): string {
   return process.platform === 'win32' ? canonical.toLowerCase() : canonical
 }
 
+function reportPhases(text: string): void {
+  process.stdout.write(`${text}\n`)
+}
+
 describe('worktree artifact routing', () => {
   test('keeps a nested source root in a primary checkout local', () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'madar-primary-workspace-'))
+    const phases = createPhaseRun({ label: 'primary-workspace', report: reportPhases })
+    onTestFinished(() => phases.emit())
+    const tempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar-primary-workspace-')))
     const primary = join(tempDir, 'primary')
     const nested = join(primary, 'packages', 'api')
+    let workSucceeded = false
     try {
-      execFileSync('git', ['init', primary], { stdio: 'pipe' })
-      mkdirSync(nested, { recursive: true })
+      phases.phase('git-init', () => execFileSync('git', ['init', primary], { stdio: 'pipe' }))
+      phases.phase('mkdir-nested', () => mkdirSync(nested, { recursive: true }))
 
-      const workspace = resolveMadarWorkspace(nested)
+      const workspace = phases.phase('resolve-workspace', () => resolveMadarWorkspace(nested))
 
-      expect(canonicalPhysicalPath(workspace.worktreeRoot ?? '')).toBe(canonicalPhysicalPath(primary))
-      expect(workspace.isLinkedWorktree).toBe(false)
-      expect(workspace.outputDir).toBe(join(resolve(nested), 'out'))
-      expect(workspace.graphPath).toBe(join(resolve(nested), 'out', 'graph.json'))
+      phases.phase('assert-workspace', () => {
+        expect(canonicalPhysicalPath(workspace.worktreeRoot ?? '')).toBe(canonicalPhysicalPath(primary))
+        expect(workspace.isLinkedWorktree).toBe(false)
+        expect(workspace.outputDir).toBe(join(resolve(nested), 'out'))
+        expect(workspace.graphPath).toBe(join(resolve(nested), 'out', 'graph.json'))
+      })
+      workSucceeded = true
     } finally {
-      rmSync(tempDir, { recursive: true, force: true })
+      phases.cleanup('remove-temp-root', () => rmSync(tempDir, { recursive: true, force: true }))
+      if (workSucceeded && phases.cleanupErrors().length > 0) {
+        throw new AggregateError(phases.cleanupErrors(), 'primary-workspace cleanup failed')
+      }
     }
   })
 
   test('keeps a linked worktree graph outside the source checkout and isolated from the primary checkout', () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'madar-worktree-'))
+    const phases = createPhaseRun({ label: 'linked-worktree', report: reportPhases })
+    onTestFinished(() => phases.emit())
+    const tempDir = phases.phase('temp-root', () => mkdtempSync(join(tmpdir(), 'madar-worktree-')))
     const primary = join(tempDir, 'primary')
     const linked = join(tempDir, 'linked')
+    let workSucceeded = false
     try {
-      execFileSync('git', ['init', primary], { stdio: 'pipe' })
-      git(primary, ['config', 'user.email', 'madar-tests@example.com'])
-      git(primary, ['config', 'user.name', 'Madar Tests'])
-      writeFileSync(join(primary, 'main.ts'), 'export const primaryValue = 1\n', 'utf8')
-      git(primary, ['add', '.'])
-      git(primary, ['commit', '-m', 'initial'])
-      git(primary, ['worktree', 'add', '-b', 'feature/worktree-routing', linked])
-      mkdirSync(join(linked, 'src'))
+      phases.phase('git-init', () => execFileSync('git', ['init', primary], { stdio: 'pipe' }))
+      phases.phase('git-config-email', () => git(primary, ['config', 'user.email', 'madar-tests@example.com']))
+      phases.phase('git-config-name', () => git(primary, ['config', 'user.name', 'Madar Tests']))
+      phases.phase('write-main', () => writeFileSync(join(primary, 'main.ts'), 'export const primaryValue = 1\n', 'utf8'))
+      phases.phase('git-add', () => git(primary, ['add', '.']))
+      phases.phase('git-commit', () => git(primary, ['commit', '-m', 'initial']))
+      phases.phase('worktree-add', () => git(primary, ['worktree', 'add', '-b', 'feature/worktree-routing', linked]))
+      phases.phase('mkdir-linked-src', () => mkdirSync(join(linked, 'src')))
 
-      const primaryWorkspace = resolveMadarWorkspace(primary)
-      const linkedWorkspace = resolveMadarWorkspace(linked)
-      const scopedWorkspace = resolveMadarWorkspace(join(linked, 'src'))
+      const primaryWorkspace = phases.phase('resolve-primary-workspace', () => resolveMadarWorkspace(primary))
+      const linkedWorkspace = phases.phase('resolve-linked-workspace', () => resolveMadarWorkspace(linked))
+      const scopedWorkspace = phases.phase('resolve-scoped-workspace', () => resolveMadarWorkspace(join(linked, 'src')))
 
-      expect(primaryWorkspace.isLinkedWorktree).toBe(false)
-      expect(primaryWorkspace.graphPath).toBe(join(resolve(primary), 'out', 'graph.json'))
-      expect(linkedWorkspace.isLinkedWorktree).toBe(true)
-      expect(canonicalPhysicalPath(linkedWorkspace.gitCommonDir ?? '')).toBe(canonicalPhysicalPath(join(primary, '.git')))
-      expect(linkedWorkspace.graphPath).not.toBe(primaryWorkspace.graphPath)
-      expect(isInside(linkedWorkspace.graphPath, linked)).toBe(false)
-      expect(scopedWorkspace.graphPath).not.toBe(linkedWorkspace.graphPath)
-      expect(resolveWorkspaceGraphPath('out/graph.json', linked)).toBe(linkedWorkspace.graphPath)
-      expect(resolveWorkspaceGraphPath('./out/graph.json', linked)).toBe(linkedWorkspace.graphPath)
-      expect(resolveWorkspaceOutputPath('out/compare', linked)).toBe(join(linkedWorkspace.outputDir, 'compare'))
-      expect(validateGraphOutputPath('out/compare', 'out', linked)).toBe(join(linkedWorkspace.outputDir, 'compare'))
+      phases.phase('assert-routing', () => {
+        expect(primaryWorkspace.isLinkedWorktree).toBe(false)
+        expect(primaryWorkspace.graphPath).toBe(join(resolve(primary), 'out', 'graph.json'))
+        expect(linkedWorkspace.isLinkedWorktree).toBe(true)
+        expect(canonicalPhysicalPath(linkedWorkspace.gitCommonDir ?? '')).toBe(canonicalPhysicalPath(join(primary, '.git')))
+        expect(linkedWorkspace.graphPath).not.toBe(primaryWorkspace.graphPath)
+        expect(isInside(linkedWorkspace.graphPath, linked)).toBe(false)
+        expect(scopedWorkspace.graphPath).not.toBe(linkedWorkspace.graphPath)
+        expect(resolveWorkspaceGraphPath('out/graph.json', linked)).toBe(linkedWorkspace.graphPath)
+        expect(resolveWorkspaceGraphPath('./out/graph.json', linked)).toBe(linkedWorkspace.graphPath)
+        expect(resolveWorkspaceOutputPath('out/compare', linked)).toBe(join(linkedWorkspace.outputDir, 'compare'))
+        expect(validateGraphOutputPath('out/compare', 'out', linked)).toBe(join(linkedWorkspace.outputDir, 'compare'))
+      })
 
-      writeFileSync(join(linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 2 }\n', 'utf8')
-      const result = generateGraph(linked, { noHtml: true })
-      const graph = JSON.parse(readFileSync(result.graphPath, 'utf8')) as { root_path?: string; nodes?: Array<{ source_file?: string }> }
+      phases.phase('write-feature', () => writeFileSync(join(linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 2 }\n', 'utf8'))
+      const result = phases.phase('generate-graph', () => generateGraph(linked, { noHtml: true }))
+      const graph = phases.phase('read-graph', () => JSON.parse(readFileSync(result.graphPath, 'utf8')) as { root_path?: string; nodes?: Array<{ source_file?: string }> })
 
-      expect(result.outputDir).toBe(linkedWorkspace.outputDir)
-      expect(result.graphPath).toBe(linkedWorkspace.graphPath)
-      expect(existsSync(join(linked, 'out'))).toBe(false)
-      expect(graph.root_path).toBe(resolve(linked))
-      expect(graph.nodes?.some((node) => node.source_file?.endsWith('feature.ts'))).toBe(true)
+      phases.phase('assert-graph-artifacts', () => {
+        expect(result.outputDir).toBe(linkedWorkspace.outputDir)
+        expect(result.graphPath).toBe(linkedWorkspace.graphPath)
+        expect(existsSync(join(linked, 'out'))).toBe(false)
+        expect(graph.root_path).toBe(resolve(linked))
+        expect(graph.nodes?.some((node) => node.source_file?.endsWith('feature.ts'))).toBe(true)
+      })
 
-      writeFileSync(join(linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 3 }\n', 'utf8')
-      const update = generateGraph(linked, { update: true, noHtml: true })
-      expect(update.outputDir).toBe(linkedWorkspace.outputDir)
+      phases.phase('write-feature-update', () => writeFileSync(join(linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 3 }\n', 'utf8'))
+      const update = phases.phase('generate-update', () => generateGraph(linked, { update: true, noHtml: true }))
+      phases.phase('assert-update', () => {
+        expect(update.outputDir).toBe(linkedWorkspace.outputDir)
+      })
 
-      const spi = generateGraph(linked, { useSpi: true, noHtml: true })
-      expect(spi.outputDir).toBe(linkedWorkspace.outputDir)
-      expect(existsSync(join(linked, 'out'))).toBe(false)
-      expect(existsSync(join(linkedWorkspace.outputDir, '.spi-cache'))).toBe(true)
+      const spi = phases.phase('generate-spi', () => generateGraph(linked, { useSpi: true, noHtml: true }))
+      phases.phase('assert-spi', () => {
+        expect(spi.outputDir).toBe(linkedWorkspace.outputDir)
+        expect(existsSync(join(linked, 'out'))).toBe(false)
+        expect(existsSync(join(linkedWorkspace.outputDir, '.spi-cache'))).toBe(true)
+      })
+      workSucceeded = true
     } finally {
-      if (existsSync(primary)) {
-        try {
+      phases.cleanup('worktree-remove', () => {
+        if (existsSync(primary)) {
           git(primary, ['worktree', 'remove', '--force', linked])
-        } catch {
-          // The temp directory cleanup below is still safe if setup failed.
         }
+        // The temp directory cleanup below is still safe if setup failed.
+      })
+      phases.cleanup('remove-temp-root', () => rmSync(tempDir, { recursive: true, force: true }))
+      if (workSucceeded && phases.cleanupErrors().length > 0) {
+        throw new AggregateError(phases.cleanupErrors(), 'linked-worktree cleanup failed')
       }
-      rmSync(tempDir, { recursive: true, force: true })
     }
   }, 20_000)
 })

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -38,6 +38,8 @@ const GIT_DEADLOCK_LIMIT_MS = 30_000
 // close to the ~2.3x margin that already failed once.
 const NON_GATING_ELAPSED_CEILING_MS = 60_000
 
+const BASELINE_FEATURE_SOURCE = 'export function worktreeOnlyFeature() { return 2 }\n'
+
 interface GitProcessError {
   readonly code?: unknown
   readonly signal?: unknown
@@ -109,6 +111,21 @@ function throwCleanupErrors(label: string, phases: ReturnType<typeof createPhase
   }
 }
 
+function attachCleanupErrors(error: unknown, cleanupErrors: readonly PhaseFailure[]): void {
+  if (cleanupErrors.length === 0 || (typeof error !== 'object' && typeof error !== 'function') || error === null) {
+    return
+  }
+  try {
+    Object.defineProperty(error, 'cleanupErrors', {
+      configurable: true,
+      value: cleanupErrors,
+    })
+  } catch {
+    // The phase report still makes these cleanup failures visible without
+    // risking replacement of the original setup failure.
+  }
+}
+
 describe('worktree artifact routing', () => {
   test('keeps a nested source root in a primary checkout local', () => {
     const phases = usePhaseRun('primary-workspace')
@@ -147,6 +164,7 @@ describe('linked worktree artifact routing', () => {
   let primaryWorkspace: Workspace | undefined
   let linkedWorkspace: Workspace | undefined
   let scopedWorkspace: Workspace | undefined
+  let setupFailure: unknown
 
   const fixturePaths = (): { tempDir: string; primary: string; linked: string } => {
     if (!tempDir || !primary || !linked) {
@@ -179,30 +197,47 @@ describe('linked worktree artifact routing', () => {
       phases.phase('git-commit', () => git(createdPrimary, ['commit', '-m', 'initial']))
       phases.phase('worktree-add', () => git(createdPrimary, ['worktree', 'add', '-b', 'feature/worktree-routing', createdLinked]))
       phases.phase('mkdir-linked-src', () => mkdirSync(join(createdLinked, 'src')))
-    } finally {
+
+      const resolvedPrimary = phases.phase('resolve-primary-workspace', () => resolveMadarWorkspace(createdPrimary))
+      const resolvedLinked = phases.phase('resolve-linked-workspace', () => resolveMadarWorkspace(createdLinked))
+      const resolvedScoped = phases.phase('resolve-scoped-workspace', () => resolveMadarWorkspace(join(createdLinked, 'src')))
+      phases.phase('write-feature', () => writeFileSync(join(createdLinked, 'feature.ts'), BASELINE_FEATURE_SOURCE, 'utf8'))
+      phases.phase('generate-graph', () => generateGraph(createdLinked, { noHtml: true }))
+
+      primaryWorkspace = resolvedPrimary
+      linkedWorkspace = resolvedLinked
+      scopedWorkspace = resolvedScoped
+    } catch (error) {
+      setupFailure = error
+      phases.cleanup('worktree-remove', () => {
+        if (primary && linked && existsSync(primary) && existsSync(linked)) {
+          git(primary, ['worktree', 'remove', '--force', linked])
+        }
+      })
+      phases.cleanup('remove-temp-root', () => {
+        if (tempDir) {
+          rmSync(tempDir, { recursive: true, force: true })
+        }
+      })
+      attachCleanupErrors(error, phases.cleanupErrors())
       phases.emit()
+      throw error
     }
   }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('resolves the linked worktree to the primary Git common directory', () => {
     const phases = usePhaseRun('linked-worktree-resolve')
     const paths = fixturePaths()
-
-    const resolvedPrimary = phases.phase('resolve-primary-workspace', () => resolveMadarWorkspace(paths.primary))
-    const resolvedLinked = phases.phase('resolve-linked-workspace', () => resolveMadarWorkspace(paths.linked))
-    const resolvedScoped = phases.phase('resolve-scoped-workspace', () => resolveMadarWorkspace(join(paths.linked, 'src')))
-    primaryWorkspace = resolvedPrimary
-    linkedWorkspace = resolvedLinked
-    scopedWorkspace = resolvedScoped
+    const workspaces = resolvedWorkspaces()
 
     phases.phase('assert-routing', () => {
-      expect(resolvedPrimary.isLinkedWorktree).toBe(false)
-      expect(resolvedPrimary.graphPath).toBe(join(resolve(paths.primary), 'out', 'graph.json'))
-      expect(resolvedLinked.isLinkedWorktree).toBe(true)
-      expect(canonicalPhysicalPath(resolvedLinked.gitCommonDir ?? '')).toBe(canonicalPhysicalPath(join(paths.primary, '.git')))
-      expect(resolvedLinked.graphPath).not.toBe(resolvedPrimary.graphPath)
-      expect(isInside(resolvedLinked.graphPath, paths.linked)).toBe(false)
-      expect(resolvedScoped.graphPath).not.toBe(resolvedLinked.graphPath)
+      expect(workspaces.primary.isLinkedWorktree).toBe(false)
+      expect(workspaces.primary.graphPath).toBe(join(resolve(paths.primary), 'out', 'graph.json'))
+      expect(workspaces.linked.isLinkedWorktree).toBe(true)
+      expect(canonicalPhysicalPath(workspaces.linked.gitCommonDir ?? '')).toBe(canonicalPhysicalPath(join(paths.primary, '.git')))
+      expect(workspaces.linked.graphPath).not.toBe(workspaces.primary.graphPath)
+      expect(isInside(workspaces.linked.graphPath, paths.linked)).toBe(false)
+      expect(workspaces.scoped.graphPath).not.toBe(workspaces.linked.graphPath)
     })
   }, NON_GATING_ELAPSED_CEILING_MS)
 
@@ -228,7 +263,6 @@ describe('linked worktree artifact routing', () => {
     const paths = fixturePaths()
     const workspace = resolvedWorkspaces().linked
 
-    phases.phase('write-feature', () => writeFileSync(join(paths.linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 2 }\n', 'utf8'))
     const result = phases.phase('generate-graph', () => generateGraph(paths.linked, { noHtml: true }))
     const graph = phases.phase('read-graph', () => JSON.parse(readFileSync(result.graphPath, 'utf8')) as { root_path?: string; nodes?: Array<{ source_file?: string }> })
 
@@ -245,12 +279,20 @@ describe('linked worktree artifact routing', () => {
     const phases = usePhaseRun('linked-worktree-update')
     const paths = fixturePaths()
     const workspace = resolvedWorkspaces().linked
-
-    phases.phase('write-feature-update', () => writeFileSync(join(paths.linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 3 }\n', 'utf8'))
-    const update = phases.phase('generate-update', () => generateGraph(paths.linked, { update: true, noHtml: true }))
-    phases.phase('assert-update', () => {
-      expect(update.outputDir).toBe(workspace.outputDir)
-    })
+    let workSucceeded = false
+    try {
+      phases.phase('write-feature-update', () => writeFileSync(join(paths.linked, 'feature.ts'), 'export function worktreeOnlyFeature() { return 3 }\n', 'utf8'))
+      const update = phases.phase('generate-update', () => generateGraph(paths.linked, { update: true, noHtml: true }))
+      phases.phase('assert-update', () => {
+        expect(update.outputDir).toBe(workspace.outputDir)
+      })
+      workSucceeded = true
+    } finally {
+      phases.cleanup('restore-feature', () => writeFileSync(join(paths.linked, 'feature.ts'), BASELINE_FEATURE_SOURCE, 'utf8'))
+      if (workSucceeded) {
+        throwCleanupErrors('linked-worktree-update', phases)
+      }
+    }
   }, NON_GATING_ELAPSED_CEILING_MS)
 
   test('keeps the SPI cache outside the linked source checkout', () => {
@@ -285,7 +327,11 @@ describe('linked worktree artifact routing', () => {
       }
     })
     phases.emit()
-    throwCleanupErrors('linked-worktree', phases)
+    if (setupFailure === undefined) {
+      throwCleanupErrors('linked-worktree', phases)
+    } else {
+      attachCleanupErrors(setupFailure, phases.cleanupErrors())
+    }
   }, NON_GATING_ELAPSED_CEILING_MS)
 })
 


### PR DESCRIPTION
**Ready for exact-head merge into `next` after independent maintainer verification.**

Reviewed head: `9530e48b9180d8628cfea2dda0c8637d24f90987`. Focused on `tests/unit/workspace.test.ts` and its helpers. No production change — three test files only.

**Merge-readiness summary.** Three complete six-lane protected matrices ran against this exact head (`31742328001`, `31743043019`, `31743659051`): **18/18 lanes green**, **0** `Failed to start forks worker` and **0** `Timeout waiting for worker to respond` in every lane, **no** `[phase-run]` failure timeline in any accepted lane, and the scanner positive control passing on all eighteen. Each lane performs **exactly one** guarded Vitest invocation — five lanes `npm run test:run`, Ubuntu Node 22 `npm run test:coverage`. All seven named workspace tests pass alone from fresh invocations and the inter-test order dependency is removed. Production workspace Git process policy is owned by #697 and is deliberately out of scope here. **This PR is ready for merge on the evidence above.** #654 remains open pending merged-`next` qualification.

## Windows failure receipt

| Field | Value |
| --- | --- |
| Commit | `b1300f8fcc2758404abc5e6064433c4d8b2ab40b` |
| Workflow run / attempt | `31711572439` / 3 |
| Lane | `windows-latest`, Node 22 |
| Job | `94523609780` |
| Runner | Windows Server 2025, Node 22.23.2, npm 10.9.8 |
| Failure | `tests/unit/workspace.test.ts:46` — `Error: Test timed out in 20000ms` |
| File duration | ~21.3 s |
| Worker-start / handshake signatures | **0 / 0** — not the #690 absorbed-worker symptom |
| Raw-log artifact | `vitest-guard-logs-31711572439-3-windows-latest-node22`, id `9190243054`, SHA-256 `90520d018b7a76cb3e172f8b78b070d94e5fa7bd0a0c131d33a0d567def9fa08` |

Five other lanes passed on the same commit.

## The bound could not do what it appeared to do

The test body is entirely synchronous, and Vitest cannot interrupt a synchronous body. Measured directly: a sync busy-wait of 3000 ms under a `1_000` ms per-test timeout runs to completion — `[probe] sync body finished after 3000 ms` — and is only then reported as `Error: Test timed out in 1000ms`.

So the `20_000` bound was a post-hoc elapsed-time verdict. It named no phase, and it provided **zero deadlock protection** — a genuinely hung synchronous phase blocks the worker forever and the timer can never fire. Note also that `vitest.config.ts` already allows 30 s on Windows; this test's own `20_000` override was **tighter than the platform default** on the one lane that needed the most headroom.

## Phase inventory (contract before this PR)

| # | Phase | Operation | Sync/async | Existing timeout | Cleanup owner | Failure visibility |
| ---: | --- | --- | --- | --- | --- | --- |
| 1 | temp root | `mkdtempSync` | sync fs | aggregate only | `finally` `rmSync` | raw errno, no phase name |
| 2 | git init | `execFileSync git init` | sync child proc | none (no `timeout` option) | `finally` | `Command failed`; stderr unread on `.stderr` |
| 3–4 | git config email / name | `execFileSync` | sync child proc | none | `finally` | as above |
| 5 | write `main.ts` | `writeFileSync` | sync fs | aggregate only | `finally` | raw errno |
| 6–7 | git add / commit | `execFileSync` | sync child proc | none | `finally` | as above |
| 8 | worktree add | `git worktree add -b` | sync child proc | none | `finally` | as above |
| 9 | mkdir `linked/src` | `mkdirSync` | sync fs | aggregate only | `finally` | raw errno |
| 10–12 | resolve primary / linked / scoped workspace | `resolveMadarWorkspace` ×3 | sync, **9 git spawns** | none | `finally` | assertion or errno only |
| 13 | routing assertions | 11 expectations, 4 of which re-enter `resolveMadarWorkspace` = up to **12 further git spawns** | sync | aggregate only | `finally` | Vitest diff, phase unnamed |
| 14 | write `feature.ts` | `writeFileSync` | sync fs | aggregate only | `finally` | raw errno |
| 15 | generate graph | `generateGraph(noHtml)` | sync, in-process | none | `finally` | phase unnamed |
| 16 | read graph | `readFileSync` + `JSON.parse` | sync fs | aggregate only | `finally` | phase unnamed |
| 17 | artifact assertions | 5 expectations | sync | aggregate only | `finally` | Vitest diff |
| 18 | write update | `writeFileSync` | sync fs | aggregate only | `finally` | raw errno |
| 19 | generate update | `generateGraph(update)` | sync, in-process | none | `finally` | phase unnamed |
| 20 | generate SPI | `generateGraph(useSpi)` + `.spi-cache` | sync, in-process | none | `finally` | phase unnamed |
| 21 | worktree remove | `git worktree remove --force` | sync child proc | none | `finally`, **empty `catch`** | **none — swallowed** |
| 22 | temp cleanup | `rmSync(force: true)` | sync fs | aggregate only | `finally` | **none — `force` swallows** |

## Instrumentation evidence (six green lanes, run `31730399080`)

Stage 1 added phase instrumentation with no semantic change and collected real timings from protected CI. `linked-worktree` totals and largest phases, in ms:

| Lane | total | generate-graph | generate-update | assert-routing | resolve ×3 | setup git | cleanup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| **windows Node 22** | **8308** | 3139 | 1888 | 1437 | 643 | 598 | 70 |
| **windows Node 20** | **8707** | 3211 | 1915 | 1608 | 759 | 555 | 95 |
| ubuntu Node 22 (coverage) | 7486 | 4102 | 3097 | 101 | 60 | ~90 | 10 |
| ubuntu Node 20 | 2998 | 1734 | 904 | 89 | 60 | ~85 | 18 |
| macOS Node 22 | 3579 | 1488 | 751 | 552 | 331 | ~300 | 17 |
| macOS Node 20 | 4163 | 1759 | 850 | 680 | 225 | ~250 | 24 |

Slowest single git command anywhere in the matrix: **177 ms**. Slowest single phase anywhere: **4102 ms**.

### Identified failing phase — and why no single phase is the answer

**No phase approaches 20 s.** The failure is a property of the aggregate, and the evidence says so precisely:

1. A healthy Windows total is 8.3–8.7 s against the 20 s bound — a surviving margin of only **~2.3x**.
2. The variance of these same phases is **larger than that margin**, and it is visible inside this one green run: ubuntu Node 20 totalled 2998 ms while ubuntu Node 22 totalled 7486 ms (**2.5x**), and `generate-graph` ranged 1488–4102 ms (**2.8x**) on identical code.
3. The bound therefore sat inside the noise band. That explains the observed behavior exactly — intermittent, attempt 3 but not attempts 1–2, one lane and not the other five.

The cost is concentrated, though, and that shapes the fix: `generate-graph` is 38% of the Windows run, `generate-update` 23%, and **~25% is repeated git subprocess spawning** — `assert-routing` (1437 ms) plus the three `resolve-*` phases (643 ms) come from roughly 21 `resolveMadarWorkspace` spawns at 50–120 ms each on Windows.

Attributing this to one phase would have been a guess; the aggregate structure is the defect.

## Architecture choice

Split the 22-phase monolith into a shared fixture plus focused tests, so the largest single unit is one `generateGraph` call rather than the whole sum. A wall-clock verdict then names its unit structurally, and the correctness contract is carried by assertions.

### The two limits, named honestly

Only one of them is a deadlock mechanism.

- **`GIT_DEADLOCK_LIMIT_MS = 30_000`** on every git subprocess — this *is* the mechanism. `execFileSync`'s `timeout` kills the child and returns control, which is the only interruption available in a synchronous body. The previous contract ran 22 phases with **no** subprocess timeout at all, so a wedged `git worktree add` would have blocked the worker permanently with nothing able to rescue it. 30 s is ~170x the slowest observed git command (177 ms), so it can only fire on a genuine hang.
- **`NON_GATING_ELAPSED_CEILING_MS = 60_000`** per unit and per hook — this is **not** deadlock protection and is not presented as such. Vitest requires a per-test bound; this one is parked far outside the measured envelope so it cannot act as a gate. The slowest unit across six lanes is 3617 ms and that same unit varies 2.9x between lanes, so 60 s leaves ~17x.

#### What the 30 s bound does and does not cover

Stated exactly, because overstating it would be the same failure this PR exists to correct. The bound applies to Git commands the fixture invokes **directly** through the `git()` helper. Git reached **indirectly** is *not* bounded:

- `resolveMadarWorkspace()` → `gitPath()` at `src/shared/workspace.ts:30` calls `execFileSync('git', …)` with `encoding`, `stdio` and `windowsHide` but **no `timeout`** (`grep -c timeout src/shared/workspace.ts` → 0). Each `resolveMadarWorkspace()` call spawns up to three such commands.
- `generateGraph()` reaches the same unbounded path via `resolveMadarOutputDirectory()` (`src/infrastructure/generate.ts:360`).

Those indirect spawns are the majority, and by this PR's own measurements they dominate Windows cost. A hang there blocks the synchronous worker exactly as before, and `NON_GATING_ELAPSED_CEILING_MS` can only report it after the fact — the precise property this PR establishes a per-test bound cannot provide. So for those paths the ceiling is a post-hoc report, not protection.

This is a **pre-existing production gap**. This PR did not create it; it only needed to stop claiming coverage that does not reach it. Closing it would change production behavior — a wedged Git would begin returning `null` after N seconds instead of hanging, which affects every Madar invocation and needs its own analysis of what bound is safe for legitimately slow Git on large repositories. #695's non-goals forbid production changes, so it is deliberately out of scope here and recorded separately for the maintainer.

One detail worth carrying into that separate issue: `gitPath()` also swallows every error with `catch { return null }`. So even if a `timeout` were added there, a killed Git would surface as a silent `null` rather than a diagnosable failure. Both halves need addressing together.

Credit: found by CodeRabbit at `97a65528`, verified against source before being written up here.

Why keep the override at all rather than letting the config default stand? Because the default is 15 s off Windows, and the slowest unit on the ubuntu coverage lane is 3469 ms — a ~4x margin against 2.9x measured variance for that unit. That is the same shape of exposure that just failed at 2.3x. An explicit, justified, non-gating value is safer than inheriting a tight one.

### On reducing the git spawns

The spawn cost is confirmed as the dominant Windows factor: ~25% of the old test's Windows runtime, and `routes conventional out paths` is still 1667–2759 ms on Windows because each expectation re-enters `resolveMadarWorkspace` for three more spawns.

The three *explicit* `resolveMadarWorkspace` calls are now resolved once and reused across units, which removes those spawns from every later test. The remaining spawns cannot be hoisted: they happen inside `resolveWorkspaceGraphPath`, `resolveWorkspaceOutputPath` and `validateGraphOutputPath`, which are the functions under test. Each of the eight inputs (`out/graph.json`, `./out/graph.json`, the four backslash forms, `out/compare`) is a distinct routing case, so removing a call removes a correctness check. The structural split is what neutralizes the risk instead: that unit now sits against a non-gating ceiling rather than sharing one budget with graph generation.

## Before / after contract

| | Before | After |
| --- | --- | --- |
| Correctness criterion | one 20 s wall-clock sum over 22 phases | direct assertions per unit |
| Failure attribution | none | exact phase name, original error as `cause` |
| Deadlock protection | **none** — 22 phases, no subprocess timeout, sync body uninterruptible | 30 s kill on every git subprocess (the only real mechanism) |
| Git failure detail | `Command failed` | argv + captured stderr, deadlock distinguished from failure |
| Cleanup on failure | empty `catch`, `force: true` — both silent | explicit runner, failures recorded and surfaced separately |
| Stale registration | never checked | `git worktree list --porcelain` verified |
| Spaces / non-ASCII paths | not covered | fixture prefix `madar worktree ünïcode ` |
| Windows separators | not covered | explicit `out\graph.json` inputs asserted on every platform |
| Evidence on timeout | none | timeline emitted; quiet on success |

## Cleanup model

Cleanup is owned by the phase runner rather than by a bare `finally`. `cleanup()` never throws inline, so it cannot pre-empt an in-flight failure; errors accumulate and are raised afterwards as an `AggregateError` only when the work itself succeeded. Cleanup covers failure during worktree creation, graph generation, assertions, and worktree removal, and the four failure classes stay distinct: assertion failure, generation failure, worktree-remove failure, filesystem cleanup failure.

Proof that the timeline survives a post-hoc timeout — one real test's limit temporarily set to 1 ms, then reverted:

```text
[phase-run] linked-worktree-graph total=554ms
[phase-run] linked-worktree-graph 1. work write-feature ok 0ms
[phase-run] linked-worktree-graph 2. work generate-graph ok 554ms
[phase-run] linked-worktree-graph 3. work read-graph ok 0ms
[phase-run] linked-worktree-graph 4. work assert-graph-artifacts ok 0ms
Error: Test timed out in 1ms.
```

Every phase reports `ok` — exactly the diagnostic the Windows lane could not produce. After that forced failure, zero fixture temp directories remained (`madar worktree*`, `madar-worktree-*`, `madar-primary-workspace-*` all absent) and no stale worktree registration was left.

## Issue checklist 1–13

| # | Requirement | Where |
| ---: | --- | --- |
| 1 | Setup completes; git commands report actionable failures | `git()` helper: argv + stderr + `cause`; asserted in the worktree-add failure test |
| 2 | Worktree creation with spaces in the path | fixture prefix `madar worktree ünïcode ` (also non-ASCII) |
| 3 | Windows separators do not affect routing | explicit `out\graph.json`, `.\out\graph.json`, `out\compare` inputs, asserted on every platform, plus Windows CI |
| 4 | Artifacts outside the linked source checkout | `writes generated graph artifacts outside the linked source checkout` |
| 5 | Primary and linked isolation | `resolves the linked worktree to the primary Git common directory` |
| 6 | Generation failure names the generation phase | `workspace-phase-run.test.ts`, stub generator |
| 7 | Worktree-add failure names the worktree-add phase | real integration test against an occupied target path |
| 8 | Cleanup after assertion failure | `workspace-phase-run.test.ts` |
| 9 | Cleanup after generation failure | `workspace-phase-run.test.ts` |
| 10 | No stale porcelain registration | dedicated real test plus `afterAll` verification |
| 11 | Slow phase is not a correctness failure | injected clock drives a logical 45 s run to a clean pass |
| 12 | Hang reported with phase name and diagnostics | `PhaseDeadlock` classification test |
| 13 | No global timeout, retry, skip, quarantine or worker change | none present; `vitest.config.ts` and `package.json` untouched |

## Files changed

- `tests/unit/helpers/phase-run.ts` (new) — phase runner: stable unique names, injectable clock, `PhaseFailure` / `PhaseDeadlock`, cleanup recorded separately, quiet-on-success emission that still fires on a failed test.
- `tests/unit/workspace.test.ts` — restructured into a shared fixture plus focused tests; actionable git helper; porcelain verification.
- `tests/unit/workspace-phase-run.test.ts` (new) — 11 deterministic injected-clock tests for the diagnostics and cleanup contract.

Nothing under `src/`, `package.json`, `vitest.config.ts`, or `.github/` is touched.

## Focused results (macOS, local, this branch)

`npm run typecheck` clean. `npm run build` clean.

`npx vitest run tests/unit/workspace.test.ts tests/unit/workspace-phase-run.test.ts` — 19 passed, three repetitions at `--maxWorkers=1` and three at `--maxWorkers=4`, all green. Zero `[phase-run]` lines emitted on success. Zero leftover fixture temp directories after every run.

Per-test durations are now 52–470 ms locally, against a 60 s deadlock alarm.


## Test independence

Review found the tests were not independent, and it was a real defect. Reproduced before changing anything:

```
npx vitest run tests/unit/workspace.test.ts \
  -t "routes conventional out paths outside the linked source checkout"
→ Error: Linked worktree fixture was not resolved
  Tests  1 failed | 7 skipped (8)
```

Four of the five linked-worktree tests failed alone. `beforeAll` built the repository, but the three resolved workspace objects were assigned inside the first test, so every later test threw when that test did not run; the update test also relied on an earlier test having written `feature.ts` and generated a baseline graph. One test body was acting as another's setup — and whole-file runs, however many times repeated, cannot detect that.

All shared state now lives in `beforeAll`. Per-test fixtures were rejected deliberately: a fresh repository, worktree and graph per test would multiply the ~21 indirect git spawns and the `generateGraph` cost across five tests, recreating the aggregate-runtime exposure this PR exists to remove. The update test restores `feature.ts` in a `finally`. `beforeAll` owns its own failure path — best-effort cleanup, cleanup failures recorded separately and attached, original failure rethrown — and `afterAll` tolerates a fixture that was never built.

### Independence proof (macOS, local)

| Check | Result |
| --- | --- |
| Each of the 7 named tests alone, fresh invocation via `-t` | all pass (`1 passed \| 7 skipped`) |
| Shuffle seeds `695`, `20260813`, `314159` (`--sequence.shuffle.tests --sequence.seed`) | 23 passed + 1 expected fail each |
| Full file ×3 at `--maxWorkers=1` and ×3 at `--maxWorkers=4` | 23 passed + 1 expected fail each |
| `--reporter=hanging-process` | no output, exit 0 — no hanging handles reported |
| `[phase-run]` emissions on success | 0 in every run |
| Fixture temp dirs remaining (`madar worktree*`, `madar-worktree-*`, `madar-primary-workspace-*`) | 0 |
| Stale worktree registrations | 0 |

### Why this file reports `1 expected fail`

Every lane prints `1 expected fail` for `tests/unit/workspace-phase-run.test.ts` — `2953 passed | 1 expected fail | 2 skipped` on Linux and macOS, `2938 | 1 | 17` on Windows, 2956 total in every lane. Nothing is failing.

`usePhaseRun` only emits its phase timeline when its test fails, so the only honest way to exercise that path is to let a test genuinely fail. `usePhaseRun emits through console.log when its test fails` is declared with `test.fails`, which marks the failure as expected.

`test.fails` alone would be a weak assertion — it passes on any throw — so the emission is captured by a `console.log` spy and asserted in the suite's `afterAll`. If the emission is ever lost, the `afterAll` fails and takes the file with it. The spy also suppresses the output, so the run still emits zero `[phase-run]` lines and the CI zero-emission check stays meaningful.

The path matters because it is the one that produces diagnostics when a test fails in CI. Left uncovered, a regression there would delete those diagnostics without failing anything.

## Protected CI

Six lanes green on every head pushed so far, with 0 `Failed to start forks worker`, 0 `Timeout waiting for worker to respond`, 0 `[phase-run]` emissions, and the guarded runner invoked on each lane:

| Head | Run |
| --- | --- |
| `3d238c97` | `31733046918` |
| `97a65528` | `31734192333` |
| `f658a4c6` | `31736115096` |
| `56fbd06d` | `31737077555` |
| `15d3144f` | `31739065737` |
| `9530e48b` | `31742160331` |

**One guarded invocation per lane, not two.** An earlier revision of this section said `guarded=2`, from counting the bare string `run-guarded-vitest` in each lane log. Two of those hits are one real invocation plus the guard's own test file, `tests/unit/run-guarded-vitest.test.ts`, matching on filename alone. Counting `node scripts/run-guarded-vitest.mjs` gives **1** per lane, corroborated by exactly **1** Vitest summary per lane. The matrix is mutually exclusive by design — `ci.yml:58` gates `test:run` to every lane except ubuntu Node 22, and `ci.yml:62` gates `test:coverage` to ubuntu Node 22 alone — so five lanes run in `run` mode and one in coverage mode. The verdict is unchanged: the guard is invoked on every lane, all six are signature-scanned, and all counts are zero. The accurate claim is "one guarded command per lane", not "both guarded commands on every lane".

Per-unit Windows durations measured at `56fbd06d` — largest single unit 3617 ms against the 60 s non-gating ceiling (16.6x), replacing 8.3–8.7 s against 20 s (2.3x).

### Qualification matrices (exact head `9530e48b`)

Three sequential `workflow_dispatch` runs on the branch head itself, so each executes `9530e48b` rather than a merge commit. `ci.yml` sets `cancel-in-progress: true`, so they cannot overlap and were run strictly in sequence. Every lane of all three was inspected from its raw log.

| Matrix | Run | Lanes | `Failed to start forks worker` | `Timeout waiting for worker to respond` | `[phase-run]` | Guarded invocations/lane | Positive control |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `31742328001` | 6/6 green | 0 | 0 | 0 | 1 | PASS |
| 2 | `31743043019` | 6/6 green | 0 | 0 | 0 | 1 | PASS |
| 3 | `31743659051` | 6/6 green | 0 | 0 | 0 | 1 | PASS |

**18 lanes, 0 signatures.** The positive control appends a synthetic `Failed to start forks worker` line to a copy of each lane log and re-scans it; every lane's count rises by exactly one, so the zeros are demonstrated rather than merely absent. Mode split confirmed per matrix: five lanes `run`, ubuntu Node 22 `run --coverage`.

## Commands deliberately not run

`npm run test:run` and `npm run test:coverage` were **not** run locally, and no local complete-suite result is claimed for this PR.

This workstation is a known-unsuitable qualification environment. Per the pre-registered experiment recorded on #693, guarded `test:run` here produces 13–20 worker-start signatures on **every** run, including runs starting at 0.1% aggregate Node CPU, and controlled contention does not change the rate. A local complete suite would fail for host reasons unrelated to this change, and reporting that against #695 would misattribute it.

**Protected CI is the authoritative gate for this PR.** Everything else in the validation list was run: `npm run typecheck`, `npm run build`, and the focused workspace tests repeatedly at `--maxWorkers=1` and `--maxWorkers=4`.

The three complete exact-commit six-lane protected matrices are recorded above under Protected CI.

## Not in this PR

No graph identity, multigraph, artifact-v2, retrieval, Pack, extraction, MCP, installer, or release changes. No global Vitest timeout increase, no retry, no skip, no quarantine, no worker-count change. #690's guarded commands and policy test are untouched. #657 is not started.

## Rollback

Revert the two commits together. The helper and the deterministic test file are new and have no other consumer. Do not restore the fixed 20 s aggregate as the permanent gate; if this design is judged invalid, return to investigation with the retained Windows receipt and the phase table above.

Refs #695.
Related parent: #654.
#654 remains open.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded workspace test coverage for primary and linked workspaces, graph generation, incremental updates, caching, and stale registrations.
  - Added clearer diagnostics for failures, including command details, causes, cleanup issues, and deadlock detection.
  - Improved tracking of setup and cleanup phases with deterministic timing and reporting.
  - Added coverage for failure handling, nested errors, duplicate phase names, long-running operations, and cleanup behavior.
  - Added timeout safeguards to prevent stalled tests from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
