### PR TITLE
test(watch): assert the observed watcher state instead of re-reading it (#700)

### DIFF
--- a/tests/unit/watch.test.ts
+++ b/tests/unit/watch.test.ts
@@ -224,8 +224,8 @@ describe('watch', () => {
         expect(refresh.startupComplete?.()).toBe(true)
         expect(refresh.initialRebuilt).toBe(false)
         expect(rebuild).not.toHaveBeenCalled()
-        await waitForWatcherStatus(generated.graphPath, 'idle')
-        expect(readWatcherStateForGraph(generated.graphPath)).toMatchObject({
+        const settled = await waitForWatcherStatus(generated.graphPath, 'idle')
+        expect(settled).toMatchObject({
           status: 'idle',
           coverage: 'complete',
           policy_match: true,
@@ -258,8 +258,8 @@ describe('watch', () => {
         expect(refresh.startupComplete?.()).toBe(true)
         expect(refresh.initialRebuilt).toBe(false)
         expect(rebuild).not.toHaveBeenCalled()
-        await waitForWatcherStatus(generated.graphPath, 'idle')
-        expect(readWatcherStateForGraph(generated.graphPath)).toMatchObject({
+        const settled = await waitForWatcherStatus(generated.graphPath, 'idle')
+        expect(settled).toMatchObject({
           status: 'idle',
           coverage: 'complete',
           policy_match: true,
@@ -584,10 +584,20 @@ describe('watch', () => {
       })
 
       writeFileSync(join(tempDir, 'main.ts'), 'export const changed = true\n', 'utf8')
-      await waitFor(() => readWatcherStateForGraph(graphPath)?.status === 'pending')
-      const pending = readWatcherStateForGraph(graphPath)
-      expect(pending).toMatchObject({ coverage: 'complete', policy_match: true })
-      expect(pending?.pending_since).toMatch(/^\d{4}-/)
+      // Capture the state the wait observed. Re-reading afterwards samples a live poll loop
+      // again: the debounce can fire between the two reads, advancing status away from
+      // `pending` and clearing `pending_since` to null.
+      const observed: { state?: ReturnType<typeof readWatcherStateForGraph> } = {}
+      await waitFor(() => {
+        const watcherState = readWatcherStateForGraph(graphPath)
+        if (watcherState?.status !== 'pending') {
+          return false
+        }
+        observed.state = watcherState
+        return true
+      }, 5_000, () => `watcher status 'pending' (last observed '${readWatcherStateForGraph(graphPath)?.status ?? 'none'}')`)
+      expect(observed.state).toMatchObject({ coverage: 'complete', policy_match: true })
+      expect(observed.state?.pending_since).toMatch(/^\d{4}-/)
 
       controller.abort()
       await watcher
@@ -969,29 +979,43 @@ describe('watch', () => {
         await waitFor(() => readWatcherStateForGraph(graphPath)?.status === 'idle')
         writeFileSync(join(tempDir, 'main.py'), 'def hello():\n    return 2\n', 'utf8')
 
+        // Capture the state the wait observed. The failure schedules an automatic retry, so a
+        // second read can land after the retry has already advanced the watcher past `failed`.
+        const observedFailure: { state?: ReturnType<typeof readWatcherStateForGraph> } = {}
         await waitFor(() => {
           const watcherState = readWatcherStateForGraph(graphPath)
-          return watcherState?.status === 'failed'
+          const matched = watcherState?.status === 'failed'
             && watcherState.coverage === 'failed'
             && watcherState.failure_reason?.includes('retry is scheduled automatically') === true
+          if (matched) {
+            observedFailure.state = watcherState
+          }
+          return matched
         })
         expect(rebuild).toHaveBeenCalledTimes(1)
-        expect(readWatcherStateForGraph(graphPath)).toMatchObject({
+        expect(observedFailure.state).toMatchObject({
           status: 'failed',
           coverage: 'failed',
           failure_reason: expect.stringContaining('retry is scheduled automatically'),
         })
 
+        // Same capture rule: the watcher is still running with a 10ms reconcile interval, so a
+        // periodic reconcile can move it off `idle` between the wait and a second read.
+        const observedRecovery: { state?: ReturnType<typeof readWatcherStateForGraph> } = {}
         await waitFor(() => {
           const watcherState = readWatcherStateForGraph(graphPath)
-          return rebuild.mock.calls.length === 2
+          const matched = rebuild.mock.calls.length === 2
             && watcherState?.status === 'idle'
             && watcherState.coverage === 'complete'
             && watcherState.failure_reason === null
+          if (matched) {
+            observedRecovery.state = watcherState
+          }
+          return matched
         })
         expect(rebuild).toHaveBeenCalledTimes(2)
         expect(notify).toHaveBeenCalledTimes(1)
-        expect(readWatcherStateForGraph(graphPath)).toMatchObject({
+        expect(observedRecovery.state).toMatchObject({
           status: 'idle',
           coverage: 'complete',
           failure_reason: null,
@@ -1297,10 +1321,25 @@ async function waitFor(
  * depends on the platform's filesystem-event timing. Wait for the required status
  * instead, and name the last observed one when the wait times out.
  */
-async function waitForWatcherStatus(graphPath: string, expected: string): Promise<void> {
+async function waitForWatcherStatus(
+  graphPath: string,
+  expected: string,
+): Promise<NonNullable<ReturnType<typeof readWatcherStateForGraph>>> {
+  // Returns the state the wait actually observed. Callers must assert on this value rather
+  // than reading again: the watcher keeps running, so a periodic reconcile can move it off
+  // `expected` between the wait succeeding and a second read.
+  const observed: { state?: ReturnType<typeof readWatcherStateForGraph> } = {}
   await waitFor(
-    () => readWatcherStateForGraph(graphPath)?.status === expected,
+    () => {
+      const watcherState = readWatcherStateForGraph(graphPath)
+      if (watcherState?.status !== expected) {
+        return false
+      }
+      observed.state = watcherState
+      return true
+    },
     5_000,
     () => `watcher status '${expected}' (last observed '${readWatcherStateForGraph(graphPath)?.status ?? 'none'}')`,
   )
+  return observed.state as NonNullable<ReturnType<typeof readWatcherStateForGraph>>
 }


### PR DESCRIPTION
Closes the last outstanding criterion on #700.

#701 fixed the reported failure by replacing instantaneous single-sample assertions with bounded waits. It left the second half of the pattern: several sites wait for a status and then **read again** to assert on it. The watcher is still running at those points, so the second read is another sample of a live poll loop.

#700 recorded **one** residual. Auditing every site found **five**.

| Site | Why the second read can lose |
|---|---|
| `pending` | asserts `pending_since` matches a date, which becomes `null` the moment the debounce fires and the status leaves `pending` |
| transient rebuild failure | asserts `failed`, which the automatic retry it just scheduled advances away from |
| recovery | asserts `idle` with a 10 ms reconcile interval live |
| two startup sites | re-read after `waitForWatcherStatus` — the sites #701 itself touched, with `refresh.stop()` only in the `finally` |

`waitForWatcherStatus` now **returns** the state it observed, so the class is removed rather than patched site by site: a caller cannot take a second sample without deliberately reintroducing one.

**Nothing is weakened.** Every assertion still requires the same status and the same fields; only the sampling changed. No test is skipped, retried or quarantined.

### #700 criterion 3, discharged explicitly

Every `readWatcherStateForGraph` call in the file is now one of: inside a wait predicate, a captured observation, or a terminal read. Four bare asserting reads remain and all four are terminal — after `await watch(...)` completes, or after abort plus `await watcher` — where no further transition is possible.

### On evidence

A race fix cannot be proven by a passing test: the previous code passed too, which is precisely the problem. The argument is structural, and the enumeration above is the evidence. A six-lane exact-head matrix follows for criterion 4.

Local: typecheck clean, `watch.test.ts` 41 passed.

Refs #700. Related parent: #649.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved watcher test reliability by asserting the exact state observed during polling.
  * Added coverage for idle, pending, failed, and recovery states.
  * Reduced race conditions when validating watcher status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->