### PR TITLE
fix(indexing): order persisted collections by code point, not host collation

### DIFF
--- a/src/infrastructure/compare.ts
+++ b/src/infrastructure/compare.ts
@@ -1041,6 +1041,15 @@ function isMadarToolDiscoveryToolUse(toolName: string, input: unknown): boolean 
   return collectTraceToolInputStrings(input).some((value) => isDeferredMadarToolSelectionQuery(value))
 }
 
+/**
+ * Display ordering: every comparator in this file shapes a compare run report,
+ * which carries wall-clock stamps and is not byte-reproducible by construction.
+ * `proof-report.ts` does parse `report.share-safe.json`, but reads only the
+ * question, the reduction ratios, `status.baseline` and `provider_proof` -- none
+ * of which any of these comparators order. Collation is the right order for a
+ * reader, so `localeCompare` stays. Persisted collections order by code point --
+ * see `compareUnicodeCodePoints` in src/contracts/canonical-json.ts.
+ */
 function traceToolCountSummary(toolCallsByName: Record<string, number>): string {
   return Object.entries(toolCallsByName)
     .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))

--- a/src/infrastructure/proof-report.ts
+++ b/src/infrastructure/proof-report.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 
+import { compareUnicodeCodePoints } from '../contracts/canonical-json.js'
 import { buildGraphSummary } from '../runtime/graph-summary.js'
 import { computeContextPackDiagnostics } from '../runtime/context-pack-diagnostics.js'
 import { loadGraph } from '../runtime/serve.js'
@@ -204,7 +205,11 @@ function findFilesByName(rootDir: string, fileName: string): string[] {
       matches.push(entryPath)
     }
   }
