### PR TITLE
fix(update): make version comparison host-independent

### DIFF
--- a/src/shared/update-notifier.ts
+++ b/src/shared/update-notifier.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync 
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
+import { compareUnicodeCodePoints } from '../contracts/canonical-json.js'
 import { safeFetchText } from './security.js'
 
 const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000
@@ -134,7 +135,11 @@ function compareIdentifiers(left: string, right: string): number {
     return 1
   }
 
-  return left.localeCompare(right)
+  // Semver §11 orders identifiers with letters or hyphens in ASCII sort order.
+  // Host collation does not: it ranks `Alpha` after `alpha` on en-US and before
+  // it on da-DK, so the same pair of releases orders differently on two
+  // machines. Ordering has one owner in this repository.
+  return compareUnicodeCodePoints(left, right)
 }
 
 export function compareVersions(left: string, right: string): number {
@@ -142,7 +147,10 @@ export function compareVersions(left: string, right: string): number {
   const rightVersion = parseVersion(right)
 
   if (!leftVersion || !rightVersion) {
-    return left.localeCompare(right)
+    // Semver defines no precedence for input the parser rejects, but the answer
+    // still has to be the same everywhere: it selects what is reported to the
+    // user and what is written to the persisted update cache.
+    return compareUnicodeCodePoints(left, right)
   }
 
   for (let index = 0; index < leftVersion.core.length; index += 1) {

--- a/tests/unit/update-notifier.test.ts
+++ b/tests/unit/update-notifier.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 
 import { describe, expect, it } from 'vitest'
 
-import { getUpdateNotification } from '../../src/shared/update-notifier.js'
+import { compareVersions, getUpdateNotification } from '../../src/shared/update-notifier.js'
 
 describe('update notifier', () => {
   it('returns a notice and caches the latest version when a newer release exists', async () => {
@@ -194,5 +194,310 @@ describe('update notifier', () => {
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true })
     }
+  })
+})
+
+/**
+ * Independent code-point oracle for #717.
+ *
+ * Derived from Unicode scalar values directly rather than by calling the
+ * production comparator, so the expected ordering in these controls is not
+ * the implementation restating itself.
+ */
+function codePointOrder(left: string, right: string): number {
+  const leftPoints = [...left].map((character) => character.codePointAt(0) ?? 0)
+  const rightPoints = [...right].map((character) => character.codePointAt(0) ?? 0)
+  const shared = Math.min(leftPoints.length, rightPoints.length)
+
+  for (let index = 0; index < shared; index += 1) {
+    if (leftPoints[index] !== rightPoints[index]) {
+      return Math.sign((leftPoints[index] ?? 0) - (rightPoints[index] ?? 0))
+    }
+  }
+
+  return Math.sign(leftPoints.length - rightPoints.length)
+}
+
+/** Named collations used to characterise fixtures. Never the host default. */
+const NAMED_COLLATIONS = ['en-US', 'da-DK', 'sv-SE'] as const
+
+function collationOrders(left: string, right: string): Record<string, number> {
+  return Object.fromEntries(NAMED_COLLATIONS.map((locale) => [
+    locale,
+    Math.sign(new Intl.Collator(locale).compare(left, right)),
+  ]))
+}
+
+/**
+ * `discriminates` — at least two named collations disagree with each other, so
+ * the pre-#717 answer provably depended on the host's ICU collation.
+ *
+ * `opposesEveryCollation` — code-point order differs from every named
+ * collation, so the control fails against the pre-#717 implementation on any
+ * host rather than only on one whose default locale happens to disagree.
+ *
+ * en-US and sv-SE order ASCII case identically, so neither is used as the sole
+ * counterpart for a case-only fixture.
+ */
+interface OrderingFixture {
+  readonly label: string
+  readonly left: string
+  readonly right: string
+  readonly discriminates: boolean
+  readonly opposesEveryCollation: boolean
+}
+
+/** Site A — `compareIdentifiers`, nonnumeric prerelease identifiers. */
+const PRERELEASE_IDENTIFIER_FIXTURES: readonly OrderingFixture[] = [
+  { label: 'Alpha/alpha', left: 'Alpha', right: 'alpha', discriminates: true, opposesEveryCollation: false },
+  { label: 'B/a', left: 'B', right: 'a', discriminates: false, opposesEveryCollation: true },
+]
+
+/** Site B — `compareVersions` fallback, unparseable version strings. */
+const UNPARSEABLE_FIXTURES: readonly OrderingFixture[] = [
+  { label: 'Ångström/apple', left: 'Ångström', right: 'apple', discriminates: true, opposesEveryCollation: false },
+  { label: 'éclair/zebra', left: 'éclair', right: 'zebra', discriminates: false, opposesEveryCollation: true },
+]
+
+describe('#717 fixture characterisation', () => {
+  const allFixtures = [...PRERELEASE_IDENTIFIER_FIXTURES, ...UNPARSEABLE_FIXTURES]
+
+  it.each(allFixtures)('$label carries the discrimination it claims', (fixture) => {
+    const orders = collationOrders(fixture.left, fixture.right)
+    const expected = codePointOrder(fixture.left, fixture.right)
+    const distinct = new Set(Object.values(orders))
+
+    expect(expected).not.toBe(0)
+    expect(distinct.has(0)).toBe(false)
+
+    // Claimed host-sensitivity must actually hold: two named collations disagree.
+    expect(distinct.size > 1).toBe(fixture.discriminates)
+
+    // Claimed universal falsifiability must actually hold: no collation agrees
+    // with code-point order, so restoring localeCompare fails on every host.
+    expect(Object.values(orders).every((order) => order !== expected))
+      .toBe(fixture.opposesEveryCollation)
+  })
+
+  it('gives each comparison site both a host-sensitivity witness and a universal falsifier', () => {
+    for (const site of [PRERELEASE_IDENTIFIER_FIXTURES, UNPARSEABLE_FIXTURES]) {
+      expect(site.some((fixture) => fixture.discriminates)).toBe(true)
+      expect(site.some((fixture) => fixture.opposesEveryCollation)).toBe(true)
+    }
+  })
+
+  it('never leans on the en-US/sv-SE pair for a case-only fixture', () => {
+    const caseOnly = PRERELEASE_IDENTIFIER_FIXTURES
+      .filter((fixture) => fixture.left.toLowerCase() === fixture.right.toLowerCase())
+
+    expect(caseOnly.length).toBeGreaterThan(0)
+    for (const fixture of caseOnly) {
+      const orders = collationOrders(fixture.left, fixture.right)
+      expect(orders['en-US']).toBe(orders['sv-SE'])
+      expect(new Set(Object.values(orders)).size).toBeGreaterThan(1)
+    }
+  })
+})
+
+describe('#717 parsed prerelease identifier ordering', () => {
+  it.each(PRERELEASE_IDENTIFIER_FIXTURES)(
+    '$label orders by code point on every host, not by collation',
+    (fixture) => {
+      const expected = codePointOrder(fixture.left, fixture.right)
+      const forward = Math.sign(compareVersions(`1.0.0-${fixture.left}`, `1.0.0-${fixture.right}`))
+      const reverse = Math.sign(compareVersions(`1.0.0-${fixture.right}`, `1.0.0-${fixture.left}`))
+
+      expect(forward).toBe(expected)
+      expect(reverse).toBe(-expected)
+
+      if (fixture.opposesEveryCollation) {
+        for (const order of Object.values(collationOrders(fixture.left, fixture.right))) {
+          expect(forward).not.toBe(order)
+        }
+      }
+    },
+  )
+
+  it('orders 1.0.0-Alpha below 1.0.0-alpha as semver §11 requires', () => {
+    expect(Math.sign(compareVersions('1.0.0-Alpha', '1.0.0-alpha'))).toBe(-1)
+    expect(Math.sign(compareVersions('1.0.0-alpha', '1.0.0-Alpha'))).toBe(1)
+  })
+
+  it('preserves semver precedence rules the fix must not disturb', () => {
+    // Numeric identifiers compare numerically, not as strings.
+    expect(Math.sign(compareVersions('1.0.0-2', '1.0.0-10'))).toBe(-1)
+
+    // Numeric identifiers have lower precedence than nonnumeric identifiers.
+    expect(Math.sign(compareVersions('1.0.0-1', '1.0.0-alpha'))).toBe(-1)
+    expect(Math.sign(compareVersions('1.0.0-alpha', '1.0.0-1'))).toBe(1)
+    expect(Math.sign(compareVersions('1.0.0-1', '1.0.0-Alpha'))).toBe(-1)
+
+    // A larger set of prerelease fields has higher precedence when the
+    // preceding identifiers are equal.
+    expect(Math.sign(compareVersions('1.0.0-alpha', '1.0.0-alpha.1'))).toBe(-1)
+    expect(Math.sign(compareVersions('1.0.0-alpha.1', '1.0.0-alpha'))).toBe(1)
+
+    // A release outranks any of its prereleases.
+    expect(Math.sign(compareVersions('1.0.0', '1.0.0-alpha'))).toBe(1)
+    expect(Math.sign(compareVersions('1.0.0-alpha', '1.0.0'))).toBe(-1)
+
+    // Core ordering is numeric and still dominates the prerelease comparison.
+    expect(Math.sign(compareVersions('1.0.10', '1.0.9'))).toBe(1)
+    expect(Math.sign(compareVersions('2.0.0-alpha', '1.9.9'))).toBe(1)
+
+    // Build metadata is ignored, and a leading `v` still parses.
+    expect(compareVersions('1.0.0+build.9', '1.0.0+build.1')).toBe(0)
+    expect(compareVersions('v1.0.0', '1.0.0')).toBe(0)
+    expect(Math.sign(compareVersions('1.0.0-Alpha+meta', '1.0.0-alpha+meta'))).toBe(-1)
+  })
+})
+
+describe('#717 unparseable version fallback', () => {
+  it.each(UNPARSEABLE_FIXTURES)(
+    '$label falls back to code-point order on every host',
+    (fixture) => {
+      const expected = codePointOrder(fixture.left, fixture.right)
+      const forward = Math.sign(compareVersions(fixture.left, fixture.right))
+
+      expect(forward).toBe(expected)
+      expect(Math.sign(compareVersions(fixture.right, fixture.left))).toBe(-expected)
+
+      if (fixture.opposesEveryCollation) {
+        for (const order of Object.values(collationOrders(fixture.left, fixture.right))) {
+          expect(forward).not.toBe(order)
+        }
+      }
+    },
+  )
+
+  it('reaches the fallback only for unparseable input', () => {
+    // A fixture of valid versions never executes the fallback, so these
+    // controls are stated on input the parser genuinely rejects.
+    for (const fixture of UNPARSEABLE_FIXTURES) {
+      expect(Math.sign(compareVersions(fixture.left, `${fixture.left}`))).toBe(0)
+    }
+
+    // One parseable side is still enough to take the fallback.
+    expect(Math.sign(compareVersions('1.0.0', 'not-a-version')))
+      .toBe(codePointOrder('1.0.0', 'not-a-version'))
+  })
+
+  it('stays antisymmetric and keeps distinct invalid strings distinct', () => {
+    const invalid = ['Ångström', 'apple', 'éclair', 'zebra', 'not-a-version', 'Not-A-Version', '']
+
+    for (const left of invalid) {
+      expect(compareVersions(left, left)).toBe(0)
+
+      for (const right of invalid) {
+        const forward = Math.sign(compareVersions(left, right))
+        const reverse = Math.sign(compareVersions(right, left))
+
+        // `-0` and `0` are distinct under `Object.is`, so negate only a
+        // genuine ordering rather than the equal case.
+        expect(forward).toBe(reverse === 0 ? 0 : -reverse)
+        expect(forward === 0).toBe(left === right)
+      }
+    }
+  })
+
+  it('is deterministic across repeated calls', () => {
+    const results = Array.from({ length: 5 }, () => compareVersions('not-a-version', 'Not-A-Version'))
+    expect(new Set(results).size).toBe(1)
+    expect(Math.sign(results[0] ?? 0)).toBe(codePointOrder('not-a-version', 'Not-A-Version'))
+  })
+})
+
+describe('#717 notifier decisions follow code-point order', () => {
+  async function notify(currentVersion: string, latestVersion: string): Promise<{
+    notice: string | null
+    cache: unknown
+  }> {
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'madar-update-notifier-717-'))
+
+    try {
+      const notice = await getUpdateNotification({
+        packageName: '@lubab/madar',
+        currentVersion,
+        cacheRoot,
+        stdoutIsTTY: true,
+        env: {},
+        now: () => 1_700_000_000_000,
+        fetchText: async () => JSON.stringify({ version: latestVersion }),
+      })
+
+      return {
+        notice,
+        cache: JSON.parse(readFileSync(join(cacheRoot, 'madar', 'update-check.json'), 'utf8')),
+      }
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true })
+    }
+  }
+
+  it('reports a newer prerelease', async () => {
+    const { notice } = await notify('1.0.0-alpha', '1.0.0-beta')
+    expect(notice).toContain('1.0.0-alpha -> 1.0.0-beta')
+  })
+
+  it('does not report an older prerelease', async () => {
+    const { notice } = await notify('1.0.0-beta', '1.0.0-alpha')
+    expect(notice).toBeNull()
+  })
+
+  it('emits no notice merely because host collation orders case differently', async () => {
+    // Every named collation orders `B` after `a`; code point orders it before.
+    // Under the pre-#717 comparator this published a downgrade as an update.
+    expect(Object.values(collationOrders('B', 'a')).every((order) => order === 1)).toBe(true)
+    expect(codePointOrder('B', 'a')).toBe(-1)
+
+    const { notice } = await notify('1.0.0-a', '1.0.0-B')
+    expect(notice).toBeNull()
+  })
+
+  it('reports the case-sensitive upgrade that code-point order does mandate', async () => {
+    const { notice } = await notify('1.0.0-B', '1.0.0-a')
+    expect(notice).toContain('1.0.0-B -> 1.0.0-a')
+  })
+
+  it('follows semver rather than collation for Alpha/alpha', async () => {
+    expect((await notify('1.0.0-alpha', '1.0.0-Alpha')).notice).toBeNull()
+    expect((await notify('1.0.0-Alpha', '1.0.0-alpha')).notice).toContain('1.0.0-Alpha -> 1.0.0-alpha')
+  })
+
+  it('keeps the persisted cache decision intact for a prerelease upgrade', async () => {
+    const { notice, cache } = await notify('1.0.0-Alpha', '1.0.0-alpha')
+
+    expect(notice).toContain('npm i -g @lubab/madar@latest')
+    expect(cache).toEqual({
+      checked_at: 1_700_000_000_000,
+      latest_version: '1.0.0-alpha',
+      notified_at: 1_700_000_000_000,
+    })
+  })
+
+  it('records the refreshed check without notifying when no upgrade is due', async () => {
+    const { notice, cache } = await notify('1.0.0-a', '1.0.0-B')
+
+    expect(notice).toBeNull()
+    expect(cache).toEqual({
+      checked_at: 1_700_000_000_000,
+      latest_version: '1.0.0-B',
+    })
+  })
+
+  it('decides the unparseable fallback deterministically end to end', async () => {
+    // Every named collation orders `éclair` before `zebra`; code point does not.
+    expect(Object.values(collationOrders('éclair', 'zebra')).every((order) => order === -1)).toBe(true)
+
+    const upgrade = await notify('zebra', 'éclair')
+    expect(upgrade.notice).toContain('zebra -> éclair')
+    expect(upgrade.cache).toEqual({
+      checked_at: 1_700_000_000_000,
+      latest_version: 'éclair',
+      notified_at: 1_700_000_000_000,
+    })
+
+    const downgrade = await notify('éclair', 'zebra')
+    expect(downgrade.notice).toBeNull()
   })
 })


