### PR TITLE
test(setup): give worker Codex homes a run owner that reaps them (#699)

### DIFF
--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,22 @@
+import { createRunRoot, removeRunRoot, RUN_ROOT_ENV } from './helpers/run-home.js'
+
+/**
+ * One run identity, created before any worker starts and removed after the run
+ * finishes -- including a run that finished because tests failed.
+ *
+ * Vitest calls the returned teardown for an ordinary failing run as well as a
+ * passing one, which is what makes this the right owner: a per-worker
+ * `afterAll` would not survive a worker that never reached its hooks, and the
+ * previous layout had no owner at all.
+ */
+export async function setup(): Promise<() => Promise<void>> {
+  const runRoot = createRunRoot()
+  process.env[RUN_ROOT_ENV] = runRoot
+
+  return async () => {
+    // Idempotent and tolerant: workers may already have removed their own
+    // directories, and the root may already be gone.
+    removeRunRoot(runRoot)
+    if (process.env[RUN_ROOT_ENV] === runRoot) delete process.env[RUN_ROOT_ENV]
+  }
+}

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -9,14 +9,51 @@ import { createRunRoot, removeRunRoot, RUN_ROOT_ENV } from './helpers/run-home.j
  * `afterAll` would not survive a worker that never reached its hooks, and the
  * previous layout had no owner at all.
  */
+
+/**
+ * Builds the teardown Vitest will call, with the remover injectable so the
+ * failure path can be exercised without breaking a real filesystem.
+ *
+ * The exit status is set here on purpose, and an earlier version of this file
+ * was wrong about why it has to be. Vitest 4.1.10 does not fail a run because
+ * global teardown rejected: `Vitest.close()` collects the teardown rejection,
+ * awaits it through `Promise.allSettled`, logs `error during close`, and then
+ * neither rethrows nor touches `process.exitCode`. Leaving the error to
+ * "propagate" therefore propagates it precisely nowhere -- the run root would
+ * survive, the invocation would exit 0, and the leak this issue exists to stop
+ * would be back, now invisible.
+ *
+ * So the teardown sets the status itself and still rethrows: the status is what
+ * fails the invocation, and the rethrow is what puts the real filesystem error
+ * in front of whoever has to fix it.
+ *
+ * A status that is already non-zero is left alone. A run that failed for its own
+ * reasons should keep reporting that reason rather than have it overwritten by a
+ * cleanup code.
+ */
+export function createRunTeardown(
+  runRoot: string,
+  remove: (root: string) => boolean = removeRunRoot,
+): () => Promise<void> {
+  return async () => {
+    try {
+      // Idempotent and tolerant: workers may already have removed their own
+      // directories, and the root may already be gone.
+      remove(runRoot)
+    } catch (error) {
+      if (process.exitCode == null || Number(process.exitCode) === 0) {
+        process.exitCode = 1
+      }
+      throw error
+    } finally {
+      // Only this run's variable, and only while it still names this root.
+      if (process.env[RUN_ROOT_ENV] === runRoot) delete process.env[RUN_ROOT_ENV]
+    }
+  }
+}
+
 export async function setup(): Promise<() => Promise<void>> {
   const runRoot = createRunRoot()
   process.env[RUN_ROOT_ENV] = runRoot
-
-  return async () => {
-    // Idempotent and tolerant: workers may already have removed their own
-    // directories, and the root may already be gone.
-    removeRunRoot(runRoot)
-    if (process.env[RUN_ROOT_ENV] === runRoot) delete process.env[RUN_ROOT_ENV]
-  }
+  return createRunTeardown(runRoot)
 }

--- a/tests/helpers/run-home.ts
+++ b/tests/helpers/run-home.ts
@@ -34,10 +34,10 @@ import { isAbsolute, join, relative, resolve, sep } from 'node:path'
  * is true). A worker that has just exited, an antivirus scanner, or a Windows
  * handle still closing can all produce exactly those errors for a moment.
  *
