### PR TITLE
feat(context-pack): cap answerability from graph-integrity state (#659)

### DIFF
--- a/src/contracts/context-recovery.ts
+++ b/src/contracts/context-recovery.ts
@@ -84,6 +84,25 @@ export interface ContextPackRecoveryPlan {
  * ever disagree would be a defect class of its own, so the rank moved here,
  * beside the union it ranks, and every consumer imports it.
  */
+export const MADAR_ANSWERABILITY_STATES = Object.freeze([
+  'ready',
+  'ready_with_caveat',
+  'verify_targets',
+  'insufficient',
+] as const)
+
+/**
+ * Narrows an untyped value to the union.
+ *
+ * Needed where a published payload is handled as plain JSON rather than as the
+ * typed assessment -- the Pack projections travel as records, and a cap applied
+ * there still has to know it is looking at an answerability state.
+ */
+export function isMadarAnswerabilityState(value: unknown): value is MadarAnswerabilityState {
+  return typeof value === 'string'
+    && (MADAR_ANSWERABILITY_STATES as readonly string[]).includes(value)
+}
+
 export function readinessRank(state: MadarAnswerabilityState): number {
   switch (state) {
     case 'ready': return 4

--- a/src/contracts/context-recovery.ts
+++ b/src/contracts/context-recovery.ts
@@ -74,3 +74,36 @@ export interface ContextPackRecoveryPlan {
   attempts: ContextPackRecoveryAttempt[]
   improved: boolean
 }
+
+/**
+ * The one ordering over answerability.
+ *
+ * It lived privately inside the recovery planner, which was fine while
+ * recovery was the only thing that had to compare two states. #659 introduces a
+ * second comparison -- the graph-integrity cap -- and two orderings that could
+ * ever disagree would be a defect class of its own, so the rank moved here,
+ * beside the union it ranks, and every consumer imports it.
+ */
+export function readinessRank(state: MadarAnswerabilityState): number {
+  switch (state) {
+    case 'ready': return 4
+    case 'ready_with_caveat': return 3
+    case 'verify_targets': return 2
+    case 'insufficient': return 1
+  }
+}
+
+/**
+ * The more restrictive of two answerability states.
+ *
+ * Total, pure and idempotent: `min(min(a, b), b) === min(a, b)`. Every cap in
+ * the product is expressed through this one helper rather than by re-deriving
+ * a comparison, so "may only lower, never raise" is a property of the helper
+ * instead of a rule each call site is trusted to re-implement.
+ */
+export function minByReadinessRank(
+  left: MadarAnswerabilityState,
+  right: MadarAnswerabilityState,
+): MadarAnswerabilityState {
+  return readinessRank(right) < readinessRank(left) ? right : left
+}

--- a/src/contracts/graph-artifact.ts
+++ b/src/contracts/graph-artifact.ts
@@ -1600,6 +1600,17 @@ export interface GraphArtifactMetadata {
   readonly generationPolicy: Readonly<Record<string, unknown>> | null
   readonly graphBuildFreshness: unknown
   readonly discoverySafety: unknown
+  /**
+   * The raw normalized accounting block a v2 artifact carries, or
+   * `undefined` when the artifact predates it.
+   *
+   * Surfaced unvalidated and untyped on purpose. Validation belongs to the
+   * integrity contracts, and metadata reading never throws, so a reader that
+   * needs the receipt parses it through the owning validator rather than
+   * trusting a shape this function guessed at. Absence and a receipt that
+   * fails to validate are different answers and must stay distinguishable.
+   */
+  readonly integrityReceipt: unknown
   readonly communityLabels: Readonly<Record<string, unknown>>
   /** Machine-local; sourced from the sidecar for v2 and inline for v1. */
   readonly rootPath: string | null
@@ -1660,6 +1671,7 @@ const ABSENT_METADATA: GraphArtifactMetadata = Object.freeze({
   generationPolicy: null,
   graphBuildFreshness: undefined,
   discoverySafety: undefined,
+  integrityReceipt: undefined,
   communityLabels: Object.freeze({}),
   rootPath: null,
   nodeSourceFiles: Object.freeze([]),
@@ -1768,6 +1780,7 @@ export function readGraphArtifactMetadata(
         generationPolicy: optionalRecord(provenance.generation_policy),
         graphBuildFreshness: provenance.graph_build_freshness,
         discoverySafety: provenance.discovery_safety,
+        integrityReceipt: parsed.integrity_receipt,
         communityLabels: parsed.community_labels,
         rootPath: readLocalSidecarRootPath(resolvedPath),
         resolvedPath,
@@ -1786,6 +1799,8 @@ export function readGraphArtifactMetadata(
       generationPolicy: optionalRecord(payload.generation_policy),
       graphBuildFreshness: payload.graph_build_freshness,
       discoverySafety: payload.discovery_safety,
+      // A v1 artifact predates the receipt. Absence, never a fabricated valid one.
+      integrityReceipt: undefined,
       communityLabels: optionalRecord(payload.community_labels) ?? {},
       rootPath: nonEmptyStringOrNull(payload.root_path) ?? readLocalSidecarRootPath(resolvedPath),
       resolvedPath,

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -28,6 +28,7 @@ import { buildTaskContextPlan } from '../runtime/task-context-planner.js'
 import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
+import { capPublishedRecoveryByFinalAnswerability } from '../shared/graph-integrity-answerability.js'
 import {
   assessMadarResponseEvidence,
   collectWorkflowOwners,
@@ -2795,12 +2796,27 @@ function buildPackSchemaV1<TPack extends PackPayload>(
       })
     : buildContextPackGovernanceReceipt(governanceBase)
 
+  // `pack.recovery` and `evidence.recovery` are two serialisations of the same
+  // plan, and the pack was built before the answer was assessed. This is the
+  // first point where the final answerability exists beside the pack, so it is
+  // where the published copy is bounded -- not the pressure-compaction path,
+  // which only runs when the response is over budget.
+  const publishedPack = 'recovery' in response.pack
+    ? {
+        ...response.pack,
+        recovery: capPublishedRecoveryByFinalAnswerability(
+          response.pack.recovery,
+          evidence.answerability.state,
+        ),
+      }
+    : response.pack
+
   return {
     schema_version: 1,
     ...serializableResponse,
     evidence,
     governance,
-    pack: packForSchema(response.task, response.pack, compatibilityFields),
+    pack: packForSchema(response.task, publishedPack, compatibilityFields),
     workflow_centers: centers,
     recommended_first_read: firstRead,
     likely_edit_files: response.implementation?.likely_edit_files ?? [],

--- a/src/infrastructure/context-pack-command.ts
+++ b/src/infrastructure/context-pack-command.ts
@@ -28,7 +28,10 @@ import { buildTaskContextPlan } from '../runtime/task-context-planner.js'
 import { resolveTaskSelection } from '../runtime/task-intent.js'
 import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../runtime/retrieve.js'
 import { buildImplementationPackGuidance } from '../runtime/implementation-pack.js'
-import { capPublishedRecoveryByFinalAnswerability } from '../shared/graph-integrity-answerability.js'
+import {
+  capPublishedRecoveryByFinalAnswerability,
+  finalizePublishedAnswerability,
+} from '../shared/graph-integrity-answerability.js'
 import {
   assessMadarResponseEvidence,
   collectWorkflowOwners,
@@ -2811,7 +2814,10 @@ function buildPackSchemaV1<TPack extends PackPayload>(
       }
     : response.pack
 
-  return {
+  // The CLI response passes the same publication boundary the MCP surfaces use,
+  // so a channel added to this payload later cannot publish a readier state
+  // than the answer just computed for it.
+  return finalizePublishedAnswerability({
     schema_version: 1,
     ...serializableResponse,
     evidence,
@@ -2836,7 +2842,7 @@ function buildPackSchemaV1<TPack extends PackPayload>(
       response.implementation,
       evidence.confidence_reasons,
     ),
-  }
+  }, evidence.answerability.state)
 }
 
 function renderTextSection(title: string, lines: string[]): string[] {

--- a/src/runtime/context-pack-recovery.ts
+++ b/src/runtime/context-pack-recovery.ts
@@ -1,3 +1,4 @@
+import { readinessRank } from '../contracts/context-recovery.js'
 import type { ContextPackRecoveryPlan, MadarAnswerabilityState, MadarVerificationTarget } from '../contracts/context-recovery.js'
 import type { KnowledgeGraph } from '../contracts/graph.js'
 import { assessMadarResponseEvidence } from './mcp-response-evidence.js'
@@ -45,15 +46,6 @@ function assess(result: RetrieveResult, question: string): RecoveryAssessment {
     verificationTargets: assessment.answerability.verification_targets,
     strength: assessment.evidence_strength.level,
     selectedRelationships: assessment.evidence_strength.selected_relationships,
-  }
-}
-
-function readinessRank(state: MadarAnswerabilityState): number {
-  switch (state) {
-    case 'ready': return 4
-    case 'ready_with_caveat': return 3
-    case 'verify_targets': return 2
-    case 'insufficient': return 1
   }
 }
 

--- a/src/runtime/mcp-response-evidence.ts
+++ b/src/runtime/mcp-response-evidence.ts
@@ -18,6 +18,15 @@ import {
   readIndexingManifestForGraph,
   relevantIndexingUncertainty,
 } from '../infrastructure/indexing-manifest.js'
+import {
+  applyGraphIntegrityCap,
+  capPublishedRecovery,
+  graphIntegrityCap,
+  graphIntegrityDiagnostic,
+  readGraphIntegrityCap,
+  NO_GRAPH_INTEGRITY_CAP,
+  type GraphIntegrityDiagnostic,
+} from '../shared/graph-integrity-answerability.js'
 import { readGraphSourceRoot } from '../shared/graph-source-root.js'
 import {
   readDiscoverySafetyMetadata,
@@ -54,6 +63,13 @@ export interface MadarResponseEvidence {
     reasons: Partial<Record<DiscoveryExclusionReason, number>>
     relevant_reasons: Partial<Record<DiscoveryExclusionReason, number>>
   }
+  /**
+   * Share-safe projection of the graph-integrity receipt.
+   *
+   * Absent entirely when the artifact carries no receipt, so a legacy graph is
+   * never described as having been checked.
+   */
+  graph_integrity?: GraphIntegrityDiagnostic
   /** Share-safe aggregate. Local paths remain only in indexing-manifest.json. */
   indexing_completeness?: {
     state: 'complete' | 'partial' | 'failed'
@@ -559,6 +575,11 @@ export function assessMadarResponseEvidence(input: {
   coveredWorkflowOwners?: readonly string[] | undefined
   discoverySafety?: DiscoverySafetyMetadata | null | undefined
   expandable?: readonly ContextPackExpandableRef[] | undefined
+  /**
+   * Raw integrity receipt override. `undefined` means "read it from
+   * `graphPath`"; `null` means "there is none", matching `discoverySafety`.
+   */
+  graphIntegrity?: unknown
   executionSlice?: ContextPackExecutionSlice | undefined
   graphPath?: string | undefined
   indexingManifest?: IndexingManifestV1 | null | undefined
@@ -767,7 +788,7 @@ export function assessMadarResponseEvidence(input: {
     coveredWorkflowOwners,
     coverageDetail.missing_obligations,
   )
-  const answerability = answerabilityAssessment({
+  const uncappedAnswerability = answerabilityAssessment({
     strength: evidenceStrength,
     coverage: coverageDetail,
     answerContained,
@@ -775,7 +796,26 @@ export function assessMadarResponseEvidence(input: {
     sourceReliabilityFailed,
     sourceVerificationBlocked,
   })
+  // The one place graph integrity meets answerability.
+  //
+  // Applied here, before `pack_confidence` and `agent_directive` are derived
+  // from it, so all three renderings agree structurally instead of by keeping
+  // three inventories in step. CLI, Pack and MCP all reach this function.
+  const integrityCap = input.graphIntegrity !== undefined
+    ? graphIntegrityCap(input.graphIntegrity)
+    : input.graphPath
+      ? readGraphIntegrityCap(input.graphPath)
+      : NO_GRAPH_INTEGRITY_CAP
+  const answerability = applyGraphIntegrityCap(uncappedAnswerability, integrityCap)
   const packConfidence = compatibilityConfidence(answerability, evidenceStrength, sourceReliabilityFailed)
+  // Bounded by the FINAL answerability, not by the integrity ceiling. The
+  // top-level result may already have been lowered by evidence, coverage or the
+  // answer contract, and a recovery plan bounded only by the ceiling could still
+  // publish a more optimistic state than the answer beside it.
+  const publishedRecovery = input.recovery
+    ? capPublishedRecovery(input.recovery, answerability.state)
+    : undefined
+  const integrityDiagnostic = graphIntegrityDiagnostic(integrityCap)
 
   return {
     score: effectiveScore,
@@ -784,7 +824,8 @@ export function assessMadarResponseEvidence(input: {
     coverage,
     coverage_detail: coverageDetail,
     answerability,
-    ...(input.recovery ? { recovery: input.recovery } : {}),
+    ...(publishedRecovery ? { recovery: publishedRecovery } : {}),
+    ...(integrityDiagnostic ? { graph_integrity: integrityDiagnostic } : {}),
     missing_phases: missingPhases,
     covered_workflow_owners: coveredWorkflowOwners,
     confidence_reasons: confidenceReasons,
@@ -822,6 +863,11 @@ export function buildMadarResponseEvidence(input: {
   coveredWorkflowOwners?: readonly string[] | undefined
   discoverySafety?: DiscoverySafetyMetadata | null | undefined
   expandable?: readonly ContextPackExpandableRef[] | undefined
+  /**
+   * Raw integrity receipt override. `undefined` means "read it from
+   * `graphPath`"; `null` means "there is none", matching `discoverySafety`.
+   */
+  graphIntegrity?: unknown
   executionSlice?: ContextPackExecutionSlice | undefined
   graphPath?: string | undefined
   indexingManifest?: IndexingManifestV1 | null | undefined

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -52,6 +52,7 @@ import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-del
 import { buildContextPackGovernanceReceipt } from '../context-pack-governance.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
 import { buildImplementationPackGuidance } from '../implementation-pack.js'
+import { capPublishedRecoveryByFinalAnswerability } from '../../shared/graph-integrity-answerability.js'
 import {
   buildMadarResponseEvidence,
   collectWorkflowOwners,
@@ -2021,10 +2022,22 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
         matched_nodes: resolvedNodes.nodes,
         relationships: serializedPack.relationships,
       }, graphPath)
+      // The same helper the CLI seam uses. The serialized pack carries its own
+      // copy of the recovery plan, built before the answer was assessed, so it
+      // is bounded here rather than given an MCP-specific rule of its own.
+      const publishedPack = 'recovery' in serializedPack
+        ? {
+            ...serializedPack,
+            recovery: capPublishedRecoveryByFinalAnswerability(
+              serializedPack.recovery,
+              evidence.answerability.state,
+            ),
+          }
+        : serializedPack
       const basePayload = withContextPackGovernance({
         ...contextPackBasePayload(task, prompt, resolvedBudget, graphPath, initialPlan),
         resolution,
-        pack: serializedPack,
+        pack: publishedPack,
         ...(resolvedNodes.bytes_saved > 0
           ? { bytes_saved_by_resolution: resolvedNodes.bytes_saved, resolution_map: resolvedNodes.resolution_map }
           : {}),

--- a/src/runtime/stdio/tools.ts
+++ b/src/runtime/stdio/tools.ts
@@ -52,7 +52,10 @@ import { collectPackNodeIds, computeDeltaContextPack } from '../context-pack-del
 import { buildContextPackGovernanceReceipt } from '../context-pack-governance.js'
 import { applyContextPackResolution, type ContextPackResolution } from '../context-pack-resolution.js'
 import { buildImplementationPackGuidance } from '../implementation-pack.js'
-import { capPublishedRecoveryByFinalAnswerability } from '../../shared/graph-integrity-answerability.js'
+import {
+  capPublishedRecoveryByFinalAnswerability,
+  finalizePublishedAnswerability,
+} from '../../shared/graph-integrity-answerability.js'
 import {
   buildMadarResponseEvidence,
   collectWorkflowOwners,
@@ -1581,10 +1584,17 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
               ...compactPayload,
               ...contextMetadata(compactPayload),
             }
-        return helpers.ok(id, helpers.textToolResult(JSON.stringify({
-          ...payload,
-          evidence: evidenceForRetrievePayload(payload, graphPath),
-        })))
+        const retrieveEvidence = evidenceForRetrievePayload(payload, graphPath)
+        // The whole response passes the publication boundary once, rather than
+        // each remembered field being capped on its own. `payload` carries its
+        // own serialisation of the recovery plan, and capping only `evidence`
+        // published a readier state beside the answer.
+        return helpers.ok(id, helpers.textToolResult(JSON.stringify(
+          finalizePublishedAnswerability(
+            { ...payload, evidence: retrieveEvidence },
+            retrieveEvidence.answerability.state,
+          ),
+        )))
       }).catch((error: unknown) => {
         // A rejected retrieve (e.g. missing optional semantic dependency) must
         // surface as an MCP tool error the agent can read and react to —
@@ -2063,7 +2073,14 @@ export function handleToolCall(id: string | number | null, graphPath: string, pa
       const unconstrainedResponsePayload = task === 'explain' && !includeSelectionDiagnostics
         ? buildAnswerReadyPackSchema(basePayload, resolvedBudget, fullPack.selection_diagnostics)
         : basePayload
-      const responsePayload = constrainStrictContextPackPayload(unconstrainedResponsePayload, helpers)
+      // The last thing the context_pack response passes through. Placed after
+      // the answer-ready schema builder and the strict constrainer, both of
+      // which rewrite the payload, so a channel either of them reintroduces is
+      // still bounded.
+      const responsePayload = finalizePublishedAnswerability(
+        constrainStrictContextPackPayload(unconstrainedResponsePayload, helpers),
+        evidence.answerability.state,
+      )
       storeFinalContextPackHandles(
         prompt,
         task,

--- a/src/shared/graph-integrity-answerability.ts
+++ b/src/shared/graph-integrity-answerability.ts
@@ -6,7 +6,7 @@ import type {
   MadarAnswerabilityState,
   MadarVerificationTarget,
 } from '../contracts/context-recovery.js'
-import { minByReadinessRank } from '../contracts/context-recovery.js'
+import { isMadarAnswerabilityState, minByReadinessRank } from '../contracts/context-recovery.js'
 import {
   NORMALIZED_ACCOUNTING_ARTIFACT_KEY,
   parseGraphArtifactNormalizedAccounting,
@@ -356,4 +356,43 @@ export function readGraphIntegrityCap(graphPath: string): GraphIntegrityCap {
   } catch {
     return NO_GRAPH_INTEGRITY_CAP
   }
+}
+
+/**
+ * Bounds a published recovery projection by the final top-level answerability.
+ *
+ * The one helper both publication seams use. `pack.recovery` and
+ * `evidence.recovery` are separate serialisations of the same plan, and the
+ * pack is built before the answer is assessed, so the pack copy has to be
+ * bounded where the final answerability actually exists rather than where the
+ * pack is assembled.
+ *
+ * Only the two state fields move. Attempt counts, budgets, improvement flags
+ * and every other field are recovery-execution metadata that this cap has no
+ * business rewriting, and an absent plan stays absent rather than being
+ * fabricated into an empty one.
+ *
+ * Returns the original reference when nothing changed, which is what makes a
+ * second application a provable no-op.
+ */
+export function capPublishedRecoveryByFinalAnswerability<T>(
+  recovery: T,
+  finalAnswerability: MadarAnswerabilityState,
+): T {
+  if (recovery === null || typeof recovery !== 'object' || Array.isArray(recovery)) {
+    return recovery
+  }
+  const plan = recovery as Record<string, unknown>
+  const initial = plan.initial_state
+  const final = plan.final_state
+  const nextInitial = isMadarAnswerabilityState(initial)
+    ? minByReadinessRank(initial, finalAnswerability)
+    : initial
+  const nextFinal = isMadarAnswerabilityState(final)
+    ? minByReadinessRank(final, finalAnswerability)
+    : final
+  if (nextInitial === initial && nextFinal === final) {
+    return recovery
+  }
+  return { ...plan, initial_state: nextInitial, final_state: nextFinal } as T
 }

--- a/src/shared/graph-integrity-answerability.ts
+++ b/src/shared/graph-integrity-answerability.ts
@@ -396,3 +396,162 @@ export function capPublishedRecoveryByFinalAnswerability<T>(
   }
   return { ...plan, initial_state: nextInitial, final_state: nextFinal } as T
 }
+
+/**
+ * A published field that carries an answerability value.
+ *
+ * `bounded` separates a channel that states what the product IS answering from
+ * a diagnostic that describes policy. An integrity ceiling of
+ * `ready_with_caveat` beside a final answer of `insufficient` is correct and
+ * must survive; a recovery plan claiming `ready` beside it must not.
+ */
+export interface PublishedAnswerabilityChannel {
+  readonly path: string
+  readonly carrier: 'answerability' | 'recovery' | 'integrity_ceiling'
+  readonly bounded: boolean
+  readonly value: MadarAnswerabilityState | null
+}
+
+export interface PublishedAnswerabilityScan {
+  readonly channels: readonly PublishedAnswerabilityChannel[]
+  /**
+   * Answerability-shaped values at fields this contract does not recognise.
+   *
+   * Never empty-and-ignored: an unrecognised channel is the exact shape of
+   * every defect this boundary exists to stop, so it fails closed instead.
+   */
+  readonly unclassified: readonly string[]
+}
+
+function isRecoveryPlanShape(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const record = value as Record<string, unknown>
+  return isMadarAnswerabilityState(record.initial_state) || isMadarAnswerabilityState(record.final_state)
+}
+
+function isAnswerabilityAssessmentShape(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    && isMadarAnswerabilityState((value as Record<string, unknown>).state)
+}
+
+/**
+ * Walks a finished response and reports every answerability-bearing field.
+ *
+ * Schema-aware rather than textual: it recognises the declared carriers by key
+ * and shape, and it deliberately does NOT treat every `state` property as an
+ * answerability -- a retrieval plan status and a recovery status are both
+ * `state`-ish and neither is an answer. What it does treat as significant is a
+ * value drawn from the readiness union, because those four strings appear
+ * nowhere else in these payloads. One reached at a field this contract has not
+ * declared is reported rather than skipped.
+ */
+export function scanPublishedAnswerability(response: unknown): PublishedAnswerabilityScan {
+  const channels: PublishedAnswerabilityChannel[] = []
+  const unclassified: string[] = []
+
+  const visit = (value: unknown, path: string, key: string | null, parentKey: string | null): void => {
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => visit(entry, `${path}[${index}]`, key, parentKey))
+      return
+    }
+    if (value !== null && typeof value === 'object') {
+      const record = value as Record<string, unknown>
+
+      if (key === 'answerability' && isAnswerabilityAssessmentShape(record)) {
+        channels.push({
+          path: `${path}.state`,
+          carrier: 'answerability',
+          bounded: true,
+          value: record.state as MadarAnswerabilityState,
+        })
+        for (const [childKey, child] of Object.entries(record)) {
+          if (childKey === 'state') continue
+          visit(child, `${path}.${childKey}`, childKey, key)
+        }
+        return
+      }
+
+      if (key === 'recovery' && isRecoveryPlanShape(record)) {
+        for (const stateKey of ['initial_state', 'final_state'] as const) {
+          if (!isMadarAnswerabilityState(record[stateKey])) continue
+          channels.push({
+            path: `${path}.${stateKey}`,
+            carrier: 'recovery',
+            bounded: true,
+            value: record[stateKey] as MadarAnswerabilityState,
+          })
+        }
+        for (const [childKey, child] of Object.entries(record)) {
+          if (childKey === 'initial_state' || childKey === 'final_state') continue
+          visit(child, `${path}.${childKey}`, childKey, key)
+        }
+        return
+      }
+
+      for (const [childKey, child] of Object.entries(record)) {
+        visit(child, `${path}.${childKey}`, childKey, key)
+      }
+      return
+    }
+
+    if (!isMadarAnswerabilityState(value)) return
+
+    // A bare readiness value. Recognised carriers first, then fail closed.
+    if (key === 'answerability') {
+      channels.push({ path, carrier: 'answerability', bounded: true, value })
+      return
+    }
+    if (key === 'max_answerability' && parentKey === 'graph_integrity') {
+      // The integrity ceiling. It describes what integrity permits, not what
+      // the product is answering, so it is classified and left alone.
+      channels.push({ path, carrier: 'integrity_ceiling', bounded: false, value })
+      return
+    }
+    unclassified.push(path)
+  }
+
+  visit(response, '', null, null)
+  return { channels, unclassified }
+}
+
+/**
+ * Bounds every published answerability channel by the canonical final answer.
+ *
+ * The last thing a response passes through before serialization. Three separate
+ * channels in this product were found to bypass a per-seam cap, one at a time,
+ * so the boundary is placed once at the finished object rather than at each
+ * field somebody remembered.
+ *
+ * Only readiness values move. Selection, ranking, retrieval plans, recovery
+ * execution metadata, budgets, snippets, claims and non-answerability
+ * diagnostics are structurally untouched, and an absent channel stays absent.
+ *
+ * Idempotent: a second application finds every channel already at or below the
+ * bound and rewrites nothing.
+ */
+export function finalizePublishedAnswerability<T>(response: T, finalTopLevel: MadarAnswerabilityState): T {
+  const rewrite = (value: unknown, key: string | null): unknown => {
+    if (Array.isArray(value)) return value.map((entry) => rewrite(entry, key))
+    if (value !== null && typeof value === 'object') {
+      const record = value as Record<string, unknown>
+      const next: Record<string, unknown> = {}
+      const isAnswerability = key === 'answerability' && isAnswerabilityAssessmentShape(record)
+      const isRecovery = key === 'recovery' && isRecoveryPlanShape(record)
+      for (const [childKey, child] of Object.entries(record)) {
+        if (isAnswerability && childKey === 'state' && isMadarAnswerabilityState(child)) {
+          next[childKey] = minByReadinessRank(child, finalTopLevel)
+        } else if (isRecovery && (childKey === 'initial_state' || childKey === 'final_state') && isMadarAnswerabilityState(child)) {
+          next[childKey] = minByReadinessRank(child, finalTopLevel)
+        } else {
+          next[childKey] = rewrite(child, childKey)
+        }
+      }
+      return next
+    }
+    if (key === 'answerability' && isMadarAnswerabilityState(value)) {
+      return minByReadinessRank(value, finalTopLevel)
+    }
+    return value
+  }
+  return rewrite(response, null) as T
+}

--- a/src/shared/graph-integrity-answerability.ts
+++ b/src/shared/graph-integrity-answerability.ts
@@ -1,0 +1,359 @@
+import { statSync } from 'node:fs'
+
+import type {
+  ContextPackRecoveryPlan,
+  MadarAnswerabilityAssessment,
+  MadarAnswerabilityState,
+  MadarVerificationTarget,
+} from '../contracts/context-recovery.js'
+import { minByReadinessRank } from '../contracts/context-recovery.js'
+import {
+  NORMALIZED_ACCOUNTING_ARTIFACT_KEY,
+  parseGraphArtifactNormalizedAccounting,
+  type GraphArtifactNormalizedAccountingV1,
+} from '../contracts/graph-artifact-normalized-accounting.js'
+import { readGraphArtifactMetadata } from '../contracts/graph-artifact.js'
+import { assertNormalizedIntegrityReceipt } from '../contracts/graph-integrity-receipt.js'
+import type { GraphIntegrityStatus, IntegrityVerificationTarget } from '../contracts/graph-integrity.js'
+import { MAX_GRAPH_ARTIFACT_BYTES } from './discovery-safety.js'
+
+/**
+ * The single owner of "what does graph integrity permit an answer to claim".
+ *
+ * #659 consumes the #658 receipt; it never recomputes integrity. `status` is
+ * derived by `deriveIntegrityStatus` inside the graph contracts and read here
+ * verbatim, and the bounded/unbounded split is read out of the receipt's own
+ * `durable_records` retention rather than parsed out of reason text.
+ */
+
+/** How the integrity state of an artifact was resolved. */
+export type GraphIntegrityResolution =
+  /** No receipt at all: a legacy v1 artifact, or no artifact. */
+  | { readonly kind: 'absent' }
+  /**
+   * A receipt is present but cannot be trusted: it failed the #658 validator,
+   * or its own counters contradict the status it claims. Never treated as
+   * absent, because an artifact that claims graph-backed evidence and then
+   * presents an unreadable receipt is the case this issue exists to catch.
+   */
+  | { readonly kind: 'unreadable', readonly reason: string }
+  | {
+      readonly kind: 'present'
+      readonly block: GraphArtifactNormalizedAccountingV1
+    }
+
+/** `null` means "no graph-integrity constraint", never "ready". */
+export type GraphIntegrityCeiling = MadarAnswerabilityState | null
+
+export interface GraphIntegrityCap {
+  readonly ceiling: GraphIntegrityCeiling
+  /** Machine-readable, appended to caveats when the cap actually binds. */
+  readonly reason: string | null
+  /** Deterministic, deduplicated, share-safe. Empty unless degraded with targets. */
+  readonly targets: readonly MadarVerificationTarget[]
+  /**
+   * What the receipt said, for the share-safe diagnostic.
+   *
+   * `null` when no receipt was present. Never synthesised: absence stays
+   * absence so the projection cannot claim an integrity status that was never
+   * recorded.
+   */
+  readonly status: GraphIntegrityStatus | null
+  readonly reasons: readonly string[]
+}
+
+/** The share-safe projection handed to Pack, CLI and MCP alike. */
+export interface GraphIntegrityDiagnostic {
+  readonly status: GraphIntegrityStatus
+  readonly reasons: readonly string[]
+  readonly max_answerability: MadarAnswerabilityState | null
+  readonly verification_targets: readonly string[]
+}
+
+/**
+ * The diagnostic for a cap, or `undefined` when no receipt existed.
+ *
+ * Absence emits nothing at all rather than an "unknown" status, so a legacy
+ * artifact never appears to have been checked and found fine.
+ */
+export function graphIntegrityDiagnostic(cap: GraphIntegrityCap): GraphIntegrityDiagnostic | undefined {
+  if (cap.status === null) return undefined
+  return {
+    status: cap.status,
+    reasons: cap.reasons,
+    max_answerability: cap.ceiling,
+    verification_targets: cap.targets.flatMap((target) => target.focus_files),
+  }
+}
+
+export const NO_GRAPH_INTEGRITY_CAP: GraphIntegrityCap = Object.freeze({
+  ceiling: null,
+  reason: null,
+  targets: Object.freeze([]),
+  status: null,
+  reasons: Object.freeze([]),
+})
+
+/**
+ * Resolves the raw `integrity_receipt` wire value into one of three states.
+ *
+ * `undefined` and `null` are absence, which is not a defect: a v1 artifact
+ * predates the receipt entirely. Anything else must parse and validate, and a
+ * value that does not is `unreadable`, deliberately distinct from absent.
+ */
+export function resolveGraphIntegrity(raw: unknown): GraphIntegrityResolution {
+  if (raw === undefined || raw === null) {
+    return { kind: 'absent' }
+  }
+  // `integrity_receipt` is the storage receipt, and the #658 normalized
+  // accounting rides on it under a dedicated key. Unwrapping here rather than
+  // handing the whole receipt to the block parser is the difference between
+  // reading the accounting and refusing every real artifact as malformed.
+  const carrier = typeof raw === 'object' && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)[NORMALIZED_ACCOUNTING_ARTIFACT_KEY]
+    : undefined
+  if (carrier === undefined) {
+    // Either a storage-only receipt from before normalized accounting existed,
+    // or something that is not a receipt at all. Neither can establish
+    // integrity, and neither is allowed to assert it: the caller gets no cap
+    // and, critically, no diagnostic claiming the graph was found valid.
+    return { kind: 'absent' }
+  }
+  let block: GraphArtifactNormalizedAccountingV1
+  try {
+    block = parseGraphArtifactNormalizedAccounting(carrier, 'integrity_receipt.normalized_accounting')
+    assertNormalizedIntegrityReceipt(block.receipt)
+  } catch (error) {
+    return { kind: 'unreadable', reason: error instanceof Error ? error.name : 'unparseable_receipt' }
+  }
+  // No second consistency check here on purpose.
+  //
+  // `assertNormalizedIntegrityReceipt` is the one receipt authority and it
+  // re-derives status and reasons from the receipt's own counters before
+  // comparing, so a forged `valid` beside an invariant failure is already
+  // refused above and arrives as `unreadable`. Re-deriving any part of that
+  // judgement here would create a second integrity policy owner that could
+  // drift from the first, which is the failure this issue is meant to avoid.
+  return { kind: 'present', block }
+}
+
+/**
+ * Whether a degraded receipt can tell a consumer what to check.
+ *
+ * Truncation anywhere means the retained records are not the whole set, so the
+ * consumer would be handed a partial list presented as complete. The issue is
+ * explicit that a degraded state without a bounded target set is
+ * `insufficient`, not a vague `verify_targets`.
+ */
+function boundedIntegrityTargets(
+  block: GraphArtifactNormalizedAccountingV1,
+): readonly MadarVerificationTarget[] {
+  const records = block.receipt.durable_records
+  if (block.receipt.reasons.includes('durable_records_truncated')) return []
+  if (records.unresolved.truncated || records.rejected.truncated || records.conflicting.truncated) return []
+
+  const collected: IntegrityVerificationTarget[] = [
+    ...block.unresolved_records.flatMap((record) => [...record.verificationTargets]),
+    ...block.rejected_records.flatMap((record) => [...record.verificationTargets]),
+    ...block.conflict_records.flatMap((record) => [...record.verificationTargets]),
+  ]
+
+  // Keyed on file plus reason and sorted in code-unit order, so two runs that
+  // retained the same records in a different arrival order project the same
+  // target list. `localeCompare` is locale-sensitive and would not.
+  const byKey = new Map<string, IntegrityVerificationTarget>()
+  for (const target of collected) {
+    const key = `${target.file}\u0000${target.reason}`
+    if (!byKey.has(key)) byKey.set(key, target)
+  }
+  return [...byKey.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([, target]): MadarVerificationTarget => ({
+      focus_files: [target.file],
+      focus_ranges: [],
+      reason: `verify graph integrity: ${target.reason}`,
+    }))
+}
+
+/**
+ * The receipt-to-ceiling mapping. Exactly the policy table in the issue.
+ *
+ * `valid` and absence both return `null` rather than `'ready'`: integrity never
+ * grants readiness, it only withholds it. Every existing evidence, coverage and
+ * answer-contract gate still applies on top.
+ */
+export function graphIntegrityCap(raw: unknown): GraphIntegrityCap {
+  const resolution = resolveGraphIntegrity(raw)
+
+  if (resolution.kind === 'absent') {
+    return NO_GRAPH_INTEGRITY_CAP
+  }
+  if (resolution.kind === 'unreadable') {
+    return {
+      ceiling: 'insufficient',
+      reason: `graph_integrity_unreadable:${resolution.reason}`,
+      targets: [],
+      // A receipt that failed validation has no status worth quoting, but it is
+      // emphatically present, so the diagnostic reports `invalid` rather than
+      // vanishing the way a genuine absence does.
+      status: 'invalid',
+      reasons: [resolution.reason],
+    }
+  }
+
+  const { block } = resolution
+  const status = block.receipt.status
+
+  const reasons = [...block.receipt.reasons]
+  if (status === 'valid') {
+    return { ceiling: null, reason: null, targets: [], status, reasons }
+  }
+  if (status === 'invalid' || status === 'incompatible') {
+    return { ceiling: 'insufficient', reason: `graph_integrity_${status}`, targets: [], status, reasons }
+  }
+  if (status === 'valid_with_warnings') {
+    // Uniform, per the design ruling. Discriminating a "permitted" boundary
+    // warning from any other would need the declared-exception authority #658
+    // states this contract does not have, and inferring permission from a
+    // warning that merely looks benign is exactly what it forbids.
+    return { ceiling: 'ready_with_caveat', reason: 'graph_integrity_valid_with_warnings', targets: [], status, reasons }
+  }
+
+  const targets = boundedIntegrityTargets(block)
+  return targets.length > 0
+    ? { ceiling: 'verify_targets', reason: 'graph_integrity_degraded_with_targets', targets, status, reasons }
+    : { ceiling: 'insufficient', reason: 'graph_integrity_degraded_without_bounded_targets', targets: [], status, reasons }
+}
+
+function withCaveat(caveats: readonly string[], reason: string | null): string[] {
+  if (reason === null || caveats.includes(reason)) return [...caveats]
+  return [...caveats, reason]
+}
+
+/**
+ * Applies the ceiling to a computed answerability assessment.
+ *
+ * The result satisfies every structural invariant the uncapped assessment
+ * satisfies, because consumers read those invariants rather than the state
+ * alone. The compact CLI serializer decides whether it may still offer a target
+ * by testing `verification_targets.length`, so a capped `insufficient` that
+ * left targets in place would be silently promoted back to `verify_targets`
+ * downstream. Lowering the state is therefore never enough on its own.
+ *
+ * Idempotent: once the state equals the ceiling the assessment is returned
+ * unchanged, so applying the cap twice cannot append a second caveat.
+ */
+export function applyGraphIntegrityCap(
+  assessment: MadarAnswerabilityAssessment,
+  cap: GraphIntegrityCap,
+): MadarAnswerabilityAssessment {
+  if (cap.ceiling === null) return assessment
+  const next = minByReadinessRank(assessment.state, cap.ceiling)
+  if (next === assessment.state) return assessment
+
+  if (next === 'insufficient') {
+    return {
+      ...assessment,
+      state: 'insufficient',
+      answer_scope: 'none',
+      caveats: withCaveat(assessment.caveats, cap.reason),
+      verification_targets: [],
+      broad_search_fallback: assessment.broad_search_fallback === 'blocked' ? 'blocked' : 'allowed',
+    }
+  }
+  if (next === 'verify_targets') {
+    // The ceiling is only ever `verify_targets` when the receipt produced a
+    // bounded, non-empty target set, so this cannot emit an unactionable
+    // `verify_targets`.
+    return {
+      ...assessment,
+      state: 'verify_targets',
+      answer_scope: 'partial',
+      caveats: withCaveat(assessment.caveats, cap.reason),
+      verification_targets: [...cap.targets],
+      broad_search_fallback: assessment.broad_search_fallback === 'blocked' ? 'blocked' : 'targeted_only',
+    }
+  }
+  return {
+    ...assessment,
+    state: 'ready_with_caveat',
+    caveats: withCaveat(assessment.caveats, cap.reason),
+  }
+}
+
+/**
+ * Bounds a published recovery plan by the FINAL top-level answerability.
+ *
+ * Not by the integrity ceiling. The top-level result may already have been
+ * lowered by evidence strength, coverage or an answer contract, and a recovery
+ * plan bounded only by the ceiling could still publish `ready_with_caveat`
+ * beside a top-level `verify_targets`. The bound is the published answer, so
+ * that no published channel can be more optimistic than it.
+ */
+export function capPublishedRecovery(
+  plan: ContextPackRecoveryPlan,
+  finalTopLevel: MadarAnswerabilityState,
+): ContextPackRecoveryPlan {
+  const initial = minByReadinessRank(plan.initial_state, finalTopLevel)
+  const final = minByReadinessRank(plan.final_state, finalTopLevel)
+  if (initial === plan.initial_state && final === plan.final_state) return plan
+  return { ...plan, initial_state: initial, final_state: final }
+}
+
+const MAX_INTEGRITY_CACHE_ENTRIES = 16
+
+interface CachedIntegrityCap {
+  readonly resolvedPath: string
+  readonly mtimeMs: number
+  readonly size: number
+  readonly value: GraphIntegrityCap
+}
+
+const integrityCapCache = new Map<string, CachedIntegrityCap>()
+
+function freshAgainst(path: string, mtimeMs: number, size: number): boolean {
+  try {
+    const stats = statSync(path)
+    return stats.mtimeMs === mtimeMs && stats.size === size
+  } catch {
+    // The artifact moved or vanished; the cached value describes nothing.
+    return false
+  }
+}
+
+/**
+ * Reads the cap for a graph path, bounded and cached.
+ *
+ * Deliberately the same shape as `readDiscoverySafetyMetadata`: one bounded
+ * `readGraphArtifactMetadata` under the shared byte ceiling, keyed on the
+ * artifact actually resolved and invalidated by mtime and size. An assessment
+ * runs this once per request, so an unbounded or uncached read here would be a
+ * new hot path rather than a projection.
+ *
+ * Never throws. A read failure yields no cap rather than a fabricated one:
+ * refusing to answer because an artifact could not be stat-ed is not this
+ * function's decision to make, and `format` already distinguishes unreadable
+ * from absent for callers that care.
+ */
+export function readGraphIntegrityCap(graphPath: string): GraphIntegrityCap {
+  try {
+    const cacheKey = graphPath
+    const cached = integrityCapCache.get(cacheKey)
+    if (cached !== undefined && freshAgainst(cached.resolvedPath, cached.mtimeMs, cached.size)) {
+      return cached.value
+    }
+    const metadata = readGraphArtifactMetadata(graphPath, { maxBytes: MAX_GRAPH_ARTIFACT_BYTES })
+    const value = graphIntegrityCap(metadata.integrityReceipt)
+    const resolvedPath = metadata.resolvedPath ?? graphPath
+    const stats = statSync(resolvedPath)
+    integrityCapCache.set(cacheKey, { resolvedPath, mtimeMs: stats.mtimeMs, size: stats.size, value })
+    while (integrityCapCache.size > MAX_INTEGRITY_CACHE_ENTRIES) {
+      const oldestKey = integrityCapCache.keys().next().value as string | undefined
+      if (!oldestKey) break
+      integrityCapCache.delete(oldestKey)
+    }
+    return value
+  } catch {
+    return NO_GRAPH_INTEGRITY_CAP
+  }
+}

--- a/tests/manifests/658-focused.json
+++ b/tests/manifests/658-focused.json
@@ -5,6 +5,8 @@
   "tests/unit/endpoint-qualification-invalidation.test.ts",
   "tests/unit/exact-manifest-controls.test.ts",
   "tests/unit/graph-artifact-old-reader-compat.test.ts",
+  "tests/unit/graph-integrity-answerability-e2e.test.ts",
+  "tests/unit/graph-integrity-answerability.test.ts",
   "tests/unit/graph-integrity-contracts.test.ts",
   "tests/unit/graph-integrity-receipt.test.ts",
   "tests/unit/integrity-closed-schemas.test.ts",

--- a/tests/unit/artifact-format-answer-differential.test.ts
+++ b/tests/unit/artifact-format-answer-differential.test.ts
@@ -4,27 +4,41 @@ import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { executeCli } from '../../src/cli/main.js'
-import { GRAPH_ARTIFACT_V2_TOMBSTONE } from '../../src/contracts/graph-artifact.js'
+import type { MadarAnswerabilityAssessment, MadarAnswerabilityState } from '../../src/contracts/context-recovery.js'
+import { detailRetention, emptyTerminalCounts, type CandidateTerminalCounts, type EndpointIdentityFactMatrix } from '../../src/contracts/graph-integrity.js'
+import { ENDPOINT_IDENTITY_STATUSES, type EndpointIdentityStatus } from '../../src/contracts/endpoint-identity.js'
+import { buildNormalizedIntegrityReceipt } from '../../src/contracts/graph-integrity-receipt.js'
+import { GRAPH_ARTIFACT_V2_TOMBSTONE, readGraphArtifactMetadata } from '../../src/contracts/graph-artifact.js'
 import { classifyWorkspaceGraph } from '../../src/contracts/graph-artifact-selection.js'
 import { generateGraph } from '../../src/infrastructure/generate.js'
+import {
+  applyGraphIntegrityCap,
+  capPublishedRecoveryByFinalAnswerability,
+  graphIntegrityCap,
+  graphIntegrityDiagnostic,
+} from '../../src/shared/graph-integrity-answerability.js'
 import { readGeneratedGraphJson } from './helpers/generated-graph.js'
 
 /**
- * The cutover must change which artifact is read, not what the product answers.
+ * The cutover must change which artifact is read, not what the product answers
+ * -- with one deliberate exception.
  *
- * Most behaviour tests in this suite still describe a v1 `graph.json`, because
- * that is what generation used to write and those assertions remain valid for a
- * workspace that never cut over. The risk that leaves is a silent divergence: if
- * canonical reading returned subtly different content, the legacy-shaped
- * majority of the suite would stay green.
+ * Complete answer neutrality between `graph.json` and `graph.madar` was the
+ * right contract while the two carried the same information. #659 ended that:
+ * the v2 artifact carries a graph-integrity receipt that v1 cannot, and the
+ * product is required to use it. Demanding identical answers would now mean
+ * demanding that the product ignore evidence it has.
  *
- * So this pins the two against each other -- one source tree, one generated
- * graph, one directory, presented twice: once as the canonical v2 artifact and
- * once as a v1 graph.json derived from that same artifact. The workspace path is
- * identical across both phases on purpose. An earlier version derived the v1
- * copy in a second directory and every command "diverged", but only because a
- * graph records the absolute paths it was built from, so the comparison was
- * measuring the fixture rather than the product.
+ * So the contract is narrower and sharper. Graph content, retrieval, ranking,
+ * coverage, evidence selection, recovery execution and token budgets must still
+ * be identical -- those are the things a storage format has no business
+ * touching. Only the published trust fields may differ, only through the single
+ * #659 policy owner, and only to a value this suite RE-DERIVES from the real
+ * receipt. A difference anywhere else, or a differing field this contract does
+ * not name, fails.
+ *
+ * The cause must be the receipt, never the file extension. Nothing here is
+ * keyed on `.madar` versus `.json`.
  */
 
 const SOURCE_FILES: ReadonlyArray<readonly [string, string]> = [
@@ -53,7 +67,7 @@ const SOURCE_FILES: ReadonlyArray<readonly [string, string]> = [
   ].join('\n')],
 ]
 
-/** Commands whose answers must not depend on which artifact carries the graph. */
+/** Commands compared across the two artifact formats. */
 const COMMANDS: ReadonlyArray<readonly [string, string[]]> = [
   ['summary', ['summary']],
   ['query', ['query', 'login']],
@@ -69,27 +83,90 @@ interface Answer {
 }
 
 /**
- * Removes only what cannot be identical: identifiers derived from the artifact
- * bytes, which genuinely differ between a v2 artifact and a v1 file describing
- * the same graph, plus wall-clock values. Paths are NOT normalized -- both
- * phases run in the same directory, so a path difference would be a real one.
+ * The closed set of leaf paths whose value may differ between the two formats.
+ *
+ * Every one of these is derived from the final answerability by the #659 owner.
+ * Deliberately exact paths: a prefix such as `evidence.*` would let a genuine
+ * retrieval regression hide inside the same object as a trust field.
  */
+const INTEGRITY_DERIVED_PATHS: ReadonlySet<string> = new Set([
+  '.evidence.answerability.state',
+  '.evidence.answerability.answer_scope',
+  '.evidence.answerability.broad_search_fallback',
+  '.evidence.pack_confidence',
+  '.evidence.agent_directive',
+  '.evidence.recovery.initial_state',
+  '.evidence.recovery.final_state',
+  '.pack.recovery.initial_state',
+  '.pack.recovery.final_state',
+  '.governance.directive.answerability',
+  '.governance.directive.pack_confidence',
+  '.governance.directive.agent_directive',
+])
+
+/** Path prefixes that carry graph content, retrieval or budget -- never trust. */
+const NEUTRAL_PREFIXES: readonly string[] = [
+  '.pack.matched_nodes',
+  '.pack.relationships',
+  '.pack.community_context',
+  '.pack.graph_signals',
+  '.pack.retrieval_plan',
+  '.pack.retrieval_gate',
+  '.pack.snippet_budget',
+  '.pack.token_count',
+  '.serialized_budget.max_tokens',
+  '.serialized_budget.enforced',
+  '.pack.question',
+  '.pack.shared_file_type',
+  '.pack.retrieval_strategy',
+  '.plan',
+  '.coverage',
+  '.claims',
+  '.expandable',
+  '.evidence.evidence_strength',
+  '.evidence.coverage',
+  '.evidence.covered_workflow_owners',
+  '.evidence.missing_phases',
+  '.workflow_centers',
+  '.recommended_first_read',
+  '.likely_edit_files',
+  '.likely_test_files',
+  '.public_contracts',
+  '.why_explanation',
+  '.pack.recovery.attempts',
+  '.pack.recovery.improved',
+  '.pack.recovery.budget',
+  '.pack.recovery.status',
+  '.evidence.recovery.attempts',
+  '.evidence.recovery.improved',
+  '.evidence.recovery.budget',
+  '.evidence.recovery.status',
+  '.governance.graph_freshness',
+  '.governance.request',
+]
+
+/** Additive integrity diagnostic. Present on v2, absent on v1, never on both. */
+const DIAGNOSTIC_ROOT = '.evidence.graph_integrity'
+/**
+ * The response envelope's own size.
+ *
+ * Not neutral and not a trust field: it is a measurement OF the payload, and
+ * the payload legitimately carries one additional object. Listing it as neutral
+ * would demand that an additive field weigh nothing; ignoring it would hide a
+ * budget regression. It is classified separately and proven below by
+ * reconstruction.
+ */
+const ENVELOPE_SIZE_PATH = '.serialized_budget.token_count'
+const CAVEATS_ROOT = '.evidence.answerability.caveats'
+
 function normalize(text: string): string {
   return text
     .replaceAll('graph.madar', '<artifact>')
     .replaceAll('graph.json', '<artifact>')
     .replace(/\b[0-9a-f]{12,64}\b/g, '<digest>')
     .replace(/\d{4}-\d{2}-\d{2}T[0-9:.]+Z/g, '<timestamp>')
-    // HTTP-date too. The two phases run a moment apart, so an artifact mtime
-    // rendered as `Mon, 17 Aug 2026 20:14:18 GMT` differs by a second between
-    // them -- a clock reading, not an answer.
     .replace(/[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT/g, '<http-date>')
     .replace(/\b\d+ ?ms\b/g, '<duration>')
-    // A serialized payload carries the artifact path inside it, and
-    // `graph.madar` is one character longer than `graph.json`, so its own token
-    // count cannot be equal. The counts are compared separately below with a
-    // bound, rather than dropped.
-    .replace(/"token_count":\d+/g, '"token_count":<count>')
 }
 
 /** Every token count in a response, in order. */
@@ -97,13 +174,141 @@ function tokenCounts(text: string): number[] {
   return [...text.matchAll(/"token_count":(\d+)/g)].map((match) => Number(match[1]))
 }
 
-describe('answers do not depend on which artifact carries the graph', () => {
+/**
+ * Rewrites the artifact's own filename inside string values.
+ *
+ * The payload records the path it was built from, and one workspace being read
+ * as `graph.madar` rather than `graph.json` is not a difference in the answer.
+ * Only that substitution: everything else must survive to be compared.
+ */
+function normalizeArtifactNames(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replaceAll('graph.madar', '<artifact>').replaceAll('graph.json', '<artifact>')
+  }
+  if (Array.isArray(value)) return value.map(normalizeArtifactNames)
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .map(([key, entry]) => [key, normalizeArtifactNames(entry)]))
+  }
+  return value
+}
+
+/** Leaf paths of a JSON value, so two payloads compare field by field. */
+function leafPaths(value: unknown, prefix = ''): Map<string, unknown> {
+  const out = new Map<string, unknown>()
+  if (Array.isArray(value)) {
+    if (value.length === 0) out.set(prefix, '[]')
+    value.forEach((entry, index) => {
+      for (const [path, leaf] of leafPaths(entry, `${prefix}[${index}]`)) out.set(path, leaf)
+    })
+  } else if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) out.set(prefix, '{}')
+    for (const [key, entry] of entries) {
+      for (const [path, leaf] of leafPaths(entry, `${prefix}.${key}`)) out.set(path, leaf)
+    }
+  } else {
+    out.set(prefix, value)
+  }
+  return out
+}
+
+function startsWithAny(path: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}.`) || path.startsWith(`${prefix}[`))
+}
+
+interface Classified {
+  readonly integrityDerived: string[]
+  readonly diagnosticOnly: string[]
+  readonly caveatOnly: string[]
+  readonly neutralViolations: string[]
+  readonly unclassified: string[]
+  readonly envelopeSize: string[]
+}
+
+/**
+ * Splits the differing leaf paths into the classes this contract recognises.
+ *
+ * A difference in a neutral field and a difference in a field nobody declared
+ * are separate failures on purpose: the first says the storage format changed
+ * the product's reasoning, the second says the contract has drifted from the
+ * payload and must be re-read rather than widened.
+ */
+function classifyDifferences(v2: Map<string, unknown>, v1: Map<string, unknown>): Classified {
+  const result: Classified = {
+    integrityDerived: [], diagnosticOnly: [], caveatOnly: [], neutralViolations: [], unclassified: [], envelopeSize: [],
+  }
+  for (const path of new Set([...v2.keys(), ...v1.keys()])) {
+    if (v2.get(path) === v1.get(path) && v2.has(path) === v1.has(path)) continue
+    if (path === DIAGNOSTIC_ROOT || path.startsWith(`${DIAGNOSTIC_ROOT}.`) || path.startsWith(`${DIAGNOSTIC_ROOT}[`)) {
+      result.diagnosticOnly.push(path)
+    } else if (path === CAVEATS_ROOT || path.startsWith(`${CAVEATS_ROOT}[`)) {
+      result.caveatOnly.push(path)
+    } else if (path === ENVELOPE_SIZE_PATH) {
+      result.envelopeSize.push(path)
+    } else if (INTEGRITY_DERIVED_PATHS.has(path)) {
+      result.integrityDerived.push(path)
+    } else if (startsWithAny(path, NEUTRAL_PREFIXES)) {
+      result.neutralViolations.push(path)
+    } else {
+      result.unclassified.push(path)
+    }
+  }
+  return result
+}
+
+function identityMatrix(cells: Partial<Record<EndpointIdentityStatus, Partial<Record<EndpointIdentityStatus, number>>>>): EndpointIdentityFactMatrix {
+  const built = {} as Record<EndpointIdentityStatus, Record<EndpointIdentityStatus, number>>
+  for (const source of ENDPOINT_IDENTITY_STATUSES) {
+    built[source] = {} as Record<EndpointIdentityStatus, number>
+    for (const target of ENDPOINT_IDENTITY_STATUSES) built[source][target] = cells[source]?.[target] ?? 0
+  }
+  return built
+}
+
+/** A block around a producer-built receipt, in the shape a reader receives. */
+function wireBlockAround(counts: Partial<CandidateTerminalCounts>): Record<string, unknown> {
+  const receipt = buildNormalizedIntegrityReceipt({
+    emittedCandidates: 3,
+    counts: { ...emptyTerminalCounts(), retained_new_fact: 3, ...counts },
+    terminalReasonCounts: {},
+    factsRetained: 3,
+    occurrencesRetained: 3,
+    uniqueEndpointPairs: 3,
+    endpointFactPairCounts: identityMatrix({ stable: { stable: 3 } }),
+    endpointReasonFactCounts: {},
+    unresolvedRetention: detailRetention(0, 0),
+    rejectedRetention: detailRetention(0, 0),
+    conflictingRetention: detailRetention(0, 0),
+    strictModeResult: 'not_run',
+  })
+  return {
+    accounting_scope: 'normalized_extraction_boundary',
+    status: receipt.status,
+    reasons: [],
+    endpoint_identity: {},
+    storage_admission: {},
+    reserved: {},
+    normalized_accounting: JSON.parse(JSON.stringify({
+      receipt,
+      unresolved_records: [],
+      rejected_records: [],
+      conflict_records: [],
+      scope_failures: [],
+      scope_failure_retention: detailRetention(0, 0),
+      reserved: {},
+    })),
+  }
+}
+
+describe('artifact format preserves semantic retrieval while integrity evidence may lower published trust', () => {
   let root: string
   let canonicalAnswers: Map<string, Answer>
   let legacyAnswers: Map<string, Answer>
   let canonicalState: string
   let legacyState: string
   let nodeCounts: { canonical: number, legacy: number }
+  let receiptCap: ReturnType<typeof graphIntegrityCap>
 
   beforeAll(async () => {
     root = mkdtempSync(join(tmpdir(), 'artifact-differential-'))
@@ -116,10 +321,12 @@ describe('answers do not depend on which artifact carries the graph', () => {
 
     const outputDir = join(root, 'out')
     const canonicalBytes = readFileSync(join(outputDir, 'graph.madar'))
-    // Derived from the artifact just generated, so the two describe the same
-    // graph by construction. Generating twice could differ for unrelated
-    // reasons and would reduce the comparison to a coincidence.
     const derivedV1 = readGeneratedGraphJson(outputDir)
+
+    // The real receipt this fixture actually carries, read through the same
+    // production reader the product uses. Every expected difference below is
+    // derived from this, not from the artifact's name.
+    receiptCap = graphIntegrityCap(readGraphArtifactMetadata(join(outputDir, 'graph.madar')).integrityReceipt)
 
     const originalCwd = process.cwd()
     const collect = async (): Promise<Map<string, Answer>> => {
@@ -144,12 +351,7 @@ describe('answers do not depend on which artifact carries the graph', () => {
     canonicalAnswers = await collect()
     nodeCounts = { canonical: derivedV1.nodes.length, legacy: 0 }
 
-    // Same directory, same source, only the artifact changes.
     unlinkSync(join(outputDir, 'graph.madar'))
-    // A v1 graph.json written by an older binary records root_path; the v2
-    // artifact keeps it in the machine-local sidecar instead, so the helper does
-    // not carry it over. Without it the legacy reader resolves source paths
-    // differently and the comparison measures the fixture, not the product.
     writeFileSync(join(outputDir, 'graph.json'), JSON.stringify({ ...derivedV1, root_path: root }))
     legacyState = classifyWorkspaceGraph(outputDir).state
     legacyAnswers = await collect()
@@ -158,67 +360,256 @@ describe('answers do not depend on which artifact carries the graph', () => {
       legacy: (JSON.parse(readFileSync(join(outputDir, 'graph.json'), 'utf8')) as { nodes: unknown[] }).nodes.length,
     }
 
-    // Leave the workspace cut over again so nothing downstream inherits the
-    // legacy state from this fixture.
     writeFileSync(join(outputDir, 'graph.madar'), canonicalBytes)
     writeFileSync(join(outputDir, 'graph.json'), GRAPH_ARTIFACT_V2_TOMBSTONE)
-    // One generation plus every command twice. That exceeds the default budget
-    // when the worker pool is saturated, and a timeout here is reported against
-    // whichever test the hook was blocking.
   }, 180_000)
 
   afterAll(() => {
     rmSync(root, { recursive: true, force: true })
   })
 
+  function payloads(name: string): { v2: Map<string, unknown>, v1: Map<string, unknown>, v2Raw: Record<string, unknown>, v1Raw: Record<string, unknown> } {
+    // Parsed from the raw text, then normalized structurally. The textual
+    // normalizer rewrites digest-like runs, which corrupts numeric literals such
+    // as a match score, so it cannot run before JSON.parse.
+    const v2Raw = normalizeArtifactNames(JSON.parse(canonicalAnswers.get(name)?.text ?? '{}')) as Record<string, unknown>
+    const v1Raw = normalizeArtifactNames(JSON.parse(legacyAnswers.get(name)?.text ?? '{}')) as Record<string, unknown>
+    return { v2: leafPaths(v2Raw), v1: leafPaths(v1Raw), v2Raw, v1Raw }
+  }
+
   it('compares a cut-over workspace against one that never cut over', () => {
     expect(canonicalState).toBe('current_v2')
     expect(legacyState).toBe('legacy_v1_only')
     expect(classifyWorkspaceGraph(join(root, 'out')).state).toBe('current_v2')
-
-    // Both phases must describe the same graph, or every comparison is vacuous.
     expect(nodeCounts.canonical).toBeGreaterThan(0)
     expect(nodeCounts.legacy).toBe(nodeCounts.canonical)
   })
 
-  it.each(COMMANDS)('%s answers identically from either artifact', (name) => {
+  it('records the integrity reasons this generated fixture actually carries', () => {
+    // Measured, not assumed. If generation stops emitting these, the recorded
+    // consequence below stops applying and this control says so.
+    expect(receiptCap.status).toBe('valid_with_warnings')
+    expect([...receiptCap.reasons].sort()).toEqual([
+      'full_emission_accounting_not_available',
+      'legacy_endpoint_identity',
+      'partial_discriminator_retained',
+    ])
+    // The cap follows from the approved policy for that status, and no reason
+    // is discarded or exempted on the way.
+    expect(receiptCap.ceiling).toBe('ready_with_caveat')
+    expect(receiptCap.reason).toBe('graph_integrity_valid_with_warnings')
+  })
+
+  it.each(COMMANDS)('%s: artifact format changes no non-integrity output', (name) => {
     const fromCanonical = canonicalAnswers.get(name)
     const fromLegacy = legacyAnswers.get(name)
-
-    // A shared failure would make the texts match while proving nothing.
     expect(fromCanonical?.exitCode).toBe(0)
     expect(fromLegacy?.exitCode).toBe(0)
     expect(fromCanonical?.text.length ?? 0).toBeGreaterThan(0)
 
     const canonicalText = normalize(fromCanonical?.text ?? '')
     const legacyText = normalize(fromLegacy?.text ?? '')
-    if (canonicalText !== legacyText && process.env.ARTIFACT_DIFF_OUT !== undefined) {
-      const a = canonicalText.split('\n')
-      const b = legacyText.split('\n')
-      for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
-        if (a[index] !== b[index]) {
-          appendFileSync(
-            process.env.ARTIFACT_DIFF_OUT,
-            `\n[${name} L${index}]\n  v2: ${String(a[index])}\n  v1: ${String(b[index])}\n`,
-          )
-        }
-      }
+    if (canonicalText === legacyText) return
+
+    if (process.env.ARTIFACT_DIFF_OUT !== undefined) {
+      appendFileSync(process.env.ARTIFACT_DIFF_OUT, `\n[${name}]\n  v2: ${canonicalText}\n  v1: ${legacyText}\n`)
     }
 
-    expect(canonicalText).toBe(legacyText)
+    // A differing answer must be JSON this contract can classify. A differing
+    // text-only surface would mean an integrity value reached a rendering the
+    // closed field set cannot describe.
+    const { v2, v1 } = payloads(name)
+    const classified = classifyDifferences(v2, v1)
+
+    expect(
+      classified.neutralViolations,
+      `ARTIFACT_FORMAT_CHANGED_NON_INTEGRITY_OUTPUT (${name}): ${classified.neutralViolations.join(', ')}`,
+    ).toEqual([])
+    expect(
+      classified.unclassified,
+      `ARTIFACT_DIFFERENTIAL_FIELD_UNCLASSIFIED (${name}): ${classified.unclassified.join(', ')}`,
+    ).toEqual([])
   })
 
-  it.each(COMMANDS)('%s token counts differ only by the artifact filename length', (name) => {
-    const fromCanonical = tokenCounts(canonicalAnswers.get(name)?.text ?? '')
-    const fromLegacy = tokenCounts(legacyAnswers.get(name)?.text ?? '')
+  it.each(COMMANDS)('%s: pack token accounting is unchanged by the artifact format', (name) => {
+    const canonicalText = normalize(canonicalAnswers.get(name)?.text ?? '')
+    const legacyText = normalize(legacyAnswers.get(name)?.text ?? '')
+    if (canonicalText === legacyText) return
 
-    expect(fromLegacy.length).toBe(fromCanonical.length)
-    for (const [index, count] of fromCanonical.entries()) {
-      // `graph.madar` is one character longer than `graph.json`. Anything beyond
-      // a couple of tokens would mean the two artifacts produced different
-      // context, not differently spelled paths.
-      expect(Math.abs(count - (fromLegacy[index] ?? 0))).toBeLessThanOrEqual(2)
+    const { v2, v1 } = payloads(name)
+    // Every token count EXCEPT the response envelope measures pack content, and
+    // pack content is not the artifact format's to change. Compared by path
+    // rather than by position, so an added field cannot shift the alignment and
+    // silently compare two different counters.
+    for (const [path, value] of v2) {
+      if (!path.endsWith('.token_count') || path === ENVELOPE_SIZE_PATH) continue
+      expect(value, `ARTIFACT_FORMAT_CHANGED_NON_INTEGRITY_OUTPUT (${name} ${path})`).toBe(v1.get(path))
     }
+  })
+
+  it('Case A — every permitted difference equals what the real receipt derives', () => {
+    const { v2Raw, v1Raw } = payloads('pack')
+    const v1Evidence = (v1Raw.evidence ?? {}) as Record<string, unknown>
+    const v2Evidence = (v2Raw.evidence ?? {}) as Record<string, unknown>
+
+    // INTEGRITY_DIFFERENTIAL_NOT_APPLIED guards this: the v2 answerability must
+    // be exactly what the production cap owner produces from the v1 answer plus
+    // the real receipt -- not merely "lower", and not a hard-coded transition.
+    const derived = applyGraphIntegrityCap(v1Evidence.answerability as MadarAnswerabilityAssessment, receiptCap)
+    expect(v2Evidence.answerability, 'INTEGRITY_DIFFERENTIAL_NOT_APPLIED').toEqual(derived)
+
+    // The diagnostic is the projection of the same receipt, not a second story.
+    expect(v2Evidence.graph_integrity).toEqual(graphIntegrityDiagnostic(receiptCap))
+    expect(v1Evidence.graph_integrity).toBeUndefined()
+
+    // Both published recovery copies equal the derived bound.
+    const finalState = derived.state as MadarAnswerabilityState
+    for (const [label, v1Recovery, v2Recovery] of [
+      ['evidence.recovery', v1Evidence.recovery, v2Evidence.recovery],
+      ['pack.recovery', (v1Raw.pack as Record<string, unknown>)?.recovery, (v2Raw.pack as Record<string, unknown>)?.recovery],
+    ] as Array<[string, unknown, unknown]>) {
+      if (v1Recovery === undefined) continue
+      expect(v2Recovery, `${label} does not equal the derived bound`)
+        .toEqual(capPublishedRecoveryByFinalAnswerability(v1Recovery, finalState))
+    }
+  })
+
+  it('Case A — v2 reduces to v1 when exactly the classified differences are undone', () => {
+    // The strongest form of the contract. Enumerating permitted paths says what
+    // MAY differ; this says nothing else DOES, without trusting the enumeration
+    // to be complete.
+    const { v2Raw, v1Raw } = payloads('pack')
+    const reduced = JSON.parse(JSON.stringify(v2Raw)) as Record<string, unknown>
+    const evidence = reduced.evidence as Record<string, unknown>
+    const v1Evidence = v1Raw.evidence as Record<string, unknown>
+
+    delete evidence.graph_integrity
+    evidence.answerability = v1Evidence.answerability
+    evidence.pack_confidence = v1Evidence.pack_confidence
+    evidence.agent_directive = v1Evidence.agent_directive
+    evidence.recovery = v1Evidence.recovery
+    ;(reduced.pack as Record<string, unknown>).recovery = (v1Raw.pack as Record<string, unknown>).recovery
+    ;(reduced.governance as Record<string, unknown>).directive = (v1Raw.governance as Record<string, unknown>).directive
+    // A measurement of the payload, restored because the payload it measured
+    // just lost the object that grew it.
+    ;(reduced.serialized_budget as Record<string, unknown>).token_count =
+      (v1Raw.serialized_budget as Record<string, unknown>).token_count
+
+    expect(reduced).toEqual(v1Raw)
+  })
+
+  it('Case A — the envelope grew only by the additive integrity evidence', () => {
+    const { v2Raw, v1Raw } = payloads('pack')
+    const v2Size = ((v2Raw.serialized_budget as Record<string, unknown>).token_count ?? 0) as number
+    const v1Size = ((v1Raw.serialized_budget as Record<string, unknown>).token_count ?? 0) as number
+    // It grew, and it grew because something was added rather than because the
+    // pack was rebuilt: the pack's own accounting is asserted equal above.
+    expect(v2Size).toBeGreaterThan(v1Size)
+    const addition = JSON.stringify((v2Raw.evidence as Record<string, unknown>).graph_integrity ?? {})
+    // A crude but honest upper bound: the growth cannot exceed the serialized
+    // additions themselves, so it cannot be hiding re-serialized pack content.
+    expect(v2Size - v1Size).toBeLessThanOrEqual(addition.length)
+  })
+
+  it('Case A — the cause is the receipt, not the artifact name', () => {
+    // Feeding the same receipt to the owner reproduces the ceiling with no file
+    // path involved at all, so nothing here is keyed on `.madar` vs `.json`.
+    const outputDir = join(root, 'out')
+    const cap = graphIntegrityCap(readGraphArtifactMetadata(join(outputDir, 'graph.madar')).integrityReceipt)
+    expect(cap.ceiling).toBe(receiptCap.ceiling)
+    expect(cap.status).toBe(receiptCap.status)
+  })
+
+  it('Case B — a valid receipt applies no cap and fabricates no caveat', () => {
+    // Policy-level, and deliberately so: current production generation retains
+    // inherited warnings, so a valid receipt is asserted against the contract
+    // rather than claimed of the generated corpus.
+    const cap = graphIntegrityCap(wireBlockAround({}))
+    expect(cap.status).toBe('valid')
+    expect(cap.ceiling).toBeNull()
+    expect(cap.reason).toBeNull()
+
+    for (const state of ['ready', 'ready_with_caveat', 'verify_targets', 'insufficient'] as MadarAnswerabilityState[]) {
+      const before: MadarAnswerabilityAssessment = {
+        state,
+        answer_scope: state === 'ready' ? 'complete' : 'none',
+        caveats: [],
+        missing_obligations: [],
+        verification_targets: [],
+        broad_search_fallback: 'not_needed',
+      }
+      const after = applyGraphIntegrityCap(before, cap)
+      expect(after).toEqual(before)
+      // valid never raises a lower pre-existing state either.
+      expect(after.state).toBe(state)
+    }
+    // A truthful valid diagnostic may be published; it claims nothing more.
+    expect(graphIntegrityDiagnostic(cap)?.max_answerability).toBeNull()
+  })
+
+  it('Case C — a degraded receipt caps, and only the trust fields move', () => {
+    const cap = graphIntegrityCap(wireBlockAround({ retained_new_fact: 2, invariant_failed: 1 }))
+    expect(cap.status).toBe('invalid')
+    expect(cap.ceiling).toBe('insufficient')
+
+    const before: MadarAnswerabilityAssessment = {
+      state: 'ready',
+      answer_scope: 'complete',
+      caveats: [],
+      missing_obligations: [],
+      verification_targets: [],
+      broad_search_fallback: 'not_needed',
+    }
+    const after = applyGraphIntegrityCap(before, cap)
+    expect(after.state).toBe('insufficient')
+    expect(after.missing_obligations).toEqual(before.missing_obligations)
+  })
+
+  it('Case D — an absent receipt caps nothing and fabricates no integrity', () => {
+    const cap = graphIntegrityCap(undefined)
+    expect(cap.ceiling).toBeNull()
+    expect(cap.status).toBeNull()
+    expect(graphIntegrityDiagnostic(cap)).toBeUndefined()
+    // Absence is not silently reinterpreted as one of the inherited warnings.
+    expect(cap.reasons).toEqual([])
+  })
+
+  it('Case E — a non-integrity difference is reported as such', () => {
+    const { v2, v1 } = payloads('pack')
+    for (const injected of ['.pack.matched_nodes[0].node_id', '.pack.token_count', '.coverage.available_relationships']) {
+      const tampered = new Map(v2)
+      tampered.set(injected, '__injected__')
+      const classified = classifyDifferences(tampered, v1)
+      expect(classified.neutralViolations, `expected ${injected} to be reported neutral-violating`)
+        .toContain(injected)
+    }
+  })
+
+  it('Case F — a differing field nobody classified fails rather than passing', () => {
+    const { v2, v1 } = payloads('pack')
+    const tampered = new Map(v2)
+    tampered.set('.evidence.some_future_trust_field', 'surprise')
+    const classified = classifyDifferences(tampered, v1)
+    expect(classified.unclassified).toContain('.evidence.some_future_trust_field')
+    expect(classified.neutralViolations).toEqual([])
+  })
+
+  it('does not exempt the inherited warning reasons', () => {
+    // INHERITED_INTEGRITY_WARNING_WAS_UNSAFELY_EXEMPTED guards this. The three
+    // reasons are real integrity reasons owned upstream; #659 caps on them and
+    // does not carve them out.
+    for (const reason of ['full_emission_accounting_not_available', 'legacy_endpoint_identity', 'partial_discriminator_retained']) {
+      expect(receiptCap.reasons, 'INHERITED_INTEGRITY_WARNING_WAS_UNSAFELY_EXEMPTED').toContain(reason)
+    }
+    expect(receiptCap.ceiling, 'INHERITED_INTEGRITY_WARNING_WAS_UNSAFELY_EXEMPTED').toBe('ready_with_caveat')
+
+    // At the current implementation head, the exercised generated v2 fixtures
+    // retain universal inherited warnings and therefore cannot publish `ready`.
+    // Restoring `ready` requires the receipt to become valid through its owning
+    // upstream work, not a downstream answerability exception.
+    const { v2Raw } = payloads('pack')
+    const evidence = (v2Raw.evidence ?? {}) as Record<string, unknown>
+    expect((evidence.answerability as { state?: string })?.state).not.toBe('ready')
   })
 
   it.each([
@@ -229,28 +620,19 @@ describe('answers do not depend on which artifact carries the graph', () => {
     ['the logical graph path', 'out/<artifact>', 'out/elsewhere'],
     ['a community label', 'Src Auth', 'Src Elsewhere'],
   ])('still fails when %s differs', (_label, from, to) => {
-    // The normalizer removes exactly two volatile representations: digests that
-    // cover artifact bytes, and clock readings. Everything that carries meaning
-    // has to survive it, or the differential would pass on a broken cutover.
     const answer = normalize(canonicalAnswers.get('pack')?.text ?? '')
     const tampered = answer.replace(from, to)
-
     expect(tampered).not.toBe(answer)
     expect(normalize(tampered)).not.toBe(answer)
   })
 
   it('normalizes only the volatile mtime representation, not every date-like string', () => {
-    // graph_modified_at is an artifact mtime rendered as an HTTP-date and moves
-    // between the two phases. A date appearing inside answer content must not be
-    // swallowed with it.
     expect(normalize('"graph_modified_at":"Mon, 17 Aug 2026 20:14:18 GMT"'))
       .toBe('"graph_modified_at":"<http-date>"')
     expect(normalize('"label":"release 2026-08-17 notes"')).toBe('"label":"release 2026-08-17 notes"')
   })
 
   it('proves the comparison can fail', () => {
-    // Control for the normalizer: if it flattened enough to make any two
-    // answers look alike, the assertions above would pass on a broken cutover.
     expect(normalize(canonicalAnswers.get('query')?.text ?? ''))
       .not.toBe(normalize(canonicalAnswers.get('explain')?.text ?? ''))
   })

--- a/tests/unit/graph-integrity-answerability-e2e.test.ts
+++ b/tests/unit/graph-integrity-answerability-e2e.test.ts
@@ -1,0 +1,218 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, describe, expect, it } from 'vitest'
+
+import type { ContextPackRecoveryPlan, MadarAnswerabilityState } from '../../src/contracts/context-recovery.js'
+import { readinessRank } from '../../src/contracts/context-recovery.js'
+import { serializeGraphArtifactV2 } from '../../src/contracts/graph-artifact.js'
+import { buildFromJson } from '../../src/pipeline/build.js'
+import {
+  assessMadarResponseEvidence,
+  buildMadarResponseEvidence,
+} from '../../src/runtime/mcp-response-evidence.js'
+import { readGraphIntegrityCap } from '../../src/shared/graph-integrity-answerability.js'
+
+/**
+ * End-to-end against a real artifact written to disk.
+ *
+ * The unit controls exercise the mapping on a decoded block. This suite reads
+ * the same information the way production does -- through
+ * `readGraphArtifactMetadata` off a serialized v2 artifact -- which is the only
+ * way a mistake about the wire shape becomes visible. An earlier revision of
+ * this work handed the whole storage receipt to the block parser and every real
+ * artifact would have resolved as unreadable; the unit controls passed anyway,
+ * because they fed the parser the shape it wanted.
+ */
+
+const NODES = [
+  { id: 'alpha', label: 'Alpha', file_type: 'code', source_file: 'src/alpha.ts' },
+  { id: 'beta', label: 'Beta', file_type: 'code', source_file: 'src/beta.ts' },
+  { id: 'gamma', label: 'Gamma', file_type: 'code', source_file: 'src/gamma.ts' },
+]
+
+const RESOLVED_EDGES = [
+  { source: 'alpha', target: 'beta', relation: 'calls', confidence: 'EXTRACTED', source_file: 'src/alpha.ts' },
+  { source: 'beta', target: 'gamma', relation: 'imports_from', confidence: 'EXTRACTED', source_file: 'src/beta.ts' },
+]
+
+/** A critical relationship whose endpoint is missing from traversable topology. */
+const MISSING_REGION_EDGES = [
+  ...RESOLVED_EDGES,
+  { source: 'alpha', target: 'nowhere', relation: 'imports_from', confidence: 'EXTRACTED', source_file: 'src/alpha.ts' },
+  { source: 'beta', target: 'gamma', relation: 'totally_unregistered', confidence: 'EXTRACTED', source_file: 'src/beta.ts' },
+]
+
+const roots: string[] = []
+
+function artifactFor(edges: Record<string, unknown>[]): string {
+  const graph = buildFromJson(
+    { schema_version: 1, directed: true, nodes: NODES, edges },
+    { directed: true, accounting: 'normalized_extraction_boundary' },
+  )
+  const root = mkdtempSync(join(tmpdir(), 'madar-659-'))
+  roots.push(root)
+  const outDir = join(root, 'out')
+  mkdirSync(outDir, { recursive: true })
+  const graphPath = join(outDir, 'graph.madar')
+  writeFileSync(graphPath, serializeGraphArtifactV2({
+    graph,
+    repositoryRevision: 'rev-659',
+    generationMode: 'full',
+    generatedAt: '2026-08-30T00:00:00.000Z',
+  }))
+  return graphPath
+}
+
+function legacyArtifact(): string {
+  const root = mkdtempSync(join(tmpdir(), 'madar-659-v1-'))
+  roots.push(root)
+  const outDir = join(root, 'out')
+  mkdirSync(outDir, { recursive: true })
+  const graphPath = join(outDir, 'graph.json')
+  writeFileSync(graphPath, JSON.stringify({ schema_version: 1, directed: true, nodes: [], links: [] }))
+  return graphPath
+}
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true })
+})
+
+/** Coverage strong enough that nothing but graph integrity can lower the result. */
+function readyInputs(): Parameters<typeof assessMadarResponseEvidence>[0] {
+  return {
+    coverage: {
+      required_evidence: ['primary'],
+      semantic_required: ['implementation'],
+      semantic_optional: [],
+      entries: [
+        { evidence_class: 'primary', required: true, available_nodes: 2, selected_nodes: 2, status: 'covered' },
+      ],
+      semantic_entries: [
+        { category: 'implementation', label: 'implementation', required: true, available_nodes: 1, selected_nodes: 1, status: 'covered' },
+      ],
+      missing_required: [],
+      missing_semantic: [],
+      available_relationships: 2,
+      selected_relationships: 2,
+    },
+    coveredWorkflowOwners: ['src/alpha.ts'],
+    discoverySafety: null,
+    indexingManifest: null,
+    question: 'explain the alpha to gamma path',
+  }
+}
+
+function recoveryPlan(state: MadarAnswerabilityState): ContextPackRecoveryPlan {
+  return {
+    version: 1,
+    status: 'not_needed',
+    budget: { max_attempts: 2, max_candidate_nodes: 64, max_elapsed_ms: 750, output_token_budget: 1_800 },
+    initial_state: state,
+    final_state: state,
+    attempts: [],
+    improved: false,
+  }
+}
+
+describe('659 — the cap reaches a real artifact through the production reader', () => {
+  it('reads a degraded receipt off a serialized v2 artifact', () => {
+    const cap = readGraphIntegrityCap(artifactFor(MISSING_REGION_EDGES))
+    // The whole point of this suite: the real wire shape resolves, and it does
+    // not fall through to the unreadable branch.
+    expect(cap.status).toBe('degraded')
+    expect(cap.ceiling).toBe('verify_targets')
+    expect(cap.targets.flatMap((target) => target.focus_files)).toContain('src/alpha.ts')
+  })
+
+  it('control 13 — a missing unretrieved region cannot yield ready', () => {
+    const graphPath = artifactFor(MISSING_REGION_EDGES)
+    const uncapped = assessMadarResponseEvidence(readyInputs())
+    // Without integrity the same evidence is ready. That is the defect.
+    expect(uncapped.answerability.state).toBe('ready')
+
+    const capped = assessMadarResponseEvidence({ ...readyInputs(), graphPath })
+    expect(capped.answerability.state).toBe('verify_targets')
+    expect(capped.answerability.verification_targets.length).toBeGreaterThan(0)
+  })
+
+  it('control 15 / P1 — a legacy artifact keeps its exact prior behaviour', () => {
+    const baseline = assessMadarResponseEvidence(readyInputs())
+    const legacy = assessMadarResponseEvidence({ ...readyInputs(), graphPath: legacyArtifact() })
+    expect(legacy.answerability).toEqual(baseline.answerability)
+    expect(legacy.agent_directive).toBe(baseline.agent_directive)
+    expect(legacy.pack_confidence).toBe(baseline.pack_confidence)
+    // No fabricated integrity: absence is reported as absence, not as valid.
+    expect(legacy.graph_integrity).toBeUndefined()
+  })
+
+  it('control 14 — every rendering derives from the one capped computation', () => {
+    const graphPath = artifactFor(MISSING_REGION_EDGES)
+    const assessed = assessMadarResponseEvidence({ ...readyInputs(), graphPath })
+    const built = buildMadarResponseEvidence({ ...readyInputs(), graphPath })
+
+    // `assessMadarResponseEvidence` is the CLI and recovery entry point;
+    // `buildMadarResponseEvidence` is the MCP one. Same computation, so the
+    // capped answerability and the diagnostic cannot disagree between them.
+    expect(built.answerability).toEqual(assessed.answerability)
+    expect(built.graph_integrity).toEqual(assessed.graph_integrity)
+    expect(built.agent_directive).toEqual(assessed.agent_directive)
+    expect(built.pack_confidence).toEqual(assessed.pack_confidence)
+  })
+
+  it('derives pack_confidence and agent_directive from the capped state, not the uncapped one', () => {
+    const graphPath = artifactFor(MISSING_REGION_EDGES)
+    const uncapped = assessMadarResponseEvidence(readyInputs())
+    const capped = assessMadarResponseEvidence({ ...readyInputs(), graphPath })
+
+    expect(uncapped.agent_directive).toBe('answer_from_pack')
+    // Applied before the directive is derived, so the instruction changes too.
+    expect(capped.agent_directive).toBe('verify_one_targeted_file')
+    expect(capped.pack_confidence).not.toBe('high')
+  })
+
+  it('control 18 — published recovery is bounded by the final answerability', () => {
+    const graphPath = artifactFor(MISSING_REGION_EDGES)
+    const evidence = assessMadarResponseEvidence({
+      ...readyInputs(),
+      graphPath,
+      recovery: recoveryPlan('ready'),
+    })
+    expect(evidence.answerability.state).toBe('verify_targets')
+    expect(evidence.recovery?.final_state).toBe('verify_targets')
+    expect(evidence.recovery?.initial_state).toBe('verify_targets')
+    expect(readinessRank(evidence.recovery!.final_state))
+      .toBeLessThanOrEqual(readinessRank(evidence.answerability.state))
+  })
+
+  it('control 18 — an already lower recovery state is preserved, never raised', () => {
+    const evidence = assessMadarResponseEvidence({
+      ...readyInputs(),
+      recovery: recoveryPlan('insufficient'),
+    })
+    expect(evidence.answerability.state).toBe('ready')
+    expect(evidence.recovery?.final_state).toBe('insufficient')
+  })
+
+  it('emits a share-safe diagnostic with no absolute paths', () => {
+    const graphPath = artifactFor(MISSING_REGION_EDGES)
+    const evidence = assessMadarResponseEvidence({ ...readyInputs(), graphPath })
+    const diagnostic = evidence.graph_integrity
+    expect(diagnostic).toBeDefined()
+    expect(diagnostic?.status).toBe('degraded')
+    for (const target of diagnostic?.verification_targets ?? []) {
+      expect(target.startsWith('/')).toBe(false)
+      expect(target).not.toContain(tmpdir())
+    }
+    const serialized = JSON.stringify(evidence)
+    expect(serialized).not.toContain(tmpdir())
+  })
+
+  it('is idempotent across repeated assessments of the same artifact', () => {
+    const graphPath = artifactFor(MISSING_REGION_EDGES)
+    const first = assessMadarResponseEvidence({ ...readyInputs(), graphPath, recovery: recoveryPlan('ready') })
+    const second = assessMadarResponseEvidence({ ...readyInputs(), graphPath, recovery: recoveryPlan('ready') })
+    expect(second).toEqual(first)
+  })
+})

--- a/tests/unit/graph-integrity-answerability.test.ts
+++ b/tests/unit/graph-integrity-answerability.test.ts
@@ -1,0 +1,490 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  ContextPackRecoveryPlan,
+  MadarAnswerabilityAssessment,
+  MadarAnswerabilityState,
+} from '../../src/contracts/context-recovery.js'
+import { minByReadinessRank, readinessRank } from '../../src/contracts/context-recovery.js'
+import { ENDPOINT_IDENTITY_STATUSES, type EndpointIdentityStatus } from '../../src/contracts/endpoint-identity.js'
+import { buildGraphArtifactNormalizedAccounting } from '../../src/contracts/graph-artifact-normalized-accounting.js'
+import { buildNormalizedIntegrityReceipt } from '../../src/contracts/graph-integrity-receipt.js'
+import {
+  detailRetention,
+  emptyTerminalCounts,
+  type CandidateTerminalCounts,
+  type EndpointIdentityFactMatrix,
+} from '../../src/contracts/graph-integrity.js'
+import { buildFromJson } from '../../src/pipeline/build.js'
+import {
+  applyGraphIntegrityCap,
+  capPublishedRecovery,
+  graphIntegrityCap,
+  graphIntegrityDiagnostic,
+} from '../../src/shared/graph-integrity-answerability.js'
+
+/**
+ * Every receipt below is built from a real graph through the real accounting
+ * builder, then decoded exactly the way a reader receives it. Nothing is a
+ * hand-typed receipt literal: a literal would let a control pass against a
+ * shape the producer never emits.
+ */
+const NODES = [
+  { id: 'alpha', label: 'Alpha', file_type: 'code', source_file: 'src/alpha.ts' },
+  { id: 'beta', label: 'Beta', file_type: 'code', source_file: 'src/beta.ts' },
+  { id: 'gamma', label: 'Gamma', file_type: 'code', source_file: 'src/gamma.ts' },
+]
+
+function accountingFor(edges: Record<string, unknown>[]): Record<string, unknown> {
+  const graph = buildFromJson(
+    { schema_version: 1, directed: true, nodes: NODES, edges },
+    { directed: true, accounting: 'normalized_extraction_boundary' },
+  )
+  const block = buildGraphArtifactNormalizedAccounting(graph.normalizedIntegritySnapshot()!)
+  // A decoded artifact hands a reader a mutable clone, not the frozen original.
+  return JSON.parse(JSON.stringify(block)) as Record<string, unknown>
+}
+
+const RESOLVED_EDGES = [
+  { source: 'alpha', target: 'beta', relation: 'calls', confidence: 'EXTRACTED', source_file: 'src/alpha.ts' },
+  { source: 'beta', target: 'gamma', relation: 'imports_from', confidence: 'EXTRACTED', source_file: 'src/beta.ts' },
+]
+
+const DEGRADING_EDGES = [
+  ...RESOLVED_EDGES,
+  { source: 'alpha', target: 'nowhere', relation: 'imports_from', confidence: 'EXTRACTED', source_file: 'src/alpha.ts' },
+  { source: 'beta', target: 'gamma', relation: 'totally_unregistered', confidence: 'EXTRACTED', source_file: 'src/beta.ts' },
+]
+
+function receiptOf(block: Record<string, unknown>): Record<string, unknown> {
+  return block.receipt as Record<string, unknown>
+}
+
+/**
+ * The exact wire shape a reader receives.
+ *
+ * The normalized accounting rides on the storage receipt under its own key, so
+ * a control that handed the bare block to the mapping would be testing a shape
+ * no artifact ever carries.
+ */
+function wire(block: Record<string, unknown>): Record<string, unknown> {
+  return {
+    accounting_scope: 'normalized_extraction_boundary',
+    status: (block.receipt as Record<string, unknown>).status,
+    reasons: [],
+    endpoint_identity: {},
+    storage_admission: {},
+    reserved: {},
+    normalized_accounting: block,
+  }
+}
+
+function identityMatrix(cells: Partial<Record<EndpointIdentityStatus, Partial<Record<EndpointIdentityStatus, number>>>>): EndpointIdentityFactMatrix {
+  const built = {} as Record<EndpointIdentityStatus, Record<EndpointIdentityStatus, number>>
+  for (const source of ENDPOINT_IDENTITY_STATUSES) {
+    built[source] = {} as Record<EndpointIdentityStatus, number>
+    for (const target of ENDPOINT_IDENTITY_STATUSES) {
+      built[source][target] = cells[source]?.[target] ?? 0
+    }
+  }
+  return built
+}
+
+function terminalCounts(overrides: Partial<CandidateTerminalCounts>): CandidateTerminalCounts {
+  return { ...emptyTerminalCounts(), ...overrides }
+}
+
+/**
+ * A block around a receipt built by the real producer.
+ *
+ * `status` is derived by the producer from the counters, never supplied, and
+ * the block validator re-derives it again on read. That is why the fixtures
+ * below vary *counters* to reach a status rather than writing one down: a
+ * receipt with a hand-set status is refused by the receipt authority, so a
+ * control built on one would prove nothing about the mapping.
+ */
+function blockAround(counts: Partial<CandidateTerminalCounts>): Record<string, unknown> {
+  const receipt = buildNormalizedIntegrityReceipt({
+    emittedCandidates: 3,
+    counts: terminalCounts({ retained_new_fact: 3, ...counts }),
+    terminalReasonCounts: {},
+    factsRetained: 3,
+    occurrencesRetained: 3,
+    uniqueEndpointPairs: 3,
+    endpointFactPairCounts: identityMatrix({ stable: { stable: 3 } }),
+    endpointReasonFactCounts: {},
+    unresolvedRetention: detailRetention(0, 0),
+    rejectedRetention: detailRetention(0, 0),
+    conflictingRetention: detailRetention(0, 0),
+    strictModeResult: 'not_run',
+  })
+  return JSON.parse(JSON.stringify({
+    receipt,
+    unresolved_records: [],
+    rejected_records: [],
+    conflict_records: [],
+    scope_failures: [],
+    scope_failure_retention: detailRetention(0, 0),
+    reserved: {},
+  })) as Record<string, unknown>
+}
+
+/**
+ * A receipt whose retained records are a truncated sample of the real set.
+ *
+ * Built through the producer so `durable_records_truncated` and `degraded` are
+ * derived rather than written down. A hand-edited retention flag would make the
+ * re-derived reasons disagree with the array beside them and the block would be
+ * refused before the discriminator ever ran.
+ */
+function blockWithTruncatedRecords(): Record<string, unknown> {
+  const sample = (accountingFor(DEGRADING_EDGES).unresolved_records as Record<string, unknown>[])[0]!
+  const receipt = buildNormalizedIntegrityReceipt({
+    emittedCandidates: 3,
+    counts: terminalCounts({ retained_new_fact: 2, unresolved: 1 }),
+    terminalReasonCounts: { missing_target_endpoint: 1 },
+    factsRetained: 2,
+    occurrencesRetained: 2,
+    uniqueEndpointPairs: 2,
+    endpointFactPairCounts: identityMatrix({ stable: { stable: 2 } }),
+    endpointReasonFactCounts: {},
+    unresolvedRetention: detailRetention(1, 5),
+    rejectedRetention: detailRetention(0, 0),
+    conflictingRetention: detailRetention(0, 0),
+    strictModeResult: 'not_run',
+  })
+  return JSON.parse(JSON.stringify({
+    receipt,
+    unresolved_records: [sample],
+    rejected_records: [],
+    conflict_records: [],
+    scope_failures: [],
+    scope_failure_retention: detailRetention(0, 0),
+    reserved: {},
+  })) as Record<string, unknown>
+}
+
+const degradedBlock = accountingFor(DEGRADING_EDGES)
+const warningBlock = accountingFor(RESOLVED_EDGES)
+/** A clean run with stable endpoints: the producer derives `valid`. */
+const validBlock = blockAround({})
+/** One candidate failed an invariant: the producer derives `invalid`. */
+const invalidBlock = blockAround({ retained_new_fact: 2, invariant_failed: 1 })
+
+const STATES: MadarAnswerabilityState[] = ['ready', 'ready_with_caveat', 'verify_targets', 'insufficient']
+
+function assessment(
+  state: MadarAnswerabilityState,
+  overrides: Partial<MadarAnswerabilityAssessment> = {},
+): MadarAnswerabilityAssessment {
+  const base: MadarAnswerabilityAssessment = {
+    state,
+    answer_scope: state === 'ready' || state === 'ready_with_caveat' ? 'complete' : state === 'verify_targets' ? 'partial' : 'none',
+    caveats: [],
+    missing_obligations: [],
+    // Deliberately populated for every state so a cap that lowers the state
+    // without clearing targets is observable.
+    verification_targets: [{ focus_files: ['src/pre-existing.ts'], focus_ranges: [], reason: 'pre-existing target' }],
+    broad_search_fallback: state === 'verify_targets' ? 'targeted_only' : 'not_needed',
+  }
+  return { ...base, ...overrides }
+}
+
+function recoveryPlan(initial: MadarAnswerabilityState, final: MadarAnswerabilityState): ContextPackRecoveryPlan {
+  return {
+    version: 1,
+    status: 'not_needed',
+    budget: { max_attempts: 2, max_candidate_nodes: 64, max_elapsed_ms: 750, output_token_budget: 1_800 },
+    initial_state: initial,
+    final_state: final,
+    attempts: [],
+    improved: false,
+  }
+}
+
+describe('659 control 1 / I1-I8 — the receipt-to-ceiling mapping', () => {
+  it('I1 applies no cap and emits no diagnostic when no receipt exists', () => {
+    for (const absent of [undefined, null]) {
+      const cap = graphIntegrityCap(absent)
+      expect(cap.ceiling).toBeNull()
+      expect(cap.status).toBeNull()
+      // Control 15: absence must never be described as a checked, valid graph.
+      expect(graphIntegrityDiagnostic(cap)).toBeUndefined()
+    }
+  })
+
+  it('I2 caps a present but malformed normalized accounting block to insufficient', () => {
+    for (const broken of [{}, { receipt: {} }, 'not-an-object', 42, [], { receipt: { status: 'valid' } }]) {
+      const cap = graphIntegrityCap({ normalized_accounting: broken })
+      expect(cap.ceiling).toBe('insufficient')
+      // Present-but-broken still reports, unlike a genuine absence.
+      expect(graphIntegrityDiagnostic(cap)).toBeDefined()
+    }
+  })
+
+  it('treats a storage-only receipt as carrying no normalized accounting, and never as valid', () => {
+    // A #657-era receipt predates normalized accounting. It cannot establish
+    // integrity, so it earns no cap; the point that matters for false readiness
+    // is that it is never reported as a graph that was checked and found valid.
+    const storageOnly = {
+      accounting_scope: 'storage_only',
+      status: 'valid',
+      reasons: [],
+      endpoint_identity: {},
+      storage_admission: {},
+      reserved: {},
+    }
+    const cap = graphIntegrityCap(storageOnly)
+    expect(cap.ceiling).toBeNull()
+    expect(cap.status).toBeNull()
+    expect(graphIntegrityDiagnostic(cap)).toBeUndefined()
+  })
+
+  it('I2 refuses a receipt whose status was forged to disagree with its counters', () => {
+    // `assertNormalizedIntegrityReceipt` re-derives status and reasons from the
+    // receipt's own counters, so a forged `valid` beside an invariant failure
+    // never reaches the mapping: it arrives as unreadable and still caps.
+    const forged = JSON.parse(JSON.stringify(invalidBlock)) as Record<string, unknown>
+    expect(receiptOf(forged).status).toBe('invalid')
+    receiptOf(forged).status = 'valid'
+
+    const cap = graphIntegrityCap(wire(forged))
+    expect(cap.ceiling).toBe('insufficient')
+    // Critically, not `null`: a forged valid must never buy "no cap".
+    expect(cap.ceiling).not.toBeNull()
+  })
+
+  it('I3 caps a genuinely invalid receipt to insufficient', () => {
+    // Derived, not asserted: one candidate failed an invariant, and
+    // `deriveIntegrityStatus` turns that into `invalid`.
+    expect(receiptOf(invalidBlock).status).toBe('invalid')
+    expect((receiptOf(invalidBlock).terminal_counts as Record<string, number>).invariant_failed).toBe(1)
+    const cap = graphIntegrityCap(wire(invalidBlock))
+    expect(cap.ceiling).toBe('insufficient')
+    expect(cap.reason).toBe('graph_integrity_invalid')
+  })
+
+  it('I4 caps an incompatible claim to insufficient, whichever way it arrives', () => {
+    // `deriveIntegrityStatus` never derives `incompatible`: it describes an
+    // artifact a loader refused, not an accounting outcome. A block claiming it
+    // therefore disagrees with its own counters and is refused by the receipt
+    // authority. Either way the answer is the same, which is what matters for
+    // false-ready prevention.
+    const claimed = JSON.parse(JSON.stringify(validBlock)) as Record<string, unknown>
+    receiptOf(claimed).status = 'incompatible'
+    const cap = graphIntegrityCap(wire(claimed))
+    expect(cap.ceiling).toBe('insufficient')
+    expect(cap.reason).toMatch(/^graph_integrity_(incompatible|unreadable)/)
+  })
+
+  it('I5 caps degraded with bounded actionable targets to verify_targets', () => {
+    const cap = graphIntegrityCap(wire(degradedBlock))
+    expect(receiptOf(degradedBlock).status).toBe('degraded')
+    expect(cap.ceiling).toBe('verify_targets')
+    expect(cap.reason).toBe('graph_integrity_degraded_with_targets')
+    expect(cap.targets.length).toBeGreaterThan(0)
+    // Repository-relative, sourced from the record, never invented from text.
+    expect(cap.targets.flatMap((target) => target.focus_files)).toContain('src/alpha.ts')
+  })
+
+  it('I6 caps degraded to insufficient when the record set is truncated', () => {
+    const truncatedBlock = blockWithTruncatedRecords()
+    expect(receiptOf(truncatedBlock).status).toBe('degraded')
+    expect(receiptOf(truncatedBlock).reasons).toContain('durable_records_truncated')
+    const truncatedCap = graphIntegrityCap(wire(truncatedBlock))
+    expect(truncatedCap.ceiling).toBe('insufficient')
+    expect(truncatedCap.reason).toBe('graph_integrity_degraded_without_bounded_targets')
+    expect(truncatedCap.targets).toHaveLength(0)
+
+    const truncated = JSON.parse(JSON.stringify(degradedBlock)) as Record<string, unknown>
+    const records = receiptOf(truncated).durable_records as Record<string, Record<string, unknown>>
+    const unresolved = records.unresolved as Record<string, unknown>
+    unresolved.total = (unresolved.retained as number) + 5
+    unresolved.omitted = 5
+    unresolved.truncated = true
+
+    const cap = graphIntegrityCap(wire(truncated))
+    expect(cap.ceiling).toBe('insufficient')
+    expect(cap.targets).toHaveLength(0)
+  })
+
+  it('I6 caps degraded to insufficient when no record carries an actionable target', () => {
+    const targetless = JSON.parse(JSON.stringify(degradedBlock)) as Record<string, unknown>
+    for (const key of ['unresolved_records', 'rejected_records', 'conflict_records'] as const) {
+      for (const record of targetless[key] as Record<string, unknown>[]) {
+        record.verificationTargets = []
+      }
+    }
+    const cap = graphIntegrityCap(wire(targetless))
+    expect(cap.ceiling).toBe('insufficient')
+    expect(cap.reason).toBe('graph_integrity_degraded_without_bounded_targets')
+  })
+
+  it('I7 caps valid_with_warnings to ready_with_caveat', () => {
+    expect(receiptOf(warningBlock).status).toBe('valid_with_warnings')
+    expect(graphIntegrityCap(wire(warningBlock)).ceiling).toBe('ready_with_caveat')
+  })
+
+  it('I8 applies no cap for valid, and valid alone never grants readiness', () => {
+    const cap = graphIntegrityCap(wire(validBlock))
+    expect(cap.ceiling).toBeNull()
+    // Control 12: a lower prior state stays exactly where it was.
+    for (const state of STATES) {
+      expect(applyGraphIntegrityCap(assessment(state), cap).state).toBe(state)
+    }
+  })
+})
+
+describe('659 controls 2/3/4 — the cap matrix, monotonicity and idempotence', () => {
+  const ceilings = [
+    { label: 'none', block: validBlock },
+    { label: 'ready_with_caveat', block: warningBlock },
+    { label: 'verify_targets', block: degradedBlock },
+    { label: 'insufficient', block: invalidBlock },
+  ] as const
+
+  it('control 2 — every existing state under every ceiling equals the lower rank', () => {
+    for (const { block } of ceilings) {
+      const cap = graphIntegrityCap(wire(block))
+      for (const state of STATES) {
+        const result = applyGraphIntegrityCap(assessment(state), cap)
+        const expected = cap.ceiling === null ? state : minByReadinessRank(state, cap.ceiling)
+        expect(result.state).toBe(expected)
+      }
+    }
+  })
+
+  it('control 3 — the cap never raises answerability', () => {
+    for (const { block } of ceilings) {
+      const cap = graphIntegrityCap(wire(block))
+      for (const state of STATES) {
+        const result = applyGraphIntegrityCap(assessment(state), cap)
+        expect(readinessRank(result.state)).toBeLessThanOrEqual(readinessRank(state))
+      }
+    }
+  })
+
+  it('control 4 — applying the cap twice is idempotent', () => {
+    for (const { block } of ceilings) {
+      const cap = graphIntegrityCap(wire(block))
+      for (const state of STATES) {
+        const once = applyGraphIntegrityCap(assessment(state), cap)
+        const twice = applyGraphIntegrityCap(once, cap)
+        expect(twice).toEqual(once)
+      }
+    }
+  })
+
+  it('control 16 — a capped insufficient always clears its verification targets', () => {
+    // The compact CLI serializer decides whether it may still offer a target by
+    // testing `verification_targets.length`. A capped `insufficient` that left
+    // targets populated would be silently promoted back to `verify_targets`
+    // downstream, which is the readiness-raising path this control closes.
+    const cap = graphIntegrityCap(wire(invalidBlock))
+    for (const state of STATES) {
+      const before = assessment(state)
+      const result = applyGraphIntegrityCap(before, cap)
+      if (result.state === 'insufficient' && result.state !== before.state) {
+        expect(result.verification_targets).toHaveLength(0)
+        expect(result.answer_scope).toBe('none')
+      }
+    }
+  })
+
+  it('control 16 — a capped verify_targets always carries at least one actionable target', () => {
+    const cap = graphIntegrityCap(wire(degradedBlock))
+    for (const state of ['ready', 'ready_with_caveat'] as MadarAnswerabilityState[]) {
+      const result = applyGraphIntegrityCap(assessment(state), cap)
+      expect(result.state).toBe('verify_targets')
+      expect(result.verification_targets.length).toBeGreaterThan(0)
+      expect(result.verification_targets.every((target) => target.focus_files.length > 0)).toBe(true)
+    }
+  })
+
+  it('preserves a blocked broad-search fallback rather than loosening it', () => {
+    const cap = graphIntegrityCap(wire(invalidBlock))
+    const blocked = assessment('ready', { broad_search_fallback: 'blocked' })
+    expect(applyGraphIntegrityCap(blocked, cap).broad_search_fallback).toBe('blocked')
+  })
+})
+
+describe('659 controls 5/6 — determinism', () => {
+  it('control 5 — reason order cannot reach the mapping at all', () => {
+    // Stronger than "order does not change the answer": the receipt authority
+    // re-derives `reasons` and refuses a permuted array outright, so a
+    // reordered receipt is never mapped in the first place. The ceiling is
+    // computed from `status` and the retention counters, and reasons are only
+    // ever membership-tested.
+    const permuted = JSON.parse(JSON.stringify(degradedBlock)) as Record<string, unknown>
+    const reasons = receiptOf(degradedBlock).reasons as string[]
+    expect(reasons.length).toBeGreaterThan(1)
+    receiptOf(permuted).reasons = [...reasons].reverse()
+    expect(graphIntegrityCap(wire(permuted)).ceiling).toBe('insufficient')
+  })
+
+  it('control 6 — record order cannot reach the mapping, and the projection is stable', () => {
+    // Record arrays are a strictly ascending wire contract, so a reordered
+    // array is refused rather than silently re-sorted.
+    const reordered = JSON.parse(JSON.stringify(degradedBlock)) as Record<string, unknown>
+    reordered.unresolved_records = [...(reordered.unresolved_records as unknown[])].reverse()
+    reordered.rejected_records = [...(reordered.rejected_records as unknown[])].reverse()
+    const records = reordered.unresolved_records as unknown[]
+    if (records.length > 1) {
+      expect(graphIntegrityCap(wire(reordered)).ceiling).toBe('insufficient')
+    }
+
+    // And two independent builds of the same graph project an identical list.
+    expect(graphIntegrityCap(wire(accountingFor(DEGRADING_EDGES))).targets)
+      .toEqual(graphIntegrityCap(wire(accountingFor(DEGRADING_EDGES))).targets)
+  })
+
+  it('projects each file and reason pair exactly once, in a stable order', () => {
+    const cap = graphIntegrityCap(wire(degradedBlock))
+    const keys = cap.targets.map((target) => `${target.focus_files.join(',')}|${target.reason}`)
+    expect(new Set(keys).size).toBe(keys.length)
+    expect([...keys].sort()).toEqual(keys)
+  })
+})
+
+describe('659 control 18 — published recovery is bounded by the FINAL top-level answerability', () => {
+  it('equals the lower-ranked input in every cell of the pairwise matrix', () => {
+    for (const recoveryState of STATES) {
+      for (const topLevel of STATES) {
+        const capped = capPublishedRecovery(recoveryPlan(recoveryState, recoveryState), topLevel)
+        const expected = minByReadinessRank(recoveryState, topLevel)
+        expect(capped.final_state).toBe(expected)
+        expect(capped.initial_state).toBe(expected)
+        expect(readinessRank(capped.final_state)).toBeLessThanOrEqual(readinessRank(recoveryState))
+      }
+    }
+  })
+
+  it('covers the maintainer-named cases explicitly', () => {
+    expect(capPublishedRecovery(recoveryPlan('ready', 'ready'), 'insufficient').final_state).toBe('insufficient')
+    expect(capPublishedRecovery(recoveryPlan('ready_with_caveat', 'ready_with_caveat'), 'verify_targets').final_state).toBe('verify_targets')
+    expect(capPublishedRecovery(recoveryPlan('verify_targets', 'verify_targets'), 'ready_with_caveat').final_state).toBe('verify_targets')
+    expect(capPublishedRecovery(recoveryPlan('insufficient', 'insufficient'), 'ready').final_state).toBe('insufficient')
+    const equal = recoveryPlan('verify_targets', 'verify_targets')
+    expect(capPublishedRecovery(equal, 'verify_targets')).toEqual(equal)
+  })
+
+  it('is idempotent', () => {
+    for (const recoveryState of STATES) {
+      for (const topLevel of STATES) {
+        const once = capPublishedRecovery(recoveryPlan(recoveryState, recoveryState), topLevel)
+        expect(capPublishedRecovery(once, topLevel)).toEqual(once)
+      }
+    }
+  })
+
+  it('bounds by the final answerability, not by the integrity ceiling alone', () => {
+    // Finding D. The ceiling permits `ready_with_caveat`, but other factors
+    // lowered the published answer to `verify_targets`; a recovery plan bounded
+    // only by the ceiling would still publish the more optimistic state.
+    const ceiling = graphIntegrityCap(wire(warningBlock)).ceiling
+    expect(ceiling).toBe('ready_with_caveat')
+    const published = capPublishedRecovery(recoveryPlan('ready', 'ready'), 'verify_targets')
+    expect(published.final_state).toBe('verify_targets')
+    expect(published.final_state).not.toBe(ceiling)
+  })
+})

--- a/tests/unit/published-answerability-boundary.test.ts
+++ b/tests/unit/published-answerability-boundary.test.ts
@@ -1,0 +1,487 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { resolve as resolvePath, join } from 'node:path'
+
+import { afterAll, describe, expect, it } from 'vitest'
+
+import type { MadarAnswerabilityState } from '../../src/contracts/context-recovery.js'
+import { readinessRank } from '../../src/contracts/context-recovery.js'
+import { serializeGraphArtifactV2 } from '../../src/contracts/graph-artifact.js'
+import { buildFromJson } from '../../src/pipeline/build.js'
+import { runContextPackCommand } from '../../src/infrastructure/context-pack-command.js'
+import { handleStdioRequest } from '../../src/runtime/stdio-server.js'
+import {
+  finalizePublishedAnswerability,
+  scanPublishedAnswerability,
+} from '../../src/shared/graph-integrity-answerability.js'
+
+/**
+ * The publication boundary.
+ *
+ * Three separate published answerability channels were found in this issue, one
+ * at a time, by three different means. Enumerating seams by inspection failed
+ * every time, so this suite does not enumerate: it walks the real serialized
+ * response and requires that NO answerability-bearing field anywhere in it
+ * exceeds the canonical final answerability, and that no such field is
+ * unrecognised.
+ */
+
+const roots: string[] = []
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true })
+})
+
+/**
+ * A workspace whose only integrity degradation is an unsupported relation.
+ *
+ * That produces a rejected record carrying no verification target, so the
+ * receipt is `degraded` WITHOUT bounded targets and the ceiling is
+ * `insufficient` -- strictly below the `verify_targets` that retrieval reaches
+ * on its own. A missing-endpoint degradation would put the ceiling exactly
+ * where retrieval already sits and every assertion here would hold vacuously.
+ */
+function degradedWorkspace(): string {
+  const parent = resolvePath('out', 'test-runtime')
+  mkdirSync(parent, { recursive: true })
+  const root = mkdtempSync(join(parent, 'madar-659-boundary-'))
+  roots.push(root)
+  writeFileSync(join(root, 'auth.ts'), 'export function AuthService() {\n  return new HttpClient()\n}\n', 'utf8')
+  writeFileSync(join(root, 'client.ts'), 'export class HttpClient {\n  request() {\n    return new Transport()\n  }\n}\n', 'utf8')
+  writeFileSync(join(root, 'transport.ts'), 'export class Transport {}\n', 'utf8')
+
+  const graph = buildFromJson({
+    schema_version: 1,
+    directed: true,
+    nodes: [
+      { id: 'auth', label: 'AuthService', source_file: 'auth.ts', source_location: '1', file_type: 'code' },
+      { id: 'client', label: 'HttpClient', source_file: 'client.ts', source_location: '2', file_type: 'code' },
+      { id: 'transport', label: 'Transport', source_file: 'transport.ts', source_location: '1', file_type: 'code' },
+    ],
+    edges: [
+      { source: 'auth', target: 'client', relation: 'calls', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+      { source: 'client', target: 'transport', relation: 'calls', confidence: 'EXTRACTED', source_file: 'client.ts' },
+      { source: 'auth', target: 'transport', relation: 'totally_unregistered', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+    ],
+  }, { directed: true, accounting: 'normalized_extraction_boundary' })
+
+  const graphPath = join(root, 'graph.madar')
+  writeFileSync(graphPath, serializeGraphArtifactV2({
+    graph,
+    repositoryRevision: 'rev-659-boundary',
+    generationMode: 'full',
+    generatedAt: '2026-08-30T00:00:00.000Z',
+  }))
+  return graphPath
+}
+
+async function callTool(graphPath: string, name: string, args: Record<string, unknown>, profile: string): Promise<Record<string, unknown>> {
+  const previous = process.env.MADAR_TOOL_PROFILE
+  process.env.MADAR_TOOL_PROFILE = profile
+  try {
+    const response = await Promise.resolve(handleStdioRequest(graphPath, {
+      id: 1,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }, {
+      logLevel: 'info' as const,
+      subscribedResourceUris: new Set<string>(),
+      resourceVersions: new Map<string, string>(),
+      resourceListSignature: null,
+    }))
+    const text = (response?.result as { content?: Array<{ text?: string }> } | undefined)?.content?.[0]?.text
+    expect(text, `tool ${name} returned no text: ${JSON.stringify(response)}`).toBeTruthy()
+    return JSON.parse(text!) as Record<string, unknown>
+  } finally {
+    if (previous === undefined) delete process.env.MADAR_TOOL_PROFILE
+    else process.env.MADAR_TOOL_PROFILE = previous
+  }
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}
+
+describe('659 — the motivating MCP retrieve defect', () => {
+  it('reproduces an uncapped top-level recovery beside a capped evidence', async () => {
+    const graphPath = degradedWorkspace()
+    const payload = await callTool(graphPath, 'retrieve', { question: 'How does AuthService reach Transport?', budget: 1500 }, 'full')
+
+    const evidence = payload.evidence as Record<string, unknown> | undefined
+    const answerability = (evidence?.answerability as { state?: string } | undefined)?.state
+    const evidenceRecovery = (evidence?.recovery as { final_state?: string } | undefined)?.final_state
+    const topLevelRecovery = (payload.recovery as { final_state?: string, initial_state?: string } | undefined)
+
+    // The reproduction is only meaningful if the channel is actually present
+    // and the cap actually engaged on the evidence side.
+    expect(topLevelRecovery, 'top-level recovery channel absent; reproduction would be vacuous').toBeDefined()
+    expect(answerability, 'integrity cap did not engage; reproduction would be vacuous').toBe('insufficient')
+    expect(evidenceRecovery).toBe('insufficient')
+
+    // Retained for the record: the exact serialized response and its digest.
+    writeFileSync(
+      join(roots[0] ?? '.', 'retrieve-response.json'),
+      JSON.stringify({ payload, digest: digest(payload) }, null, 2),
+    )
+
+    // MCP_RETRIEVE_RECOVERY_EXCEEDS_FINAL_ANSWERABILITY guards this.
+    for (const [field, value] of [
+      ['recovery.final_state', topLevelRecovery?.final_state],
+      ['recovery.initial_state', topLevelRecovery?.initial_state],
+    ] as Array<[string, string | undefined]>) {
+      if (value === undefined) continue
+      expect(
+        readinessRank(value as MadarAnswerabilityState),
+        `MCP_RETRIEVE_RECOVERY_EXCEEDS_FINAL_ANSWERABILITY: top-level ${field}=${value} exceeds evidence.answerability=${answerability}`,
+      ).toBeLessThanOrEqual(readinessRank(answerability as MadarAnswerabilityState))
+    }
+  }, 120_000)
+})
+
+/**
+ * The structural inventory required of every #659 public output.
+ *
+ * Records what was found, at which path, whether the contract recognised it,
+ * and whether it ended up bounded. The point is not that a remembered list of
+ * fields is capped -- it is that nothing unrecognised is present at all.
+ */
+interface ChannelRow {
+  readonly path: string
+  readonly carrier: string
+  readonly bounded: boolean
+  readonly finalized: MadarAnswerabilityState | null
+  readonly finalTopLevel: MadarAnswerabilityState
+  readonly withinBound: boolean
+}
+
+function inventory(response: unknown, finalTopLevel: MadarAnswerabilityState): {
+  rows: ChannelRow[]
+  unclassified: readonly string[]
+} {
+  const scan = scanPublishedAnswerability(response)
+  const rows = scan.channels.map((channel): ChannelRow => ({
+    path: channel.path,
+    carrier: channel.carrier,
+    bounded: channel.bounded,
+    finalized: channel.value,
+    finalTopLevel,
+    withinBound: channel.value === null || !channel.bounded
+      || readinessRank(channel.value) <= readinessRank(finalTopLevel),
+  }))
+  return { rows, unclassified: scan.unclassified }
+}
+
+function finalAnswerabilityOf(payload: Record<string, unknown>): MadarAnswerabilityState {
+  const evidence = payload.evidence as Record<string, unknown> | undefined
+  const state = (evidence?.answerability as { state?: string } | undefined)?.state
+  expect(state, 'response carries no canonical final answerability').toBeTruthy()
+  return state as MadarAnswerabilityState
+}
+
+/** Graph shapes reaching each integrity state a real artifact can carry. */
+const ARTIFACT_STATES: ReadonlyArray<readonly [string, Record<string, unknown>[]]> = [
+  ['valid_with_warnings (clean)', [
+    { source: 'auth', target: 'client', relation: 'calls', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+    { source: 'client', target: 'transport', relation: 'calls', confidence: 'EXTRACTED', source_file: 'client.ts' },
+  ]],
+  ['degraded with bounded targets', [
+    { source: 'auth', target: 'client', relation: 'calls', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+    { source: 'client', target: 'transport', relation: 'calls', confidence: 'EXTRACTED', source_file: 'client.ts' },
+    { source: 'auth', target: 'vanished', relation: 'imports_from', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+  ]],
+  ['degraded without bounded targets', [
+    { source: 'auth', target: 'client', relation: 'calls', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+    { source: 'client', target: 'transport', relation: 'calls', confidence: 'EXTRACTED', source_file: 'client.ts' },
+    { source: 'auth', target: 'transport', relation: 'totally_unregistered', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+  ]],
+]
+
+function workspaceWith(edges: Record<string, unknown>[], legacy = false): string {
+  const parent = resolvePath('out', 'test-runtime')
+  mkdirSync(parent, { recursive: true })
+  const root = mkdtempSync(join(parent, 'madar-659-scan-'))
+  roots.push(root)
+  writeFileSync(join(root, 'auth.ts'), 'export function AuthService() {\n  return new HttpClient()\n}\n', 'utf8')
+  writeFileSync(join(root, 'client.ts'), 'export class HttpClient {\n  request() {\n    return new Transport()\n  }\n}\n', 'utf8')
+  writeFileSync(join(root, 'transport.ts'), 'export class Transport {}\n', 'utf8')
+  const graph = buildFromJson({
+    schema_version: 1,
+    directed: true,
+    nodes: [
+      { id: 'auth', label: 'AuthService', source_file: 'auth.ts', source_location: '1', file_type: 'code' },
+      { id: 'client', label: 'HttpClient', source_file: 'client.ts', source_location: '2', file_type: 'code' },
+      { id: 'transport', label: 'Transport', source_file: 'transport.ts', source_location: '1', file_type: 'code' },
+    ],
+    edges,
+  }, { directed: true, accounting: 'normalized_extraction_boundary' })
+
+  if (legacy) {
+    // A v1 workspace carries no receipt at all.
+    const graphPath = join(root, 'graph.json')
+    writeFileSync(graphPath, JSON.stringify({
+      schema_version: 1,
+      directed: true,
+      root_path: root,
+      nodes: graph.graph.nodes,
+      links: [],
+    }))
+    return graphPath
+  }
+  const graphPath = join(root, 'graph.madar')
+  writeFileSync(graphPath, serializeGraphArtifactV2({
+    graph, repositoryRevision: 'rev-scan', generationMode: 'full', generatedAt: '2026-08-30T00:00:00.000Z',
+  }))
+  return graphPath
+}
+
+describe('659 — published answerability channel inventory across every public output', () => {
+  const surfaces: ReadonlyArray<readonly [string, string, Record<string, unknown>, string]> = [
+    ['MCP retrieve', 'retrieve', { question: 'How does AuthService reach Transport?', budget: 1500 }, 'full'],
+    ['MCP context_pack', 'context_pack', { prompt: 'How does AuthService reach Transport?', task: 'explain' }, 'strict'],
+  ]
+
+  for (const [stateLabel, edges] of ARTIFACT_STATES) {
+    for (const [surfaceLabel, tool, args, profile] of surfaces) {
+      it(`${surfaceLabel} / ${stateLabel}: every channel is classified and bounded`, async () => {
+        const payload = await callTool(workspaceWith([...edges]), tool, args, profile)
+        const finalState = finalAnswerabilityOf(payload)
+        const { rows, unclassified } = inventory(payload, finalState)
+
+        expect(unclassified, `PUBLISHED_ANSWERABILITY_CHANNEL_UNCLASSIFIED: ${unclassified.join(', ')}`).toEqual([])
+        expect(rows.length, 'no answerability channel found; the scan would be vacuous').toBeGreaterThan(0)
+
+        const exceeding = rows.filter((row) => !row.withinBound)
+        expect(exceeding.map((row) => `${row.path}=${row.finalized}`),
+          `channel exceeds final ${finalState}`).toEqual([])
+
+        // Deterministic identity: no path reported twice.
+        expect(new Set(rows.map((row) => row.path)).size).toBe(rows.length)
+      }, 120_000)
+    }
+  }
+
+  it('absent receipt: channels stay classified and no integrity is fabricated', async () => {
+    const payload = await callTool(
+      workspaceWith([...(ARTIFACT_STATES[0]?.[1] ?? [])], true),
+      'retrieve',
+      { question: 'How does AuthService reach Transport?', budget: 1500 },
+      'full',
+    )
+    const finalState = finalAnswerabilityOf(payload)
+    const { rows, unclassified } = inventory(payload, finalState)
+    expect(unclassified).toEqual([])
+    expect(rows.every((row) => row.withinBound)).toBe(true)
+    expect((payload.evidence as Record<string, unknown>).graph_integrity).toBeUndefined()
+  }, 120_000)
+
+  it('the scan is deterministic across repeated runs of the same response', async () => {
+    const graphPath = workspaceWith([...(ARTIFACT_STATES[2]?.[1] ?? [])])
+    const payload = await callTool(graphPath, 'retrieve', { question: 'How does AuthService reach Transport?', budget: 1500 }, 'full')
+    const finalState = finalAnswerabilityOf(payload)
+    expect(inventory(payload, finalState).rows).toEqual(inventory(payload, finalState).rows)
+  }, 120_000)
+})
+
+describe('659 — finalization cases', () => {
+  const plan = (state: MadarAnswerabilityState) => ({
+    version: 1, status: 'not_needed',
+    budget: { max_attempts: 2, max_candidate_nodes: 64, max_elapsed_ms: 750, output_token_budget: 1800 },
+    initial_state: state, final_state: state, attempts: [], improved: false,
+  })
+  const response = (recovery: MadarAnswerabilityState, top: MadarAnswerabilityState) => ({
+    recovery: plan(recovery),
+    pack: { recovery: plan(recovery), matched_nodes: [{ node_id: 'a' }], token_count: 12 },
+    evidence: {
+      answerability: { state: top, caveats: [], verification_targets: [] },
+      recovery: plan(recovery),
+    },
+    governance: { directive: { answerability: recovery } },
+  })
+
+  it('Case B — bounded by the final answer, not by any single upstream factor', () => {
+    // Integrity would permit ready_with_caveat; another factor already lowered
+    // the answer to verify_targets. Every channel follows the answer.
+    const finalized = finalizePublishedAnswerability(response('ready_with_caveat', 'verify_targets'), 'verify_targets')
+    for (const row of inventory(finalized, 'verify_targets').rows) expect(row.withinBound).toBe(true)
+    expect(finalized.recovery.final_state).toBe('verify_targets')
+    expect(finalized.pack.recovery.final_state).toBe('verify_targets')
+    expect(finalized.evidence.recovery.final_state).toBe('verify_targets')
+    expect(finalized.governance.directive.answerability).toBe('verify_targets')
+  })
+
+  it('Case C — a ready recovery beside an insufficient answer becomes insufficient', () => {
+    const finalized = finalizePublishedAnswerability(response('ready', 'insufficient'), 'insufficient')
+    for (const row of inventory(finalized, 'insufficient').rows) expect(row.withinBound).toBe(true)
+    expect(JSON.stringify(finalized)).not.toContain('"ready"')
+  })
+
+  it('Case D — an already lower channel is preserved, never raised', () => {
+    const finalized = finalizePublishedAnswerability(response('insufficient', 'ready'), 'ready')
+    expect(finalized.recovery.final_state).toBe('insufficient')
+    expect(finalized.evidence.recovery.final_state).toBe('insufficient')
+  })
+
+  it('Case E — an absent channel is not fabricated', () => {
+    const bare = { evidence: { answerability: { state: 'insufficient' as const } }, pack: { matched_nodes: [] } }
+    const finalized = finalizePublishedAnswerability(bare, 'insufficient')
+    expect(finalized).toEqual(bare)
+    expect('recovery' in finalized).toBe(false)
+    expect('recovery' in finalized.pack).toBe(false)
+  })
+
+  it('Case F — a valid ceiling raises nothing', () => {
+    const finalized = finalizePublishedAnswerability(response('verify_targets', 'ready'), 'ready')
+    expect(finalized.recovery.final_state).toBe('verify_targets')
+    expect(finalized.evidence.answerability.state).toBe('ready')
+  })
+
+  it('Case H — finalization is idempotent, byte-identically', () => {
+    for (const [recovery, top] of [
+      ['ready', 'insufficient'], ['ready_with_caveat', 'verify_targets'],
+      ['insufficient', 'ready'], ['verify_targets', 'verify_targets'],
+    ] as Array<[MadarAnswerabilityState, MadarAnswerabilityState]>) {
+      const once = finalizePublishedAnswerability(response(recovery, top), top)
+      const twice = finalizePublishedAnswerability(once, top)
+      expect(JSON.stringify(twice)).toBe(JSON.stringify(once))
+      expect(twice).toEqual(once)
+    }
+  })
+
+  it('leaves every non-answerability field structurally untouched', () => {
+    const before = response('ready', 'insufficient')
+    const after = finalizePublishedAnswerability(before, 'insufficient')
+    expect(after.pack.matched_nodes).toEqual(before.pack.matched_nodes)
+    expect(after.pack.token_count).toBe(before.pack.token_count)
+    expect(after.recovery.attempts).toEqual(before.recovery.attempts)
+    expect(after.recovery.improved).toBe(before.recovery.improved)
+    expect(after.recovery.budget).toEqual(before.recovery.budget)
+    expect(after.recovery.status).toBe(before.recovery.status)
+  })
+
+  it('classifies the integrity ceiling as a diagnostic and leaves it alone', () => {
+    // `max_answerability` states what integrity permits, not what is answered.
+    // A ceiling above the final answer is correct and must survive.
+    const withDiagnostic = {
+      evidence: {
+        answerability: { state: 'verify_targets' as const },
+        graph_integrity: { status: 'valid_with_warnings', reasons: [], max_answerability: 'ready_with_caveat', verification_targets: [] },
+      },
+    }
+    const scan = scanPublishedAnswerability(withDiagnostic)
+    expect(scan.unclassified).toEqual([])
+    const ceiling = scan.channels.find((channel) => channel.carrier === 'integrity_ceiling')
+    expect(ceiling?.bounded).toBe(false)
+    const finalized = finalizePublishedAnswerability(withDiagnostic, 'verify_targets')
+    expect(finalized.evidence.graph_integrity.max_answerability).toBe('ready_with_caveat')
+  })
+
+  it('fails closed on an answerability value at a field it does not recognise', () => {
+    const rogue = {
+      evidence: { answerability: { state: 'insufficient' as const } },
+      trust_summary: { overall_readiness: 'ready' },
+    }
+    const scan = scanPublishedAnswerability(rogue)
+    expect(scan.unclassified, 'PUBLISHED_ANSWERABILITY_CHANNEL_UNCLASSIFIED')
+      .toContain('.trust_summary.overall_readiness')
+  })
+
+  it('does not mistake a status or plan field for an answerability', () => {
+    // `status` values are deliberately outside the readiness union, and the
+    // scanner must not widen to every state-ish property.
+    const benign = {
+      evidence: { answerability: { state: 'ready' as const } },
+      pack: {
+        retrieval_plan: { status: 'recovered', state: 'applied' },
+        recovery: { status: 'exhausted', initial_state: 'ready', final_state: 'ready', attempts: [] },
+      },
+    }
+    const scan = scanPublishedAnswerability(benign)
+    expect(scan.unclassified).toEqual([])
+    expect(scan.channels.map((channel) => channel.path).sort()).toEqual([
+      '.evidence.answerability.state',
+      '.pack.recovery.final_state',
+      '.pack.recovery.initial_state',
+    ])
+  })
+})
+
+describe('659 — CLI context-pack output is inside the same boundary', () => {
+  for (const [stateLabel, edges] of ARTIFACT_STATES) {
+    it(`CLI context pack / ${stateLabel}: every channel is classified and bounded`, async () => {
+      const graphPath = workspaceWith([...edges])
+      const raw = await runContextPackCommand({
+        prompt: 'How does AuthService reach Transport?',
+        budget: 1_500,
+        task: 'explain',
+        graphPath,
+        graphPathIntent: 'explicit' as const,
+        format: 'json',
+      })
+      const payload = JSON.parse(raw) as Record<string, unknown>
+      const finalState = finalAnswerabilityOf(payload)
+      const { rows, unclassified } = inventory(payload, finalState)
+
+      expect(unclassified, `PUBLISHED_ANSWERABILITY_CHANNEL_UNCLASSIFIED: ${unclassified.join(', ')}`).toEqual([])
+      expect(rows.length, 'no answerability channel found; the scan would be vacuous').toBeGreaterThan(0)
+      expect(rows.filter((row) => !row.withinBound).map((row) => `${row.path}=${row.finalized}`),
+        `channel exceeds final ${finalState}`).toEqual([])
+      expect(new Set(rows.map((row) => row.path)).size).toBe(rows.length)
+    }, 120_000)
+  }
+})
+
+describe('659 — the boundary changes nothing but published answerability', () => {
+  it('leaves every retrieval-derived field identical across integrity states', async () => {
+    // Same source tree, two artifacts whose only difference is the integrity
+    // receipt they carry. Everything retrieval produced must be identical; only
+    // the published readiness values may move.
+    const clean = await callTool(
+      workspaceWith([...(ARTIFACT_STATES[0]?.[1] ?? [])]),
+      'retrieve', { question: 'How does AuthService reach Transport?', budget: 1500 }, 'full',
+    )
+    const degraded = await callTool(
+      workspaceWith([...(ARTIFACT_STATES[2]?.[1] ?? [])]),
+      'retrieve', { question: 'How does AuthService reach Transport?', budget: 1500 }, 'full',
+    )
+
+    const neutral = (payload: Record<string, unknown>) => {
+      const recovery = payload.recovery as Record<string, unknown> | undefined
+      return {
+        matched_nodes: payload.matched_nodes,
+        relationships: payload.relationships,
+        retrieval_plan: payload.retrieval_plan,
+        retrieval_strategy: payload.retrieval_strategy,
+        community_context: payload.community_context,
+        graph_signals: payload.graph_signals,
+        token_count: payload.token_count,
+        snippet_budget_tokens_used: payload.snippet_budget_tokens_used,
+        snippet_budget_tokens_remaining: payload.snippet_budget_tokens_remaining,
+        // Recovery EXECUTION, as distinct from its published readiness.
+        recovery_attempts: recovery?.attempts,
+        recovery_improved: recovery?.improved,
+        recovery_status: recovery?.status,
+        recovery_budget: recovery?.budget,
+      }
+    }
+
+    // The degraded arm carries one extra unsupported-relation edge that is
+    // rejected before it becomes a fact, so the traversable graph is the same.
+    expect(neutral(degraded)).toEqual(neutral(clean))
+
+    // And the published readiness genuinely differs, or the comparison above
+    // would be proving nothing.
+    expect((degraded.evidence as Record<string, unknown>)).toBeDefined()
+    expect(finalAnswerabilityOf(degraded)).not.toBe(finalAnswerabilityOf(clean))
+  }, 120_000)
+
+  it('is idempotent on a real response', async () => {
+    const payload = await callTool(
+      workspaceWith([...(ARTIFACT_STATES[2]?.[1] ?? [])]),
+      'retrieve', { question: 'How does AuthService reach Transport?', budget: 1500 }, 'full',
+    )
+    const finalState = finalAnswerabilityOf(payload)
+    const once = finalizePublishedAnswerability(payload, finalState)
+    expect(JSON.stringify(once)).toBe(JSON.stringify(payload))
+    expect(JSON.stringify(finalizePublishedAnswerability(once, finalState))).toBe(JSON.stringify(once))
+  }, 120_000)
+})

--- a/tests/unit/published-recovery-cap.test.ts
+++ b/tests/unit/published-recovery-cap.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MadarAnswerabilityState } from '../../src/contracts/context-recovery.js'
+import { MADAR_ANSWERABILITY_STATES, minByReadinessRank, readinessRank } from '../../src/contracts/context-recovery.js'
+import { runContextPackCommand, type ContextPackCommandDependencies } from '../../src/infrastructure/context-pack-command.js'
+import { compactRetrieveResult, retrieveContext, type RetrieveResult } from '../../src/runtime/retrieve.js'
+import { capPublishedRecoveryByFinalAnswerability } from '../../src/shared/graph-integrity-answerability.js'
+import { buildCrossLayerMonitorFlowFixture } from '../fixtures/cross-layer-monitor-flow.js'
+
+/**
+ * `pack.recovery` and `evidence.recovery` are two serialisations of one plan.
+ * The pack is assembled before the answer is assessed, so the published copy is
+ * bounded at the publication seam, where the final answerability first exists
+ * beside it. These controls prove that on the real response paths, and prove it
+ * for the ordinary response rather than relying on the pressure-compaction path
+ * that only runs when a response is over budget.
+ */
+
+const PROMPT = 'Explain the exact end-to-end path from a failed HTTP monitor check to incident creation, notification delivery, and the public status-page result. Compare every distinct overall-status computation. Read-only: do not modify files.'
+
+const STATES = MADAR_ANSWERABILITY_STATES
+
+function recoveryPlan(state: MadarAnswerabilityState): NonNullable<RetrieveResult['recovery']> {
+  return {
+    version: 1,
+    status: 'not_needed',
+    budget: { max_attempts: 2, max_candidate_nodes: 64, max_elapsed_ms: 750, output_token_budget: 1_800 },
+    initial_state: state,
+    final_state: state,
+    attempts: [],
+    improved: false,
+  }
+}
+
+interface CliPayload {
+  evidence?: {
+    answerability?: { state?: string }
+    recovery?: { initial_state?: string, final_state?: string }
+  }
+  pack?: {
+    recovery?: { initial_state?: string, final_state?: string, attempts?: unknown[], improved?: boolean, budget?: unknown }
+    matched_nodes?: Array<{ label: string, source_file: string, node_id?: string }>
+    relationships?: unknown[]
+    retrieval_plan?: unknown
+  }
+  serialized_budget?: { enforced?: boolean }
+}
+
+/**
+ * Drives the real CLI response path with an injected retrieval whose recovery
+ * plan is deliberately more optimistic than the answer will turn out to be.
+ */
+async function cliResponse(options: {
+  recoveryState: MadarAnswerabilityState
+  budget?: number
+  omitObligations?: boolean
+}): Promise<CliPayload> {
+  const budget = options.budget ?? 1_800
+  const graph = buildCrossLayerMonitorFlowFixture()
+  const retrieval = retrieveContext(graph, {
+    question: PROMPT,
+    budget,
+    taskKind: 'explain',
+    retrievalStrategy: 'slice-v1',
+  })
+  const compact = compactRetrieveResult(retrieval)
+
+  // Dropping the checker nodes leaves the serialized pack unable to cover every
+  // prompt obligation, which is what lowers the final answer independently of
+  // graph integrity.
+  const omitted = new Set(
+    compact.matched_nodes
+      .filter((node) => /apps\/workflows\/src\/checker\/(?:index|alerting|utils)\.ts$/.test(node.source_file))
+      .flatMap((node) => (node.node_id ? [node.node_id] : [])),
+  )
+  const serialized = options.omitObligations === false ? compact : {
+    ...compact,
+    matched_nodes: compact.matched_nodes.filter((node) => !node.node_id || !omitted.has(node.node_id)),
+    relationships: compact.relationships.filter((relationship) => (
+      (!relationship.from_id || !omitted.has(relationship.from_id))
+      && (!relationship.to_id || !omitted.has(relationship.to_id))
+    )),
+  }
+
+  const plan = recoveryPlan(options.recoveryState)
+  const optimistic: RetrieveResult = { ...retrieval, recovery: plan }
+  // The compact pack is a second serialisation of the same plan. Injecting it
+  // here is what makes the published duplicate observable; leaving the
+  // fixture's own recovery in place would silently test a different object.
+  const serializedWithPlan = { ...serialized, recovery: plan }
+  const dependencies: ContextPackCommandDependencies = {
+    loadGraph: vi.fn().mockReturnValue(graph),
+    retrieveContext: vi.fn().mockReturnValue(optimistic),
+    compactRetrieveResult: vi.fn().mockReturnValue(serializedWithPlan),
+    analyzePrImpact: vi.fn(),
+    compactPrImpactResult: vi.fn(),
+    analyzeImpact: vi.fn(),
+    compactImpactResult: vi.fn(),
+  }
+
+  return JSON.parse(await runContextPackCommand({
+    prompt: PROMPT,
+    budget,
+    task: 'explain',
+    graphPath: 'out/graph.json',
+    graphPathIntent: 'explicit' as const,
+    retrievalStrategy: 'slice-v1',
+    format: 'json',
+  }, dependencies)) as CliPayload
+}
+
+describe('659 — the publication cap helper', () => {
+  it('equals the lower-ranked input in every cell of the 4x4 matrix', () => {
+    for (const recoveryState of STATES) {
+      for (const finalState of STATES) {
+        const published = capPublishedRecoveryByFinalAnswerability(recoveryPlan(recoveryState), finalState)
+        // Expected values are derived through the one ordering owner, never
+        // from a second table maintained beside it.
+        const expected = minByReadinessRank(recoveryState, finalState)
+        expect(published.final_state).toBe(expected)
+        expect(published.initial_state).toBe(expected)
+        expect(readinessRank(published.final_state)).toBeLessThanOrEqual(readinessRank(recoveryState))
+      }
+    }
+  })
+
+  it('covers each focused case the ruling names', () => {
+    const published = (recovery: MadarAnswerabilityState, final: MadarAnswerabilityState) =>
+      capPublishedRecoveryByFinalAnswerability(recoveryPlan(recovery), final).final_state
+
+    expect(published('ready', 'insufficient')).toBe('insufficient')
+    expect(published('ready', 'verify_targets')).toBe('verify_targets')
+    expect(published('ready_with_caveat', 'verify_targets')).toBe('verify_targets')
+    expect(published('verify_targets', 'ready_with_caveat')).toBe('verify_targets')
+    expect(published('insufficient', 'ready')).toBe('insufficient')
+    expect(published('verify_targets', 'verify_targets')).toBe('verify_targets')
+  })
+
+  it('preserves an absent plan rather than fabricating one', () => {
+    for (const absent of [undefined, null]) {
+      expect(capPublishedRecoveryByFinalAnswerability(absent, 'insufficient')).toBe(absent)
+    }
+  })
+
+  it('alters only the two state fields and leaves recovery metadata intact', () => {
+    const original = { ...recoveryPlan('ready'), attempts: [{ attempt: 1 }], improved: true, extra: 'kept' }
+    const published = capPublishedRecoveryByFinalAnswerability(original, 'insufficient')
+    expect(published.final_state).toBe('insufficient')
+    expect(published.initial_state).toBe('insufficient')
+    expect(published.attempts).toEqual(original.attempts)
+    expect(published.improved).toBe(true)
+    expect(published.extra).toBe('kept')
+    expect(published.budget).toEqual(original.budget)
+    expect(published.status).toBe(original.status)
+  })
+
+  it('is idempotent, and returns the original reference when nothing moves', () => {
+    for (const recoveryState of STATES) {
+      for (const finalState of STATES) {
+        const once = capPublishedRecoveryByFinalAnswerability(recoveryPlan(recoveryState), finalState)
+        expect(capPublishedRecoveryByFinalAnswerability(once, finalState)).toEqual(once)
+      }
+    }
+    const unchanged = recoveryPlan('insufficient')
+    expect(capPublishedRecoveryByFinalAnswerability(unchanged, 'ready')).toBe(unchanged)
+  })
+
+  it('leaves a plan whose states are not answerability values alone', () => {
+    const odd = { initial_state: 'something_else', final_state: 42, attempts: [] }
+    expect(capPublishedRecoveryByFinalAnswerability(odd, 'insufficient')).toBe(odd)
+  })
+})
+
+describe('659 — PACK_RECOVERY_UNCAPPED_IN_NORMAL_RESPONSE', () => {
+  it('bounds published pack.recovery in an ordinary non-pressure response', async () => {
+    const payload = await cliResponse({ recoveryState: 'ready' })
+
+    // The probe: this is the normal path, not the pressure path. If the budget
+    // had forced compaction, `pack.recovery` would have been deleted as a
+    // duplicate and this control would prove nothing about the normal owner.
+    expect(payload.pack?.recovery).toBeDefined()
+
+    const finalState = payload.evidence?.answerability?.state
+    expect(finalState).toBe('verify_targets')
+    expect(payload.pack?.recovery?.final_state).toBe('verify_targets')
+    expect(payload.pack?.recovery?.initial_state).toBe('verify_targets')
+  })
+
+  it('keeps every other recovery field on the published pack', async () => {
+    const payload = await cliResponse({ recoveryState: 'ready' })
+    expect(payload.pack?.recovery?.attempts).toEqual([])
+    expect(payload.pack?.recovery?.improved).toBe(false)
+    expect(payload.pack?.recovery?.budget).toBeDefined()
+  })
+})
+
+describe('659 — PACK_RECOVERY_EXCEEDS_FINAL_ANSWERABILITY', () => {
+  it('bounds pack.recovery by the final answer, not by any single upstream factor', async () => {
+    // The final answer here is lowered by serialized coverage, with no graph
+    // integrity involved at all. A cap that consulted only the integrity
+    // ceiling would leave `ready` published beside a `verify_targets` answer.
+    const payload = await cliResponse({ recoveryState: 'ready_with_caveat' })
+    const finalState = payload.evidence?.answerability?.state as MadarAnswerabilityState
+
+    expect(finalState).toBe('verify_targets')
+    expect(payload.pack?.recovery?.final_state).toBe('verify_targets')
+    expect(readinessRank(payload.pack!.recovery!.final_state as MadarAnswerabilityState))
+      .toBeLessThanOrEqual(readinessRank(finalState))
+  })
+})
+
+describe('659 — published channel agreement', () => {
+  it('leaves no published channel more optimistic than the final answerability', async () => {
+    const payload = await cliResponse({ recoveryState: 'ready' })
+    const finalState = payload.evidence?.answerability?.state as MadarAnswerabilityState
+    const ceiling = readinessRank(finalState)
+
+    const channels: Array<[string, string | undefined]> = [
+      ['evidence.answerability.state', payload.evidence?.answerability?.state],
+      ['evidence.recovery.final_state', payload.evidence?.recovery?.final_state],
+      ['evidence.recovery.initial_state', payload.evidence?.recovery?.initial_state],
+      ['pack.recovery.final_state', payload.pack?.recovery?.final_state],
+      ['pack.recovery.initial_state', payload.pack?.recovery?.initial_state],
+    ]
+    for (const [name, value] of channels) {
+      if (value === undefined) continue
+      expect(readinessRank(value as MadarAnswerabilityState), `${name} is more optimistic than ${finalState}`)
+        .toBeLessThanOrEqual(ceiling)
+    }
+  })
+
+  it('never reports ready anywhere once the final answer is lowered', async () => {
+    const payload = await cliResponse({ recoveryState: 'ready' })
+    expect(payload.evidence?.answerability?.state).not.toBe('ready')
+    const serialized = JSON.stringify(payload)
+    // The optimistic plan went in as `ready`; nothing may publish it back out.
+    expect(serialized).not.toContain('"final_state":"ready"')
+    expect(serialized).not.toContain('"initial_state":"ready"')
+  })
+})
+
+describe('659 — normal and pressure paths independently', () => {
+  it('publishes a bounded recovery answerability under pressure compaction too', async () => {
+    const payload = await cliResponse({ recoveryState: 'ready', budget: 800 })
+    expect(payload.serialized_budget?.enforced).toBe(true)
+    // Distinct from the normal path: compaction dropped the duplicate.
+    expect(payload.pack?.recovery).toBeUndefined()
+
+    const finalState = payload.evidence?.answerability?.state as MadarAnswerabilityState
+    // Under pressure the pack copy is dropped as a duplicate, so the bounded
+    // value travels on `evidence.recovery`. Either way, nothing published is
+    // more optimistic than the answer.
+    for (const value of [
+      payload.pack?.recovery?.final_state,
+      payload.evidence?.recovery?.final_state,
+    ]) {
+      if (value === undefined) continue
+      expect(readinessRank(value as MadarAnswerabilityState)).toBeLessThanOrEqual(readinessRank(finalState))
+    }
+    expect(JSON.stringify(payload)).not.toContain('"final_state":"ready"')
+  })
+
+  it('agrees between the two paths for the same semantic input', async () => {
+    const normal = await cliResponse({ recoveryState: 'ready' })
+    const pressured = await cliResponse({ recoveryState: 'ready', budget: 800 })
+    const bounded = (payload: CliPayload) =>
+      payload.pack?.recovery?.final_state ?? payload.evidence?.recovery?.final_state
+    expect(bounded(normal)).toBe(bounded(pressured))
+  })
+})
+
+describe('659 — retrieval non-regression', () => {
+  it('changes nothing but the published recovery state', async () => {
+    // Same retrieval, two different published recovery plans. Everything the
+    // retrieval produced must be identical; only the recovery states may differ.
+    const optimistic = await cliResponse({ recoveryState: 'ready' })
+    const alreadyLow = await cliResponse({ recoveryState: 'insufficient' })
+
+    expect(optimistic.pack?.matched_nodes).toEqual(alreadyLow.pack?.matched_nodes)
+    expect(optimistic.pack?.relationships).toEqual(alreadyLow.pack?.relationships)
+    expect(optimistic.pack?.retrieval_plan).toEqual(alreadyLow.pack?.retrieval_plan)
+    expect(optimistic.evidence?.answerability?.state).toBe(alreadyLow.evidence?.answerability?.state)
+
+    // Recovery execution metadata is untouched by the cap.
+    expect(optimistic.pack?.recovery?.attempts).toEqual(alreadyLow.pack?.recovery?.attempts)
+    expect(optimistic.pack?.recovery?.improved).toEqual(alreadyLow.pack?.recovery?.improved)
+  })
+
+  it('leaves an already-lower recovery exactly where it was', async () => {
+    const payload = await cliResponse({ recoveryState: 'insufficient' })
+    expect(payload.pack?.recovery?.final_state).toBe('insufficient')
+    expect(payload.evidence?.recovery?.final_state).toBe('insufficient')
+  })
+})
+
+describe('659 — MCP publication seam', () => {
+  it('bounds published pack.recovery in a real stdio context_pack response', async () => {
+    const { mkdirSync, mkdtempSync, writeFileSync: write } = await import('node:fs')
+    const { join: joinPath, resolve: resolvePath } = await import('node:path')
+    const { handleStdioRequest } = await import('../../src/runtime/stdio-server.js')
+    const { serializeGraphArtifactV2 } = await import('../../src/contracts/graph-artifact.js')
+    const { buildFromJson } = await import('../../src/pipeline/build.js')
+
+    const parent = resolvePath('out', 'test-runtime')
+    mkdirSync(parent, { recursive: true })
+    const root = mkdtempSync(joinPath(parent, 'madar-659-mcp-'))
+    write(joinPath(root, 'auth.ts'), 'export function AuthService() {\n  return new HttpClient()\n}\n', 'utf8')
+    write(joinPath(root, 'client.ts'), 'export class HttpClient {\n  request() {\n    return new Transport()\n  }\n}\n', 'utf8')
+    write(joinPath(root, 'transport.ts'), 'export class Transport {}\n', 'utf8')
+
+    // The degradation is an unsupported relation, which produces a rejected
+    // record carrying no verification target. That makes the receipt `degraded`
+    // WITHOUT bounded targets, so the ceiling is `insufficient` -- strictly
+    // below whatever retrieval's own recovery reports. Choosing a
+    // missing-endpoint degradation instead would land the ceiling on
+    // `verify_targets`, which is exactly where retrieval already sits, and the
+    // control would hold vacuously against an uncapped implementation.
+    const graph = buildFromJson({
+      schema_version: 1,
+      directed: true,
+      nodes: [
+        { id: 'auth', label: 'AuthService', source_file: 'auth.ts', source_location: '1', file_type: 'code' },
+        { id: 'client', label: 'HttpClient', source_file: 'client.ts', source_location: '2', file_type: 'code' },
+        { id: 'transport', label: 'Transport', source_file: 'transport.ts', source_location: '1', file_type: 'code' },
+      ],
+      edges: [
+        { source: 'auth', target: 'client', relation: 'calls', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+        { source: 'client', target: 'transport', relation: 'calls', confidence: 'EXTRACTED', source_file: 'client.ts' },
+        { source: 'auth', target: 'transport', relation: 'totally_unregistered', confidence: 'EXTRACTED', source_file: 'auth.ts' },
+      ],
+    }, { directed: true, accounting: 'normalized_extraction_boundary' })
+
+    const graphPath = joinPath(root, 'graph.madar')
+    write(graphPath, serializeGraphArtifactV2({
+      graph,
+      repositoryRevision: 'rev-659-mcp',
+      generationMode: 'full',
+      generatedAt: '2026-08-30T00:00:00.000Z',
+    }))
+
+    // context_pack lives in the bounded strict profile.
+    const previousProfile = process.env.MADAR_TOOL_PROFILE
+    process.env.MADAR_TOOL_PROFILE = 'strict'
+    let response
+    try {
+      response = await Promise.resolve(handleStdioRequest(graphPath, {
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'context_pack',
+          // The strict profile accepts only prompt and task.
+          arguments: { prompt: 'How does AuthService reach Transport?', task: 'explain' },
+        },
+      }, {
+        logLevel: 'info' as const,
+        subscribedResourceUris: new Set<string>(),
+        resourceVersions: new Map<string, string>(),
+        resourceListSignature: null,
+      }))
+    } finally {
+      if (previousProfile === undefined) delete process.env.MADAR_TOOL_PROFILE
+      else process.env.MADAR_TOOL_PROFILE = previousProfile
+    }
+
+    const text = (response?.result as { content?: Array<{ text?: string }> } | undefined)?.content?.[0]?.text
+    expect(text, JSON.stringify(response)).toBeTruthy()
+    const payload = JSON.parse(text!) as CliPayload & { evidence?: { graph_integrity?: { status?: string } } }
+
+    // The probe: integrity was read through the MCP path and did cap the answer.
+    expect(payload.evidence?.graph_integrity?.status).toBe('degraded')
+    const finalState = payload.evidence?.answerability?.state as MadarAnswerabilityState
+    expect(finalState).toBe('insufficient')
+    // The duplicate really is published on this path, so the assertion below
+    // has something to bind.
+    expect(payload.pack?.recovery).toBeDefined()
+
+    for (const [name, value] of [
+      ['pack.recovery.final_state', payload.pack?.recovery?.final_state],
+      ['pack.recovery.initial_state', payload.pack?.recovery?.initial_state],
+      ['evidence.recovery.final_state', payload.evidence?.recovery?.final_state],
+    ] as Array<[string, string | undefined]>) {
+      if (value === undefined) continue
+      expect(readinessRank(value as MadarAnswerabilityState), `${name} exceeds ${finalState}`)
+        .toBeLessThanOrEqual(readinessRank(finalState))
+    }
+  })
+})

--- a/tests/unit/verification-target-policy.test.ts
+++ b/tests/unit/verification-target-policy.test.ts
@@ -169,6 +169,11 @@ describe('R1 — the policy has one owner', () => {
         'src/contracts/graph-integrity.ts',
         'src/contracts/graph-integrity-session.ts',
         'src/pipeline/build.ts',
+        // #659 consumes targets the policy already sanitized and projects them
+        // into the Pack answerability domain. It reads `file` and `reason` off
+        // a retained record and never assembles an IntegrityVerificationTarget,
+        // so the sanitizer cannot be bypassed through it.
+        'src/shared/graph-integrity-answerability.ts',
       ]
       if (!permitted.includes(rel)) offenders.push(rel)
     }


### PR DESCRIPTION
Closes #659.

Introduces the first edge between the merged #658 graph-integrity receipt and answerability, and makes every published answerability-bearing channel agree with the answer it sits beside.

## What this does

`final = min(existing, graphIntegrityCeiling)` under one shared ordering. The cap may lower or preserve; it can never raise.

The policy **consumes** the #658 receipt and never recomputes integrity. `status` is read verbatim from `deriveIntegrityStatus`, and the bounded/unbounded split for verification targets comes from the receipt's own `durable_records` retention rather than from parsing reason text.

| graph-integrity state | maximum answerability |
|---|---|
| receipt absent (legacy artifact) | no cap, and no diagnostic claiming validity |
| receipt present but fails the #658 validator | `insufficient` |
| `invalid` / `incompatible` | `insufficient` |
| `degraded` with bounded actionable targets | `verify_targets` |
| `degraded` without bounded targets | `insufficient` |
| `valid_with_warnings` | `ready_with_caveat` |
| `valid` | no cap — and `valid` alone never establishes `ready` |

## Where it is applied

`assessMadarResponseEvidence` is the single computation every rendering reaches. The cap runs there, **before** `pack_confidence` and `agent_directive` are derived from it, so CLI, Pack and MCP agree structurally rather than by keeping three inventories in step.

The capped assessment preserves every structural invariant the uncapped one holds. That matters concretely: the compact CLI serializer decides whether it may still offer a target by testing `verification_targets.length`, so a capped `insufficient` that left targets populated would be promoted straight back to `verify_targets` downstream.

## Published recovery

`pack.recovery` and `evidence.recovery` are two serialisations of one plan, and the pack is assembled before the answer is assessed. Both are bounded by the **final** answerability — not by the integrity ceiling, since the answer may already have been lowered by coverage, evidence strength or the answer contract.

`src/runtime/retrieve.ts` cannot carry that bound: `RetrieveOptions` has no graph path, all three recovery projections are pass-throughs, and the pack is serialised before the assessment runs. The cap therefore lives at the two publication seams, both calling one shared helper. The pressure-compaction path drops the duplicate outright, so it was never the owner for ordinary responses; both paths are proven separately.

Recovery **attempt gating is deliberately unchanged** — altering it would change which retrieval passes run, which is out of scope. Only what is published moves.

## Compatibility

Pack v1 required fields are untouched. An absent receipt leaves the assessment value- and shape-identical to base and emits no `graph_integrity` object at all, so a legacy graph is never reported as one that was checked and found valid. A storage-only #657-era receipt likewise never reports as valid.

## Evidence

- 7 production files. `src/runtime/retrieve.ts` untouched.
- 477/477 across 14 isolated suites; typecheck, build, `qualify:validate`, `release:verify`, `npm pack --dry-run` all clean.
- **12 narrow mutants, all caught**, each by a named owning control, with byte-identical restoration and the truthful tree passing afterwards.

The mutation harness earned its place: on its first run three controls **survived** their mutants and were decorative — the 4×4 matrix was running against an unwrapped (absent) fixture and asserting nothing, the `invalid` arm fell through to the `degraded` arm and returned the same answer by coincidence, and a hand-edited truncation fixture failed validation before ever reaching the discriminator. All three were rebuilt on producer-derived receipts and re-proven.

Two defects were caught before they shipped. The `integrity_receipt` wire field is a storage-receipt **wrapper** carrying `normalized_accounting` under its own key; the first implementation handed the whole receipt to the block parser, which would have resolved every real artifact as unreadable and capped the entire product to `insufficient`. The unit controls passed anyway — only reading a serialized artifact off disk exposed it. Separately, a raw NUL byte in a dedupe key made git classify the new source file as binary.

## Not in this PR

No Pack v2, no graph schema or artifact change, no graph generation or artifact writing, no retrieval or ranking change, no installer/profile/MCP tool-surface change, no #716/#719/#721 work.
## Product-contract correction — artifact-format differential

Complete artifact-format answer neutrality is **intentionally superseded**, not repaired.

It was the right contract while `graph.json` and `graph.madar` carried the same information. The v2 artifact now carries a graph-integrity receipt that v1 cannot, and #659 requires the product to use it. Demanding identical answers from both would mean demanding that the product ignore evidence it holds.

**What remains required.** Graph content, retrieval, ranking, coverage, evidence selection, recovery execution and pack token budgets must still be identical across formats. A storage format has no business touching any of them.

**What may now differ.** Only the published trust fields, only through the single #659 policy owner, and only to a value the suite re-derives from the real receipt:

`evidence.answerability` (state, scope, fallback, integrity caveat) · `evidence.graph_integrity` · `evidence.pack_confidence` · `evidence.agent_directive` · `evidence.recovery` published state · `pack.recovery` published state · the matching `governance.directive` fields.

The set is closed and compared by exact leaf path — never by prefix, never by ignoring an object. A differing field the contract does not name fails as unclassified rather than passing. Beyond enumerating what may differ, the suite reconstructs: undoing exactly the classified differences must reduce the v2 payload to the v1 payload.

The response envelope's own token count is classified apart from the pack's. It measures the payload, and the payload legitimately gained one additive object; the pack's own accounting is asserted unchanged, so growth cannot hide a rebuilt pack.

**Inherited warning reasons are not exempted.** `full_emission_accounting_not_available`, `legacy_endpoint_identity` and `partial_discriminator_retained` remain real integrity reasons, owned by their upstream work (#657 / #704). #659 caps on them and carves out no exception.

At the current implementation head, the exercised generated v2 fixtures retain these universal inherited warnings and therefore cannot publish `ready`. Restoring `ready` requires the receipt to become **valid** through its owning upstream work — not a downstream answerability exception.

**Falsifiability.** Four injected defects each fail their exact owning test: bypassing the cap (`INTEGRITY_DIFFERENTIAL_NOT_APPLIED`), changing a semantic field by format (`ARTIFACT_FORMAT_CHANGED_NON_INTEGRITY_OUTPUT`), widening the comparator (`ARTIFACT_DIFFERENTIAL_FIELD_UNCLASSIFIED`), and exempting the inherited reasons (`INHERITED_INTEGRITY_WARNING_WAS_UNSAFELY_EXEMPTED`). With the twelve earlier mutants, 16/16 are caught with byte-identical restoration.

No production file changed for this correction. Strict qualification policy is untouched — a retained partial required discriminator remains strict-fatal, and normal answerability compatibility is not equated with strict eligibility.

## Terminal correction — one publication boundary

The MCP `retrieve` handler spread its payload verbatim beside a capped `evidence`, so the payload's own serialisation of the recovery plan reached the client unbounded — publishing `verify_targets` next to an answer of `insufficient`.

That was the third published answerability channel found in this issue, each by a different means, each after the previous was declared closed. Capping the newly reported field would have left the class open, so the boundary moved to the finished response.

`finalizePublishedAnswerability` runs last, immediately before serialization, on all three public outputs — CLI context pack, MCP `context_pack`, MCP `retrieve`. For `context_pack` it sits after the answer-ready schema builder and the strict constrainer, both of which rewrite the payload, so a channel either reintroduces is still bounded.

The scan is schema-aware rather than textual. It recognises the declared carriers by key and shape and deliberately does not treat every `state` property as an answerability — a retrieval plan status and a recovery status are both `state`-ish and neither is an answer. What it does treat as significant is a value drawn from the readiness union, because those four strings appear nowhere else in these payloads. One found at a field the contract has not declared is reported rather than skipped, so adding a channel cannot silently reopen the class.

`graph_integrity.max_answerability` is classified as an unbounded diagnostic: it states what integrity permits, not what is being answered, and a ceiling above the final answer is correct.

Nine channels are discovered across the three surfaces, zero unclassified, zero exceeding. Only readiness values move; selection, ranking, retrieval plans, recovery execution metadata, budgets, snippets and claims are structurally untouched, an absent channel stays absent, and finalization is idempotent.

Still exactly seven production files, with `src/runtime/retrieve.ts` untouched.

**Falsifiability, reported as measured:** 18 injected defects, 15 caught, 3 subsumed. The per-seam caps are retained as defense-in-depth but are no longer independently observable, since the boundary bounds the same fields — proven by removing one and watching every control still hold.