### PR DESCRIPTION
Implements #717.

`compareVersions` in `src/shared/update-notifier.ts` decided ordering with
`String.prototype.localeCompare` at two sites. That is host-dependent, and for
prerelease identifiers it contradicts semver §11, which requires ASCII sort
order. The ordering is a selection, not a display detail: it decides whether a
notice is shown and what is written to the persisted update cache.

## The two sites

| site | path | before | after |
|---|---|---|---|
| A | `compareIdentifiers` — nonnumeric prerelease identifiers | host collation | `compareUnicodeCodePoints` |
| B | `compareVersions` — fallback when either side fails to parse | host collation | `compareUnicodeCodePoints` |

`compareUnicodeCodePoints` from `src/contracts/canonical-json.ts` is the
repository's single comparator owner; `src/shared/git.ts` already imports it the
same way. No second comparator is introduced, and `canonical-json.ts` is untouched.

## Reproduced at the base

Real exported `compareVersions`, one process per host locale, `Math.sign`:

```
comparison                          en-US   sv-SE   da-DK   code point (required)
1.0.0-Alpha    vs 1.0.0-alpha         +1      +1      -1      -1
1.0.0-beta     vs 1.0.0-Beta          -1      -1      +1      +1
Ångström       vs apple               -1      +1      +1      +1     (site B)
not-a-version  vs Not-A-Version       -1      -1      +1      +1     (site B)
```