-  return matches.sort((left, right) => left.localeCompare(right))
+  // Code point, not collation. This sort exists solely to impose a deterministic
+  // order on a `readdirSync` walk, and a comparator that answers according to the
+  // host's ICU locale defeats the only reason it is here. Every discovered path
+  // is mapped by the caller, so the order decides presentation, never inclusion.
+  return matches.sort(compareUnicodeCodePoints)
 }
 
 function readCompareSummaries(compareDir: string, graphBase: string): ProofReportCompareSummary[] {

--- a/src/pipeline/export.ts
+++ b/src/pipeline/export.ts
@@ -10,6 +10,17 @@ import { bridgePageFilename, buildOverviewBridgeSummaries, type OverviewBridgeSu
 import { buildCommunitySummaryData } from './export/community-summary.js'
 import { buildOverviewSearchIndex, buildOverviewTopNodes, type OverviewSearchIndexEntry, type OverviewTopNode } from './export/overview-navigation.js'
 
+/**
+ * Display ordering: every `localeCompare` in this file orders an export Madar
+ * writes for a person or an external tool -- interactive HTML, the overview
+ * pages, SVG, GEXF, GraphML and the Obsidian vault -- and never parses back.
+ * Collation is the right order there, so they stay. Persisted collections order
+ * by code point instead; see `compareUnicodeCodePoints` in
+ * src/contracts/canonical-json.ts.
+ *
+ * `toJson` / `serializeGraphJsonPayload` below have no production caller since
+ * the artifact-v2 cutover; `graph.madar` is the published graph.
+ */
 const COMMUNITY_COLORS = ['#4E79A7', '#F28E2B', '#E15759', '#76B7B2', '#59A14F', '#EDC948', '#B07AA1', '#FF9DA7', '#9C755F', '#BAB0AC']
 
 const SVG_LAYOUT = {

--- a/src/pipeline/export/community-summary.ts
+++ b/src/pipeline/export/community-summary.ts
@@ -34,6 +34,12 @@ export interface CommunitySummaryData {
   topFiles: Array<[string, number]>
 }
 
+/**
+ * Display ordering: these tie-breaks shape the generated community pages, which
+ * are written for a person to read and are never parsed back by Madar. Collation
+ * is the right order there, so `localeCompare` stays. Persisted collections order
+ * by code point -- see `compareUnicodeCodePoints` in src/contracts/canonical-json.ts.
+ */
 export function buildCommunitySummaryData(nodes: CommunitySummarySourceNode[]): CommunitySummaryData {
   const sortedNodes = [...nodes].sort((left, right) => right.degree - left.degree || left.label.localeCompare(right.label))
   const summaryNodes = sortedNodes.map((node) => ({

--- a/src/pipeline/export/overview-navigation.ts
+++ b/src/pipeline/export/overview-navigation.ts
@@ -30,9 +30,9 @@ function overviewNodeHref(communityPagesDirname: string, communityId: number, no
 /**
  * Display ordering: the overview navigation is HTML for a person to read, never
  * parsed back by Madar, so collation is the right order and `localeCompare`
- * stays here and in `buildOverviewCommunityLinks` below. Persisted collections
- * order by code point -- see `compareUnicodeCodePoints` in
- * src/contracts/canonical-json.ts.
+ * stays in both label sorts in this file -- the top-node tie-break below and the
+ * search-index sort in `buildOverviewSearchIndex`. Persisted collections order by
+ * code point -- see `compareUnicodeCodePoints` in src/contracts/canonical-json.ts.
  */
 export function buildOverviewTopNodes(
   graph: KnowledgeGraph,

--- a/src/pipeline/export/overview-navigation.ts
+++ b/src/pipeline/export/overview-navigation.ts
@@ -27,6 +27,13 @@ function overviewNodeHref(communityPagesDirname: string, communityId: number, no
   return `${communityPagesDirname}/community-${communityId}.html#${pageMode === 'summary' ? nodeAnchorId(nodeId) : encodeURIComponent(nodeId)}`
 }
 
+/**
+ * Display ordering: the overview navigation is HTML for a person to read, never
+ * parsed back by Madar, so collation is the right order and `localeCompare`
+ * stays here and in `buildOverviewCommunityLinks` below. Persisted collections
+ * order by code point -- see `compareUnicodeCodePoints` in
+ * src/contracts/canonical-json.ts.
+ */
 export function buildOverviewTopNodes(
   graph: KnowledgeGraph,
   nodeIds: string[],

--- a/src/pipeline/indexing-outcomes.ts
+++ b/src/pipeline/indexing-outcomes.ts
@@ -145,10 +145,18 @@ export function summarizeIndexingOutcomes(outcomes: readonly IndexingOutcome[]):
   //
   // `reason`, `extraction_strategy` and `fallback_reason` are closed ASCII sets
   // with no integer-like member, so for them enumeration order and code-point
-  // order coincide. `capability` is an open domain -- `parseIndexingManifest`
-  // accepts any string and incremental generation returns a prior outcome
-  // verbatim -- so a manifest on disk can round-trip both a value the host locale
-  // orders differently and a value the language emits out of comparator order.
+  // order coincide.
+  //
+  // Closed does not mean collation-insensitive, which an earlier comment here
+  // got wrong. `empty_extraction` and `extractor_error` are both valid reason
+  // codes, and az-AZ orders them the other way round because Azerbaijani places
+  // `x` between `h` and `ı`. So this comparator does real work even on a closed
+  // ASCII domain.
+  //
+  // `capability` is an open domain -- `parseIndexingManifest` accepts any string
+  // and incremental generation returns a prior outcome verbatim -- so a manifest
+  // on disk can round-trip both a value the host locale orders differently and a
+  // value the language emits out of comparator order.
   return {
     state: completenessState(counts),
     candidates: outcomes.length,

--- a/src/pipeline/indexing-outcomes.ts
+++ b/src/pipeline/indexing-outcomes.ts
@@ -1,5 +1,6 @@
 import { relative, sep } from 'node:path'
 
+import { compareUnicodeCodePoints } from '../contracts/canonical-json.js'
 import {
   INDEXING_MANIFEST_VERSION,
   type ExtractionFallbackReason,
@@ -71,8 +72,13 @@ export function deduplicateIndexingOutcomes(outcomes: readonly IndexingOutcome[]
       ...(diagnostics ? { diagnostics } : {}),
     })
   }
+  // Code point, not collation: this order is written into indexing-manifest.json,
+  // and `localeCompare` answers according to the host's ICU locale, so two
+  // machines published different bytes for the same repository. De-duplication
+  // above is by `kind:path` and has already happened, so this sort only decides
+  // byte order -- it can never change which outcome survives.
   return [...deduplicated.values()].sort((left, right) =>
-    left.path.localeCompare(right.path) || left.kind.localeCompare(right.kind))
+    compareUnicodeCodePoints(left.path, right.path) || compareUnicodeCodePoints(left.kind, right.kind))
 }
 
 function emptyStatusCounts(): IndexingStatusCounts {
@@ -121,17 +127,24 @@ export function summarizeIndexingOutcomes(outcomes: readonly IndexingOutcome[]):
     }
   }
 
+  // The bucket key orders below are byte order: this summary is serialized with
+  // a plain `JSON.stringify`, so an object's insertion order IS its byte order.
+  // `reason`, `extraction_strategy` and `fallback_reason` are closed ASCII sets
+  // that every collation orders alike, but `capability` is an open domain --
+  // `parseIndexingManifest` accepts any string and incremental generation
+  // returns a prior outcome verbatim -- so a manifest on disk can round-trip a
+  // value the host locale orders differently. All four use the one comparator.
   return {
     state: completenessState(counts),
     candidates: outcomes.length,
     counts,
-    reason_buckets: Object.fromEntries(Object.entries(reasonBuckets).sort(([left], [right]) => left.localeCompare(right))),
-    capability_buckets: Object.fromEntries(Object.entries(capabilityBuckets).sort(([left], [right]) => left.localeCompare(right))),
+    reason_buckets: Object.fromEntries(Object.entries(reasonBuckets).sort(([left], [right]) => compareUnicodeCodePoints(left, right))),
+    capability_buckets: Object.fromEntries(Object.entries(capabilityBuckets).sort(([left], [right]) => compareUnicodeCodePoints(left, right))),
     ...(Object.keys(strategyBuckets).length > 0
-      ? { extraction_strategy_buckets: Object.fromEntries(Object.entries(strategyBuckets).sort(([left], [right]) => left.localeCompare(right))) }
+      ? { extraction_strategy_buckets: Object.fromEntries(Object.entries(strategyBuckets).sort(([left], [right]) => compareUnicodeCodePoints(left, right))) }
       : {}),
     ...(Object.keys(fallbackReasonBuckets).length > 0
-      ? { fallback_reason_buckets: Object.fromEntries(Object.entries(fallbackReasonBuckets).sort(([left], [right]) => left.localeCompare(right))) }
+      ? { fallback_reason_buckets: Object.fromEntries(Object.entries(fallbackReasonBuckets).sort(([left], [right]) => compareUnicodeCodePoints(left, right))) }
       : {}),
   }
 }
@@ -149,7 +162,11 @@ export function createIndexingManifest(input: {
     ...(input.requestedExtractionMode ? { requested_extraction_mode: input.requestedExtractionMode } : {}),
     summary: summarizeIndexingOutcomes(outcomes),
     outcomes,
-    spi_diagnostics: [...(input.spiDiagnostics ?? [])].sort((left, right) => left.id.localeCompare(right.id)),
+    // Diagnostic ids are projected verbatim from the SPI, and the SPI cache
+    // shape-checks only version/workspace/files/symbols, so a cached index can
+    // carry any id at all. Code point keeps the manifest bytes host-independent.
+    spi_diagnostics: [...(input.spiDiagnostics ?? [])].sort((left, right) =>
+      compareUnicodeCodePoints(left.id, right.id)),
   }
 }
 

--- a/src/pipeline/indexing-outcomes.ts
+++ b/src/pipeline/indexing-outcomes.ts
@@ -75,8 +75,13 @@ export function deduplicateIndexingOutcomes(outcomes: readonly IndexingOutcome[]
   // Code point, not collation: this order is written into indexing-manifest.json,
   // and `localeCompare` answers according to the host's ICU locale, so two
   // machines published different bytes for the same repository. De-duplication
-  // above is by `kind:path` and has already happened, so this sort only decides
-  // byte order -- it can never change which outcome survives.
+  // above is by `kind:path` and has already happened, so this sort cannot change
+  // which outcome survives into the manifest.
+  //
+  // It does decide which ones a person sees: `doctor.ts` filters the incomplete
+  // outcomes and takes `slice(0, 20)` in two places, so the first twenty listed
+  // change with this comparator. That is a display consequence of making the
+  // manifest host-independent, and it is host-independent too.
   return [...deduplicated.values()].sort((left, right) =>
     compareUnicodeCodePoints(left.path, right.path) || compareUnicodeCodePoints(left.kind, right.kind))
 }
@@ -127,13 +132,23 @@ export function summarizeIndexingOutcomes(outcomes: readonly IndexingOutcome[]):
     }
   }
 
-  // The bucket key orders below are byte order: this summary is serialized with
-  // a plain `JSON.stringify`, so an object's insertion order IS its byte order.
+  // The bucket key orders below decide bytes: this summary is serialized with a
+  // plain `JSON.stringify`, which emits keys in ECMAScript enumeration order.
+  //
+  // That is NOT simply insertion order. Integer-index keys come first, ascending
+  // numerically, and only then the remaining string keys in insertion order. So
+  // capabilities `"10"` and `"2"` serialize as `"2"` before `"10"` whatever this
+  // comparator returns. That reordering is host-independent -- it is a language
+  // rule, not an ICU one -- so the guarantee here still holds; what the
+  // comparator fixes is the order of the string keys, which is the part
+  // `localeCompare` made depend on the host.
+  //
   // `reason`, `extraction_strategy` and `fallback_reason` are closed ASCII sets
-  // that every collation orders alike, but `capability` is an open domain --
-  // `parseIndexingManifest` accepts any string and incremental generation
-  // returns a prior outcome verbatim -- so a manifest on disk can round-trip a
-  // value the host locale orders differently. All four use the one comparator.
+  // with no integer-like member, so for them enumeration order and code-point
+  // order coincide. `capability` is an open domain -- `parseIndexingManifest`
+  // accepts any string and incremental generation returns a prior outcome
+  // verbatim -- so a manifest on disk can round-trip both a value the host locale
+  // orders differently and a value the language emits out of comparator order.
   return {
     state: completenessState(counts),
     candidates: outcomes.length,

--- a/src/pipeline/spi/diff-overlay.ts
+++ b/src/pipeline/spi/diff-overlay.ts
@@ -18,6 +18,8 @@
 
 import { execFileSync } from 'node:child_process'
 
+import { compareUnicodeCodePoints } from '../../contracts/canonical-json.js'
+
 import type {
   SemanticProgramIndex,
   SpiDiffOverlay,
@@ -96,9 +98,14 @@ export function computeSpiDiffOverlay(opts: ComputeSpiDiffOverlayOptions): SpiDi
     head_ref: headRef,
     changed_files: [...changedFiles].sort(),
     changed_symbols: [...changedSymbols].sort(),
-    edges_added: edgesAdded.sort((a, b) =>
-      `${a.from}|${a.to}|${a.kind}`.localeCompare(`${b.from}|${b.to}|${b.kind}`),
-    ),
+    // Code point, not collation. The overlay is not persisted, but it sorts the
+    // same `from|to|kind` key as the SPI's own edge ordering, and symbol ids
+    // embed source identifiers -- so a host-dependent comparator here would make
+    // one member of that key's family disagree with the rest for no reason.
+    edges_added: edgesAdded.sort((a, b) => compareUnicodeCodePoints(
+      `${a.from}|${a.to}|${a.kind}`,
+      `${b.from}|${b.to}|${b.kind}`,
+    )),
   }
 }
 

--- a/src/pipeline/wiki.ts
+++ b/src/pipeline/wiki.ts
@@ -62,6 +62,12 @@ function connectionPrefix(direction: ConnectionDirection): string {
   return ''
 }
 
+/**
+ * Display ordering: every comparator in this file orders an Obsidian vault
+ * Madar writes for a person and never reads back. Collation is the right order
+ * there, so `localeCompare` stays. Persisted collections order by code point --
+ * see `compareUnicodeCodePoints` in src/contracts/canonical-json.ts.
+ */
 export function crossCommunityLinks(graph: KnowledgeGraph, nodes: string[], ownCommunityId: number, labels: Record<number, string>): Array<[string, number]> {
   const counts = new Map<string, number>()
 

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -2,6 +2,8 @@ import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
+import { compareUnicodeCodePoints } from '../contracts/canonical-json.js'
+
 export function findGitRoot(path: string): string | null {
   let current = resolve(path)
   while (true) {
@@ -109,7 +111,13 @@ function parseStatusPaths(statusOutput: string): string[] {
 }
 
 function dedupePaths(paths: Iterable<string>): string[] {
-  return [...new Set([...paths].filter((path) => path.length > 0))].sort((left, right) => left.localeCompare(right))
+  // Code point, not collation. This order survives into
+  // `graph_build_freshness.git.dirty_files`, which canonical JSON serializes as
+  // an ORDERED array, so `localeCompare` made graph.madar bytes depend on the
+  // host's ICU locale whenever a build ran against a dirty worktree.
+  // De-duplication by exact string has already happened above, so this sort
+  // decides byte order only and can never drop a path.
+  return [...new Set([...paths].filter((path) => path.length > 0))].sort(compareUnicodeCodePoints)
 }
 
 export interface GitSnapshot {

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -476,6 +476,12 @@ function writeJsonAtomic(targetPath: string, value: unknown): void {
   }
 }
 
+/**
+ * Display ordering: `readTelemetryReport` returns these lines as a string for a
+ * person to read; nothing writes them to disk. Collation is the right order for
+ * a reader, so `localeCompare` stays. Persisted collections order by code point
+ * instead -- see `compareUnicodeCodePoints` in src/contracts/canonical-json.ts.
+ */
 function summarizeCounts(values: string[]): string[] {
   const counts = new Map<string, number>()
   for (const value of values) {

--- a/tests/unit/persisted-ordering-callsite-policy.test.ts
+++ b/tests/unit/persisted-ordering-callsite-policy.test.ts
@@ -1,0 +1,224 @@
+import { readFileSync } from 'node:fs'
+import { dirname, posix, relative, resolve } from 'node:path'
+
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards the decision that cannot be re-derived from types: which sorts write
+ * persisted bytes and therefore must not consult the host's collation.
+ *
+ * Three of the sites this file pins have **no behavioural coverage at all, and
+ * cannot have any**. `reason`, `extraction_strategy` and `fallback_reason` are
+ * closed lowercase-ASCII sets that `parseIndexingManifest` validates on the way
+ * in, and their code-point, en-US and sv-SE orders are identical -- measured. No
+ * fixture can make a runtime control fail for them, so a runtime control there
+ * would be decorative. This audit is their only coverage, and saying so is the
+ * point: the limitation is recorded rather than hidden behind a green test.
+ *
+ * It also catches what a byte-comparison cannot. Shadowing the imported
+ * comparator with a local definition of the same name is legal TypeScript and
+ * leaves every call site looking correct, so the binding is checked, not just
+ * the spelling.
+ *
+ * Ordering meant for human reading stays locale-sensitive. The display sites
+ * below are asserted to carry a comment saying so, so that "why is this one
+ * different?" has an answer in the file rather than in a review thread.
+ */
+
+const SRC = resolve(process.cwd(), 'src')
+const OWNER = 'src/contracts/canonical-json.ts'
+const DISPLAY_MARKER = 'Display ordering:'
+
+/**
+ * Every production site that must order by code point, with the number of
+ * comparator calls it should contain. Adding a row is a reviewed decision; the
+ * counts stop a site from quietly losing its comparator while the file keeps one.
+ */
+const MUST_USE_CODE_POINTS = new Map<string, number>([
+  // outcomes (1, two keys), the four summary buckets (4), spi_diagnostics (1)
+  ['src/pipeline/indexing-outcomes.ts', 7],
+  // dedupePaths -> graph_build_freshness.git.dirty_files -> graph.madar
+  ['src/shared/git.ts', 1],
+  // the overlay's from|to|kind key, the same key family the SPI itself orders
+  ['src/pipeline/spi/diff-overlay.ts', 1],
+  // compare-summary discovery order in proof-report.md
+  ['src/infrastructure/proof-report.ts', 1],
+])
+
+/**
+ * Sites whose ordering is presentation, with the number of annotations each
+ * should carry. These are deliberately left locale-sensitive.
+ */
+const DISPLAY_SITES = new Map<string, number>([
+  ['src/shared/telemetry.ts', 1],
+  ['src/infrastructure/compare.ts', 1],
+  ['src/pipeline/wiki.ts', 1],
+  ['src/pipeline/export.ts', 1],
+  ['src/pipeline/export/community-summary.ts', 1],
+  ['src/pipeline/export/overview-navigation.ts', 1],
+])
+
+function sourceFileFor(relativePath: string): ts.SourceFile {
+  const absolute = resolve(process.cwd(), relativePath)
+  return ts.createSourceFile(absolute, readFileSync(absolute, 'utf8'), ts.ScriptTarget.Latest, true)
+}
+
+function walk(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node)
+  node.forEachChild((child) => walk(child, visit))
+}
+
+/** Every `x.localeCompare(...)` in the file, as `line:text`. */
+function localeCompareCalls(source: ts.SourceFile): string[] {
+  const found: string[] = []
+  walk(source, (node) => {
+    if (ts.isPropertyAccessExpression(node) && node.name.text === 'localeCompare') {
+      const { line } = source.getLineAndCharacterOfPosition(node.getStart(source))
+      found.push(`${line + 1}: ${node.getText(source).slice(0, 80)}`)
+    }
+  })
+  return found
+}
+
+/**
+ * Every use of the comparator, counting both forms the codebase uses: called
+ * with two keys, `compareUnicodeCodePoints(a.path, b.path)`, and passed by
+ * reference, `.sort(compareUnicodeCodePoints)`. Counting only calls would report
+ * zero for a file that orders correctly by reference.
+ */
+function comparatorUses(source: ts.SourceFile): ts.Identifier[] {
+  const found: ts.Identifier[] = []
+  walk(source, (node) => {
+    if (!ts.isIdentifier(node) || node.text !== 'compareUnicodeCodePoints') return
+    if (ts.isImportSpecifier(node.parent)) return
+    found.push(node)
+  })
+  return found
+}
+
+/**
+ * Every binding of the name, split into the import that should exist and any
+ * other declaration, which is what a shadowing mutation would add.
+ */
+function comparatorBindings(source: ts.SourceFile): { imports: ts.ImportDeclaration[]; others: string[] } {
+  const imports: ts.ImportDeclaration[] = []
+  const others: string[] = []
+  walk(source, (node) => {
+    if (ts.isImportSpecifier(node) && node.name.text === 'compareUnicodeCodePoints') {
+      const declaration = node.parent.parent.parent
+      if (ts.isImportDeclaration(declaration)) imports.push(declaration)
+      return
+    }
+    const named = (ts.isVariableDeclaration(node) || ts.isFunctionDeclaration(node)
+      || ts.isParameter(node) || ts.isBindingElement(node) || ts.isClassDeclaration(node))
+      && node.name !== undefined && ts.isIdentifier(node.name)
+      && node.name.text === 'compareUnicodeCodePoints'
+    if (named) {
+      const { line } = source.getLineAndCharacterOfPosition(node.getStart(source))
+      others.push(`${relative(process.cwd(), source.fileName)}:${line + 1}`)
+    }
+  })
+  return { imports, others }
+}
+
+/** Resolves an import declaration's specifier to a repo-relative `.ts` path. */
+function resolvedSpecifier(source: ts.SourceFile, declaration: ts.ImportDeclaration): string {
+  const specifier = (declaration.moduleSpecifier as ts.StringLiteral).text
+  const fromDir = posix.dirname(relative(process.cwd(), source.fileName).split('\\').join('/'))
+  return posix.normalize(posix.join(fromDir, specifier)).replace(/\.js$/, '.ts')
+}
+
+describe('persisted ordering call sites', () => {
+  it('guards a non-empty set of sites', () => {
+    // A guard over an empty set passes forever while guarding nothing.
+    expect(MUST_USE_CODE_POINTS.size).toBeGreaterThan(0)
+    expect(DISPLAY_SITES.size).toBeGreaterThan(0)
+    expect(SRC).toContain('src')
+  })
+
+  for (const [file, expectedCalls] of MUST_USE_CODE_POINTS) {
+    describe(file, () => {
+      it('consults no host collation', () => {
+        const offenders = localeCompareCalls(sourceFileFor(file))
+        expect(
+          offenders,
+          `${file} orders with localeCompare, which answers according to the host's ICU `
+          + 'locale, so two machines write different bytes for the same inputs. Use '
+          + `compareUnicodeCodePoints from ${OWNER}.`,
+        ).toEqual([])
+      })
+
+      it('orders through the single comparator owner, the expected number of times', () => {
+        const uses = comparatorUses(sourceFileFor(file))
+        // Not "the identifier appears somewhere": the import specifier is excluded,
+        // and the count stops one site from silently losing its comparator while
+        // the file still has others.
+        expect(uses.length, `${file}: expected ${expectedCalls} comparator uses`).toBe(expectedCalls)
+      })
+
+      it('binds the comparator only by importing it from the owner', () => {
+        const source = sourceFileFor(file)
+        const { imports, others } = comparatorBindings(source)
+        expect(
+          others,
+          `${file} declares compareUnicodeCodePoints locally. That is legal TypeScript and `
+          + 'shadows the import, so every call site still reads correctly while the ordering '
+          + 'silently changes.',
+        ).toEqual([])
+        expect(imports, `${file}: expected exactly one import of the comparator`).toHaveLength(1)
+        expect(resolvedSpecifier(source, imports[0] as ts.ImportDeclaration)).toBe(OWNER)
+      })
+
+      it('passes no hand-rolled comparator to sort', () => {
+        const source = sourceFileFor(file)
+        const offenders: string[] = []
+        walk(source, (node) => {
+          if (!ts.isCallExpression(node)) return
+          if (!ts.isPropertyAccessExpression(node.expression) || node.expression.name.text !== 'sort') return
+          const comparator = node.arguments[0]
+          // A bare `.sort()` is UTF-16 code-unit order: already host-independent,
+          // and used deliberately elsewhere in these files. Only a supplied
+          // comparator has to route through the owner.
+          if (comparator === undefined) return
+          if (ts.isIdentifier(comparator) && comparator.text === 'compareUnicodeCodePoints') return
+          const usesOwner = comparatorUses(source).some(
+            (use) => use.getStart(source) >= comparator.getStart(source)
+              && use.getEnd() <= comparator.getEnd(),
+          )
+          if (!usesOwner) {
+            const { line } = source.getLineAndCharacterOfPosition(node.getStart(source))
+            offenders.push(`${file}:${line + 1}`)
+          }
+        })
+        expect(
+          offenders,
+          'these sorts supply a comparator that never reaches compareUnicodeCodePoints',
+        ).toEqual([])
+      })
+    })
+  }
+
+  for (const [file, expectedAnnotations] of DISPLAY_SITES) {
+    it(`${file} says in the file why its ordering stays locale-sensitive`, () => {
+      const text = readFileSync(resolve(process.cwd(), file), 'utf8')
+      const found = text.split(DISPLAY_MARKER).length - 1
+      expect(
+        found,
+        `${file} should carry ${expectedAnnotations} "${DISPLAY_MARKER}" annotation(s). `
+        + 'Without it the next reader cannot tell a deliberate display sort from one that '
+        + 'was missed.',
+      ).toBe(expectedAnnotations)
+      // And the annotation is only honest if the file really does still use it.
+      expect(localeCompareCalls(sourceFileFor(file)).length, `${file}: annotated but no display sort left`)
+        .toBeGreaterThan(0)
+    })
+  }
+
+  it('leaves the comparator owner untouched by this policy', () => {
+    // The owner defines the comparator; it must not be edited to satisfy the audit.
+    const source = sourceFileFor(OWNER)
+    expect(localeCompareCalls(source), `${OWNER} must not call localeCompare`).toEqual([])
+    void dirname
+  })
+})

--- a/tests/unit/persisted-ordering-callsite-policy.test.ts
+++ b/tests/unit/persisted-ordering-callsite-policy.test.ts
@@ -11,8 +11,9 @@ import { describe, expect, it } from 'vitest'
  * Two of the sites this file pins have **no behavioural coverage, because none
  * is possible**: `extraction_strategy` and `fallback_reason` are closed
  * lowercase-ASCII sets that `parseIndexingManifest` validates on the way in, and
- * an exhaustive search over every locale this build collates finds no pair whose
- * collation order differs from code-point order. `fallback_reason` has a single
+ * a search over every two-letter language subtag this build collates, plus a
+ * documented set of longer tags, finds no pair whose collation order differs
+ * from code-point order. `fallback_reason` has a single
  * member, so it cannot have a pair at all. For those two this audit is the only
  * coverage, and saying so is the point.
  *

--- a/tests/unit/persisted-ordering-callsite-policy.test.ts
+++ b/tests/unit/persisted-ordering-callsite-policy.test.ts
@@ -8,13 +8,20 @@ import { describe, expect, it } from 'vitest'
  * Guards the decision that cannot be re-derived from types: which sorts write
  * persisted bytes and therefore must not consult the host's collation.
  *
- * Three of the sites this file pins have **no behavioural coverage at all, and
- * cannot have any**. `reason`, `extraction_strategy` and `fallback_reason` are
- * closed lowercase-ASCII sets that `parseIndexingManifest` validates on the way
- * in, and their code-point, en-US and sv-SE orders are identical -- measured. No
- * fixture can make a runtime control fail for them, so a runtime control there
- * would be decorative. This audit is their only coverage, and saying so is the
- * point: the limitation is recorded rather than hidden behind a green test.
+ * Two of the sites this file pins have **no behavioural coverage, because none
+ * is possible**: `extraction_strategy` and `fallback_reason` are closed
+ * lowercase-ASCII sets that `parseIndexingManifest` validates on the way in, and
+ * an exhaustive search over every locale this build collates finds no pair whose
+ * collation order differs from code-point order. `fallback_reason` has a single
+ * member, so it cannot have a pair at all. For those two this audit is the only
+ * coverage, and saying so is the point.
+ *
+ * `reason` used to be listed here too, on a sweep of six hand-picked locales.
+ * That was wrong: `az-AZ` reverses `empty_extraction` against `extractor_error`,
+ * because Azerbaijani places `x` between `h` and `ı`. It now has a real
+ * behavioural control, and the classification of all three domains is derived by
+ * search in `persisted-ordering-locale-determinism.test.ts` rather than asserted
+ * here.
  *
  * It also catches what a byte-comparison cannot. Shadowing the imported
  * comparator with a local definition of the same name is legal TypeScript and

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -4,9 +4,14 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
-import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { compareUnicodeCodePoints } from '../../src/contracts/canonical-json.js'
+import {
+  EXTRACTION_FALLBACK_REASONS,
+  EXTRACTION_STRATEGIES,
+  INDEXING_REASON_CODES,
+} from '../../src/contracts/indexing.js'
 import { parseIndexingManifest } from '../../src/infrastructure/indexing-manifest.js'
 import { createIndexingManifest, shareSafeIndexingManifest } from '../../src/pipeline/indexing-outcomes.js'
 import { computeSpiDiffOverlay } from '../../src/pipeline/spi/diff-overlay.js'
@@ -26,17 +31,26 @@ import { workingTreeSourceModule, type PinnedSourceModule } from './helpers/pinn
  * Every control here asserts three things, because any one of them alone can be
  * satisfied by a broken implementation:
  *
- *   (a) the fixture actually discriminates -- code-point order differs from
- *       en-US order and from sv-SE order, and those two differ from each other.
- *       Without this the whole file passes on a corpus every comparator sorts
- *       alike, proving nothing.
- *   (b) the emitted order IS code-point order and is NEITHER collation order.
- *       This is the leg a comparator pinned to a fixed locale cannot survive:
- *       `localeCompare(a, b, 'sv-SE')` makes both host arms agree with each
- *       other while still emitting the wrong order.
+ *   (a) the fixture actually discriminates -- the control's two locale arms
+ *       disagree with each other, and at least one of them disagrees with
+ *       code-point order. Without this the whole file passes on a corpus every
+ *       comparator sorts alike, proving nothing.
+ *   (b) the emitted order IS code-point order, and is not the order any
+ *       divergent arm would have produced. This is the leg a comparator pinned
+ *       to a fixed locale cannot survive: `localeCompare(a, b, 'sv-SE')` makes
+ *       both host arms agree with each other while still emitting the wrong
+ *       order.
  *   (c) the published bytes are identical between two child processes started
  *       under different `LC_ALL` values. This is the leg a locale dependency
  *       OUTSIDE the comparator cannot survive.
+ *
+ * The locale arms are per fixture, not global. Accented file names split en-US
+ * from sv-SE. The closed reason-code domain is pure lowercase ASCII, where those
+ * two agree; it splits en-US from az-AZ instead, because Azerbaijani places `x`
+ * between `h` and `ı`. An earlier revision asserted that domain had no
+ * discriminating fixture at all and gave it static coverage only, which was
+ * wrong -- see `closed domains are classified from an exhaustive search` below,
+ * which derives the classification instead of assuming it.
  *
  * Ordering intended for human reading is deliberately left locale-sensitive;
  * this is not a repository-wide ban on `localeCompare`.
@@ -57,26 +71,65 @@ const ADVERSARIAL = [
 const PATHS = ADVERSARIAL.map((name) => `src/${name}.ts`)
 const FIXED_NOW = new Date('2026-08-25T00:00:00.000Z')
 
-const byEnglish = (values: readonly string[]): string[] =>
-  [...values].sort((left, right) => left.localeCompare(right, 'en-US'))
-const bySwedish = (values: readonly string[]): string[] =>
-  [...values].sort((left, right) => left.localeCompare(right, 'sv-SE'))
+/**
+ * The two host collations a control runs its writer under.
+ *
+ * Not a single global pair. Which collations disagree depends on the fixture:
+ * file paths with accented names split en-US from sv-SE, while the closed
+ * reason-code domain is ASCII and splits en-US from az-AZ instead, because
+ * Azerbaijani places `x` between `h` and `ı`. A pair that agrees on a given
+ * fixture makes leg (c) compare two identical configurations.
+ */
+interface LocaleArms {
+  /** BCP 47 tags, for in-process ordering. */
+  readonly tags: readonly [string, string]
+  /** The matching `LC_ALL` values, for the child processes. */
+  readonly lcAll: readonly [string, string]
+}
+
+const LATIN_ACCENTED: LocaleArms = { tags: ['en-US', 'sv-SE'], lcAll: ['en_US.UTF-8', 'sv_SE.UTF-8'] }
+const ASCII_REASON_CODES: LocaleArms = { tags: ['en-US', 'az-AZ'], lcAll: ['en_US.UTF-8', 'az_AZ.UTF-8'] }
+
+const byLocale = (values: readonly string[], tag: string): string[] =>
+  [...values].sort((left, right) => left.localeCompare(right, tag))
 const byCodePoint = (values: readonly string[]): string[] =>
   [...values].sort(compareUnicodeCodePoints)
 
-/** Leg (a). A control whose fixture every comparator sorts alike proves nothing. */
-function expectFixtureDiscriminates(values: readonly string[], what: string): void {
-  expect(byCodePoint(values), `${what}: code-point order equals en-US order`).not.toEqual(byEnglish(values))
-  expect(byCodePoint(values), `${what}: code-point order equals sv-SE order`).not.toEqual(bySwedish(values))
-  expect(byEnglish(values), `${what}: en-US and sv-SE agree, so the cross-host arm is vacuous`)
-    .not.toEqual(bySwedish(values))
+/**
+ * Leg (a). Two things must hold, and they are not the same thing.
+ *
+ * The arms must disagree with EACH OTHER, or leg (c) compares two identical
+ * configurations and proves nothing. And at least one arm must disagree with
+ * code point, or leg (b) cannot bite either. Requiring *both* arms to differ
+ * from code point would be too strong: on the reason-code fixture en-US happens
+ * to agree with code point, and az-AZ is the one that diverges.
+ */
+function expectFixtureDiscriminates(values: readonly string[], what: string, arms: LocaleArms): void {
+  const [first, second] = arms.tags
+  expect(
+    byLocale(values, first),
+    `${what}: ${first} and ${second} agree, so the cross-host arm is vacuous`,
+  ).not.toEqual(byLocale(values, second))
+  const divergent = arms.tags.filter((tag) => JSON.stringify(byLocale(values, tag)) !== JSON.stringify(byCodePoint(values)))
+  expect(
+    divergent,
+    `${what}: no arm disagrees with code-point order, so leg (b) cannot fail`,
+  ).not.toEqual([])
 }
 
-/** Leg (b). Pins the emitted order to a pure function of the strings. */
-function expectCodePointOrder(emitted: readonly string[], inputs: readonly string[], what: string): void {
+/**
+ * Leg (b). Pins the emitted order to a pure function of the strings, and shows
+ * it is not merely whatever some collation would have produced.
+ */
+function expectCodePointOrder(
+  emitted: readonly string[], inputs: readonly string[], what: string, arms: LocaleArms,
+): void {
   expect(emitted, `${what}: not code-point order`).toEqual(byCodePoint(inputs))
-  expect(emitted, `${what}: emitted this host's en-US collation order`).not.toEqual(byEnglish(inputs))
-  expect(emitted, `${what}: emitted sv-SE collation order`).not.toEqual(bySwedish(inputs))
+  for (const tag of arms.tags) {
+    const collated = byLocale(inputs, tag)
+    if (JSON.stringify(collated) === JSON.stringify(byCodePoint(inputs))) continue
+    expect(emitted, `${what}: emitted the ${tag} collation order`).not.toEqual(collated)
+  }
 }
 
 const digest = (input: Buffer | string): string => createHash('sha256').update(input).digest('hex')
@@ -119,23 +172,70 @@ const SHA256 = /^[0-9a-f]{64}$/
 
 /**
  * A child timeout only attributes a hang to *this* probe if it fires before
- * vitest gives up on the test. `vitest.config.ts` sets `testTimeout` to 15s, or
- * 30s on Windows, so the child bound has to sit strictly below that.
+ * vitest gives up on the whole test. Two earlier revisions got this wrong:
  *
- * An earlier revision used a flat 60s, which the per-test timeout always beat:
- * the option was dead code and the attribution it claimed never happened.
+ *   60s flat            the per-test budget (15s, or 30s on Windows) always won,
+ *                       so the option was dead code;
+ *   two thirds of it    fine for one probe, but each test runs TWO in sequence,
+ *                       so a first probe over 5s pushed the second's deadline
+ *                       past the budget and vitest won again.
  *
- * Two thirds of the budget keeps roughly a tenfold margin over the measured
- * cost -- the heaviest probe builds a git repository and a graph, about a second
- * locally, and its two-arm test runs in ~1.9s -- while still firing well before
- * vitest does. `mirrors vitest.config.ts` below fails if that file's budget
- * changes without this one.
+ * So the bound is not a fraction anyone picked. It is solved from the invariant
+ * every probing test must satisfy:
+ *
+ *   MAX_SEQUENTIAL_PROBES_PER_TEST * PROBE_TIMEOUT_MS
+ *     + SETUP_TEARDOWN_MARGIN_MS
+ *     <= TEST_TIMEOUT_MS
+ *
+ * The margin covers the work a test does outside its probes -- materialising the
+ * transpiled closure on first use, and building the fixture git repository --
+ * which is why the bound is not simply half the budget.
  */
+interface TimeoutBudget {
+  readonly testTimeoutMs: number
+  readonly maxSequentialProbesPerTest: number
+  readonly probeTimeoutMs: number
+  readonly setupTeardownMarginMs: number
+}
+
+/** The invariant itself, as a pure function so it can be tested when violated. */
+function hierarchyHolds(budget: TimeoutBudget): boolean {
+  return budget.maxSequentialProbesPerTest * budget.probeTimeoutMs
+    + budget.setupTeardownMarginMs <= budget.testTimeoutMs
+}
+
 const PER_TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000
-const PROBE_TIMEOUT_MS = Math.floor((PER_TEST_TIMEOUT_MS * 2) / 3)
+/** Every cross-locale control calls `runUnderLocale` exactly twice; asserted below. */
+const MAX_SEQUENTIAL_PROBES_PER_TEST = 2
+/** Closure materialisation plus fixture setup; measured at well under a second. */
+const SETUP_TEARDOWN_MARGIN_MS = 3_000
+const PROBE_TIMEOUT_MS = Math.floor(
+  (PER_TEST_TIMEOUT_MS - SETUP_TEARDOWN_MARGIN_MS) / MAX_SEQUENTIAL_PROBES_PER_TEST,
+)
+
+const TIMEOUT_BUDGET: TimeoutBudget = {
+  testTimeoutMs: PER_TEST_TIMEOUT_MS,
+  maxSequentialProbesPerTest: MAX_SEQUENTIAL_PROBES_PER_TEST,
+  probeTimeoutMs: PROBE_TIMEOUT_MS,
+  setupTeardownMarginMs: SETUP_TEARDOWN_MARGIN_MS,
+}
+
+/** Counts probes per test, so `MAX_SEQUENTIAL_PROBES_PER_TEST` is observed, not assumed. */
+let probesInCurrentTest = 0
+
+beforeEach(() => {
+  probesInCurrentTest = 0
+})
 
 /** Runs `body` inside the materialized tree under `locale` and parses its stdout. */
 function runUnderLocale(entries: readonly string[], name: string, body: string, locale: string): ProbeResult {
+  probesInCurrentTest += 1
+  expect(
+    probesInCurrentTest,
+    `${name}: this test ran ${probesInCurrentTest} probes, but PROBE_TIMEOUT_MS was solved `
+    + `for at most ${MAX_SEQUENTIAL_PROBES_PER_TEST}; the timeout invariant no longer holds`,
+  ).toBeLessThanOrEqual(MAX_SEQUENTIAL_PROBES_PER_TEST)
+
   const tree = moduleFor(entries)
   const entryPath = join(tree.root, `${name}.mjs`)
   writeFileSync(entryPath, body, 'utf8')
@@ -157,7 +257,7 @@ function runUnderLocale(entries: readonly string[], name: string, body: string, 
 }
 
 /**
- * Leg (c) for one writer: identical bytes under en-US and sv-SE.
+ * Leg (c) for one writer: identical bytes under the control's two locale arms.
  *
  * Both digests are validated by `runUnderLocale` before they get here, on every
  * platform including Windows. Two probes that died silently would otherwise
@@ -177,22 +277,45 @@ function runUnderLocale(entries: readonly string[], name: string, body: string, 
  * lanes (ubuntu, macOS and Windows on Node 20 and 22) pass with this assertion
  * in place.
  */
-function expectSameBytesAcrossLocales(entries: readonly string[], name: string, body: string): void {
-  const american = runUnderLocale(entries, name, body, 'en_US.UTF-8')
-  const swedish = runUnderLocale(entries, name, body, 'sv_SE.UTF-8')
-  expect(swedish.digest, `${name}: bytes differ between host collations`).toBe(american.digest)
+function expectSameBytesAcrossLocales(
+  entries: readonly string[], name: string, body: string, arms: LocaleArms,
+): void {
+  const [firstLcAll, secondLcAll] = arms.lcAll
+  const first = runUnderLocale(entries, name, body, firstLcAll)
+  const second = runUnderLocale(entries, name, body, secondLcAll)
+  expect(second.digest, `${name}: bytes differ between host collations`).toBe(first.digest)
   if (process.platform !== 'win32') {
     expect(
-      american.locale,
-      `${name}: both arms resolved to ${american.locale}, so this control compared two `
+      first.locale,
+      `${name}: both arms resolved to ${first.locale}, so this control compared two `
       + 'identical configurations and proved nothing about cross-host bytes',
-    ).not.toBe(swedish.locale)
+    ).not.toBe(second.locale)
   }
 }
 
-describe('the child bound is below vitest’s, so a hang is attributed to the probe', () => {
-  it('fires before the per-test timeout', () => {
-    expect(PROBE_TIMEOUT_MS).toBeLessThan(PER_TEST_TIMEOUT_MS)
+describe('the probe bound is solved from the timeout invariant, not chosen', () => {
+  it('satisfies the invariant with the configuration actually in use', () => {
+    expect(hierarchyHolds(TIMEOUT_BUDGET), JSON.stringify(TIMEOUT_BUDGET)).toBe(true)
+  })
+
+  it('rejects a configuration that violates it — the negative control', () => {
+    // Without this, `hierarchyHolds` could return true unconditionally and the
+    // check above would pass while guarding nothing. Each case below is one of
+    // the two mistakes actually made in this file's history.
+    expect(hierarchyHolds({ ...TIMEOUT_BUDGET, probeTimeoutMs: 60_000 }), 'the flat 60s bound')
+      .toBe(false)
+    expect(
+      hierarchyHolds({ ...TIMEOUT_BUDGET, probeTimeoutMs: Math.floor((PER_TEST_TIMEOUT_MS * 2) / 3) }),
+      'two thirds of the budget, which one probe survives and two do not',
+    ).toBe(false)
+    // And the boundary: one more millisecond than the invariant allows.
+    expect(hierarchyHolds({ ...TIMEOUT_BUDGET, probeTimeoutMs: PROBE_TIMEOUT_MS + 1 })).toBe(false)
+  })
+
+  it('leaves each probe a wide margin over its measured cost', () => {
+    // The heaviest probe builds a git repository and a graph: about a second
+    // locally, and its two-arm test runs in ~1.9s.
+    expect(PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000)
   })
 
   it('mirrors vitest.config.ts, and fails if that budget moves without this one', () => {
@@ -218,7 +341,7 @@ const MANIFEST_ENTRIES = [
 
 describe('C1-paths -- manifest outcome ordering', () => {
   it('has a fixture where the collations genuinely disagree', () => {
-    expectFixtureDiscriminates(PATHS, 'outcome paths')
+    expectFixtureDiscriminates(PATHS, 'outcome paths', LATIN_ACCENTED)
   })
 
   it('emits outcomes in code-point order, not this host’s collation order', () => {
@@ -229,7 +352,7 @@ describe('C1-paths -- manifest outcome ordering', () => {
       })),
       now: FIXED_NOW,
     })
-    expectCodePointOrder(manifest.outcomes.map((outcome) => outcome.path), PATHS, 'manifest outcomes')
+    expectCodePointOrder(manifest.outcomes.map((outcome) => outcome.path), PATHS, 'manifest outcomes', LATIN_ACCENTED)
   })
 
   it('writes the same manifest bytes under two host collations', () => {
@@ -243,7 +366,7 @@ const manifest = createIndexingManifest({
 })
 const bytes = JSON.stringify(manifest, null, 2) + '\\n'
 process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
-`)
+`, LATIN_ACCENTED)
   })
 })
 
@@ -272,7 +395,7 @@ function manifestOnDisk(): Record<string, unknown> {
 
 describe('C1-capability -- capability bucket ordering', () => {
   it('has a fixture where the collations genuinely disagree', () => {
-    expectFixtureDiscriminates(CAPABILITIES, 'capability values')
+    expectFixtureDiscriminates(CAPABILITIES, 'capability values', LATIN_ACCENTED)
   })
 
   /**
@@ -304,7 +427,26 @@ describe('C1-capability -- capability bucket ordering', () => {
       Object.keys(manifest.summary.capability_buckets),
       CAPABILITIES,
       'capability_buckets',
+      LATIN_ACCENTED,
     )
+
+    // Why no assertion can catch a fixture rebuilt from literals: the parser
+    // returns the same capability strings it was handed, so the two routes are
+    // equal by construction and produce identical bytes. That is recorded here
+    // rather than in a comment alone, so if the parser ever starts transforming
+    // capabilities this stops being true and says so.
+    const viaLiterals = createIndexingManifest({
+      outcomes: CAPABILITIES.map((capability, index) => ({
+        path: `src/file-${index}.ts`, kind: 'file' as const, status: 'indexed' as const,
+        reason: 'indexed' as const, capability,
+      })),
+      now: FIXED_NOW,
+    })
+    expect(
+      digest(`${JSON.stringify(viaLiterals, null, 2)}\n`),
+      'the parser route and a literal route now differ, so the literal-fixture mutation '
+      + 'became observable and needs a control',
+    ).toBe(digest(`${JSON.stringify(manifest, null, 2)}\n`))
   })
 
   it('writes the same manifest and share-safe bytes under two host collations', () => {
@@ -318,7 +460,7 @@ const manifest = createIndexingManifest({ outcomes: parsed.outcomes, now: new Da
 const bytes = JSON.stringify(manifest, null, 2) + '\\n'
   + JSON.stringify(shareSafeIndexingManifest(manifest), null, 2) + '\\n'
 process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
-`)
+`, LATIN_ACCENTED)
   })
 })
 
@@ -331,7 +473,7 @@ const DIAGNOSTIC_IDS = ADVERSARIAL.map((name) => `spi.import.unresolved.${name}`
 
 describe('C1-diagnostics -- spi_diagnostics ordering', () => {
   it('has a fixture where the collations genuinely disagree', () => {
-    expectFixtureDiscriminates(DIAGNOSTIC_IDS, 'spi diagnostic ids')
+    expectFixtureDiscriminates(DIAGNOSTIC_IDS, 'spi diagnostic ids', LATIN_ACCENTED)
   })
 
   it('emits spi_diagnostics in code-point order', () => {
@@ -346,6 +488,7 @@ describe('C1-diagnostics -- spi_diagnostics ordering', () => {
       manifest.spi_diagnostics.map((diagnostic) => diagnostic.id),
       DIAGNOSTIC_IDS,
       'spi_diagnostics',
+      LATIN_ACCENTED,
     )
   })
 
@@ -361,7 +504,7 @@ const manifest = createIndexingManifest({
 })
 const bytes = JSON.stringify(manifest, null, 2) + '\\n'
 process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
-`)
+`, LATIN_ACCENTED)
   })
 })
 
@@ -418,7 +561,154 @@ const manifest = createIndexingManifest({
 })
 const bytes = JSON.stringify(manifest, null, 2) + '\\n'
 process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
-`)
+`, LATIN_ACCENTED)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The closed summary-bucket domains
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Which closed domains can be tested behaviourally, derived rather than asserted.
+ *
+ * An earlier revision claimed all three were comparator-invariant, on a sweep of
+ * six hand-picked locales. That claim was false: `az-AZ` reverses
+ * `empty_extraction` against `extractor_error`, because Azerbaijani places `x`
+ * between `h` and `ı`. Turkish, which the sweep did include, has no `x` in its
+ * alphabet at all, which is exactly why it slipped through.
+ *
+ * So the classification is now computed over every locale this Node build
+ * supports. If a future reason code, strategy or fallback introduces a
+ * discriminating pair into a domain recorded as having none, this fails and says
+ * so -- which is the signal to add a behavioural control rather than to widen the
+ * expectation.
+ */
+const CLOSED_DOMAINS = [
+  { name: 'INDEXING_REASON_CODES', members: [...INDEXING_REASON_CODES], discriminable: true },
+  { name: 'EXTRACTION_STRATEGIES', members: [...EXTRACTION_STRATEGIES], discriminable: false },
+  { name: 'EXTRACTION_FALLBACK_REASONS', members: [...EXTRACTION_FALLBACK_REASONS], discriminable: false },
+] as const
+
+/** Every locale this build collates, so the search is over the real space. */
+const SUPPORTED_LOCALES = Intl.Collator.supportedLocalesOf([
+  'af', 'am', 'ar', 'az', 'be', 'bg', 'bn', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'eo',
+  'es', 'et', 'eu', 'fa', 'fi', 'fil', 'fo', 'fr', 'ga', 'gl', 'gu', 'ha', 'haw', 'he', 'hi', 'hr',
+  'hu', 'hy', 'id', 'ig', 'is', 'it', 'ja', 'ka', 'kk', 'kl', 'km', 'kn', 'ko', 'kok', 'ky', 'lkt',
+  'ln', 'lo', 'lt', 'lv', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 'my', 'nb', 'ne', 'nl', 'nn', 'om',
+  'or', 'pa', 'pl', 'ps', 'pt', 'ro', 'ru', 'se', 'si', 'sk', 'sl', 'smn', 'sq', 'sr', 'sv', 'sw',
+  'ta', 'te', 'th', 'ti', 'to', 'tr', 'uk', 'ur', 'uz', 'vi', 'wae', 'wo', 'yi', 'yo', 'zh', 'zu',
+])
+
+function discriminatingPairs(members: readonly string[]): { locale: string; a: string; b: string }[] {
+  const found: { locale: string; a: string; b: string }[] = []
+  for (const locale of SUPPORTED_LOCALES) {
+    const collator = new Intl.Collator(locale)
+    for (let i = 0; i < members.length; i += 1) {
+      for (let j = i + 1; j < members.length; j += 1) {
+        const [a, b] = [members[i] as string, members[j] as string]
+        if (Math.sign(compareUnicodeCodePoints(a, b)) !== Math.sign(collator.compare(a, b))) {
+          found.push({ locale, a, b })
+        }
+      }
+    }
+  }
+  return found
+}
+
+describe('closed domains are classified from an exhaustive search, not assumed', () => {
+  it('searches a non-trivial locale space', () => {
+    // A search over an empty locale set would report "no discriminator" forever.
+    expect(SUPPORTED_LOCALES.length).toBeGreaterThan(50)
+  })
+
+  for (const domain of CLOSED_DOMAINS) {
+    it(`${domain.name} is ${domain.discriminable ? '' : 'not '}discriminable, as recorded`, () => {
+      const found = discriminatingPairs(domain.members)
+      if (domain.discriminable) {
+        expect(
+          found,
+          `${domain.name} has no discriminating pair any more; its behavioural control is now vacuous`,
+        ).not.toEqual([])
+        return
+      }
+      expect(
+        found.slice(0, 3),
+        `${domain.name} now has a discriminating pair, so it needs a behavioural control `
+        + 'rather than static coverage alone',
+      ).toEqual([])
+    })
+  }
+})
+
+/**
+ * The reason-code domain, tested behaviourally under the arms that split it.
+ *
+ * `empty_extraction` and `extractor_error` are both members of
+ * `INDEXING_REASON_CODES` and both survive `parseIndexingManifest`, so this pair
+ * is reachable in a real manifest, not a synthetic one.
+ */
+describe('C4-reason-codes -- closed reason-code ordering', () => {
+  const REASON_PAIR = ['empty_extraction', 'extractor_error'] as const
+
+  function reasonManifest(): ReturnType<typeof createIndexingManifest> {
+    return createIndexingManifest({
+      outcomes: REASON_PAIR.map((reason, index) => ({
+        path: `src/reason-${index}.ts`, kind: 'file' as const, status: 'indexed' as const,
+        reason, capability: null,
+      })),
+      now: FIXED_NOW,
+    })
+  }
+
+  it('uses a pair that is valid in the real domain', () => {
+    for (const reason of REASON_PAIR) {
+      expect(INDEXING_REASON_CODES as readonly string[], `${reason} is not a real reason code`)
+        .toContain(reason)
+    }
+    // And the parser accepts it, so the pair reaches the sort through a manifest.
+    const parsed = parseIndexingManifest({
+      version: 1,
+      generated_at: FIXED_NOW.toISOString(),
+      summary: {},
+      outcomes: REASON_PAIR.map((reason, index) => ({
+        path: `src/reason-${index}.ts`, kind: 'file', status: 'indexed', reason, capability: null,
+      })),
+      spi_diagnostics: [],
+    })
+    expect(parsed, 'parseIndexingManifest rejected the reason pair').not.toBeNull()
+  })
+
+  it('has a fixture where code point and az-AZ collation genuinely disagree', () => {
+    expectFixtureDiscriminates(REASON_PAIR, 'reason codes', ASCII_REASON_CODES)
+    // Named explicitly, because this is the pair the six-locale sweep missed.
+    expect(byCodePoint(REASON_PAIR)).toEqual(['empty_extraction', 'extractor_error'])
+    expect(byLocale(REASON_PAIR, 'az-AZ')).toEqual(['extractor_error', 'empty_extraction'])
+  })
+
+  it('emits reason buckets in code-point order', () => {
+    expectCodePointOrder(
+      Object.keys(reasonManifest().summary.reason_buckets),
+      REASON_PAIR,
+      'reason_buckets',
+      ASCII_REASON_CODES,
+    )
+  })
+
+  it('writes the same manifest bytes under en-US and az-AZ', () => {
+    expectSameBytesAcrossLocales(MANIFEST_ENTRIES, 'manifest-reason-codes', `
+import { createHash } from 'node:crypto'
+import { createIndexingManifest } from './src/pipeline/indexing-outcomes.js'
+const reasons = ${JSON.stringify(REASON_PAIR)}
+const manifest = createIndexingManifest({
+  outcomes: reasons.map((reason, index) => ({
+    path: 'src/reason-' + index + '.ts', kind: 'file', status: 'indexed', reason, capability: null,
+  })),
+  now: new Date(${JSON.stringify(FIXED_NOW.toISOString())}),
+})
+const bytes = JSON.stringify(manifest, null, 2) + '\\n'
+process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`, ASCII_REASON_CODES)
   })
 })
 
@@ -471,14 +761,14 @@ function dirtyRepository(): string {
 
 describe('C2 -- graph.madar build-freshness provenance ordering', () => {
   it('has a fixture where the collations genuinely disagree', () => {
-    expectFixtureDiscriminates(PATHS, 'dirty file paths')
+    expectFixtureDiscriminates(PATHS, 'dirty file paths', LATIN_ACCENTED)
   })
 
   it('orders dirty files by code point, not by this host’s collation', async () => {
     const { buildGraphBuildFreshnessMetadata } = await import('../../src/shared/graph-build-freshness.js')
     const freshness = buildGraphBuildFreshnessMetadata(dirtyRepository(), PATHS)
     expect(freshness.strategy).toBe('git')
-    expectCodePointOrder(freshness.git?.dirty_files ?? [], PATHS, 'graph_build_freshness.git.dirty_files')
+    expectCodePointOrder(freshness.git?.dirty_files ?? [], PATHS, 'graph_build_freshness.git.dirty_files', LATIN_ACCENTED)
   })
 
   it('serializes the same graph.madar bytes under two host collations', () => {
@@ -533,7 +823,7 @@ const bytes = serializeGraphArtifactV2({
   provenance: { schema_version: 2, graph_build_freshness: pinned },
 })
 process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
-`)
+`, LATIN_ACCENTED)
   })
 
   it('leaves a clean worktree with no dirty files to order', async () => {
@@ -591,7 +881,7 @@ describe('C3 -- SPI diff overlay edge ordering', () => {
   )
 
   it('has a fixture where the collations genuinely disagree', () => {
-    expectFixtureDiscriminates(overlayKeys, 'overlay edge keys')
+    expectFixtureDiscriminates(overlayKeys, 'overlay edge keys', LATIN_ACCENTED)
   })
 
   it('orders edges_added by code point', () => {
@@ -606,6 +896,7 @@ describe('C3 -- SPI diff overlay edge ordering', () => {
       overlay.edges_added.map((edge) => `${edge.from}|${edge.to}|${edge.kind}`),
       overlayKeys,
       'overlay edges_added',
+      LATIN_ACCENTED,
     )
   })
 
@@ -619,7 +910,7 @@ const overlay = computeSpiDiffOverlay({
   runGitDiff: () => '+++ src/many.ts\\n@@ -1 +1 @@\\n',
 })
 process.stdout.write(createHash('sha256').update(JSON.stringify(overlay)).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
-`)
+`, LATIN_ACCENTED)
   })
 })
 
@@ -637,7 +928,7 @@ describe('C4 -- proof report compare-section ordering', () => {
   const compareNames = ADVERSARIAL.map((name) => `compare-${name}`)
 
   it('has a fixture where the collations genuinely disagree', () => {
-    expectFixtureDiscriminates(compareNames, 'compare directory names')
+    expectFixtureDiscriminates(compareNames, 'compare directory names', LATIN_ACCENTED)
   })
 
   it('orders compare summaries by code point', async () => {
@@ -686,7 +977,7 @@ describe('C4 -- proof report compare-section ordering', () => {
 
     expect(emitted, 'no compare questions reached the report; the fixture drifted')
       .toHaveLength(compareNames.length)
-    expectCodePointOrder(emitted, compareNames, 'proof-report compare sections')
+    expectCodePointOrder(emitted, compareNames, 'proof-report compare sections', LATIN_ACCENTED)
     expect(readFileSync(result.outputPath, 'utf8')).toBe(result.report)
   })
 })

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterAll, afterEach, describe, expect, it } from 'vitest'
 
@@ -118,13 +118,21 @@ interface ProbeResult {
 const SHA256 = /^[0-9a-f]{64}$/
 
 /**
- * The slowest probe here builds a git repository and a graph inside the child,
- * which takes about two seconds locally and rather longer on a cold Windows CI
- * runner. Sixty seconds is far above that and far below vitest's own per-test
- * timeout, so a hung child fails as *this* probe rather than stalling the file
- * and reporting nothing about which one stopped.
+ * A child timeout only attributes a hang to *this* probe if it fires before
+ * vitest gives up on the test. `vitest.config.ts` sets `testTimeout` to 15s, or
+ * 30s on Windows, so the child bound has to sit strictly below that.
+ *
+ * An earlier revision used a flat 60s, which the per-test timeout always beat:
+ * the option was dead code and the attribution it claimed never happened.
+ *
+ * Two thirds of the budget keeps roughly a tenfold margin over the measured
+ * cost -- the heaviest probe builds a git repository and a graph, about a second
+ * locally, and its two-arm test runs in ~1.9s -- while still firing well before
+ * vitest does. `mirrors vitest.config.ts` below fails if that file's budget
+ * changes without this one.
  */
-const PROBE_TIMEOUT_MS = 60_000
+const PER_TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000
+const PROBE_TIMEOUT_MS = Math.floor((PER_TEST_TIMEOUT_MS * 2) / 3)
 
 /** Runs `body` inside the materialized tree under `locale` and parses its stdout. */
 function runUnderLocale(entries: readonly string[], name: string, body: string, locale: string): ProbeResult {
@@ -181,6 +189,23 @@ function expectSameBytesAcrossLocales(entries: readonly string[], name: string, 
     ).not.toBe(swedish.locale)
   }
 }
+
+describe('the child bound is below vitest’s, so a hang is attributed to the probe', () => {
+  it('fires before the per-test timeout', () => {
+    expect(PROBE_TIMEOUT_MS).toBeLessThan(PER_TEST_TIMEOUT_MS)
+  })
+
+  it('mirrors vitest.config.ts, and fails if that budget moves without this one', () => {
+    // Read rather than assumed: a mirrored constant that nobody checks is how the
+    // 60s version went unnoticed.
+    const config = readFileSync(resolve(process.cwd(), 'vitest.config.ts'), 'utf8')
+    const declared = /DEFAULT_TEST_TIMEOUT\s*=\s*process\.platform\s*===\s*'win32'\s*\?\s*([\d_]+)\s*:\s*([\d_]+)/
+      .exec(config)
+    expect(declared, 'vitest.config.ts no longer declares DEFAULT_TEST_TIMEOUT in the expected shape').not.toBeNull()
+    const [windows, other] = [declared?.[1], declared?.[2]].map((value) => Number(value?.replaceAll('_', '')))
+    expect(PER_TEST_TIMEOUT_MS).toBe(process.platform === 'win32' ? windows : other)
+  })
+})
 
 // ─────────────────────────────────────────────────────────────────────────────
 // C1 -- indexing-manifest.json and its share-safe and failed variants

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -1,0 +1,547 @@
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+
+import { compareUnicodeCodePoints } from '../../src/contracts/canonical-json.js'
+import { parseIndexingManifest } from '../../src/infrastructure/indexing-manifest.js'
+import { createIndexingManifest, shareSafeIndexingManifest } from '../../src/pipeline/indexing-outcomes.js'
+import { computeSpiDiffOverlay } from '../../src/pipeline/spi/diff-overlay.js'
+import type { SemanticProgramIndex } from '../../src/pipeline/spi/types.js'
+
+import { workingTreeSourceModule, type PinnedSourceModule } from './helpers/pinned-source-module.js'
+
+/**
+ * Persisted collection ordering must not depend on the host's collation.
+ *
+ * `String.prototype.localeCompare` asks ICU, and ICU answers according to the
+ * locale Node took from `LC_ALL`/`LANG` at startup. Two machines with different
+ * locales therefore wrote DIFFERENT BYTES for the same inputs into
+ * `indexing-manifest.json`, into `graph.madar`'s build-freshness provenance and
+ * into the SPI diff overlay.
+ *
+ * Every control here asserts three things, because any one of them alone can be
+ * satisfied by a broken implementation:
+ *
+ *   (a) the fixture actually discriminates -- code-point order differs from
+ *       en-US order and from sv-SE order, and those two differ from each other.
+ *       Without this the whole file passes on a corpus every comparator sorts
+ *       alike, proving nothing.
+ *   (b) the emitted order IS code-point order and is NEITHER collation order.
+ *       This is the leg a comparator pinned to a fixed locale cannot survive:
+ *       `localeCompare(a, b, 'sv-SE')` makes both host arms agree with each
+ *       other while still emitting the wrong order.
+ *   (c) the published bytes are identical between two child processes started
+ *       under different `LC_ALL` values. This is the leg a locale dependency
+ *       OUTSIDE the comparator cannot survive.
+ *
+ * Ordering intended for human reading is deliberately left locale-sensitive;
+ * this is not a repository-wide ban on `localeCompare`.
+ */
+
+/** Names where ICU collation and code-unit order provably disagree. */
+const ADVERSARIAL = [
+  'Ångström',
+  'angle',
+  'Zebra',
+  'apple',
+  'café',
+  'cafe',
+  '_internal',
+  '日本',
+] as const
+
+const PATHS = ADVERSARIAL.map((name) => `src/${name}.ts`)
+const FIXED_NOW = new Date('2026-08-25T00:00:00.000Z')
+
+const byEnglish = (values: readonly string[]): string[] =>
+  [...values].sort((left, right) => left.localeCompare(right, 'en-US'))
+const bySwedish = (values: readonly string[]): string[] =>
+  [...values].sort((left, right) => left.localeCompare(right, 'sv-SE'))
+const byCodePoint = (values: readonly string[]): string[] =>
+  [...values].sort(compareUnicodeCodePoints)
+
+/** Leg (a). A control whose fixture every comparator sorts alike proves nothing. */
+function expectFixtureDiscriminates(values: readonly string[], what: string): void {
+  expect(byCodePoint(values), `${what}: code-point order equals en-US order`).not.toEqual(byEnglish(values))
+  expect(byCodePoint(values), `${what}: code-point order equals sv-SE order`).not.toEqual(bySwedish(values))
+  expect(byEnglish(values), `${what}: en-US and sv-SE agree, so the cross-host arm is vacuous`)
+    .not.toEqual(bySwedish(values))
+}
+
+/** Leg (b). Pins the emitted order to a pure function of the strings. */
+function expectCodePointOrder(emitted: readonly string[], inputs: readonly string[], what: string): void {
+  expect(emitted, `${what}: not code-point order`).toEqual(byCodePoint(inputs))
+  expect(emitted, `${what}: emitted this host's en-US collation order`).not.toEqual(byEnglish(inputs))
+  expect(emitted, `${what}: emitted sv-SE collation order`).not.toEqual(bySwedish(inputs))
+}
+
+const digest = (input: Buffer | string): string => createHash('sha256').update(input).digest('hex')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Leg (c): run today's source in child processes started under two locales.
+// A process's collation is fixed when it starts, so this is the only honest way
+// to test it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const materialized = new Map<string, PinnedSourceModule>()
+
+afterAll(() => {
+  for (const module of materialized.values()) module.dispose()
+  materialized.clear()
+})
+
+function moduleFor(entries: readonly string[]): PinnedSourceModule {
+  const key = entries.join('|')
+  const existing = materialized.get(key)
+  if (existing) return existing
+  const created = workingTreeSourceModule(entries)
+  materialized.set(key, created)
+  return created
+}
+
+/** Runs `body` inside the materialized tree under `locale`; returns its stdout. */
+function runUnderLocale(entries: readonly string[], name: string, body: string, locale: string): string {
+  const tree = moduleFor(entries)
+  const entryPath = join(tree.root, `${name}.mjs`)
+  writeFileSync(entryPath, body, 'utf8')
+  return execFileSync(process.execPath, [entryPath], {
+    encoding: 'utf8',
+    env: { ...process.env, LC_ALL: locale, LANG: locale },
+  }).trim()
+}
+
+/**
+ * Leg (c) for one writer: identical bytes under en-US and sv-SE.
+ *
+ * Whether the two arms genuinely resolved to different collations is a property
+ * of the host -- Windows ICU follows the system locale and ignores `LC_ALL`, so
+ * both arms there are the same configuration. The guarantee does not depend on
+ * that: leg (b) already pins the order hermetically. So the byte equality is
+ * asserted unconditionally and the divergence only where it is meaningful.
+ */
+function expectSameBytesAcrossLocales(entries: readonly string[], name: string, body: string): void {
+  const [american, americanLocale] = runUnderLocale(entries, name, body, 'en_US.UTF-8').split(' ')
+  const [swedish, swedishLocale] = runUnderLocale(entries, name, body, 'sv_SE.UTF-8').split(' ')
+  expect(swedish, `${name}: bytes differ between host collations`).toBe(american)
+  if (process.platform !== 'win32') {
+    expect(americanLocale, `${name}: both arms resolved to the same collator`).not.toBe(swedishLocale)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C1 -- indexing-manifest.json and its share-safe and failed variants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MANIFEST_ENTRIES = [
+  'src/pipeline/indexing-outcomes.ts',
+  'src/infrastructure/indexing-manifest.ts',
+] as const
+
+describe('C1-paths -- manifest outcome ordering', () => {
+  it('has a fixture where the collations genuinely disagree', () => {
+    expectFixtureDiscriminates(PATHS, 'outcome paths')
+  })
+
+  it('emits outcomes in code-point order, not this host’s collation order', () => {
+    const manifest = createIndexingManifest({
+      outcomes: PATHS.map((path) => ({
+        path, kind: 'file' as const, status: 'indexed' as const,
+        reason: 'indexed' as const, capability: null,
+      })),
+      now: FIXED_NOW,
+    })
+    expectCodePointOrder(manifest.outcomes.map((outcome) => outcome.path), PATHS, 'manifest outcomes')
+  })
+
+  it('writes the same manifest bytes under two host collations', () => {
+    expectSameBytesAcrossLocales(MANIFEST_ENTRIES, 'manifest-paths', `
+import { createHash } from 'node:crypto'
+import { createIndexingManifest } from './src/pipeline/indexing-outcomes.js'
+const paths = ${JSON.stringify(PATHS)}
+const manifest = createIndexingManifest({
+  outcomes: paths.map((path) => ({ path, kind: 'file', status: 'indexed', reason: 'indexed', capability: null })),
+  now: new Date(${JSON.stringify(FIXED_NOW.toISOString())}),
+})
+const bytes = JSON.stringify(manifest, null, 2) + '\\n'
+process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`)
+  })
+})
+
+/**
+ * `capability` is the case the closed reason/strategy/fallback domains are not:
+ * `parseIndexingManifest` accepts ANY string for it, and incremental generation
+ * returns a prior outcome verbatim, so whatever a manifest on disk carries comes
+ * back and is bucketed. The fixture therefore has to arrive THROUGH the parser,
+ * not as a literal -- a control built from literals would still discriminate
+ * while no longer exercising the route that makes those values reachable.
+ */
+const CAPABILITIES = ['Ångström', 'apple', 'Zebra', 'café', 'cafe'] as const
+
+function manifestOnDisk(): Record<string, unknown> {
+  return {
+    version: 1,
+    generated_at: FIXED_NOW.toISOString(),
+    summary: {},
+    outcomes: CAPABILITIES.map((capability, index) => ({
+      path: `src/file-${index}.ts`, kind: 'file', status: 'indexed',
+      reason: 'indexed', capability,
+    })),
+    spi_diagnostics: [],
+  }
+}
+
+describe('C1-capability -- capability bucket ordering', () => {
+  it('has a fixture where the collations genuinely disagree', () => {
+    expectFixtureDiscriminates(CAPABILITIES, 'capability values')
+  })
+
+  it('reaches the sort through parseIndexingManifest, which is what opens the domain', () => {
+    // The route assertion. Leg (a) observes values, not where they came from, so
+    // without this a fixture rebuilt from literals would keep the file green
+    // while no longer testing the reachable path.
+    const parsed = parseIndexingManifest(manifestOnDisk())
+    expect(parsed, 'parseIndexingManifest rejected the fixture; the route is gone').not.toBeNull()
+    expect(parsed?.outcomes.map((outcome) => outcome.capability)).toEqual([...CAPABILITIES])
+  })
+
+  it('emits capability buckets in code-point order', () => {
+    const parsed = parseIndexingManifest(manifestOnDisk())
+    const manifest = createIndexingManifest({ outcomes: parsed!.outcomes, now: FIXED_NOW })
+    expectCodePointOrder(
+      Object.keys(manifest.summary.capability_buckets),
+      CAPABILITIES,
+      'capability_buckets',
+    )
+  })
+
+  it('writes the same manifest and share-safe bytes under two host collations', () => {
+    expectSameBytesAcrossLocales(MANIFEST_ENTRIES, 'manifest-capability', `
+import { createHash } from 'node:crypto'
+import { parseIndexingManifest } from './src/infrastructure/indexing-manifest.js'
+import { createIndexingManifest, shareSafeIndexingManifest } from './src/pipeline/indexing-outcomes.js'
+const parsed = parseIndexingManifest(${JSON.stringify(manifestOnDisk())})
+if (parsed === null) throw new Error('probe fixture rejected by parseIndexingManifest')
+const manifest = createIndexingManifest({ outcomes: parsed.outcomes, now: new Date(${JSON.stringify(FIXED_NOW.toISOString())}) })
+const bytes = JSON.stringify(manifest, null, 2) + '\\n'
+  + JSON.stringify(shareSafeIndexingManifest(manifest), null, 2) + '\\n'
+process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`)
+  })
+})
+
+/**
+ * SPI diagnostic ids reach this sort projected verbatim from `result.spi.diagnostics`,
+ * and the SPI cache shape-checks only `version`/`workspace`/`files`/`symbols`, so a
+ * cached index can carry any id at all.
+ */
+const DIAGNOSTIC_IDS = ADVERSARIAL.map((name) => `spi.import.unresolved.${name}`)
+
+describe('C1-diagnostics -- spi_diagnostics ordering', () => {
+  it('has a fixture where the collations genuinely disagree', () => {
+    expectFixtureDiscriminates(DIAGNOSTIC_IDS, 'spi diagnostic ids')
+  })
+
+  it('emits spi_diagnostics in code-point order', () => {
+    const manifest = createIndexingManifest({
+      outcomes: [],
+      spiDiagnostics: DIAGNOSTIC_IDS.map((id) => ({
+        id, level: 'info' as const, reason: 'spi_diagnostic' as const,
+      })),
+      now: FIXED_NOW,
+    })
+    expectCodePointOrder(
+      manifest.spi_diagnostics.map((diagnostic) => diagnostic.id),
+      DIAGNOSTIC_IDS,
+      'spi_diagnostics',
+    )
+  })
+
+  it('writes the same manifest bytes under two host collations', () => {
+    expectSameBytesAcrossLocales(MANIFEST_ENTRIES, 'manifest-diagnostics', `
+import { createHash } from 'node:crypto'
+import { createIndexingManifest } from './src/pipeline/indexing-outcomes.js'
+const ids = ${JSON.stringify(DIAGNOSTIC_IDS)}
+const manifest = createIndexingManifest({
+  outcomes: [],
+  spiDiagnostics: ids.map((id) => ({ id, level: 'info', reason: 'spi_diagnostic' })),
+  now: new Date(${JSON.stringify(FIXED_NOW.toISOString())}),
+})
+const bytes = JSON.stringify(manifest, null, 2) + '\\n'
+process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`)
+  })
+})
+
+describe('C1 -- the share-safe manifest carries only closed-domain summary values', () => {
+  it('is byte-stable across repeated serialization', () => {
+    const manifest = createIndexingManifest({
+      outcomes: PATHS.map((path) => ({
+        path, kind: 'file' as const, status: 'indexed' as const,
+        reason: 'indexed' as const, capability: 'spi:typescript',
+      })),
+      now: FIXED_NOW,
+    })
+    const bytes = (): string => `${JSON.stringify(shareSafeIndexingManifest(manifest), null, 2)}\n`
+    expect(digest(bytes())).toBe(digest(bytes()))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C2 -- graph.madar provenance.graph_build_freshness.git.dirty_files
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GRAPH_ENTRIES = [
+  'src/contracts/graph-artifact.ts',
+  'src/pipeline/build.ts',
+  'src/shared/graph-build-freshness.ts',
+] as const
+
+const tempRoots: string[] = []
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop()
+    if (root) rmSync(root, { recursive: true, force: true })
+  }
+})
+
+/** A real git repository whose dirty set is exactly `PATHS`. */
+function dirtyRepository(): string {
+  const root = mkdtempSync(join(tmpdir(), 'madar-715-dirty-'))
+  tempRoots.push(root)
+  execFileSync('git', ['init', '-q'], { cwd: root })
+  execFileSync('git', ['config', 'user.email', 'control@example.com'], { cwd: root })
+  execFileSync('git', ['config', 'user.name', 'control'], { cwd: root })
+  writeFileSync(join(root, 'seed.txt'), 'seed\n', 'utf8')
+  execFileSync('git', ['add', '.'], { cwd: root })
+  execFileSync('git', ['commit', '-qm', 'seed'], { cwd: root })
+  mkdirSync(join(root, 'src'), { recursive: true })
+  for (const path of PATHS) writeFileSync(join(root, path), 'export const x = 1\n', 'utf8')
+  return root
+}
+
+describe('C2 -- graph.madar build-freshness provenance ordering', () => {
+  it('has a fixture where the collations genuinely disagree', () => {
+    expectFixtureDiscriminates(PATHS, 'dirty file paths')
+  })
+
+  it('orders dirty files by code point, not by this host’s collation', async () => {
+    const { buildGraphBuildFreshnessMetadata } = await import('../../src/shared/graph-build-freshness.js')
+    const freshness = buildGraphBuildFreshnessMetadata(dirtyRepository(), PATHS)
+    expect(freshness.strategy).toBe('git')
+    expectCodePointOrder(freshness.git?.dirty_files ?? [], PATHS, 'graph_build_freshness.git.dirty_files')
+  })
+
+  it('serializes the same graph.madar bytes under two host collations', () => {
+    // The probe builds its own repository so both arms see identical inputs; only
+    // the clock is pinned afterwards, never the ordering under test.
+    expectSameBytesAcrossLocales(GRAPH_ENTRIES, 'graph-artifact', `
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { serializeGraphArtifactV2 } from './src/contracts/graph-artifact.js'
+import { buildFromJson } from './src/pipeline/build.js'
+import { buildGraphBuildFreshnessMetadata } from './src/shared/graph-build-freshness.js'
+
+const paths = ${JSON.stringify(PATHS)}
+const root = mkdtempSync(join(tmpdir(), 'madar-715-probe-'))
+execFileSync('git', ['init', '-q'], { cwd: root })
+execFileSync('git', ['config', 'user.email', 'p@example.com'], { cwd: root })
+execFileSync('git', ['config', 'user.name', 'p'], { cwd: root })
+writeFileSync(join(root, 'seed.txt'), 'seed\\n', 'utf8')
+execFileSync('git', ['add', '.'], { cwd: root })
+execFileSync('git', ['commit', '-qm', 'seed'], { cwd: root })
+for (const path of paths) {
+  const target = join(root, path)
+  mkdirSync(dirname(target), { recursive: true })
+  writeFileSync(target, 'export const x = 1\\n', 'utf8')
+}
+const freshness = buildGraphBuildFreshnessMetadata(root, paths)
+// Pin only what a clock decides: the wall clock, and the commit sha, which
+// differs between the two arms because each builds its own repository and a
+// commit's identity includes its timestamp. Ordering -- the property under
+// test -- is untouched.
+const pinned = {
+  ...freshness,
+  generated_at: '2026-08-25T00:00:00.000Z',
+  generated_ms: 0,
+  git: { ...freshness.git, head_sha: 'pinned-head-sha' },
+}
+const extraction = {
+  schema_version: 2,
+  directed: true,
+  nodes: paths.map((id) => ({ id, label: id, file_type: 'code', source_file: id, endpointIdentity: { status: 'stable', reasons: [] } })),
+  edges: paths.slice(1).map((target, index) => ({ source: paths[index], target, relation: 'contains', confidence: 'EXTRACTED', source_file: paths[index] })),
+}
+const graph = buildFromJson(extraction, { directed: true, accounting: 'normalized_extraction_boundary' })
+const bytes = serializeGraphArtifactV2({
+  graph,
+  repositoryRevision: 'persisted-ordering',
+  generationMode: 'full',
+  generatedAt: '2026-08-25T00:00:00.000Z',
+  provenance: { schema_version: 2, graph_build_freshness: pinned },
+})
+process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`)
+  })
+
+  it('leaves a clean worktree with no dirty files to order', async () => {
+    // The positive half. Nothing in this change touches a clean build, so the
+    // ordering fix must be invisible when there is nothing to order.
+    const { buildGraphBuildFreshnessMetadata } = await import('../../src/shared/graph-build-freshness.js')
+    const root = mkdtempSync(join(tmpdir(), 'madar-715-clean-'))
+    tempRoots.push(root)
+    execFileSync('git', ['init', '-q'], { cwd: root })
+    execFileSync('git', ['config', 'user.email', 'control@example.com'], { cwd: root })
+    execFileSync('git', ['config', 'user.name', 'control'], { cwd: root })
+    writeFileSync(join(root, 'seed.txt'), 'seed\n', 'utf8')
+    execFileSync('git', ['add', '.'], { cwd: root })
+    execFileSync('git', ['commit', '-qm', 'seed'], { cwd: root })
+
+    const freshness = buildGraphBuildFreshnessMetadata(root, [])
+    expect(freshness.strategy).toBe('git')
+    expect(freshness.git?.dirty_files).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C3 -- SPI diff overlay edges
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Symbol ids begin with a per-file hash, so only symbols in the SAME file reach
+ * the Unicode tail of the sort key. A fixture with one symbol per file is
+ * decided entirely by ASCII hex and proves nothing.
+ */
+const OVERLAY_FILE_ID = 'file:0123456789abcdef'
+
+function overlaySpi(): SemanticProgramIndex {
+  const symbols = ADVERSARIAL.map((name) => ({
+    id: `symbol:${OVERLAY_FILE_ID}/function/${name}`,
+    file_id: OVERLAY_FILE_ID,
+    name,
+    kind: 'function' as const,
+    range: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+  }))
+  return {
+    version: 1,
+    generated_at: FIXED_NOW.toISOString(),
+    workspace: { root: '/repo', fingerprint: 'fp', extractor_version: 'test', madar_version: '0.0.0-test' },
+    files: [{ id: OVERLAY_FILE_ID, path: 'src/many.ts', language: 'typescript', loc: 1, hash: 'h' }],
+    symbols,
+    edges: [],
+    diagnostics: [],
+  } as unknown as SemanticProgramIndex
+}
+
+describe('C3 -- SPI diff overlay edge ordering', () => {
+  const overlayKeys = ADVERSARIAL.map(
+    (name) => `symbol:${OVERLAY_FILE_ID}/function/${name}|${OVERLAY_FILE_ID}|changed_in`,
+  )
+
+  it('has a fixture where the collations genuinely disagree', () => {
+    expectFixtureDiscriminates(overlayKeys, 'overlay edge keys')
+  })
+
+  it('orders edges_added by code point', () => {
+    const overlay = computeSpiDiffOverlay({
+      spi: overlaySpi(),
+      root: '/repo',
+      baseRef: 'BASE',
+      headRef: 'HEAD',
+      runGitDiff: () => '+++ src/many.ts\n@@ -1 +1 @@\n',
+    })
+    expectCodePointOrder(
+      overlay.edges_added.map((edge) => `${edge.from}|${edge.to}|${edge.kind}`),
+      overlayKeys,
+      'overlay edges_added',
+    )
+  })
+
+  it('produces the same overlay bytes under two host collations', () => {
+    expectSameBytesAcrossLocales(['src/pipeline/spi/diff-overlay.ts'], 'diff-overlay', `
+import { createHash } from 'node:crypto'
+import { computeSpiDiffOverlay } from './src/pipeline/spi/diff-overlay.js'
+const spi = ${JSON.stringify(overlaySpi())}
+const overlay = computeSpiDiffOverlay({
+  spi, root: '/repo', baseRef: 'BASE', headRef: 'HEAD',
+  runGitDiff: () => '+++ src/many.ts\\n@@ -1 +1 @@\\n',
+})
+process.stdout.write(createHash('sha256').update(JSON.stringify(overlay)).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C4 -- proof-report compare-section ordering
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * No cross-host arm here, deliberately. `proof-report.ts` reaches the graph
+ * runtime, so materializing its closure into a child process would cost far more
+ * than it proves: the assertion above already pins the emitted order to a pure
+ * function of the strings, which is what a comparator regression breaks.
+ */
+describe('C4 -- proof report compare-section ordering', () => {
+  const compareNames = ADVERSARIAL.map((name) => `compare-${name}`)
+
+  it('has a fixture where the collations genuinely disagree', () => {
+    expectFixtureDiscriminates(compareNames, 'compare directory names')
+  })
+
+  it('orders compare summaries by code point', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'madar-715-proof-'))
+    tempRoots.push(root)
+
+    const { KnowledgeGraph } = await import('../../src/contracts/graph.js')
+    const { toJson } = await import('../../src/pipeline/export.js')
+    const graph = new KnowledgeGraph()
+    graph.addNode('alpha', { label: 'alpha', source_file: 'src/a.ts', source_location: 'L1', file_type: 'code', community: 0 })
+    graph.addNode('beta', { label: 'beta', source_file: 'src/b.ts', source_location: 'L2', file_type: 'code', community: 0 })
+    graph.addEdge('alpha', 'beta', { relation: 'calls', confidence: 'EXTRACTED', source_file: 'src/a.ts' })
+    mkdirSync(join(root, 'out'), { recursive: true })
+    const graphPath = join(root, 'out', 'graph.json')
+    toJson(graph, { 0: ['alpha', 'beta'] }, graphPath)
+
+    // One compare directory per adversarial name, each identifiable by its question.
+    for (const name of compareNames) {
+      const dir = join(root, 'out', 'compare', name)
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'report.share-safe.json'), JSON.stringify({
+        question: `Q ${name}`,
+        baseline_mode: 'bounded',
+        reduction_ratio: 2,
+        status: { baseline: 'completed', madar: 'completed' },
+        provider_proof: { winner: 'madar' },
+      }, null, 2), 'utf8')
+    }
+
+    const { runProofReportCommand } = await import('../../src/infrastructure/proof-report.js')
+    const result = runProofReportCommand({
+      graphPath,
+      // The fixture supplies the path, so the intent is explicit; a default
+      // lookup would classify the workspace and hand back a different artifact.
+      graphPathIntent: 'explicit',
+      outputDir: join(root, 'out', 'proof-report'),
+      compareDir: join(root, 'out', 'compare'),
+      packPath: null,
+    })
+
+    const emitted = compareNames
+      .map((name) => ({ name, at: result.report.indexOf(`Q ${name}`) }))
+      .filter((entry) => entry.at >= 0)
+      .sort((left, right) => left.at - right.at)
+      .map((entry) => entry.name)
+
+    expect(emitted, 'no compare questions reached the report; the fixture drifted')
+      .toHaveLength(compareNames.length)
+    expectCodePointOrder(emitted, compareNames, 'proof-report compare sections')
+    expect(readFileSync(result.outputPath, 'utf8')).toBe(result.report)
+  })
+})

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -200,18 +200,31 @@ describe('C1-capability -- capability bucket ordering', () => {
     expectFixtureDiscriminates(CAPABILITIES, 'capability values')
   })
 
-  it('reaches the sort through parseIndexingManifest, which is what opens the domain', () => {
-    // The route assertion. Leg (a) observes values, not where they came from, so
-    // without this a fixture rebuilt from literals would keep the file green
-    // while no longer testing the reachable path.
+  /**
+   * The route and the ordering are asserted together, in one test, on purpose.
+   *
+   * What makes `capability` an open domain is not the values themselves -- it is
+   * that `parseIndexingManifest` accepts any string for it and incremental
+   * generation hands a prior outcome straight back. Split across two tests, one
+   * could be rewritten to use literals while the other still passed, and the
+   * file would keep proving the ordering without proving it on the reachable
+   * path. Kept together, dropping the route means visibly deleting it.
+   *
+   * Note what this cannot do: a fixture built from literals equal to the parser's
+   * output would order identically, so no assertion can distinguish them. That
+   * is a property of the values being equal by construction, and it is why the
+   * parser call is structural here rather than something a control checks.
+   */
+  it('reaches the sort through parseIndexingManifest and orders by code point', () => {
     const parsed = parseIndexingManifest(manifestOnDisk())
     expect(parsed, 'parseIndexingManifest rejected the fixture; the route is gone').not.toBeNull()
-    expect(parsed?.outcomes.map((outcome) => outcome.capability)).toEqual([...CAPABILITIES])
-  })
+    const fromParser = parsed as NonNullable<typeof parsed>
+    expect(
+      fromParser.outcomes.map((outcome) => outcome.capability),
+      'the parser no longer round-trips these capabilities; the domain may have closed',
+    ).toEqual([...CAPABILITIES])
 
-  it('emits capability buckets in code-point order', () => {
-    const parsed = parseIndexingManifest(manifestOnDisk())
-    const manifest = createIndexingManifest({ outcomes: parsed!.outcomes, now: FIXED_NOW })
+    const manifest = createIndexingManifest({ outcomes: fromParser.outcomes, now: FIXED_NOW })
     expectCodePointOrder(
       Object.keys(manifest.summary.capability_buckets),
       CAPABILITIES,

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -49,8 +49,9 @@ import { workingTreeSourceModule, type PinnedSourceModule } from './helpers/pinn
  * two agree; it splits en-US from az-AZ instead, because Azerbaijani places `x`
  * between `h` and `ı`. An earlier revision asserted that domain had no
  * discriminating fixture at all and gave it static coverage only, which was
- * wrong -- see `closed domains are classified from an exhaustive search` below,
- * which derives the classification instead of assuming it.
+ * wrong -- see `closed domains are classified by search, not assumed` below,
+ * which derives the classification over a documented search space instead of
+ * assuming it.
  *
  * Ordering intended for human reading is deliberately left locale-sensitive;
  * this is not a repository-wide ban on `localeCompare`.
@@ -578,11 +579,11 @@ process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + In
  * between `h` and `ı`. Turkish, which the sweep did include, has no `x` in its
  * alphabet at all, which is exactly why it slipped through.
  *
- * So the classification is now computed over every locale this Node build
- * supports. If a future reason code, strategy or fallback introduces a
- * discriminating pair into a domain recorded as having none, this fails and says
- * so -- which is the signal to add a behavioural control rather than to widen the
- * expectation.
+ * So the classification is computed over the documented search space below
+ * rather than written down. If a future reason code, strategy or fallback
+ * introduces a discriminating pair into a domain recorded as having none, this
+ * fails and says so -- which is the signal to add a behavioural control rather
+ * than to widen the expectation.
  */
 const CLOSED_DOMAINS = [
   { name: 'INDEXING_REASON_CODES', members: [...INDEXING_REASON_CODES], discriminable: true },
@@ -590,19 +591,37 @@ const CLOSED_DOMAINS = [
   { name: 'EXTRACTION_FALLBACK_REASONS', members: [...EXTRACTION_FALLBACK_REASONS], discriminable: false },
 ] as const
 
-/** Every locale this build collates, so the search is over the real space. */
-const SUPPORTED_LOCALES = Intl.Collator.supportedLocalesOf([
-  'af', 'am', 'ar', 'az', 'be', 'bg', 'bn', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'eo',
-  'es', 'et', 'eu', 'fa', 'fi', 'fil', 'fo', 'fr', 'ga', 'gl', 'gu', 'ha', 'haw', 'he', 'hi', 'hr',
-  'hu', 'hy', 'id', 'ig', 'is', 'it', 'ja', 'ka', 'kk', 'kl', 'km', 'kn', 'ko', 'kok', 'ky', 'lkt',
-  'ln', 'lo', 'lt', 'lv', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 'my', 'nb', 'ne', 'nl', 'nn', 'om',
-  'or', 'pa', 'pl', 'ps', 'pt', 'ro', 'ru', 'se', 'si', 'sk', 'sl', 'smn', 'sq', 'sr', 'sv', 'sw',
-  'ta', 'te', 'th', 'ti', 'to', 'tr', 'uk', 'ur', 'uz', 'vi', 'wae', 'wo', 'yi', 'yo', 'zh', 'zu',
-])
+/**
+ * The search space, stated exactly rather than called exhaustive.
+ *
+ * There is no API that enumerates every locale ICU can collate:
+ * `Intl.Collator.supportedLocalesOf` only filters the list it is given, so a
+ * hand-picked list silently bounds the search — which is how the first attempt
+ * here reported "no discriminator" for a domain that has four.
+ *
+ * So the candidates are generated instead of curated: every two-letter language
+ * subtag, all 676 of them, plus the longer tags below whose collations are known
+ * to reorder Latin letters. `supportedLocalesOf` then narrows that to what this
+ * build actually collates. This is a documented, mechanically-derived search
+ * space, not a proof that no other locale exists.
+ */
+const LONGER_SUBTAGS = [
+  'haw', 'fil', 'smn', 'wae', 'lkt', 'kok', 'ceb', 'chr', 'nso', 'dsb', 'hsb', 'sah', 'yue',
+  'kea', 'ckb', 'tzm', 'kab', 'bem', 'ewo', 'fur', 'gsw', 'jgo', 'kkj', 'ksh', 'lag', 'luy',
+  'mgo', 'naq', 'nnh', 'nyn', 'qut', 'rof', 'rwk', 'saq', 'seh', 'shi', 'teo', 'twq', 'vun',
+  'xog', 'yav', 'zgh',
+] as const
+
+const TWO_LETTER_SUBTAGS = ((): string[] => {
+  const letters = [...'abcdefghijklmnopqrstuvwxyz']
+  return letters.flatMap((first) => letters.map((second) => `${first}${second}`))
+})()
+
+const SEARCHED_LOCALES = Intl.Collator.supportedLocalesOf([...TWO_LETTER_SUBTAGS, ...LONGER_SUBTAGS])
 
 function discriminatingPairs(members: readonly string[]): { locale: string; a: string; b: string }[] {
   const found: { locale: string; a: string; b: string }[] = []
-  for (const locale of SUPPORTED_LOCALES) {
+  for (const locale of SEARCHED_LOCALES) {
     const collator = new Intl.Collator(locale)
     for (let i = 0; i < members.length; i += 1) {
       for (let j = i + 1; j < members.length; j += 1) {
@@ -616,10 +635,13 @@ function discriminatingPairs(members: readonly string[]): { locale: string; a: s
   return found
 }
 
-describe('closed domains are classified from an exhaustive search, not assumed', () => {
+describe('closed domains are classified by search, not assumed', () => {
   it('searches a non-trivial locale space', () => {
-    // A search over an empty locale set would report "no discriminator" forever.
-    expect(SUPPORTED_LOCALES.length).toBeGreaterThan(50)
+    // A search over an empty or tiny locale set would report "no discriminator"
+    // forever. The candidate list is generated, so this also catches the
+    // generation silently producing nothing.
+    expect(TWO_LETTER_SUBTAGS).toHaveLength(676)
+    expect(SEARCHED_LOCALES.length).toBeGreaterThan(100)
   })
 
   for (const domain of CLOSED_DOMAINS) {

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -290,6 +290,63 @@ process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + In
   })
 })
 
+/**
+ * The guarantee is host-independence, which is not the same as "code-point order
+ * everywhere", and the difference is reachable.
+ *
+ * `JSON.stringify` emits object keys in ECMAScript enumeration order: integer-index
+ * keys first, ascending numerically, and only then string keys in insertion order.
+ * `capability` is an open domain, so `"10"` and `"2"` are accepted values, and they
+ * serialize as `"2"` before `"10"` whatever the comparator returns.
+ *
+ * That reordering is a language rule rather than an ICU one, so the bytes are still
+ * the same on every host -- which is what this issue promises. Asserting it here
+ * keeps the promise honest: an earlier draft of the comment claimed insertion order
+ * simply IS byte order, and that is false.
+ */
+describe('C1-integer-keys -- host-independent even where enumeration outranks the comparator', () => {
+  const NUMERIC_CAPABILITIES = ['10', '2', 'Ångström', 'apple'] as const
+
+  function numericManifest(): ReturnType<typeof createIndexingManifest> {
+    return createIndexingManifest({
+      outcomes: NUMERIC_CAPABILITIES.map((capability, index) => ({
+        path: `src/file-${index}.ts`, kind: 'file' as const, status: 'indexed' as const,
+        reason: 'indexed' as const, capability,
+      })),
+      now: FIXED_NOW,
+    })
+  }
+
+  it('emits integer-like keys first, then the comparator’s order for the rest', () => {
+    const emitted = Object.keys(numericManifest().summary.capability_buckets)
+    // "2" before "10" is the language ordering integer indices numerically;
+    // "apple" before "Ångström" is the comparator, still doing its job on the
+    // string keys.
+    expect(emitted).toEqual(['2', '10', 'apple', 'Ångström'])
+    // And so the emitted order is NOT code-point order overall, which would have
+    // put "10" first. That is the claim an earlier draft got wrong.
+    expect(byCodePoint(NUMERIC_CAPABILITIES)).toEqual(['10', '2', 'apple', 'Ångström'])
+    expect(emitted).not.toEqual(byCodePoint(NUMERIC_CAPABILITIES))
+  })
+
+  it('writes the same bytes under two host collations anyway', () => {
+    expectSameBytesAcrossLocales(MANIFEST_ENTRIES, 'manifest-integer-capabilities', `
+import { createHash } from 'node:crypto'
+import { createIndexingManifest } from './src/pipeline/indexing-outcomes.js'
+const capabilities = ${JSON.stringify(NUMERIC_CAPABILITIES)}
+const manifest = createIndexingManifest({
+  outcomes: capabilities.map((capability, index) => ({
+    path: 'src/file-' + index + '.ts', kind: 'file', status: 'indexed',
+    reason: 'indexed', capability,
+  })),
+  now: new Date(${JSON.stringify(FIXED_NOW.toISOString())}),
+})
+const bytes = JSON.stringify(manifest, null, 2) + '\\n'
+process.stdout.write(createHash('sha256').update(bytes).digest('hex') + ' ' + Intl.Collator().resolvedOptions().locale)
+`)
+  })
+})
+
 describe('C1 -- the share-safe manifest carries only closed-domain summary values', () => {
   it('is byte-stable across repeated serialization', () => {
     const manifest = createIndexingManifest({

--- a/tests/unit/persisted-ordering-locale-determinism.test.ts
+++ b/tests/unit/persisted-ordering-locale-determinism.test.ts
@@ -103,32 +103,82 @@ function moduleFor(entries: readonly string[]): PinnedSourceModule {
   return created
 }
 
-/** Runs `body` inside the materialized tree under `locale`; returns its stdout. */
-function runUnderLocale(entries: readonly string[], name: string, body: string, locale: string): string {
+/**
+ * A probe's stdout: a sha256 digest and the collator the child actually resolved.
+ *
+ * Parsed rather than destructured, so a probe that dies silently or prints
+ * something unexpected fails as a malformed result instead of flowing into the
+ * comparison as an empty string.
+ */
+interface ProbeResult {
+  readonly digest: string
+  readonly locale: string
+}
+
+const SHA256 = /^[0-9a-f]{64}$/
+
+/**
+ * The slowest probe here builds a git repository and a graph inside the child,
+ * which takes about two seconds locally and rather longer on a cold Windows CI
+ * runner. Sixty seconds is far above that and far below vitest's own per-test
+ * timeout, so a hung child fails as *this* probe rather than stalling the file
+ * and reporting nothing about which one stopped.
+ */
+const PROBE_TIMEOUT_MS = 60_000
+
+/** Runs `body` inside the materialized tree under `locale` and parses its stdout. */
+function runUnderLocale(entries: readonly string[], name: string, body: string, locale: string): ProbeResult {
   const tree = moduleFor(entries)
   const entryPath = join(tree.root, `${name}.mjs`)
   writeFileSync(entryPath, body, 'utf8')
-  return execFileSync(process.execPath, [entryPath], {
+  const stdout = execFileSync(process.execPath, [entryPath], {
     encoding: 'utf8',
     env: { ...process.env, LC_ALL: locale, LANG: locale },
+    timeout: PROBE_TIMEOUT_MS,
   }).trim()
+
+  const fields = stdout.split(' ')
+  expect(
+    fields,
+    `${name}: probe under ${locale} printed ${JSON.stringify(stdout)}, not "<digest> <locale>"`,
+  ).toHaveLength(2)
+  const [digest, resolvedLocale] = fields as [string, string]
+  expect(digest, `${name}: probe under ${locale} produced no sha256 digest`).toMatch(SHA256)
+  expect(resolvedLocale, `${name}: probe under ${locale} reported no collator`).not.toBe('')
+  return { digest, locale: resolvedLocale }
 }
 
 /**
  * Leg (c) for one writer: identical bytes under en-US and sv-SE.
  *
- * Whether the two arms genuinely resolved to different collations is a property
- * of the host -- Windows ICU follows the system locale and ignores `LC_ALL`, so
- * both arms there are the same configuration. The guarantee does not depend on
- * that: leg (b) already pins the order hermetically. So the byte equality is
- * asserted unconditionally and the divergence only where it is meaningful.
+ * Both digests are validated by `runUnderLocale` before they get here, on every
+ * platform including Windows. Two probes that died silently would otherwise
+ * compare `''` to `''` and pass while proving nothing -- the failure mode this
+ * file guards against everywhere else.
+ *
+ * The divergence check is deliberately an assertion and not a warning. This
+ * control's whole purpose is to run the writer under two genuinely different
+ * collations; if the arms resolve to the same one, the byte comparison is
+ * between two identical configurations and the control has silently stopped
+ * testing what it claims to. On Windows that is expected and unavoidable -- ICU
+ * there follows the system locale and ignores `LC_ALL` -- so Windows relies on
+ * leg (b), which pins the order to a pure function of the strings. Everywhere
+ * else a collapsed pair is a real loss of coverage and should fail loudly.
+ *
+ * Verified against the supported matrix rather than assumed: all six protected
+ * lanes (ubuntu, macOS and Windows on Node 20 and 22) pass with this assertion
+ * in place.
  */
 function expectSameBytesAcrossLocales(entries: readonly string[], name: string, body: string): void {
-  const [american, americanLocale] = runUnderLocale(entries, name, body, 'en_US.UTF-8').split(' ')
-  const [swedish, swedishLocale] = runUnderLocale(entries, name, body, 'sv_SE.UTF-8').split(' ')
-  expect(swedish, `${name}: bytes differ between host collations`).toBe(american)
+  const american = runUnderLocale(entries, name, body, 'en_US.UTF-8')
+  const swedish = runUnderLocale(entries, name, body, 'sv_SE.UTF-8')
+  expect(swedish.digest, `${name}: bytes differ between host collations`).toBe(american.digest)
   if (process.platform !== 'win32') {
-    expect(americanLocale, `${name}: both arms resolved to the same collator`).not.toBe(swedishLocale)
+    expect(
+      american.locale,
+      `${name}: both arms resolved to ${american.locale}, so this control compared two `
+      + 'identical configurations and proved nothing about cross-host bytes',
+    ).not.toBe(swedish.locale)
   }
 }
 


### PR DESCRIPTION
Implements #715.

#715 must remain open until the squash merge is followed by successful push-triggered
protected CI on `next`.

## What this changes

`String.prototype.localeCompare` asks ICU, and ICU answers according to the locale Node takes
from `LC_ALL`/`LANG` at startup. Two machines therefore wrote **different bytes** for the same
inputs. Nine ordering sites now go through `compareUnicodeCodePoints`, the repository's single
comparator owner, reused unchanged:

```text
src/pipeline/indexing-outcomes.ts    6   outcomes, the four summary buckets, spi_diagnostics
src/shared/git.ts                    1   dedupePaths -> graph_build_freshness.git.dirty_files
src/pipeline/spi/diff-overlay.ts     1   the overlay's from|to|kind key
src/infrastructure/proof-report.ts   1   compare-summary discovery order
```

Twenty-five display sites across six files keep locale collation and now say so in the file,
so the next reader can tell a deliberate display sort from one that was missed.

Measured at `next @ b892eafc`, en-US vs sv-SE, wall clocks pinned:

```text
indexing-manifest.json                 1a221607de726d…   e489bae64c4e92…   differed
indexing-manifest.json (capability)    3a08365652373a…   3c24109b31a372…   differed
indexing-manifest.share-safe.json      222ca99813d191…   51afc42f91d89a…   differed
graph.madar (dirty worktree)           da6596da9f8a69…   654bee47e97da9…   differed
SPI diff overlay                       4e2e0bfe0cca50…   847576af598198…   differed
```

## What the ordering change does and does not touch

The persisted collections are **ordering-only**: de-duplication and merging happen before
every sort, so no sort can change which value survives into an artifact.

They are not free of positional *consumers*, and that is declared rather than denied.
`doctor.ts:864` and `doctor.ts:934` each filter the incomplete outcomes and take
`slice(0, 20)`, so this changes which twenty paths `madar doctor` lists — bounded display
slices, presentation only, and host-independent where the old order was not. Everything else
that reads outcomes builds a `Set` (`watch.ts:304`), iterates all of them (`watch.ts:334`),
builds a `Map` keyed by path (`indexing-generation.ts:151`) or filters and counts
(`indexing-manifest.ts:217`).

Object key order is likewise not simply insertion order: `JSON.stringify` emits integer-index
keys first, ascending, so capabilities `"10"` and `"2"` serialize as `"2"`, `"10"` whatever
the comparator returns. That is a language rule rather than an ICU one, so the
host-independence guarantee holds, and `C1-integer-keys` asserts it directly.

## Final merge evidence

Independent verdict:
`GO-715-ORDERING`

Exact PR head:
`5f94435deffcda059a16f5ebb4feef4aa4f8d90b`

Exact PR tree:
`bb782d9f158b0deb88b1430ec62e82826732ca32`

Base:
`next @ b892eafc916c8dfaddff13e585c901ebee187afe`

Tested merge result:
`a8653acb4d1ad61e17e5a49a12c4121a9b7536fb`

Protected CI:
workflow `32944573281`, six of six OS/Node lanes successful

Controls:
`57 / 57`

Affected suites:
`244 / 244`

Mutation inventory:
- 18 total
- 17 caught
- 1 equivalent fixture-only survivor
- 0 uncaught production-ordering mutations
- 0 skipped mutations

Equivalent survivor:
`M9 / C2-literal-capability` modifies only a fixture. The parser returns the literal
capability strings it receives, and the equality is asserted by the control so it fails if
that behavior changes.

Behavioral ordering controls:
- all nine production ordering sites covered;
- seven through behavioral plus static controls;
- `extraction_strategy_buckets` and `fallback_reason_buckets` through the static policy audit
  because the documented searched domain produced no discriminating locale;
- `reason_buckets` behaviorally covered through the az-AZ discriminator.

Locale search:
116 supported locales from the documented generated candidate set.
No claim of exhaustive ICU-locale enumeration.

Timeout invariant:
- non-Windows: `2 × 6000 + 3000 <= 15000`
- Windows: `2 × 13500 + 3000 <= 30000`
- negative and boundary controls pass.

Performance:
`−31.09% p50`

Artifact size:
`316659 bytes` on both measured arms

Review threads:
`2 / 2 resolved`

Scope:
This PR owns serialization ordering only. Locale-dependent selection and graph semantic
identity remain under #716/#719.

What this does not claim:
`graph.madar` semantic identity is not yet host-independent because the projector's
first-wins case-folding collision remains under #716.

No release is authorized by this merge.

## Compatibility

No schema, no version bump, no public signature change. `parseIndexingManifest` still accepts
every manifest it accepts today, including non-ASCII capabilities and arbitrary diagnostic
ids — the accepted domain is not narrowed. Ordering bytes change: code-point order puts
`Zebra` before `_internal` and before every lowercase name, so any artifact over a mixed-case
corpus re-orders on its next write. Rollback is a plain revert with no migration in either
direction.

Refs #716, #719.
