### PR TITLE
test(watch): wait for the settled watcher status instead of sampling it (#700)

### DIFF
--- a/tests/unit/watch.test.ts
+++ b/tests/unit/watch.test.ts
@@ -224,6 +224,7 @@ describe('watch', () => {
         expect(refresh.startupComplete?.()).toBe(true)
         expect(refresh.initialRebuilt).toBe(false)
         expect(rebuild).not.toHaveBeenCalled()
+        await waitForWatcherStatus(generated.graphPath, 'idle')
         expect(readWatcherStateForGraph(generated.graphPath)).toMatchObject({
           status: 'idle',
           coverage: 'complete',
@@ -257,6 +258,7 @@ describe('watch', () => {
         expect(refresh.startupComplete?.()).toBe(true)
         expect(refresh.initialRebuilt).toBe(false)
         expect(rebuild).not.toHaveBeenCalled()
+        await waitForWatcherStatus(generated.graphPath, 'idle')
         expect(readWatcherStateForGraph(generated.graphPath)).toMatchObject({
           status: 'idle',
           coverage: 'complete',
@@ -367,7 +369,10 @@ describe('watch', () => {
         await refresh.startupSettled
         expect(refresh.startupComplete?.()).toBe(true)
         expect(refresh.initialRebuilt).toBe(true)
-        expect(readWatcherStateForGraph(generated.graphPath)?.status).toBe('idle')
+        // `startupSettled` is a promise about startup, not about the watcher having
+        // quiesced. Contention must resolve to a settled `idle`; requiring it to be
+        // idle the instant startup settles asserts scheduling, not behaviour.
+        await waitForWatcherStatus(generated.graphPath, 'idle')
       } finally {
         releaseOwner?.()
         refresh.stop()
@@ -400,7 +405,9 @@ describe('watch', () => {
         expect(existsSync(workspace.graphPath)).toBe(true)
         expect(existsSync(join(workspace.outputDir, 'watcher-state.json'))).toBe(true)
         expect(existsSync(join(linked, 'out'))).toBe(false)
-        expect(readWatcherStateForGraph(workspace.graphPath)?.status).toBe('idle')
+        // `git worktree add` has just written the whole linked checkout, so the watcher
+        // may still observe that activity when it attaches. Wait for the settled state.
+        await waitForWatcherStatus(workspace.graphPath, 'idle')
 
         writeFileSync(join(linked, 'added.ts'), 'export const linkedValue = 2\n', 'utf8')
         await waitFor(() => {
@@ -1268,7 +1275,11 @@ async function withTempDirAsync(callback: (tempDir: string) => Promise<void>): P
   }
 }
 
-async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<void> {
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 5_000,
+  describe: () => string = () => 'graph refresh',
+): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (condition()) {
@@ -1276,5 +1287,20 @@ async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<voi
     }
     await delay(25)
   }
-  throw new Error('Timed out waiting for graph refresh')
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${describe()}`)
+}
+
+/**
+ * The persisted watcher status is written by a live poll loop, so reading it once is
+ * a sample rather than an assertion. A change observed during startup legitimately
+ * persists `pending` before the watcher settles, and whether such a change is observed
+ * depends on the platform's filesystem-event timing. Wait for the required status
+ * instead, and name the last observed one when the wait times out.
+ */
+async function waitForWatcherStatus(graphPath: string, expected: string): Promise<void> {
+  await waitFor(
+    () => readWatcherStateForGraph(graphPath)?.status === expected,
+    5_000,
+    () => `watcher status '${expected}' (last observed '${readWatcherStateForGraph(graphPath)?.status ?? 'none'}')`,
+  )
 }


### PR DESCRIPTION
Refs #700. Related parent: #649.

## What failed

`tests/unit/watch.test.ts > watch > keeps startup unsettled during live lease contention and recovers after release` failed on one lane of the exact-head matrix for PR #681:

```
run   : https://github.com/mohanagy/madar/actions/runs/31767671776
job   : validate (macos-latest, Node 20)
lanes : 5 of 6 green

AssertionError: expected 'pending' to be 'idle' // Object.is equality
 ❯ tests/unit/watch.test.ts:370:71
 Test Files  1 failed | 210 passed (211)
      Tests  1 failed | 2990 passed | 1 expected fail | 2 skipped (2994)
```

The three assertions before it passed, so startup completed and the initial rebuild ran. Only the persisted status disagreed.

## Why it is a test defect and not a watcher defect

`src/infrastructure/watch.ts:1038` ends the startup reconcile with:

```ts
state.status = eventDirty || pending ? 'pending' : 'idle'
```

Two independent inputs can each set that to `pending`, and neither is synchronised with `startupSettled`:

- `eventDirty` — a filesystem event delivered during startup. The test rewrites `main.ts` and attaches the watcher immediately afterwards; on macOS, FSEvents can surface that write after the watcher attaches.
- a non-empty post-rebuild snapshot diff (`watch.ts:1030-1036`), which sets `pending` on the same path.

In both cases `pending` is the **correct** persisted status — a change really was observed. `startupSettled` is a promise about startup, not about the watcher having quiesced, and the test used it as if it were both. So the assertion sampled scheduling rather than behaviour.

This is a latent race, not a regression. The same test passed on all 18 lanes of the three #654 acceptance matrices at `6b6b3d84`, and PR #681 touches nothing in the watcher or its tests — it only adds a test file, which shifts how work distributes across the four Vitest workers. A trigger, not a cause.

## The correction

Wait for the required status rather than sampling it. `idle` is still required, so this synchronises the assertion without weakening it — and `waitFor` is already the idiom two lines above in the same test, which waits for `'reconciling'`.

The same single-sample pattern appears at three further sites where a live watcher is running, and all four now wait:

| line | test | why it was exposed |
|---|---|---|
| 370 | lease contention recovery | the observed failure |
| 227 | settles startup without rebuilding an unchanged valid graph | `main.ts` written just before the watcher attaches |
| 260 | does not rebuild when managed root agent instructions were added | same |
| 403 | keeps graph and watcher state outside a linked worktree | `git worktree add` writes the whole checkout immediately before attach |

At 227 and 260 the wait is inserted **before** the existing `toMatchObject`, so every field assertion is preserved unchanged.

`waitFor` gained an optional description, so a timeout now names the condition and the last observed status instead of the generic `Timed out waiting for graph refresh` — the previous message named neither, which is poor evidence for exactly this class of failure.

## Audited and deliberately left unchanged

- Reads after `refresh.stop()` / `controller.abort()` followed by an `await` (lines 570, 594, 1002) are synchronised by the watcher having finished.
- Reads inside or immediately after an existing `waitFor` (lines 366, 587-588, 625, 969-991) already establish their own predicate.
- One narrow residual is recorded on #700 rather than widened into this diff: the re-read at line 979 asserts `status: 'failed'` after a `waitFor` observed it, while an automatic retry is pending and could advance the state between the two reads. The window is microseconds against a 20 ms poll and it has never been observed failing, so correcting it here would be scope creep on a test about retry behaviour.

## Verification

```
npm run typecheck                              → clean
npm run test:run -- tests/unit/watch.test.ts   → 41 passed (41), guarded runner, in this worktree
```

A local pass is weak evidence for a race — the same test passed on five of six CI lanes before this change. The argument for the fix is structural: the assertion no longer samples a value a live poll loop keeps writing. The exact-head six-lane matrix on this branch is the evidence that matters, and it is not being predicted here.

## Non-goals honoured

No `retry`, no `.skip`, no `.todo`, no quarantine, no change to `maxWorkers` or `testTimeout`, and no change to watcher production semantics — `pending` after an observed startup change remains correct behaviour.