## Preserved

The parser is unchanged. Numeric identifiers still compare numerically and still
rank below nonnumeric ones; prerelease length ordering, release-above-its-prerelease
precedence and build-metadata handling are unchanged; the update-cache schema,
network behavior and timeout behavior are untouched.

## Controls

Each fixture is characterised against explicit `en-US` / `da-DK` / `sv-SE`
collators **before** anything is asserted about production, so non-vacuity never
rests on the machine's default locale, and the characterisation itself is a test
that fails if a fixture stops discriminating.

| site | fixture | code point | en-US | da-DK | sv-SE |
|---|---|---|---|---|---|
| A | `Alpha` / `alpha` | −1 | +1 | −1 | +1 |
| A | `B` / `a` | −1 | +1 | +1 | +1 |
| B | `Ångström` / `apple` | +1 | −1 | +1 | +1 |
| B | `éclair` / `zebra` | +1 | −1 | −1 | −1 |

Rows 1 and 3 are the issue's own fixtures and show two named collations
disagreeing. Rows 2 and 4 order **oppositely to every named collation**, so those
controls fail against the previous implementation on any host, not only on one
whose default locale happens to disagree. en-US and sv-SE order ASCII case
identically, so neither stands alone as the counterpart for a case-only fixture —
a test asserts that explicitly.