- * So retries are bounded and explicit. What is deliberately NOT here is a
- * `try`/`catch`: if removal still fails after the retries, the error propagates
- * and the run fails. Swallowing it would let an owned run root survive while CI
- * reported success, which is the leak this issue exists to stop, made invisible.
+ * So retries are bounded and explicit. If they are exhausted the error is left
+ * to the caller rather than suppressed -- `tests/global-setup.ts` is where a
+ * terminal failure is turned into a non-zero exit status, because Vitest logs a
+ * rejected global teardown and neither rethrows it nor fails the run.
  */
 const REMOVAL_OPTIONS = {
   recursive: true,

--- a/tests/helpers/run-home.ts
+++ b/tests/helpers/run-home.ts
@@ -1,0 +1,134 @@
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+/**
+ * Run-owned homes for the Vitest workers.
+ *
+ * `tests/setup.ts` gives each worker its own `CODEX_HOME` so the installer's
+ * real global-config path can be exercised without a test writing over another
+ * test's config mid-assertion. That isolation is the reason the directory
+ * exists and is preserved here; what was missing is any owner able to remove it
+ * afterwards.
+ *
+ * The previous naming keyed on `process.pid` alone, which cannot express
+ * ownership: pids are recycled, so a collector matching the prefix and probing
+ * whether the pid is alive gets the wrong answer in both directions -- it spares
+ * a dead worker's directory whose number now belongs to an unrelated live
+ * process, and it would delete a live worker's directory whose number it
+ * happened to reuse. On this host that is not hypothetical; several historical
+ * directories match currently-live unrelated pids.
+ *
+ * So a run gets one identity: a single `mkdtemp` root, created once, whose
+ * uniqueness comes from the operating system rather than from a number the
+ * platform reuses. Every worker home lives inside it, and the run removes that
+ * one root. Nothing outside it is ever a deletion target.
+ */
+
+/** Env var carrying the run root from global setup to every worker. */
+export const RUN_ROOT_ENV = 'MADAR_VITEST_RUN_ROOT'
+
+/** Distinguishes this run's root from any other temp directory. */
+export const RUN_ROOT_PREFIX = 'madar-vitest-run-'
+
+/** Worker home directories are created directly beneath the run root. */
+export const WORKER_HOME_PREFIX = 'codex-home-'
+
+/** Creates the single root that identifies one test run. */
+export function createRunRoot(): string {
+  return mkdtempSync(join(tmpdir(), RUN_ROOT_PREFIX))
+}
+
+/** The home directory this worker owns inside the run root. */
+export function workerHomePath(runRoot: string, pid: number = process.pid): string {
+  return join(runRoot, `${WORKER_HOME_PREFIX}${pid}`)
+}
+
+/**
+ * Whether `candidate` really lives inside `root`.
+ *
+ * Both sides are resolved through `realpathSync` before comparing, so a symlink
+ * or a Windows junction planted inside the run root cannot make an outside
+ * target look owned. A path that does not exist is resolved lexically instead,
+ * which is the honest answer for a directory a worker already removed.
+ *
+ * The empty-relative case is excluded deliberately: the root is not contained in
+ * itself for the purpose of deleting a *child*, and callers that mean to remove
+ * the whole root say so directly.
+ */
+export function isInsideRoot(root: string, candidate: string): boolean {
+  const resolveReal = (value: string): string => {
+    try {
+      return realpathSync(value)
+    } catch {
+      return resolve(value)
+    }
+  }
+  const realRoot = resolveReal(root)
+  const realCandidate = resolveReal(candidate)
+  if (realRoot === realCandidate) return false
+  const rel = relative(realRoot, realCandidate)
+  return rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel) && !rel.split(sep).includes('..')
+}
+
+/**
+ * Removes a path only after proving it is inside the run root.
+ *
+ * Returns whether anything was deleted, so a caller can tell "removed" from
+ * "was never there" without inspecting the filesystem twice. Missing paths and
+ * repeat calls are both ordinary: a worker may have cleaned up after itself, and
+ * teardown may run more than once.
+ */
+export function removeOwnedPath(runRoot: string, target: string): boolean {
+  if (!isInsideRoot(runRoot, target)) return false
+  if (!existsSync(target)) return false
+  rmSync(target, { recursive: true, force: true })
+  return true
+}
+
+/**
+ * Removes the run root itself.
+ *
+ * Guarded on the prefix rather than on containment, because the root is the one
+ * path a run may delete outright. A directory that does not carry the prefix is
+ * refused: that is the difference between removing what this run created and
+ * running a recursive delete over whatever a caller happened to pass in.
+ */
+export function removeRunRoot(runRoot: string): boolean {
+  const resolved = resolve(runRoot)
+  const base = resolved.split(sep).pop() ?? ''
+  if (!base.startsWith(RUN_ROOT_PREFIX)) return false
+  if (!existsSync(resolved)) return false
+  rmSync(resolved, { recursive: true, force: true })
+  return true
+}
+
+/**
+ * Prepares this worker's home and returns a restore function.
+ *
+ * When global setup has published a run root the home is created inside it and
+ * the run owns cleanup. When it has not -- someone running Vitest through a
+ * different config, for instance -- the worker creates a root of its own rather
+ * than falling back to the unowned layout, and removes it when the process
+ * exits. Either way nothing is left behind.
+ */
+export function prepareWorkerHome(): { home: string, restore: () => void } {
+  const published = process.env[RUN_ROOT_ENV]
+  const ownsRoot = published === undefined || published.length === 0
+  const runRoot = ownsRoot ? createRunRoot() : published
+  const home = workerHomePath(runRoot)
+  mkdirSync(home, { recursive: true })
+
+  const previousCodexHome = process.env.CODEX_HOME
+  process.env.CODEX_HOME = home
+
+  return {
+    home,
+    restore: () => {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME
+      else process.env.CODEX_HOME = previousCodexHome
+      if (ownsRoot) removeRunRoot(runRoot)
+      else removeOwnedPath(runRoot, home)
+    },
+  }
+}

--- a/tests/helpers/run-home.ts
+++ b/tests/helpers/run-home.ts
@@ -25,6 +25,27 @@ import { isAbsolute, join, relative, resolve, sep } from 'node:path'
  * one root. Nothing outside it is ever a deletion target.
  */
 
+/**
+ * The one removal policy, shared by both call sites.
+ *
+ * `force` only ignores a path that does not exist -- it does nothing for a
+ * transient `EBUSY`, `EPERM` or `ENOTEMPTY`, and Node's retry mechanism is off
+ * by default (`maxRetries` is 0, and it is ignored entirely unless `recursive`
+ * is true). A worker that has just exited, an antivirus scanner, or a Windows
+ * handle still closing can all produce exactly those errors for a moment.
+ *
+ * So retries are bounded and explicit. What is deliberately NOT here is a
+ * `try`/`catch`: if removal still fails after the retries, the error propagates
+ * and the run fails. Swallowing it would let an owned run root survive while CI
+ * reported success, which is the leak this issue exists to stop, made invisible.
+ */
+const REMOVAL_OPTIONS = {
+  recursive: true,
+  force: true,
+  maxRetries: 3,
+  retryDelay: 100,
+} as const
+
 /** Env var carrying the run root from global setup to every worker. */
 export const RUN_ROOT_ENV = 'MADAR_VITEST_RUN_ROOT'
 
@@ -82,7 +103,7 @@ export function isInsideRoot(root: string, candidate: string): boolean {
 export function removeOwnedPath(runRoot: string, target: string): boolean {
   if (!isInsideRoot(runRoot, target)) return false
   if (!existsSync(target)) return false
-  rmSync(target, { recursive: true, force: true })
+  rmSync(target, REMOVAL_OPTIONS)
   return true
 }
 
@@ -99,7 +120,7 @@ export function removeRunRoot(runRoot: string): boolean {
   const base = resolved.split(sep).pop() ?? ''
   if (!base.startsWith(RUN_ROOT_PREFIX)) return false
   if (!existsSync(resolved)) return false
-  rmSync(resolved, { recursive: true, force: true })
+  rmSync(resolved, REMOVAL_OPTIONS)
   return true
 }
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,11 +1,18 @@
-import { mkdirSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { prepareWorkerHome } from './helpers/run-home.js'
 
 // Project installers are allowed to update Codex's real global configuration.
-// Keep unit tests hermetic while exercising that production path. A stable
-// per-process path prevents parallel test-file setup from replacing another
-// file's global config path while its assertions are running.
-const testCodexHome = join(tmpdir(), `madar-vitest-codex-home-${process.pid}`)
-mkdirSync(testCodexHome, { recursive: true })
-process.env.CODEX_HOME = testCodexHome
+// Keep unit tests hermetic while exercising that production path. A per-worker
+// path prevents parallel test-file setup from replacing another file's global
+// config path while its assertions are running.
+//
+// The directory now lives inside the run-owned root published by
+// `tests/global-setup.ts`, so the run that created it is also the thing that
+// removes it. Keying only on `process.pid`, as this once did, left every
+// directory unowned: pids are recycled, so nothing could later tell a live
+// worker's directory from a dead one's.
+const { restore } = prepareWorkerHome()
+
+// Belt and braces for the ordinary case. Global teardown removes the whole run
+// root regardless; this lets a worker that exits cleanly tidy up immediately and
+// restores `CODEX_HOME` to whatever the process had before.
+process.on('exit', restore)

--- a/tests/unit/vitest-run-home.test.ts
+++ b/tests/unit/vitest-run-home.test.ts
@@ -261,16 +261,6 @@ describe('699 control 11 — the run leaves no owned residue', () => {
     expect(existsSync(runRoot)).toBe(false)
   })
 
-  it('leaves no run-owned root for this suite behind', () => {
-    // Any root this file created is tracked and removed; nothing schedules a
-    // timer or a child process that outlives the run.
-    for (const path of created) {
-      if (path.includes(RUN_ROOT_PREFIX) && existsSync(path)) {
-        expect(readdirSync(path).every((entry) => entry.startsWith(WORKER_HOME_PREFIX))).toBe(true)
-      }
-    }
-    expect(true).toBe(true)
-  })
 })
 
 describe('699 — the shipped global setup contract, invoked directly', () => {

--- a/tests/unit/vitest-run-home.test.ts
+++ b/tests/unit/vitest-run-home.test.ts
@@ -1,0 +1,316 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+
+import {
+  createRunRoot,
+  isInsideRoot,
+  prepareWorkerHome,
+  removeOwnedPath,
+  removeRunRoot,
+  RUN_ROOT_ENV,
+  RUN_ROOT_PREFIX,
+  WORKER_HOME_PREFIX,
+  workerHomePath,
+} from '../helpers/run-home.js'
+
+/**
+ * Real filesystem throughout. The defect was that nothing removed a directory,
+ * so a control asserting on source text would prove nothing about whether the
+ * directory is gone.
+ */
+
+const created: string[] = []
+
+function track<T extends string>(path: T): T {
+  created.push(path)
+  return path
+}
+
+afterAll(() => {
+  for (const path of created) rmSync(path, { recursive: true, force: true })
+})
+
+describe('699 control 1 — a worker home is created inside the exact run-owned root', () => {
+  it('places the home under the published run root', () => {
+    const runRoot = track(createRunRoot())
+    const previous = process.env[RUN_ROOT_ENV]
+    process.env[RUN_ROOT_ENV] = runRoot
+    try {
+      const { home, restore } = prepareWorkerHome()
+      expect(existsSync(home)).toBe(true)
+      expect(isInsideRoot(runRoot, home)).toBe(true)
+      expect(process.env.CODEX_HOME).toBe(home)
+      restore()
+    } finally {
+      if (previous === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previous
+    }
+  })
+})
+
+describe('699 control 2 — worker homes are unique but share one run owner', () => {
+  it('gives each pid a distinct directory under the same root', () => {
+    const runRoot = track(createRunRoot())
+    const homes = [101, 102, 103].map((pid) => workerHomePath(runRoot, pid))
+    for (const home of homes) mkdirSync(home, { recursive: true })
+
+    expect(new Set(homes).size).toBe(homes.length)
+    for (const home of homes) expect(isInsideRoot(runRoot, home)).toBe(true)
+    expect(readdirSync(runRoot).sort()).toEqual([
+      `${WORKER_HOME_PREFIX}101`,
+      `${WORKER_HOME_PREFIX}102`,
+      `${WORKER_HOME_PREFIX}103`,
+    ])
+  })
+})
+
+describe('699 controls 3 and 4 — a real run cleans up after success and after failure', () => {
+  const workspaces: string[] = []
+  afterEach(() => {
+    for (const path of workspaces.splice(0)) rmSync(path, { recursive: true, force: true })
+  })
+
+  /**
+   * Runs a real bounded Vitest child against this repository's own config, so
+   * the assertion covers the configured global setup rather than a re-creation
+   * of it inside the parent process.
+   */
+  function runChild(shouldPass: boolean): { rootsBefore: string[], rootsAfter: string[], exitCode: number, output: string } {
+    const repoRoot = resolve(__dirname, '..', '..')
+    const scratch = mkdtempSync(join(tmpdir(), 'madar-699-child-'))
+    workspaces.push(scratch)
+    const specPath = join(repoRoot, 'tests', 'unit', `zz-699-child-${process.pid}-${shouldPass ? 'pass' : 'fail'}.test.ts`)
+    workspaces.push(specPath)
+    writeFileSync(specPath, [
+      "import { describe, expect, it } from 'vitest'",
+      `describe('699 child', () => { it('${shouldPass ? 'passes' : 'fails'}', () => {`,
+      `  expect(1).toBe(${shouldPass ? '1' : '2'})`,
+      '}) })',
+      '',
+    ].join('\n'))
+
+    const listRoots = (): string[] =>
+      readdirSync(tmpdir()).filter((entry) => entry.startsWith(RUN_ROOT_PREFIX)).sort()
+
+    const rootsBefore = listRoots()
+    let exitCode = 0
+    let output = ''
+    try {
+      output = execFileSync('npx', ['vitest', 'run', specPath], {
+        cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', timeout: 180_000,
+      })
+    } catch (error) {
+      const failure = error as { status?: number, stdout?: string, stderr?: string }
+      exitCode = failure.status ?? 1
+      output = `${failure.stdout ?? ''}${failure.stderr ?? ''}`
+    }
+    return { rootsBefore, rootsAfter: listRoots(), exitCode, output }
+  }
+
+  it('control 3 — a passing run leaves no run-owned root behind', () => {
+    const { rootsBefore, rootsAfter, exitCode, output } = runChild(true)
+    // Prove the child really executed the spec, so a Vitest that failed to
+    // start cannot be mistaken for a run that cleaned up after itself.
+    expect(output, `child produced no run summary: ${output.slice(0, 400)}`).toMatch(/Test Files\s+1 passed/)
+    expect(exitCode).toBe(0)
+    // Nothing new survives. Pre-existing roots from a concurrent run are not
+    // this run's to remove, so only the difference is asserted.
+    expect(rootsAfter.filter((entry) => !rootsBefore.includes(entry))).toEqual([])
+  }, 200_000)
+
+  it('control 4 — an ordinary failing run still cleans up', () => {
+    const { rootsBefore, rootsAfter, exitCode, output } = runChild(false)
+    // The run must genuinely have executed and genuinely have failed, or this
+    // proves nothing about teardown on the failing path.
+    expect(output, `child produced no run summary: ${output.slice(0, 400)}`).toMatch(/Test Files\s+1 failed/)
+    expect(exitCode).not.toBe(0)
+    expect(rootsAfter.filter((entry) => !rootsBefore.includes(entry))).toEqual([])
+  }, 200_000)
+})
+
+describe('699 controls 5 and 6 — cleanup tolerates absence and repetition', () => {
+  it('control 5 — a missing worker directory does not make cleanup fail', () => {
+    const runRoot = track(createRunRoot())
+    const never = workerHomePath(runRoot, 424_242)
+    expect(existsSync(never)).toBe(false)
+    expect(removeOwnedPath(runRoot, never)).toBe(false)
+  })
+
+  it('control 6 — repeated cleanup is safe and idempotent', () => {
+    const runRoot = track(createRunRoot())
+    const home = workerHomePath(runRoot, 555)
+    mkdirSync(home, { recursive: true })
+
+    expect(removeOwnedPath(runRoot, home)).toBe(true)
+    expect(removeOwnedPath(runRoot, home)).toBe(false)
+    expect(removeOwnedPath(runRoot, home)).toBe(false)
+
+    expect(removeRunRoot(runRoot)).toBe(true)
+    expect(removeRunRoot(runRoot)).toBe(false)
+    expect(existsSync(runRoot)).toBe(false)
+  })
+})
+
+describe('699 controls 7 and 8 — nothing unowned is ever a target', () => {
+  it('control 7 — a similarly named unrelated directory survives', () => {
+    const runRoot = track(createRunRoot())
+    // Same prefix, adjacent on disk, different run. Exactly the directory a
+    // prefix-matching collector would take with it.
+    const sibling = track(createRunRoot())
+    const siblingHome = workerHomePath(sibling, 777)
+    mkdirSync(siblingHome, { recursive: true })
+
+    expect(removeOwnedPath(runRoot, siblingHome)).toBe(false)
+    expect(removeRunRoot(runRoot)).toBe(true)
+    expect(existsSync(sibling)).toBe(true)
+    expect(existsSync(siblingHome)).toBe(true)
+  })
+
+  it('control 8 — a path outside the run root is refused', () => {
+    const runRoot = track(createRunRoot())
+    const outside = track(mkdtempSync(join(tmpdir(), 'madar-699-outside-')))
+    const outsideFile = join(outside, 'keep.txt')
+    writeFileSync(outsideFile, 'keep')
+
+    for (const target of [outside, outsideFile, tmpdir(), join(runRoot, '..'), resolve(runRoot, '..', '..')]) {
+      expect(removeOwnedPath(runRoot, target), `must refuse ${target}`).toBe(false)
+    }
+    expect(existsSync(outsideFile)).toBe(true)
+
+    // The root is not a child of itself, so the child-removal path refuses it.
+    expect(removeOwnedPath(runRoot, runRoot)).toBe(false)
+    // And a directory without the run prefix is not removable as a root.
+    expect(removeRunRoot(outside)).toBe(false)
+    expect(existsSync(outside)).toBe(true)
+  })
+})
+
+describe('699 control 9 — a symlink cannot escape the owned root', () => {
+  it('refuses a link inside the root that points outside it', () => {
+    const runRoot = track(createRunRoot())
+    const outside = track(mkdtempSync(join(tmpdir(), 'madar-699-escape-')))
+    const victim = join(outside, 'victim.txt')
+    writeFileSync(victim, 'must survive')
+
+    const link = join(runRoot, `${WORKER_HOME_PREFIX}escape`)
+    try {
+      symlinkSync(outside, link, 'dir')
+    } catch {
+      // Unprivileged Windows cannot create a directory symlink. The guard is
+      // still asserted directly below, which is the part that matters.
+      expect(isInsideRoot(runRoot, outside)).toBe(false)
+      return
+    }
+
+    // Lexically the link looks like a child; through realpath it is not.
+    expect(isInsideRoot(runRoot, link)).toBe(false)
+    expect(removeOwnedPath(runRoot, link)).toBe(false)
+    expect(existsSync(victim)).toBe(true)
+
+    // Removing the whole root must not follow the link out either.
+    expect(removeRunRoot(runRoot)).toBe(true)
+    expect(existsSync(victim)).toBe(true)
+    expect(existsSync(outside)).toBe(true)
+  })
+})
+
+describe('699 control 10 — environment is set and restored truthfully', () => {
+  it('restores CODEX_HOME to its previous value', () => {
+    const runRoot = track(createRunRoot())
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    const sentinel = join(tmpdir(), 'madar-699-preexisting-codex-home')
+    const previousCodexHome = process.env.CODEX_HOME
+    process.env.CODEX_HOME = sentinel
+    process.env[RUN_ROOT_ENV] = runRoot
+    try {
+      const { home, restore } = prepareWorkerHome()
+      expect(process.env.CODEX_HOME).toBe(home)
+      restore()
+      expect(process.env.CODEX_HOME).toBe(sentinel)
+      expect(existsSync(home)).toBe(false)
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME
+      else process.env.CODEX_HOME = previousCodexHome
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+    }
+  })
+
+  it('deletes CODEX_HOME again when it was previously unset', () => {
+    const runRoot = track(createRunRoot())
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    const previousCodexHome = process.env.CODEX_HOME
+    delete process.env.CODEX_HOME
+    process.env[RUN_ROOT_ENV] = runRoot
+    try {
+      const { restore } = prepareWorkerHome()
+      expect(process.env.CODEX_HOME).toBeDefined()
+      restore()
+      expect('CODEX_HOME' in process.env).toBe(false)
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME
+      else process.env.CODEX_HOME = previousCodexHome
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+    }
+  })
+
+  it('owns and removes its own root when no run root was published', () => {
+    // The path someone takes by running Vitest through a different config.
+    // Isolation must survive it without reintroducing an unowned directory.
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    const previousCodexHome = process.env.CODEX_HOME
+    delete process.env[RUN_ROOT_ENV]
+    try {
+      const { home, restore } = prepareWorkerHome()
+      expect(existsSync(home)).toBe(true)
+      expect(home.includes(RUN_ROOT_PREFIX)).toBe(true)
+      restore()
+      expect(existsSync(home)).toBe(false)
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME
+      else process.env.CODEX_HOME = previousCodexHome
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+    }
+  })
+
+  it('uses the platform temp directory rather than a hard-coded separator', () => {
+    // Cross-platform behaviour is about resolving through the OS temp dir and
+    // path APIs. `tests/setup.ts` does not assign HOME or USERPROFILE, so there
+    // is no such variable to restore and none is invented here.
+    const runRoot = track(createRunRoot())
+    expect(runRoot.startsWith(resolve(tmpdir()))).toBe(true)
+    expect(workerHomePath(runRoot, 9)).toBe(join(runRoot, `${WORKER_HOME_PREFIX}9`))
+  })
+})
+
+describe('699 control 11 — the run leaves no owned residue', () => {
+  it('removes every worker home together with the root', () => {
+    const runRoot = track(createRunRoot())
+    for (const pid of [1, 2, 3, 4]) {
+      const home = workerHomePath(runRoot, pid)
+      mkdirSync(home, { recursive: true })
+      writeFileSync(join(home, 'config.toml'), '# worker state')
+    }
+    expect(readdirSync(runRoot)).toHaveLength(4)
+
+    expect(removeRunRoot(runRoot)).toBe(true)
+    expect(existsSync(runRoot)).toBe(false)
+  })
+
+  it('leaves no run-owned root for this suite behind', () => {
+    // Any root this file created is tracked and removed; nothing schedules a
+    // timer or a child process that outlives the run.
+    for (const path of created) {
+      if (path.includes(RUN_ROOT_PREFIX) && existsSync(path)) {
+        expect(readdirSync(path).every((entry) => entry.startsWith(WORKER_HOME_PREFIX))).toBe(true)
+      }
+    }
+    expect(true).toBe(true)
+  })
+})

--- a/tests/unit/vitest-run-home.test.ts
+++ b/tests/unit/vitest-run-home.test.ts
@@ -75,32 +75,55 @@ describe('699 controls 3 and 4 — a real run cleans up after success and after 
   })
 
   /**
-   * Runs a real bounded Vitest child against this repository's own config, so
-   * the assertion covers the configured global setup rather than a re-creation
-   * of it inside the parent process.
+   * Runs a real bounded Vitest child in its own project directory.
+   *
+   * The spec deliberately does NOT live under this repository's `tests/`. An
+   * earlier revision wrote it there and the parent run's own glob collected it,
+   * so the deliberately-failing child spec failed the parent suite as well. The
+   * child gets its own root and its own config instead, and that config points
+   * at this repository's real `tests/setup.ts` and `tests/global-setup.ts` by
+   * absolute path -- so the mechanism under test is the shipped one, not a
+   * re-creation of it.
    */
   function runChild(shouldPass: boolean): { rootsBefore: string[], rootsAfter: string[], exitCode: number, output: string } {
     const repoRoot = resolve(__dirname, '..', '..')
-    const scratch = mkdtempSync(join(tmpdir(), 'madar-699-child-'))
-    workspaces.push(scratch)
-    const specPath = join(repoRoot, 'tests', 'unit', `zz-699-child-${process.pid}-${shouldPass ? 'pass' : 'fail'}.test.ts`)
-    workspaces.push(specPath)
-    writeFileSync(specPath, [
+    const projectRoot = mkdtempSync(join(tmpdir(), 'madar-699-child-'))
+    workspaces.push(projectRoot)
+
+    const posix = (value: string): string => value.split('\\').join('/')
+    writeFileSync(join(projectRoot, 'sample.test.ts'), [
       "import { describe, expect, it } from 'vitest'",
       `describe('699 child', () => { it('${shouldPass ? 'passes' : 'fails'}', () => {`,
       `  expect(1).toBe(${shouldPass ? '1' : '2'})`,
       '}) })',
       '',
     ].join('\n'))
+    // A plain object export, not `defineConfig`: the config lives outside this
+    // repository, so it cannot resolve `vitest/config` from its own directory.
+    writeFileSync(join(projectRoot, 'vitest.config.mjs'), [
+      'export default {',
+      '  test: {',
+      `    root: '${posix(projectRoot)}',`,
+      "    environment: 'node',",
+      "    include: ['*.test.ts'],",
+      `    setupFiles: ['${posix(join(repoRoot, 'tests', 'setup.ts'))}'],`,
+      `    globalSetup: ['${posix(join(repoRoot, 'tests', 'global-setup.ts'))}'],`,
+      '  },',
+      '}',
+      '',
+    ].join('\n'))
 
     const listRoots = (): string[] =>
       readdirSync(tmpdir()).filter((entry) => entry.startsWith(RUN_ROOT_PREFIX)).sort()
 
+    // The installed binary, not `npx`: in CI `npx` resolution produced no
+    // output at all, which is indistinguishable from a run that cleaned up.
+    const vitestBin = join(repoRoot, 'node_modules', 'vitest', 'vitest.mjs')
     const rootsBefore = listRoots()
     let exitCode = 0
     let output = ''
     try {
-      output = execFileSync('npx', ['vitest', 'run', specPath], {
+      output = execFileSync(process.execPath, [vitestBin, 'run', '--config', join(projectRoot, 'vitest.config.mjs')], {
         cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', timeout: 180_000,
       })
     } catch (error) {
@@ -115,7 +138,7 @@ describe('699 controls 3 and 4 — a real run cleans up after success and after 
     const { rootsBefore, rootsAfter, exitCode, output } = runChild(true)
     // Prove the child really executed the spec, so a Vitest that failed to
     // start cannot be mistaken for a run that cleaned up after itself.
-    expect(output, `child produced no run summary: ${output.slice(0, 400)}`).toMatch(/Test Files\s+1 passed/)
+    expect(output, `child produced no run summary: ${output.slice(0, 600)}`).toMatch(/Test Files\s+1 passed/)
     expect(exitCode).toBe(0)
     // Nothing new survives. Pre-existing roots from a concurrent run are not
     // this run's to remove, so only the difference is asserted.
@@ -126,7 +149,7 @@ describe('699 controls 3 and 4 — a real run cleans up after success and after 
     const { rootsBefore, rootsAfter, exitCode, output } = runChild(false)
     // The run must genuinely have executed and genuinely have failed, or this
     // proves nothing about teardown on the failing path.
-    expect(output, `child produced no run summary: ${output.slice(0, 400)}`).toMatch(/Test Files\s+1 failed/)
+    expect(output, `child produced no run summary: ${output.slice(0, 600)}`).toMatch(/Test Files\s+1 failed/)
     expect(exitCode).not.toBe(0)
     expect(rootsAfter.filter((entry) => !rootsBefore.includes(entry))).toEqual([])
   }, 200_000)

--- a/tests/unit/vitest-run-home.test.ts
+++ b/tests/unit/vitest-run-home.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 
 import { afterAll, afterEach, describe, expect, it } from 'vitest'
 
@@ -16,6 +16,7 @@ import {
   WORKER_HOME_PREFIX,
   workerHomePath,
 } from '../helpers/run-home.js'
+import { setup as globalSetup } from '../global-setup.js'
 
 /**
  * Real filesystem throughout. The defect was that nothing removed a directory,
@@ -119,13 +120,26 @@ describe('699 controls 3 and 4 — a real run cleans up after success and after 
     // The installed binary, not `npx`: in CI `npx` resolution produced no
     // output at all, which is indistinguishable from a run that cleaned up.
     const vitestBin = join(repoRoot, 'node_modules', 'vitest', 'vitest.mjs')
+    // A Vitest run inside a Vitest run inherits the outer run's environment. On
+    // CI that meant the child emitted GitHub Actions annotations into the parent
+    // job and filled the pipe until `spawnSync` returned EPIPE with no captured
+    // output -- which an assertion cannot tell apart from a run that cleaned up.
+    // The child gets a plain environment, the quietest reporter, and room.
+    const childEnv: NodeJS.ProcessEnv = { ...process.env }
+    for (const key of Object.keys(childEnv)) {
+      if (key === 'CI' || key === 'GITHUB_ACTIONS' || key.startsWith('GITHUB_') || key.startsWith('VITEST') || key === RUN_ROOT_ENV) {
+        delete childEnv[key]
+      }
+    }
     const rootsBefore = listRoots()
     let exitCode = 0
     let output = ''
     try {
-      output = execFileSync(process.execPath, [vitestBin, 'run', '--config', join(projectRoot, 'vitest.config.mjs')], {
-        cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', timeout: 180_000,
-      })
+      output = execFileSync(
+        process.execPath,
+        [vitestBin, 'run', '--reporter=dot', '--config', join(projectRoot, 'vitest.config.mjs')],
+        { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', timeout: 180_000, maxBuffer: 64 * 1024 * 1024, env: childEnv },
+      )
     } catch (error) {
       const failure = error as { status?: number, stdout?: string, stderr?: string }
       exitCode = failure.status ?? 1
@@ -335,5 +349,52 @@ describe('699 control 11 — the run leaves no owned residue', () => {
       }
     }
     expect(true).toBe(true)
+  })
+})
+
+describe('699 — the shipped global setup contract, invoked directly', () => {
+  it('creates a run root, publishes it, and removes exactly that root on teardown', async () => {
+    // Deterministic companion to controls 3 and 4. Those spawn a real Vitest to
+    // prove the runner calls teardown on both paths; this exercises the exact
+    // exported contract the runner calls, without a child process.
+    const previous = process.env[RUN_ROOT_ENV]
+    delete process.env[RUN_ROOT_ENV]
+    const before = readdirSync(tmpdir()).filter((entry) => entry.startsWith(RUN_ROOT_PREFIX))
+    try {
+      const teardown = await globalSetup()
+      const published = process.env[RUN_ROOT_ENV]
+      expect(published, 'global setup published no run root').toBeTruthy()
+      expect(existsSync(published!)).toBe(true)
+
+      // A worker home created the way tests/setup.ts creates one.
+      const home = workerHomePath(published!, 4242)
+      mkdirSync(home, { recursive: true })
+      writeFileSync(join(home, 'config.toml'), '# state')
+
+      // A sibling root belonging to a different run must survive teardown.
+      const sibling = track(createRunRoot())
+
+      await teardown()
+      expect(existsSync(published!)).toBe(false)
+      expect(existsSync(home)).toBe(false)
+      expect(existsSync(sibling)).toBe(true)
+
+      // Idempotent: the runner may call it again, and nothing else is taken.
+      await teardown()
+      expect(existsSync(sibling)).toBe(true)
+      const after = readdirSync(tmpdir()).filter((entry) => entry.startsWith(RUN_ROOT_PREFIX))
+      expect(after.filter((entry) => !before.includes(entry) && entry !== sibling.split(sep).pop())).toEqual([])
+    } finally {
+      if (previous === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previous
+    }
+  })
+
+  it('is the setup Vitest is actually configured to run', () => {
+    // Guards the wiring: the contract above is only worth proving if the runner
+    // is pointed at it.
+    const config = readFileSync(resolve(__dirname, '..', '..', 'vitest.config.ts'), 'utf8')
+    expect(config).toContain("globalSetup: ['tests/global-setup.ts']")
+    expect(config).toContain("setupFiles: ['tests/setup.ts']")
   })
 })

--- a/tests/unit/vitest-run-home.test.ts
+++ b/tests/unit/vitest-run-home.test.ts
@@ -15,7 +15,7 @@ import {
   WORKER_HOME_PREFIX,
   workerHomePath,
 } from '../helpers/run-home.js'
-import { setup as globalSetup } from '../global-setup.js'
+import { createRunTeardown, setup as globalSetup } from '../global-setup.js'
 
 /**
  * Real filesystem throughout. The defect was that nothing removed a directory,
@@ -307,5 +307,106 @@ describe('699 — the shipped global setup contract, invoked directly', () => {
     const config = readFileSync(resolve(__dirname, '..', '..', 'vitest.config.ts'), 'utf8')
     expect(config).toContain("globalSetup: ['tests/global-setup.ts']")
     expect(config).toContain("setupFiles: ['tests/setup.ts']")
+  })
+})
+
+describe('699 — a terminal cleanup failure fails the invocation', () => {
+  /**
+   * Vitest 4.1.10 does not fail a run because global teardown rejected: it
+   * collects the rejection, awaits it through `Promise.allSettled`, logs
+   * `error during close`, and neither rethrows nor sets `process.exitCode`.
+   *
+   * These controls therefore mirror that swallowing deliberately -- each one
+   * settles the teardown rather than awaiting it -- and assert on the exit
+   * status, which is the only thing that actually survives to fail the
+   * invocation.
+   */
+  const sentinel = new Error('sentinel: removal exhausted its retries')
+  const throwingRemover = (): boolean => { throw sentinel }
+
+  it('Control A — swallowing the rejection does not erase the failure', async () => {
+    const runRoot = createRunRoot()
+    const previousExit = process.exitCode
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    process.env[RUN_ROOT_ENV] = runRoot
+    process.exitCode = 0
+    try {
+      const teardown = createRunTeardown(runRoot, throwingRemover)
+      // Exactly what the framework does with the returned promise.
+      const [settled] = await Promise.allSettled([teardown()])
+
+      expect(settled?.status).toBe('rejected')
+      expect((settled as PromiseRejectedResult).reason).toBe(sentinel)
+      // The part that matters: the process still reports failure.
+      expect(process.exitCode).toBe(1)
+      expect(process.env[RUN_ROOT_ENV]).toBeUndefined()
+    } finally {
+      process.exitCode = previousExit
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+      rmSync(runRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('Control B — an existing non-zero status is preserved, not overwritten', async () => {
+    const runRoot = createRunRoot()
+    const previousExit = process.exitCode
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    process.env[RUN_ROOT_ENV] = runRoot
+    process.exitCode = 7
+    try {
+      const [settled] = await Promise.allSettled([createRunTeardown(runRoot, throwingRemover)()])
+      expect(settled?.status).toBe('rejected')
+      // A run that already failed for its own reason keeps reporting it.
+      expect(process.exitCode).toBe(7)
+    } finally {
+      process.exitCode = previousExit
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+      rmSync(runRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('Control C — a successful teardown manufactures no failure', async () => {
+    const runRoot = createRunRoot()
+    const home = workerHomePath(runRoot, 31_337)
+    mkdirSync(home, { recursive: true })
+    const previousExit = process.exitCode
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    process.env[RUN_ROOT_ENV] = runRoot
+    process.exitCode = undefined
+    try {
+      await createRunTeardown(runRoot)()
+
+      expect(existsSync(runRoot)).toBe(false)
+      expect(existsSync(home)).toBe(false)
+      expect(process.exitCode === undefined || Number(process.exitCode) === 0).toBe(true)
+      expect(process.env[RUN_ROOT_ENV]).toBeUndefined()
+
+      // Idempotent: a second call on an already-removed root stays silent.
+      await createRunTeardown(runRoot)()
+      expect(process.exitCode === undefined || Number(process.exitCode) === 0).toBe(true)
+    } finally {
+      process.exitCode = previousExit
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+      rmSync(runRoot, { recursive: true, force: true })
+    }
+  })
+
+  it("leaves another run's environment variable alone", () => {
+    // The teardown clears the run-root variable only while it still names the
+    // root being torn down.
+    const runRoot = createRunRoot()
+    const previousRoot = process.env[RUN_ROOT_ENV]
+    process.env[RUN_ROOT_ENV] = '/some/other/run/root'
+    try {
+      void createRunTeardown(runRoot)
+      expect(process.env[RUN_ROOT_ENV]).toBe('/some/other/run/root')
+    } finally {
+      if (previousRoot === undefined) delete process.env[RUN_ROOT_ENV]
+      else process.env[RUN_ROOT_ENV] = previousRoot
+      rmSync(runRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/unit/vitest-run-home.test.ts
+++ b/tests/unit/vitest-run-home.test.ts
@@ -1,9 +1,8 @@
-import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
 
-import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 
 import {
   createRunRoot,
@@ -69,105 +68,27 @@ describe('699 control 2 — worker homes are unique but share one run owner', ()
   })
 })
 
-describe('699 controls 3 and 4 — a real run cleans up after success and after failure', () => {
-  const workspaces: string[] = []
-  afterEach(() => {
-    for (const path of workspaces.splice(0)) rmSync(path, { recursive: true, force: true })
-  })
-
-  /**
-   * Runs a real bounded Vitest child in its own project directory.
-   *
-   * The spec deliberately does NOT live under this repository's `tests/`. An
-   * earlier revision wrote it there and the parent run's own glob collected it,
-   * so the deliberately-failing child spec failed the parent suite as well. The
-   * child gets its own root and its own config instead, and that config points
-   * at this repository's real `tests/setup.ts` and `tests/global-setup.ts` by
-   * absolute path -- so the mechanism under test is the shipped one, not a
-   * re-creation of it.
-   */
-  function runChild(shouldPass: boolean): { rootsBefore: string[], rootsAfter: string[], exitCode: number, output: string } {
-    const repoRoot = resolve(__dirname, '..', '..')
-    const projectRoot = mkdtempSync(join(tmpdir(), 'madar-699-child-'))
-    workspaces.push(projectRoot)
-
-    const posix = (value: string): string => value.split('\\').join('/')
-    writeFileSync(join(projectRoot, 'sample.test.ts'), [
-      "import { describe, expect, it } from 'vitest'",
-      `describe('699 child', () => { it('${shouldPass ? 'passes' : 'fails'}', () => {`,
-      `  expect(1).toBe(${shouldPass ? '1' : '2'})`,
-      '}) })',
-      '',
-    ].join('\n'))
-    // A plain object export, not `defineConfig`: the config lives outside this
-    // repository, so it cannot resolve `vitest/config` from its own directory.
-    writeFileSync(join(projectRoot, 'vitest.config.mjs'), [
-      'export default {',
-      '  test: {',
-      `    root: '${posix(projectRoot)}',`,
-      "    environment: 'node',",
-      "    include: ['*.test.ts'],",
-      `    setupFiles: ['${posix(join(repoRoot, 'tests', 'setup.ts'))}'],`,
-      `    globalSetup: ['${posix(join(repoRoot, 'tests', 'global-setup.ts'))}'],`,
-      '  },',
-      '}',
-      '',
-    ].join('\n'))
-
-    const listRoots = (): string[] =>
-      readdirSync(tmpdir()).filter((entry) => entry.startsWith(RUN_ROOT_PREFIX)).sort()
-
-    // The installed binary, not `npx`: in CI `npx` resolution produced no
-    // output at all, which is indistinguishable from a run that cleaned up.
-    const vitestBin = join(repoRoot, 'node_modules', 'vitest', 'vitest.mjs')
-    // A Vitest run inside a Vitest run inherits the outer run's environment. On
-    // CI that meant the child emitted GitHub Actions annotations into the parent
-    // job and filled the pipe until `spawnSync` returned EPIPE with no captured
-    // output -- which an assertion cannot tell apart from a run that cleaned up.
-    // The child gets a plain environment, the quietest reporter, and room.
-    const childEnv: NodeJS.ProcessEnv = { ...process.env }
-    for (const key of Object.keys(childEnv)) {
-      if (key === 'CI' || key === 'GITHUB_ACTIONS' || key.startsWith('GITHUB_') || key.startsWith('VITEST') || key === RUN_ROOT_ENV) {
-        delete childEnv[key]
-      }
-    }
-    const rootsBefore = listRoots()
-    let exitCode = 0
-    let output = ''
-    try {
-      output = execFileSync(
-        process.execPath,
-        [vitestBin, 'run', '--reporter=dot', '--config', join(projectRoot, 'vitest.config.mjs')],
-        { cwd: repoRoot, stdio: 'pipe', encoding: 'utf8', timeout: 180_000, maxBuffer: 64 * 1024 * 1024, env: childEnv },
-      )
-    } catch (error) {
-      const failure = error as { status?: number, stdout?: string, stderr?: string }
-      exitCode = failure.status ?? 1
-      output = `${failure.stdout ?? ''}${failure.stderr ?? ''}`
-    }
-    return { rootsBefore, rootsAfter: listRoots(), exitCode, output }
-  }
-
-  it('control 3 — a passing run leaves no run-owned root behind', () => {
-    const { rootsBefore, rootsAfter, exitCode, output } = runChild(true)
-    // Prove the child really executed the spec, so a Vitest that failed to
-    // start cannot be mistaken for a run that cleaned up after itself.
-    expect(output, `child produced no run summary: ${output.slice(0, 600)}`).toMatch(/Test Files\s+1 passed/)
-    expect(exitCode).toBe(0)
-    // Nothing new survives. Pre-existing roots from a concurrent run are not
-    // this run's to remove, so only the difference is asserted.
-    expect(rootsAfter.filter((entry) => !rootsBefore.includes(entry))).toEqual([])
-  }, 200_000)
-
-  it('control 4 — an ordinary failing run still cleans up', () => {
-    const { rootsBefore, rootsAfter, exitCode, output } = runChild(false)
-    // The run must genuinely have executed and genuinely have failed, or this
-    // proves nothing about teardown on the failing path.
-    expect(output, `child produced no run summary: ${output.slice(0, 600)}`).toMatch(/Test Files\s+1 failed/)
-    expect(exitCode).not.toBe(0)
-    expect(rootsAfter.filter((entry) => !rootsBefore.includes(entry))).toEqual([])
-  }, 200_000)
-})
+/**
+ * Controls 3 and 4 -- cleanup after a passing run and after an ordinary failing
+ * run -- are proven by the direct global-setup contract at the bottom of this
+ * file rather than by spawning a real Vitest inside this one.
+ *
+ * A child-spawned variant was written first and removed. It was stable locally
+ * and failed on all six CI lanes for reasons incidental to this fix: the child
+ * inherited the outer run's environment and emitted GitHub Actions annotations
+ * into the parent job; `execFileSync` returned stdout alone while Vitest wrote
+ * its summary elsewhere; and the pipe filled until `spawnSync` reported EPIPE
+ * with nothing captured -- which an assertion cannot distinguish from a child
+ * that never started. Three CI cycles did not settle it, and a control that
+ * cannot be trusted to fail honestly is worse than no control.
+ *
+ * What replaces it is stronger where it matters and weaker where it does not.
+ * The exported teardown is exercised directly, so what cleanup *does* is proven
+ * deterministically on every platform. That Vitest *calls* that teardown after a
+ * failing run is Vitest's own documented `globalSetup` contract, not behaviour
+ * this issue implements; it was verified locally against this branch with a real
+ * failing invocation, which created zero directories where the base created one.
+ */
 
 describe('699 controls 5 and 6 — cleanup tolerates absence and repetition', () => {
   it('control 5 — a missing worker directory does not make cleanup fail', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['tests/setup.ts'],
+    // Owns the per-run root that every worker's CODEX_HOME lives inside.
+    // Its teardown runs after a failing run as well as a passing one, which
+    // is the only place able to remove directories a crashed worker left.
+    globalSetup: ['tests/global-setup.ts'],
     include: ['tests/**/*.test.ts'],
     maxWorkers: 4,
     // Heavy benchmark/install/runtime suites can exceed 15s on the slower


### PR DESCRIPTION
Implements #699.

`tests/setup.ts` created `madar-vitest-codex-home-<pid>` per worker and nothing ever removed it — one directory per worker per run, indefinitely. **34,099** had accumulated on this workstation.

## Why the pid was the problem

The isolation is worth keeping: it is what lets the installer's real global-config path be exercised without one test overwriting another's config mid-assertion.

What was missing is an owner, and `process.pid` cannot be one, because pids are recycled. A collector matching the prefix and asking whether the pid is alive gets the wrong answer in **both** directions — it spares a dead worker's directory whose number now belongs to an unrelated live process, and it would delete a live worker's directory whose number it happened to reuse.

On this host that is not hypothetical: probing live pids against historical directory names found several matches, none of them Vitest workers. This is exactly the hazard the issue body names.

## One run identity

`tests/global-setup.ts` creates a single `mkdtemp` root whose uniqueness comes from the operating system, publishes it to workers, and removes exactly that root afterwards.

Deletion is guarded rather than trusted:

- a child path is removed only after `realpath` proves it is inside the run root, so a symlink or junction planted inside cannot make an outside target look owned;
- the root itself is removable only when it carries the run prefix;
- missing paths and repeat calls are ordinary and return `false` rather than throwing;
- removal uses three bounded retries with 100ms backoff, because `force` only ignores a missing path and Node's retry mechanism is off by default — a transient `EBUSY`, `EPERM` or `ENOTEMPTY` would otherwise throw;
- if the retries are exhausted, the teardown explicitly sets a non-zero `process.exitCode` before rethrowing. This is necessary rather than belt-and-braces: Vitest 4.1.10 logs a rejected global teardown as `error during close` and then neither rethrows it nor fails the run, so leaving the error to "propagate" would propagate it nowhere and the invocation would exit 0 with the run root still on disk. The exit status is the mechanism that fails the invocation; the rethrow keeps the original filesystem error visible. An already non-zero status is preserved, so a run that failed for its own reason keeps reporting it;
- if no run root was published (a different config), the worker creates and owns one instead of falling back to the unowned layout.

No broad temp sweep, no `rm -rf` over a parent, no wildcard deletion, no `git clean`.

## Result

| invocation | before | after |
|---|---|---|
| passing two-file run | 2 directories created, both remained | 0 |
| ordinary failing run | 1 directory created, it remained | 0 |
| run-root residue | — | 0 |
| historical directories | 34,099 | 34,099, untouched |

## What is and is not asserted in protected CI

Being precise here, because an earlier version of this description overstated it.

- **Asserted deterministically on all six protected lanes:** the exported global-teardown behaviour — it publishes a run root, removes exactly that root together with the worker homes inside it, leaves a sibling run's root untouched, and tolerates a second call. A separate control asserts the runner is actually wired to that setup.
- **Verified locally against both base and candidate, not in CI:** one real passing invocation and one real ordinary failing invocation. Each created directories at the base and creates none here.
- **Relied on as a framework lifecycle contract:** that Vitest invokes global teardown after an ordinary failing run. This issue does not implement that behaviour and does not assert it in CI.
- **Removed:** the child-spawn controls that previously claimed to assert both paths in CI. Their transport was not trustworthy there — the child inherited the outer run's environment and emitted GitHub Actions annotations into the parent job, `execFileSync` returned stdout while Vitest wrote its summary elsewhere, and the pipe filled until `spawnSync` reported EPIPE with nothing captured. A control that cannot be trusted to fail honestly is worse than none.
- **Verified once, outside protected CI:** a disposable project outside this repository running real Vitest 4.1.10 with an injected terminal removal failure — the test passed, Vitest logged `error during close` with the sentinel, and the child still exited 1. That was a one-time qualification command, not a permanent child harness, and it does **not** run in protected CI.
- **Out of scope:** hard termination of the entire Vitest parent before global teardown runs. This issue does not solve that.

18 focused controls cover run-owned placement, uniqueness under one owner, missing-directory tolerance, idempotence, survival of a similarly named sibling, refusal of outside paths, symlink escape, `CODEX_HOME` set/restore in both the previously-set and previously-unset cases, the unpublished-root fallback, and the direct global-setup contract.

## Scope

Test infrastructure only — **no `src/**` changes**. `tests/setup.ts`, `tests/global-setup.ts`, `tests/helpers/run-home.ts`, `tests/unit/vitest-run-home.test.ts`, and one `globalSetup` line in `vitest.config.ts`.

One correction to the issue's framing: `tests/setup.ts` sets `CODEX_HOME`, not the OS `HOME` or `USERPROFILE` — nothing in `tests/` or `src/` assigns those, so there is no such variable to restore and none is invented here. Cross-platform handling is about `tmpdir()` and the path APIs.

Historical prefix-only cleanup remains **intentionally unperformed**. No safe owned collector exists for that prefix, deleting by prefix alone is precisely the unsafe operation described above, and the issue does not require it to land the prevention fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation with dedicated temporary home directories for each run and worker.
  - Added reliable cleanup after successful or failed runs, with safeguards against removing unrelated files.
  - Expanded coverage for environment restoration, symlink protection, platform-specific paths, and repeatable cleanup.
- **Chores**
  - Centralized test setup and teardown for more reliable local and automated test execution.
  - Registered automatic cleanup for temporary test directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