End-to-end controls drive the real exported `getUpdateNotification`: a newer
prerelease is reported, an older one is not, case order follows semver, the
persisted cache entry is asserted for both the notifying and the non-notifying
path, the unparseable fallback is deterministic, and no notice is emitted merely
because host collation ranks case differently.

## Falsifiability

Two focused fault injections, each restoring `localeCompare` at one site only,
from a byte snapshot:

| injection | failing controls | site-A controls red | site-B controls red |
|---|---|---|---|
| site A only | 9 | 9 | 0 |
| site B only | 4 | 0 | 4 |

Credit is disjoint — no unrelated failure is counted for either site. Restoration
was byte-identical after both (sha256 `568115782e1dc7…04781efb`) and the worktree
returned clean.

## Local gates

Focused `update-notifier` + `cli` suites 139/139; typecheck; build;
`qualify:validate`; `release:verify`; `npm pack --dry-run`. Exactly one
production file changed. No `localeCompare` remains in the file.

## Non-goals

No repository-wide locale sweep, no other semver parser concern, no update-cache
redesign, no change to `canonical-json.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version comparison consistency across different system locales.
  * Ensured prerelease and invalid version values are ordered deterministically.
  * Prevented inconsistent update notifications and cached update decisions.

* **Tests**
  * Added comprehensive coverage for version ordering and update-notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->