### PR TITLE
prototype: interactive TypeScript evidence navigation (#736)

### DIFF
--- a/src/cli/evidence-bin.ts
+++ b/src/cli/evidence-bin.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { resolve } from 'node:path'
+
+import { serveEvidenceStdio } from '../runtime/evidence-stdio-server.js'
+
+function usage(): string {
+  return [
+    'Madar interactive evidence prototype',
+    '',
+    'Usage:',
+    '  node dist/src/cli/evidence-bin.js [--root <repository>] ',
+    '',
+    'Starts a read-only MCP stdio server exposing only:',
+    '  resolve_anchor, search_exact, read_evidence, definition, references',
+  ].join('\n')
+}
+
+function parseRoot(args: string[]): string {
+  let root = process.cwd()
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') {
+      process.stdout.write(`${usage()}\n`)
+      process.exit(0)
+    }
+    if (argument === '--root') {
+      const value = args[index + 1]
+      if (!value) throw new Error('--root requires a directory path')
+      root = value
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${argument ?? ''}`)
+  }
+  return resolve(root)
+}
+
+try {
+  await serveEvidenceStdio({ rootDir: parseRoot(process.argv.slice(2)) })
+} catch (error) {
+  process.stderr.write(`[madar evidence] ${error instanceof Error ? error.message : 'startup failed'}\n`)
+  process.exitCode = 1
+}

--- a/src/runtime/evidence-navigation.ts
+++ b/src/runtime/evidence-navigation.ts
@@ -1,0 +1,943 @@
+import { createHash } from 'node:crypto'
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from 'node:fs'
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  relative,
+  resolve,
+  sep,
+} from 'node:path'
+import ts from 'typescript'
+
+export type EvidenceResolution =
+  | 'exact_resolved'
+  | 'ambiguous'
+  | 'unresolved'
+  | 'unsupported'
+  | 'truncated'
+
+export type EvidenceKind =
+  | 'path'
+  | 'literal'
+  | 'route'
+  | 'symbol'
+  | 'definition'
+  | 'reference'
+  | 'source'
+
+export interface EvidencePosition {
+  line: number
+  column: number
+}
+
+export interface EvidenceRange {
+  start: EvidencePosition
+  end: EvidencePosition
+}
+
+export interface EvidenceItem {
+  path: string
+  range: EvidenceRange
+  evidence_kind: EvidenceKind
+  name?: string
+  symbol_kind?: string
+  container_name?: string
+  route_method?: string
+  route_path?: string
+  preview?: string
+  is_definition?: boolean
+}
+
+export interface EvidenceProjectMetadata {
+  config_path: string | null
+  provider_capability: 'available' | 'unsupported'
+}
+
+export interface EvidenceResult {
+  schema_version: 1
+  operation: 'resolve_anchor' | 'search_exact' | 'read_evidence' | 'definition' | 'references'
+  resolution: EvidenceResolution
+  provider: 'madar-exact' | 'typescript-language-service'
+  provider_version: string
+  repository_revision: string
+  project: EvidenceProjectMetadata
+  query: string
+  truncated: boolean
+  evidence: EvidenceItem[]
+  detail?: string
+  digest: string
+}
+
+export interface EvidenceNavigatorOptions {
+  rootDir: string
+  maxSearchResults?: number
+  maxScannedFiles?: number
+  maxFileBytes?: number
+}
+
+export interface LocationRequest {
+  anchor?: string
+  path?: string
+  line?: number
+  column?: number
+  limit?: number
+}
+
+interface ProjectState {
+  configPath: string
+  configRelativePath: string
+  parsed: ts.ParsedCommandLine
+  languageService: ts.LanguageService
+}
+
+interface CandidateLocation {
+  fileName: string
+  start: number
+  length: number
+  name?: string
+  kind?: string
+  containerName?: string
+}
+
+const DEFAULT_MAX_RESULTS = 100
+const DEFAULT_MAX_SCANNED_FILES = 20_000
+const DEFAULT_MAX_FILE_BYTES = 2_000_000
+const MAX_READ_LINES = 400
+const TEXT_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.mts', '.cts',
+  '.js', '.jsx', '.mjs', '.cjs',
+  '.json', '.jsonc', '.yaml', '.yml',
+  '.md', '.mdx', '.txt', '.toml', '.graphql', '.gql',
+])
+const IGNORED_DIRECTORIES = new Set([
+  '.git', '.hg', '.svn', '.jj',
+  'node_modules', 'bower_components', 'vendor',
+  'dist', 'build', 'out', 'coverage',
+  '.next', '.nuxt', '.svelte-kit', '.astro', '.vite', '.turbo', '.nx',
+  '.cache', '.parcel-cache', '.serverless', '.vercel', '.netlify',
+  '.madar', 'madar-cache', 'madar-report',
+])
+const ROUTE_METHODS = new Map<string, string>([
+  ['Get', 'GET'],
+  ['Post', 'POST'],
+  ['Put', 'PUT'],
+  ['Patch', 'PATCH'],
+  ['Delete', 'DELETE'],
+  ['Options', 'OPTIONS'],
+  ['Head', 'HEAD'],
+  ['All', 'ALL'],
+])
+const DIRECT_ROUTE_METHODS = new Map<string, string>([
+  ['get', 'GET'],
+  ['post', 'POST'],
+  ['put', 'PUT'],
+  ['patch', 'PATCH'],
+  ['delete', 'DELETE'],
+  ['options', 'OPTIONS'],
+  ['head', 'HEAD'],
+  ['all', 'ALL'],
+])
+
+function codePointCompare(left: string, right: string): number {
+  const leftPoints = Array.from(left, (value) => value.codePointAt(0) ?? 0)
+  const rightPoints = Array.from(right, (value) => value.codePointAt(0) ?? 0)
+  const length = Math.min(leftPoints.length, rightPoints.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftPoint = leftPoints[index]
+    const rightPoint = rightPoints[index]
+    if (leftPoint === undefined || rightPoint === undefined) break
+    if (leftPoint < rightPoint) return -1
+    if (leftPoint > rightPoint) return 1
+  }
+  return leftPoints.length - rightPoints.length
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalValue(entry))
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => codePointCompare(left, right))
+        .map(([key, entry]) => [key, canonicalValue(entry)]),
+    )
+  }
+  return value
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value))
+}
+
+function resultDigest(value: Omit<EvidenceResult, 'digest'>): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex')
+}
+
+function normalizeSlash(value: string): string {
+  return value.replaceAll('\\', '/')
+}
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, '')
+}
+
+function normalizeRoutePath(...parts: string[]): string {
+  const joined = parts
+    .map((part) => trimSlashes(part.trim()))
+    .filter((part) => part.length > 0)
+    .join('/')
+  return joined.length === 0 ? '/' : `/${joined}`
+}
+
+function lineTextAt(text: string, position: number): string {
+  const start = Math.max(0, text.lastIndexOf('\n', Math.max(0, position - 1)) + 1)
+  const newline = text.indexOf('\n', position)
+  const end = newline === -1 ? text.length : newline
+  return text.slice(start, end).trim()
+}
+
+function offsetRange(text: string, start: number, length: number): EvidenceRange {
+  const sourceFile = ts.createSourceFile('evidence.ts', text, ts.ScriptTarget.Latest, false)
+  return spanRange(sourceFile, start, length)
+}
+
+function spanRange(sourceFile: ts.SourceFile, start: number, length: number): EvidenceRange {
+  const safeStart = Math.max(0, Math.min(start, sourceFile.text.length))
+  const safeEnd = Math.max(safeStart, Math.min(safeStart + Math.max(0, length), sourceFile.text.length))
+  const startPosition = sourceFile.getLineAndCharacterOfPosition(safeStart)
+  const endPosition = sourceFile.getLineAndCharacterOfPosition(safeEnd)
+  return {
+    start: { line: startPosition.line + 1, column: startPosition.character + 1 },
+    end: { line: endPosition.line + 1, column: endPosition.character + 1 },
+  }
+}
+
+function parseGitDir(rootDir: string): string | null {
+  const dotGit = resolve(rootDir, '.git')
+  try {
+    const stat = lstatSync(dotGit)
+    if (stat.isDirectory()) return dotGit
+    if (!stat.isFile()) return null
+    const content = readFileSync(dotGit, 'utf8').trim()
+    const match = /^gitdir:\s*(.+)$/i.exec(content)
+    if (!match?.[1]) return null
+    return resolve(rootDir, match[1])
+  } catch {
+    return null
+  }
+}
+
+function gitCommonDir(gitDir: string): string {
+  try {
+    const common = readFileSync(resolve(gitDir, 'commondir'), 'utf8').trim()
+    return resolve(gitDir, common)
+  } catch {
+    return gitDir
+  }
+}
+
+function readGitRevision(rootDir: string): string {
+  const gitDir = parseGitDir(rootDir)
+  if (!gitDir) return 'unknown'
+  let head: string
+  try {
+    head = readFileSync(resolve(gitDir, 'HEAD'), 'utf8').trim()
+  } catch {
+    return 'unknown'
+  }
+  if (/^[0-9a-f]{40,64}$/i.test(head)) return head.toLowerCase()
+  const refMatch = /^ref:\s*(.+)$/.exec(head)
+  if (!refMatch?.[1]) return 'unknown'
+  const ref = refMatch[1]
+  const commonDir = gitCommonDir(gitDir)
+  for (const directory of [gitDir, commonDir]) {
+    try {
+      const value = readFileSync(resolve(directory, ref), 'utf8').trim()
+      if (/^[0-9a-f]{40,64}$/i.test(value)) return value.toLowerCase()
+    } catch {
+      // Fall through to packed refs.
+    }
+  }
+  try {
+    const packedRefs = readFileSync(resolve(commonDir, 'packed-refs'), 'utf8')
+    for (const line of packedRefs.split(/\r?\n/)) {
+      if (line.startsWith('#') || line.startsWith('^')) continue
+      const [sha, packedRef] = line.trim().split(/\s+/, 2)
+      if (packedRef === ref && sha && /^[0-9a-f]{40,64}$/i.test(sha)) return sha.toLowerCase()
+    }
+  } catch {
+    // No packed refs.
+  }
+  return 'unknown'
+}
+
+function isInsideRoot(rootDir: string, candidate: string): boolean {
+  const relativePath = relative(rootDir, candidate)
+  return relativePath === '' || (!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
+}
+
+function safeExistingFile(rootDir: string, rawPath: string): string | null {
+  if (rawPath.trim().length === 0 || isAbsolute(rawPath)) return null
+  const normalized = normalizeSlash(rawPath).replace(/^\.\//, '')
+  if (normalized.split('/').some((segment) => segment === '..' || segment === '')) return null
+  const candidate = resolve(rootDir, normalized)
+  if (!isInsideRoot(rootDir, candidate)) return null
+  try {
+    const realRoot = realpathSync(rootDir)
+    const realCandidate = realpathSync(candidate)
+    if (!isInsideRoot(realRoot, realCandidate)) return null
+    return statSync(realCandidate).isFile() ? realCandidate : null
+  } catch {
+    return null
+  }
+}
+
+function relativeEvidencePath(rootDir: string, fileName: string): string | null {
+  let realRoot: string
+  let realFile: string
+  try {
+    realRoot = realpathSync(rootDir)
+    realFile = realpathSync(fileName)
+  } catch {
+    return null
+  }
+  if (!isInsideRoot(realRoot, realFile)) return null
+  const value = normalizeSlash(relative(realRoot, realFile))
+  return value.length > 0 && !value.startsWith('../') ? value : null
+}
+
+function isIdentifierQuery(value: string): boolean {
+  return /^[\p{ID_Start}_$][\p{ID_Continue}$]*(?:\.[\p{ID_Start}_$][\p{ID_Continue}$]*)*$/u.test(value)
+}
+
+function looksLikePath(value: string): boolean {
+  return /^(?:\.\/)?[^\0]+\.[A-Za-z0-9]+$/.test(value) && (value.includes('/') || value.includes('\\'))
+}
+
+function staticStringValues(node: ts.Expression | undefined): string[] | null {
+  if (!node) return ['']
+  if (ts.isStringLiteralLike(node)) return [node.text]
+  if (ts.isArrayLiteralExpression(node)) {
+    const values: string[] = []
+    for (const element of node.elements) {
+      if (!ts.isStringLiteralLike(element)) return null
+      values.push(element.text)
+    }
+    return values
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    for (const property of node.properties) {
+      if (!ts.isPropertyAssignment(property)) continue
+      const name = property.name
+      const propertyName = ts.isIdentifier(name) || ts.isStringLiteralLike(name) ? name.text : null
+      if (propertyName === 'path') return staticStringValues(property.initializer)
+    }
+  }
+  return null
+}
+
+function decoratorName(expression: ts.LeftHandSideExpression): string | null {
+  if (ts.isIdentifier(expression)) return expression.text
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text
+  return null
+}
+
+function decoratorsOf(node: ts.Node): readonly ts.Decorator[] {
+  return ts.canHaveDecorators(node) ? (ts.getDecorators(node) ?? []) : []
+}
+
+function decoratorPaths(node: ts.Node, expectedName: string): string[] | null {
+  for (const decorator of decoratorsOf(node)) {
+    if (!ts.isCallExpression(decorator.expression)) continue
+    if (decoratorName(decorator.expression.expression) !== expectedName) continue
+    return staticStringValues(decorator.expression.arguments[0])
+  }
+  return null
+}
+
+function methodNameOf(member: ts.MethodDeclaration): string | undefined {
+  if (ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name) || ts.isNumericLiteral(member.name)) {
+    return member.name.text
+  }
+  return undefined
+}
+
+function routeRequest(value: string): { method: string; path: string } | null {
+  const match = /^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|ALL)\s+(\/\S*)$/i.exec(value.trim())
+  if (!match?.[1] || !match[2]) return null
+  return { method: match[1].toUpperCase(), path: normalizeRoutePath(match[2]) }
+}
+
+function sortEvidence(items: EvidenceItem[]): EvidenceItem[] {
+  return [...items].sort((left, right) => {
+    const pathOrder = codePointCompare(left.path, right.path)
+    if (pathOrder !== 0) return pathOrder
+    const lineOrder = left.range.start.line - right.range.start.line
+    if (lineOrder !== 0) return lineOrder
+    const columnOrder = left.range.start.column - right.range.start.column
+    if (columnOrder !== 0) return columnOrder
+    const kindOrder = codePointCompare(left.evidence_kind, right.evidence_kind)
+    if (kindOrder !== 0) return kindOrder
+    return codePointCompare(left.name ?? '', right.name ?? '')
+  })
+}
+
+function dedupeEvidence(items: EvidenceItem[]): EvidenceItem[] {
+  const seen = new Set<string>()
+  const result: EvidenceItem[] = []
+  for (const item of sortEvidence(items)) {
+    const key = canonicalJson({
+      path: item.path,
+      range: item.range,
+      evidence_kind: item.evidence_kind,
+      name: item.name ?? null,
+      symbol_kind: item.symbol_kind ?? null,
+      route_method: item.route_method ?? null,
+      route_path: item.route_path ?? null,
+      is_definition: item.is_definition ?? null,
+    })
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(item)
+  }
+  return result
+}
+
+export class EvidenceNavigator {
+  readonly rootDir: string
+  readonly repositoryRevision: string
+  readonly maxSearchResults: number
+  readonly maxScannedFiles: number
+  readonly maxFileBytes: number
+  private projectState: ProjectState | null | undefined
+  private configPathHint: string | null | undefined
+
+  constructor(options: EvidenceNavigatorOptions) {
+    const resolved = resolve(options.rootDir)
+    const stat = statSync(resolved)
+    if (!stat.isDirectory()) throw new Error(`Evidence root is not a directory: ${resolved}`)
+    this.rootDir = realpathSync(resolved)
+    this.repositoryRevision = readGitRevision(this.rootDir)
+    this.maxSearchResults = Math.max(1, Math.min(options.maxSearchResults ?? DEFAULT_MAX_RESULTS, 500))
+    this.maxScannedFiles = Math.max(1, Math.min(options.maxScannedFiles ?? DEFAULT_MAX_SCANNED_FILES, 100_000))
+    this.maxFileBytes = Math.max(1_024, Math.min(options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES, 10_000_000))
+  }
+
+  resolveAnchor(anchor: string, limit = this.maxSearchResults): EvidenceResult {
+    const query = anchor.trim()
+    if (!query) return this.finish('resolve_anchor', 'unresolved', 'madar-exact', query, [], false, 'anchor must not be empty')
+
+    const route = routeRequest(query)
+    if (route) {
+      return this.resolveRoute(query, route, limit)
+    }
+
+    if (looksLikePath(query)) {
+      const pathItem = this.resolvePath(query)
+      return pathItem
+        ? this.finish('resolve_anchor', 'exact_resolved', 'madar-exact', query, [pathItem], false)
+        : this.finish('resolve_anchor', 'unresolved', 'madar-exact', query, [], false, 'exact repository-relative path was not found')
+    }
+
+    if (isIdentifierQuery(query)) {
+      const symbols = this.symbolCandidates(query, limit)
+      if (symbols.state === 'unsupported') {
+        const literal = this.literalItems(query, limit)
+        if (literal.items.length > 0) {
+          return this.finish('resolve_anchor', literal.truncated ? 'truncated' : literal.items.length === 1 ? 'exact_resolved' : 'ambiguous', 'madar-exact', query, literal.items, literal.truncated)
+        }
+        return this.finish('resolve_anchor', 'unsupported', 'typescript-language-service', query, [], false, symbols.detail)
+      }
+      if (symbols.items.length > 0) {
+        const resolution: EvidenceResolution = symbols.truncated
+          ? 'truncated'
+          : symbols.items.length === 1 ? 'exact_resolved' : 'ambiguous'
+        return this.finish('resolve_anchor', resolution, 'typescript-language-service', query, symbols.items, symbols.truncated)
+      }
+    }
+
+    const literal = this.literalItems(query, limit)
+    if (literal.items.length === 0) {
+      return this.finish('resolve_anchor', 'unresolved', 'madar-exact', query, [], false, 'no exact path, route, symbol, or literal occurrence was found')
+    }
+    return this.finish(
+      'resolve_anchor',
+      literal.truncated ? 'truncated' : literal.items.length === 1 ? 'exact_resolved' : 'ambiguous',
+      'madar-exact',
+      query,
+      literal.items,
+      literal.truncated,
+    )
+  }
+
+  searchExact(literal: string, limit = this.maxSearchResults): EvidenceResult {
+    const query = literal
+    if (query.length === 0) return this.finish('search_exact', 'unresolved', 'madar-exact', query, [], false, 'literal must not be empty')
+    const found = this.literalItems(query, limit)
+    if (found.items.length === 0) return this.finish('search_exact', 'unresolved', 'madar-exact', query, [], false, 'exact literal was not found')
+    return this.finish(
+      'search_exact',
+      found.truncated ? 'truncated' : found.items.length === 1 ? 'exact_resolved' : 'ambiguous',
+      'madar-exact',
+      query,
+      found.items,
+      found.truncated,
+    )
+  }
+
+  readEvidence(path: string, startLine = 1, endLine = startLine + 79): EvidenceResult {
+    const query = path.trim()
+    const fileName = safeExistingFile(this.rootDir, query)
+    if (!fileName) return this.finish('read_evidence', 'unresolved', 'madar-exact', query, [], false, 'path must name an existing repository-relative file and may not escape the repository')
+    const relativePath = relativeEvidencePath(this.rootDir, fileName)
+    if (!relativePath) return this.finish('read_evidence', 'unresolved', 'madar-exact', query, [], false, 'resolved path escaped the repository')
+    let text: string
+    try {
+      const stat = statSync(fileName)
+      if (stat.size > this.maxFileBytes) return this.finish('read_evidence', 'unsupported', 'madar-exact', query, [], false, `file exceeds ${this.maxFileBytes} byte prototype read limit`)
+      text = readFileSync(fileName, 'utf8')
+    } catch {
+      return this.finish('read_evidence', 'unresolved', 'madar-exact', query, [], false, 'file could not be read as UTF-8 evidence')
+    }
+    const lines = text.split(/\r?\n/)
+    const boundedStart = Math.max(1, Math.min(Math.trunc(startLine), Math.max(1, lines.length)))
+    const requestedEnd = Math.max(boundedStart, Math.trunc(endLine))
+    const boundedEnd = Math.min(lines.length, Math.min(requestedEnd, boundedStart + MAX_READ_LINES - 1))
+    const preview = lines.slice(boundedStart - 1, boundedEnd).join('\n')
+    const truncated = requestedEnd > boundedEnd
+    const item: EvidenceItem = {
+      path: relativePath,
+      range: {
+        start: { line: boundedStart, column: 1 },
+        end: { line: boundedEnd, column: (lines[boundedEnd - 1]?.length ?? 0) + 1 },
+      },
+      evidence_kind: 'source',
+      preview,
+    }
+    return this.finish('read_evidence', truncated ? 'truncated' : 'exact_resolved', 'madar-exact', query, [item], truncated)
+  }
+
+  definition(request: LocationRequest): EvidenceResult {
+    return this.semanticLocationOperation('definition', request)
+  }
+
+  references(request: LocationRequest): EvidenceResult {
+    return this.semanticLocationOperation('references', request)
+  }
+
+  private semanticLocationOperation(operation: 'definition' | 'references', request: LocationRequest): EvidenceResult {
+    const query = request.anchor?.trim() ?? `${request.path ?? ''}:${request.line ?? ''}:${request.column ?? ''}`
+    const project = this.ensureProject()
+    if (!project) {
+      return this.finish(operation, 'unsupported', 'typescript-language-service', query, [], false, 'no usable tsconfig.json was found for this repository')
+    }
+
+    let location: CandidateLocation | null = null
+    if (request.path) {
+      const fileName = safeExistingFile(this.rootDir, request.path)
+      if (!fileName) return this.finish(operation, 'unresolved', 'typescript-language-service', query, [], false, 'path must name an existing repository-relative file')
+      const source = project.languageService.getProgram()?.getSourceFile(fileName)
+      if (!source) return this.finish(operation, 'unsupported', 'typescript-language-service', query, [], false, 'file is not part of the active TypeScript project')
+      const line = Math.max(1, Math.trunc(request.line ?? 1))
+      const column = Math.max(1, Math.trunc(request.column ?? 1))
+      const lineStarts = source.getLineStarts()
+      if (line > lineStarts.length) return this.finish(operation, 'unresolved', 'typescript-language-service', query, [], false, 'requested line is outside the file')
+      const lineStart = lineStarts[line - 1] ?? 0
+      const lineEnd = line < lineStarts.length ? (lineStarts[line] ?? source.text.length) : source.text.length
+      const position = Math.min(lineEnd, lineStart + column - 1)
+      location = { fileName, start: position, length: 0 }
+    } else if (request.anchor) {
+      const candidates = this.symbolCandidateLocations(request.anchor, request.limit ?? this.maxSearchResults)
+      if (candidates.state === 'unsupported') return this.finish(operation, 'unsupported', 'typescript-language-service', query, [], false, candidates.detail)
+      if (candidates.items.length === 0) return this.finish(operation, 'unresolved', 'typescript-language-service', query, [], false, 'exact symbol was not resolved')
+      if (candidates.items.length > 1 || candidates.truncated) {
+        const evidence = candidates.items.map((candidate) => this.candidateEvidence(candidate, 'symbol')).filter((item): item is EvidenceItem => item !== null)
+        return this.finish(operation, candidates.truncated ? 'truncated' : 'ambiguous', 'typescript-language-service', query, evidence, candidates.truncated, 'select an unambiguous source location before semantic navigation')
+      }
+      location = candidates.items[0] ?? null
+    }
+
+    if (!location) return this.finish(operation, 'unresolved', 'typescript-language-service', query, [], false, 'anchor or source location is required')
+
+    if (operation === 'definition') {
+      const definitions = project.languageService.getDefinitionAtPosition(location.fileName, location.start) ?? []
+      const evidence = dedupeEvidence(definitions.flatMap((definition) => {
+        const item = this.locationEvidence(definition.fileName, definition.textSpan.start, definition.textSpan.length, 'definition', {
+          name: definition.name,
+          symbol_kind: definition.kind,
+          is_definition: true,
+        })
+        return item ? [item] : []
+      }))
+      return evidence.length === 0
+        ? this.finish(operation, 'unresolved', 'typescript-language-service', query, [], false, 'provider returned no definition for the resolved location')
+        : this.finish(operation, evidence.length === 1 ? 'exact_resolved' : 'ambiguous', 'typescript-language-service', query, evidence, false)
+    }
+
+    const referencedSymbols = project.languageService.findReferences(location.fileName, location.start) ?? []
+    const flattened: EvidenceItem[] = []
+    for (const symbol of referencedSymbols) {
+      const definition = symbol.definition
+      const definitionItem = this.locationEvidence(definition.fileName, definition.textSpan.start, definition.textSpan.length, 'definition', {
+        name: definition.name,
+        symbol_kind: definition.kind,
+        is_definition: true,
+      })
+      if (definitionItem) flattened.push(definitionItem)
+      for (const reference of symbol.references) {
+        const item = this.locationEvidence(reference.fileName, reference.textSpan.start, reference.textSpan.length, 'reference', {
+          ...(reference.isDefinition !== undefined ? { is_definition: reference.isDefinition } : {}),
+        })
+        if (item) flattened.push(item)
+      }
+    }
+    const deduped = dedupeEvidence(flattened)
+    const limit = Math.max(1, Math.min(request.limit ?? this.maxSearchResults, this.maxSearchResults))
+    const truncated = deduped.length > limit
+    const evidence = deduped.slice(0, limit)
+    return evidence.length === 0
+      ? this.finish(operation, 'unresolved', 'typescript-language-service', query, [], false, 'provider returned no references for the resolved location')
+      : this.finish(operation, truncated ? 'truncated' : evidence.length === 1 ? 'exact_resolved' : 'ambiguous', 'typescript-language-service', query, evidence, truncated)
+  }
+
+  private resolvePath(query: string): EvidenceItem | null {
+    const fileName = safeExistingFile(this.rootDir, query)
+    if (!fileName) return null
+    const relativePath = relativeEvidencePath(this.rootDir, fileName)
+    if (!relativePath) return null
+    return {
+      path: relativePath,
+      range: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+      evidence_kind: 'path',
+      name: relativePath,
+    }
+  }
+
+  private resolveRoute(query: string, route: { method: string; path: string }, limit: number): EvidenceResult {
+    const project = this.ensureProject()
+    if (!project) return this.finish('resolve_anchor', 'unsupported', 'typescript-language-service', query, [], false, 'route resolution requires a usable TypeScript project')
+    const program = project.languageService.getProgram()
+    if (!program) return this.finish('resolve_anchor', 'unsupported', 'typescript-language-service', query, [], false, 'TypeScript provider did not create a program')
+    const items: EvidenceItem[] = []
+
+    for (const sourceFile of program.getSourceFiles()) {
+      if (sourceFile.isDeclarationFile) continue
+      const relativePath = relativeEvidencePath(this.rootDir, sourceFile.fileName)
+      if (!relativePath) continue
+
+      const visit = (node: ts.Node): void => {
+        if (ts.isClassDeclaration(node)) {
+          const controllerPaths = decoratorPaths(node, 'Controller')
+          if (controllerPaths) {
+            for (const member of node.members) {
+              if (!ts.isMethodDeclaration(member)) continue
+              for (const decorator of decoratorsOf(member)) {
+                if (!ts.isCallExpression(decorator.expression)) continue
+                const routeDecorator = decoratorName(decorator.expression.expression)
+                if (!routeDecorator) continue
+                const method = ROUTE_METHODS.get(routeDecorator)
+                if (!method || method !== route.method) continue
+                const methodPaths = staticStringValues(decorator.expression.arguments[0])
+                if (!methodPaths) continue
+                for (const controllerPath of controllerPaths) {
+                  for (const methodPath of methodPaths) {
+                    const fullPath = normalizeRoutePath(controllerPath, methodPath)
+                    if (fullPath !== route.path) continue
+                    const start = member.name.getStart(sourceFile)
+                    const length = member.name.getWidth(sourceFile)
+                    const memberName = methodNameOf(member)
+                    items.push({
+                      path: relativePath,
+                      range: spanRange(sourceFile, start, length),
+                      evidence_kind: 'route',
+                      ...(memberName ? { name: memberName } : {}),
+                      ...(node.name?.text ? { container_name: node.name.text } : {}),
+                      route_method: method,
+                      route_path: fullPath,
+                      preview: lineTextAt(sourceFile.text, member.getStart(sourceFile)),
+                    })
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+          const method = DIRECT_ROUTE_METHODS.get(node.expression.name.text)
+          if (method === route.method) {
+            const paths = staticStringValues(node.arguments[0])
+            if (paths?.some((candidate) => normalizeRoutePath(candidate) === route.path)) {
+              items.push({
+                path: relativePath,
+                range: spanRange(sourceFile, node.getStart(sourceFile), Math.max(1, node.expression.getWidth(sourceFile))),
+                evidence_kind: 'route',
+                name: node.expression.name.text,
+                route_method: method,
+                route_path: route.path,
+                preview: lineTextAt(sourceFile.text, node.getStart(sourceFile)),
+              })
+            }
+          }
+        }
+
+        ts.forEachChild(node, visit)
+      }
+      visit(sourceFile)
+    }
+
+    const deduped = dedupeEvidence(items)
+    const boundedLimit = Math.max(1, Math.min(limit, this.maxSearchResults))
+    const truncated = deduped.length > boundedLimit
+    const evidence = deduped.slice(0, boundedLimit)
+    if (evidence.length === 0) return this.finish('resolve_anchor', 'unresolved', 'typescript-language-service', query, [], false, `no exact ${route.method} ${route.path} route registration was found`)
+    return this.finish('resolve_anchor', truncated ? 'truncated' : evidence.length === 1 ? 'exact_resolved' : 'ambiguous', 'typescript-language-service', query, evidence, truncated)
+  }
+
+  private symbolCandidates(query: string, limit: number): { state: 'available' | 'unsupported'; items: EvidenceItem[]; truncated: boolean; detail?: string } {
+    const candidates = this.symbolCandidateLocations(query, limit)
+    if (candidates.state === 'unsupported') return { state: 'unsupported', items: [], truncated: false, ...(candidates.detail ? { detail: candidates.detail } : {}) }
+    return {
+      state: 'available',
+      items: candidates.items.map((candidate) => this.candidateEvidence(candidate, 'symbol')).filter((item): item is EvidenceItem => item !== null),
+      truncated: candidates.truncated,
+    }
+  }
+
+  private symbolCandidateLocations(query: string, limit: number): { state: 'available' | 'unsupported'; items: CandidateLocation[]; truncated: boolean; detail?: string } {
+    const project = this.ensureProject()
+    if (!project) return { state: 'unsupported', items: [], truncated: false, detail: 'no usable tsconfig.json was found for this repository' }
+    const pieces = query.split('.')
+    const name = pieces.pop() ?? query
+    const qualifier = pieces.join('.')
+    const qualifierTail = pieces[pieces.length - 1] ?? ''
+    const maxResultCount = Math.max(this.maxSearchResults * 4, Math.min(limit * 4, 2_000))
+    const raw = project.languageService.getNavigateToItems(name, maxResultCount, undefined, true, true)
+    const exact = raw.filter((item) => {
+      if (item.name !== name) return false
+      if (!relativeEvidencePath(this.rootDir, item.fileName)) return false
+      if (!qualifier) return true
+      const container = item.containerName ?? ''
+      return container === qualifier || container === qualifierTail || container.endsWith(`.${qualifier}`)
+    })
+    const deduped = new Map<string, CandidateLocation>()
+    for (const item of exact) {
+      const key = `${item.fileName}\u0000${item.textSpan.start}\u0000${item.textSpan.length}\u0000${item.name}\u0000${item.kind}`
+      if (!deduped.has(key)) {
+        deduped.set(key, {
+          fileName: item.fileName,
+          start: item.textSpan.start,
+          length: item.textSpan.length,
+          name: item.name,
+          kind: item.kind,
+          ...(item.containerName ? { containerName: item.containerName } : {}),
+        })
+      }
+    }
+    const sorted = [...deduped.values()].sort((left, right) => {
+      const leftPath = relativeEvidencePath(this.rootDir, left.fileName) ?? left.fileName
+      const rightPath = relativeEvidencePath(this.rootDir, right.fileName) ?? right.fileName
+      const pathOrder = codePointCompare(leftPath, rightPath)
+      return pathOrder !== 0 ? pathOrder : left.start - right.start
+    })
+    const boundedLimit = Math.max(1, Math.min(limit, this.maxSearchResults))
+    return { state: 'available', items: sorted.slice(0, boundedLimit), truncated: sorted.length > boundedLimit }
+  }
+
+  private candidateEvidence(candidate: CandidateLocation, evidenceKind: EvidenceKind): EvidenceItem | null {
+    return this.locationEvidence(candidate.fileName, candidate.start, candidate.length, evidenceKind, {
+      ...(candidate.name ? { name: candidate.name } : {}),
+      ...(candidate.kind ? { symbol_kind: candidate.kind } : {}),
+      ...(candidate.containerName ? { container_name: candidate.containerName } : {}),
+      is_definition: true,
+    })
+  }
+
+  private locationEvidence(
+    fileName: string,
+    start: number,
+    length: number,
+    evidenceKind: EvidenceKind,
+    extras: Omit<EvidenceItem, 'path' | 'range' | 'evidence_kind'> = {},
+  ): EvidenceItem | null {
+    const relativePath = relativeEvidencePath(this.rootDir, fileName)
+    if (!relativePath) return null
+    let text: string
+    try {
+      text = readFileSync(fileName, 'utf8')
+    } catch {
+      return null
+    }
+    const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, false)
+    return {
+      path: relativePath,
+      range: spanRange(sourceFile, start, length),
+      evidence_kind: evidenceKind,
+      ...extras,
+      preview: lineTextAt(text, start),
+    }
+  }
+
+  private literalItems(literal: string, limit: number): { items: EvidenceItem[]; truncated: boolean } {
+    const files = this.textFiles()
+    const boundedLimit = Math.max(1, Math.min(limit, this.maxSearchResults))
+    const items: EvidenceItem[] = []
+    let truncated = false
+
+    outer: for (const fileName of files) {
+      let text: string
+      try {
+        if (statSync(fileName).size > this.maxFileBytes) continue
+        text = readFileSync(fileName, 'utf8')
+      } catch {
+        continue
+      }
+      let offset = 0
+      while (offset <= text.length) {
+        const index = text.indexOf(literal, offset)
+        if (index < 0) break
+        const relativePath = relativeEvidencePath(this.rootDir, fileName)
+        if (relativePath) {
+          items.push({
+            path: relativePath,
+            range: offsetRange(text, index, literal.length),
+            evidence_kind: 'literal',
+            name: literal,
+            preview: lineTextAt(text, index),
+          })
+          if (items.length > boundedLimit) {
+            truncated = true
+            break outer
+          }
+        }
+        offset = index + Math.max(1, literal.length)
+      }
+    }
+
+    return { items: sortEvidence(items).slice(0, boundedLimit), truncated }
+  }
+
+  private textFiles(): string[] {
+    const files: string[] = []
+    const visit = (directory: string): void => {
+      if (files.length >= this.maxScannedFiles) return
+      let entries
+      try {
+        entries = readdirSync(directory, { withFileTypes: true })
+      } catch {
+        return
+      }
+      entries.sort((left, right) => codePointCompare(left.name, right.name))
+      for (const entry of entries) {
+        if (files.length >= this.maxScannedFiles) return
+        if (entry.isSymbolicLink()) continue
+        const absolutePath = resolve(directory, entry.name)
+        if (entry.isDirectory()) {
+          if (!IGNORED_DIRECTORIES.has(entry.name)) visit(absolutePath)
+          continue
+        }
+        if (!entry.isFile()) continue
+        const extension = extname(entry.name).toLowerCase()
+        if (TEXT_EXTENSIONS.has(extension) || entry.name === 'package.json' || entry.name.startsWith('tsconfig')) files.push(absolutePath)
+      }
+    }
+    visit(this.rootDir)
+    return files
+  }
+
+  private projectConfigRelativePath(): string | null {
+    if (this.projectState) return this.projectState.configRelativePath
+    if (this.configPathHint === undefined) {
+      this.configPathHint = ts.findConfigFile(this.rootDir, ts.sys.fileExists, 'tsconfig.json') ?? null
+    }
+    if (!this.configPathHint) return null
+    return relativeEvidencePath(this.rootDir, this.configPathHint) ?? normalizeSlash(relative(this.rootDir, this.configPathHint))
+  }
+
+  private ensureProject(): ProjectState | null {
+    if (this.projectState !== undefined) return this.projectState
+    const configPath = this.configPathHint === undefined
+      ? (ts.findConfigFile(this.rootDir, ts.sys.fileExists, 'tsconfig.json') ?? null)
+      : this.configPathHint
+    this.configPathHint = configPath
+    if (!configPath) {
+      this.projectState = null
+      return null
+    }
+    const read = ts.readConfigFile(configPath, ts.sys.readFile)
+    if (read.error) {
+      this.projectState = null
+      return null
+    }
+    const parsed = ts.parseJsonConfigFileContent(read.config, ts.sys, dirname(configPath), undefined, configPath)
+    if (parsed.errors.length > 0 && parsed.fileNames.length === 0) {
+      this.projectState = null
+      return null
+    }
+
+    const host: ts.LanguageServiceHost = {
+      getCompilationSettings: () => parsed.options,
+      getScriptFileNames: () => parsed.fileNames,
+      getScriptVersion: () => '0',
+      getScriptSnapshot: (fileName) => {
+        if (!ts.sys.fileExists(fileName)) return undefined
+        const text = ts.sys.readFile(fileName)
+        return text === undefined ? undefined : ts.ScriptSnapshot.fromString(text)
+      },
+      getCurrentDirectory: () => this.rootDir,
+      getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+      fileExists: ts.sys.fileExists,
+      readFile: ts.sys.readFile,
+      readDirectory: ts.sys.readDirectory,
+      directoryExists: ts.sys.directoryExists,
+      getDirectories: ts.sys.getDirectories,
+      ...(ts.sys.realpath ? { realpath: ts.sys.realpath } : {}),
+      useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+      getNewLine: () => ts.sys.newLine,
+      getProjectVersion: () => '0',
+    }
+    const languageService = ts.createLanguageService(host, ts.createDocumentRegistry())
+    const relativeConfig = relativeEvidencePath(this.rootDir, configPath) ?? normalizeSlash(relative(this.rootDir, configPath))
+    this.projectState = { configPath, configRelativePath: relativeConfig, parsed, languageService }
+    return this.projectState
+  }
+
+  private finish(
+    operation: EvidenceResult['operation'],
+    resolution: EvidenceResolution,
+    provider: EvidenceResult['provider'],
+    query: string,
+    evidence: EvidenceItem[],
+    truncated: boolean,
+    detail?: string,
+  ): EvidenceResult {
+    const project = provider === 'typescript-language-service' ? this.ensureProject() : this.projectState ?? null
+    const configPath = project?.configRelativePath ?? this.projectConfigRelativePath()
+    const withoutDigest: Omit<EvidenceResult, 'digest'> = {
+      schema_version: 1,
+      operation,
+      resolution,
+      provider,
+      provider_version: provider === 'typescript-language-service' ? ts.version : '1',
+      repository_revision: this.repositoryRevision,
+      project: {
+        config_path: configPath,
+        provider_capability: project || configPath ? 'available' : 'unsupported',
+      },
+      query,
+      truncated,
+      evidence: dedupeEvidence(evidence),
+      ...(detail ? { detail } : {}),
+    }
+    return { ...withoutDigest, digest: resultDigest(withoutDigest) }
+  }
+}

--- a/src/runtime/evidence-stdio-server.ts
+++ b/src/runtime/evidence-stdio-server.ts
@@ -1,0 +1,256 @@
+import { createInterface } from 'node:readline'
+import type { Readable, Writable } from 'node:stream'
+
+import { EvidenceNavigator, type LocationRequest } from './evidence-navigation.js'
+
+const JSONRPC_PARSE_ERROR = -32700
+const JSONRPC_INVALID_REQUEST = -32600
+const JSONRPC_METHOD_NOT_FOUND = -32601
+const JSONRPC_INVALID_PARAMS = -32602
+const JSONRPC_SERVER_ERROR = -32000
+const MCP_PROTOCOL_VERSION = '2025-11-25'
+const MCP_SERVER_NAME = 'madar-evidence'
+const MCP_SERVER_TITLE = 'Madar Interactive Evidence Prototype'
+const MCP_SERVER_VERSION = '0.1.0-prototype'
+const MAX_INPUT_TEXT = 4_096
+const MAX_LIMIT = 500
+
+interface JsonRpcRequest {
+  jsonrpc?: unknown
+  id?: unknown
+  method?: unknown
+  params?: unknown
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: string | number | null
+  result?: unknown
+  error?: { code: number; message: string }
+}
+
+interface ToolDefinition {
+  name: string
+  description: string
+  inputSchema: {
+    type: 'object'
+    properties: Record<string, unknown>
+    required?: string[]
+  }
+}
+
+export interface EvidenceStdioOptions {
+  rootDir: string
+  input?: Readable
+  output?: Writable
+  errorOutput?: Writable
+}
+
+export const EVIDENCE_MCP_TOOLS: ToolDefinition[] = [
+  {
+    name: 'resolve_anchor',
+    description: 'Resolve an explicit repository path, literal, TypeScript symbol, or static route exactly. Exact evidence is never displaced by fuzzy ranking; ambiguity is returned explicitly.',
+    inputSchema: {
+      type: 'object',
+      required: ['anchor'],
+      properties: {
+        anchor: { type: 'string', description: 'Exact path, literal, symbol, qualified symbol, or METHOD /route anchor.' },
+        limit: { type: 'number', description: 'Maximum candidates to return (default 100, max 500).' },
+      },
+    },
+  },
+  {
+    name: 'search_exact',
+    description: 'Return exact repository text occurrences for one literal. No semantic or graph ranking is applied.',
+    inputSchema: {
+      type: 'object',
+      required: ['literal'],
+      properties: {
+        literal: { type: 'string', description: 'Exact UTF-8 text to find.' },
+        limit: { type: 'number', description: 'Maximum occurrences to return (default 100, max 500).' },
+      },
+    },
+  },
+  {
+    name: 'read_evidence',
+    description: 'Read a bounded line range from one exact repository-relative file. Absolute paths, traversal, and symlink escapes are refused.',
+    inputSchema: {
+      type: 'object',
+      required: ['path'],
+      properties: {
+        path: { type: 'string', description: 'Repository-relative file path.' },
+        start_line: { type: 'number', description: '1-based inclusive start line (default 1).' },
+        end_line: { type: 'number', description: '1-based inclusive end line (default start+79; max 400 returned lines).' },
+      },
+    },
+  },
+  {
+    name: 'definition',
+    description: 'Ask the pinned TypeScript Language Service for the definition of an exact symbol or source location. Unsupported project/provider states are explicit.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        anchor: { type: 'string', description: 'Exact symbol or qualified symbol. Ambiguous symbols must be disambiguated with a source location.' },
+        path: { type: 'string', description: 'Repository-relative source path for location-based navigation.' },
+        line: { type: 'number', description: '1-based line when path is supplied.' },
+        column: { type: 'number', description: '1-based column when path is supplied.' },
+        limit: { type: 'number', description: 'Maximum ambiguous symbol candidates (default 100, max 500).' },
+      },
+    },
+  },
+  {
+    name: 'references',
+    description: 'Ask the pinned TypeScript Language Service for references to an exact symbol or source location. Results are provider references, not a claim of every runtime caller.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        anchor: { type: 'string', description: 'Exact symbol or qualified symbol. Ambiguous symbols must be disambiguated with a source location.' },
+        path: { type: 'string', description: 'Repository-relative source path for location-based navigation.' },
+        line: { type: 'number', description: '1-based line when path is supplied.' },
+        column: { type: 'number', description: '1-based column when path is supplied.' },
+        limit: { type: 'number', description: 'Maximum references to return (default 100, max 500).' },
+      },
+    },
+  },
+]
+
+function requestId(request: JsonRpcRequest): string | number | null {
+  return typeof request.id === 'string' || typeof request.id === 'number' || request.id === null ? request.id : null
+}
+
+function ok(id: string | number | null, result: unknown): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, result }
+}
+
+function failure(id: string | number | null, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, error: { code, message } }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function stringValue(record: Record<string, unknown> | null, key: string): string | null {
+  const value = record?.[key]
+  if (typeof value !== 'string') return null
+  if (value.length === 0 || value.length > MAX_INPUT_TEXT) return null
+  return value
+}
+
+function integerValue(record: Record<string, unknown> | null, key: string, min: number, max: number): number | null {
+  const value = record?.[key]
+  return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max ? value : null
+}
+
+function locationRequest(argumentsRecord: Record<string, unknown> | null): LocationRequest | null {
+  const anchor = stringValue(argumentsRecord, 'anchor')
+  const path = stringValue(argumentsRecord, 'path')
+  if (!anchor && !path) return null
+  const line = integerValue(argumentsRecord, 'line', 1, 10_000_000)
+  const column = integerValue(argumentsRecord, 'column', 1, 10_000_000)
+  const limit = integerValue(argumentsRecord, 'limit', 1, MAX_LIMIT)
+  return {
+    ...(anchor ? { anchor } : {}),
+    ...(path ? { path } : {}),
+    ...(line !== null ? { line } : {}),
+    ...(column !== null ? { column } : {}),
+    ...(limit !== null ? { limit } : {}),
+  }
+}
+
+function toolTextResult(value: unknown): { content: Array<{ type: 'text'; text: string }>; structuredContent: unknown } {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  }
+}
+
+export function handleEvidenceMcpRequest(
+  navigator: EvidenceNavigator,
+  payload: unknown,
+): JsonRpcResponse | null {
+  const request = asRecord(payload) as JsonRpcRequest | null
+  if (!request || typeof request.method !== 'string') {
+    return failure(null, JSONRPC_INVALID_REQUEST, 'Invalid JSON-RPC request')
+  }
+  const id = requestId(request)
+
+  if (request.method === 'notifications/initialized') return null
+  if (request.method === 'ping') return ok(id, {})
+  if (request.method === 'initialize') {
+    return ok(id, {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: { name: MCP_SERVER_NAME, title: MCP_SERVER_TITLE, version: MCP_SERVER_VERSION },
+      instructions: 'Use exact evidence navigation incrementally. Resolve explicit anchors before broader exploration. Ambiguity and unsupported states are valid outcomes; never treat them as evidence absence.',
+    })
+  }
+  if (request.method === 'tools/list') return ok(id, { tools: EVIDENCE_MCP_TOOLS })
+  if (request.method !== 'tools/call') return failure(id, JSONRPC_METHOD_NOT_FOUND, `Method not found: ${request.method}`)
+
+  const params = asRecord(request.params)
+  const name = stringValue(params, 'name')
+  if (!name) return failure(id, JSONRPC_INVALID_PARAMS, 'tools/call requires a valid string name')
+  const argumentsRecord = asRecord(params?.arguments)
+
+  try {
+    switch (name) {
+      case 'resolve_anchor': {
+        const anchor = stringValue(argumentsRecord, 'anchor')
+        if (!anchor) return failure(id, JSONRPC_INVALID_PARAMS, 'resolve_anchor requires a non-empty string anchor')
+        const limit = integerValue(argumentsRecord, 'limit', 1, MAX_LIMIT) ?? undefined
+        return ok(id, toolTextResult(navigator.resolveAnchor(anchor, limit)))
+      }
+      case 'search_exact': {
+        const literal = stringValue(argumentsRecord, 'literal')
+        if (!literal) return failure(id, JSONRPC_INVALID_PARAMS, 'search_exact requires a non-empty string literal')
+        const limit = integerValue(argumentsRecord, 'limit', 1, MAX_LIMIT) ?? undefined
+        return ok(id, toolTextResult(navigator.searchExact(literal, limit)))
+      }
+      case 'read_evidence': {
+        const path = stringValue(argumentsRecord, 'path')
+        if (!path) return failure(id, JSONRPC_INVALID_PARAMS, 'read_evidence requires a repository-relative path')
+        const startLine = integerValue(argumentsRecord, 'start_line', 1, 10_000_000) ?? 1
+        const endLine = integerValue(argumentsRecord, 'end_line', startLine, 10_000_000) ?? startLine + 79
+        return ok(id, toolTextResult(navigator.readEvidence(path, startLine, endLine)))
+      }
+      case 'definition': {
+        const location = locationRequest(argumentsRecord)
+        if (!location) return failure(id, JSONRPC_INVALID_PARAMS, 'definition requires anchor or path; path navigation may include line and column')
+        return ok(id, toolTextResult(navigator.definition(location)))
+      }
+      case 'references': {
+        const location = locationRequest(argumentsRecord)
+        if (!location) return failure(id, JSONRPC_INVALID_PARAMS, 'references requires anchor or path; path navigation may include line and column')
+        return ok(id, toolTextResult(navigator.references(location)))
+      }
+      default:
+        return failure(id, JSONRPC_METHOD_NOT_FOUND, `Unknown evidence tool: ${name}`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Evidence navigation failed'
+    return failure(id, JSONRPC_SERVER_ERROR, message)
+  }
+}
+
+export async function serveEvidenceStdio(options: EvidenceStdioOptions): Promise<void> {
+  const navigator = new EvidenceNavigator({ rootDir: options.rootDir })
+  const input = options.input ?? process.stdin
+  const output = options.output ?? process.stdout
+  const errorOutput = options.errorOutput ?? process.stderr
+  errorOutput.write(`[madar evidence] stdio ready for ${navigator.rootDir}\n`)
+
+  const readline = createInterface({ input, crlfDelay: Infinity })
+  for await (const line of readline) {
+    if (line.trim().length === 0) continue
+    let payload: unknown
+    try {
+      payload = JSON.parse(line)
+    } catch {
+      output.write(`${JSON.stringify(failure(null, JSONRPC_PARSE_ERROR, 'Parse error'))}\n`)
+      continue
+    }
+    const response = handleEvidenceMcpRequest(navigator, payload)
+    if (response) output.write(`${JSON.stringify(response)}\n`)
+  }
+}

--- a/tests/unit/evidence-navigation.test.ts
+++ b/tests/unit/evidence-navigation.test.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { EvidenceNavigator } from '../../src/runtime/evidence-navigation.js'
+import { EVIDENCE_MCP_TOOLS, handleEvidenceMcpRequest } from '../../src/runtime/evidence-stdio-server.js'
+
+const roots: string[] = []
+
+function fixtureRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'madar-evidence-'))
+  roots.push(root)
+  mkdirSync(join(root, 'src'), { recursive: true })
+  mkdirSync(join(root, '.git', 'refs', 'heads'), { recursive: true })
+  writeFileSync(join(root, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+  writeFileSync(join(root, '.git', 'refs', 'heads', 'main'), '0123456789012345678901234567890123456789\n')
+  writeFileSync(join(root, 'tsconfig.json'), JSON.stringify({
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'NodeNext',
+      moduleResolution: 'NodeNext',
+      experimentalDecorators: true,
+    },
+    include: ['src/**/*.ts'],
+  }))
+  writeFileSync(join(root, 'src', 'decorators.ts'), [
+    "export const Controller = (..._args: unknown[]) => (_target: unknown) => {}",
+    "export const Get = (..._args: unknown[]) => (_target: unknown, _key: string, _desc: PropertyDescriptor) => {}",
+  ].join('\n'))
+  writeFileSync(join(root, 'src', 'users.controller.ts'), [
+    "import { Controller, Get } from './decorators.js'",
+    "@Controller('users')",
+    'export class UsersController {',
+    "  @Get('me')",
+    '  currentUser() { return refundCredit(1) }',
+    '}',
+    'export function refundCredit(value: number) { return value + 1 }',
+  ].join('\n'))
+  writeFileSync(join(root, 'src', 'queue.ts'), "export const QUEUE = 'section-research-queue'\n")
+  writeFileSync(join(root, 'src', 'other.ts'), [
+    "import { refundCredit } from './users.controller.js'",
+    'export const doubled = refundCredit(2)',
+  ].join('\n'))
+  return root
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    const root = roots.pop()
+    if (root) rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('interactive evidence navigation prototype', () => {
+  it('resolves Nest-style static route anchors exactly without global ranking', () => {
+    const navigator = new EvidenceNavigator({ rootDir: fixtureRoot() })
+    const result = navigator.resolveAnchor('GET /users/me')
+
+    expect(result.resolution).toBe('exact_resolved')
+    expect(result.evidence).toHaveLength(1)
+    expect(result.evidence[0]).toMatchObject({
+      path: 'src/users.controller.ts',
+      evidence_kind: 'route',
+      name: 'currentUser',
+      container_name: 'UsersController',
+      route_method: 'GET',
+      route_path: '/users/me',
+    })
+  })
+
+  it('resolves exact queue literals even when they are not TypeScript symbols', () => {
+    const navigator = new EvidenceNavigator({ rootDir: fixtureRoot() })
+    const result = navigator.resolveAnchor('section-research-queue')
+
+    expect(result.resolution).toBe('exact_resolved')
+    expect(result.evidence[0]).toMatchObject({
+      path: 'src/queue.ts',
+      evidence_kind: 'literal',
+      name: 'section-research-queue',
+    })
+  })
+
+  it('resolves exact TypeScript symbols and returns provider references', () => {
+    const navigator = new EvidenceNavigator({ rootDir: fixtureRoot() })
+    const anchor = navigator.resolveAnchor('refundCredit')
+    const references = navigator.references({ anchor: 'refundCredit' })
+
+    expect(anchor.resolution).toBe('exact_resolved')
+    expect(anchor.evidence[0]).toMatchObject({
+      path: 'src/users.controller.ts',
+      evidence_kind: 'symbol',
+      name: 'refundCredit',
+    })
+    expect(references.evidence.some((entry) => entry.path === 'src/other.ts' && entry.evidence_kind === 'reference')).toBe(true)
+    expect(references.evidence.some((entry) => entry.path === 'src/users.controller.ts' && entry.evidence_kind === 'definition')).toBe(true)
+  })
+
+  it('reports symbol ambiguity instead of selecting a rank winner', () => {
+    const root = fixtureRoot()
+    writeFileSync(join(root, 'src', 'duplicate.ts'), 'export function refundCredit(value: string) { return value }\n')
+    const navigator = new EvidenceNavigator({ rootDir: root })
+    const result = navigator.resolveAnchor('refundCredit')
+
+    expect(result.resolution).toBe('ambiguous')
+    expect(result.evidence.map((entry) => entry.path)).toEqual([
+      'src/duplicate.ts',
+      'src/users.controller.ts',
+    ])
+  })
+
+  it('refuses traversal and never exposes an outside file as evidence', () => {
+    const navigator = new EvidenceNavigator({ rootDir: fixtureRoot() })
+    const result = navigator.readEvidence('../outside.txt')
+
+    expect(result.resolution).toBe('unresolved')
+    expect(result.evidence).toEqual([])
+  })
+
+  it('produces stable canonical digests for repeated fixed-input queries', () => {
+    const root = fixtureRoot()
+    const first = new EvidenceNavigator({ rootDir: root }).resolveAnchor('GET /users/me')
+    const second = new EvidenceNavigator({ rootDir: root }).resolveAnchor('GET /users/me')
+
+    expect(first.digest).toBe(second.digest)
+    expect(first.repository_revision).toBe('0123456789012345678901234567890123456789')
+    expect(first.project.config_path).toBe('tsconfig.json')
+  })
+
+  it('exposes only the five prototype tools through the isolated MCP surface', () => {
+    expect(EVIDENCE_MCP_TOOLS.map((tool) => tool.name)).toEqual([
+      'resolve_anchor',
+      'search_exact',
+      'read_evidence',
+      'definition',
+      'references',
+    ])
+
+    const navigator = new EvidenceNavigator({ rootDir: fixtureRoot() })
+    const response = handleEvidenceMcpRequest(navigator, {
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'tools/call',
+      params: { name: 'resolve_anchor', arguments: { anchor: 'section-research-queue' } },
+    })
+
+    expect(response).toMatchObject({ jsonrpc: '2.0', id: 7 })
+    const result = response?.result as { structuredContent?: { resolution?: string } } | undefined
+    expect(result?.structuredContent?.resolution).toBe('exact_resolved')
+  })
+})


### PR DESCRIPTION
Implements the first bounded candidate for #736 under the accepted architecture decision #735.

## Scope

This PR deliberately does **not** modify the existing graph retrieval or Context Pack pipeline. It adds an isolated read-only MCP prototype with exactly five operations:

- `resolve_anchor`
- `search_exact`
- `read_evidence`
- `definition`
- `references`

Primary semantic provider: TypeScript Language Service. Exact path/literal/static-route resolution is separate from semantic symbol navigation. There is no fuzzy ranking, task-level answerability, Context Pack generation, or graph expansion in this candidate.

## Product contract

- Exact evidence cannot be displaced by ranking.
- `GET /users/me`-style static Nest routes are resolved from `@Controller` + method decorator composition.
- Exact literals such as queue names return literal source occurrences.
- Exact TypeScript symbols return deterministic candidates; ambiguity is surfaced rather than hidden by a rank winner.
- Definitions/references are explicitly provider results, not claims of complete runtime call graphs.
- Absolute paths, traversal and symlink escapes are refused by source-reading operations.
- Results carry repository revision, provider/version, tsconfig identity, source ranges, explicit truncation/state and a canonical digest.

## Execution

After build:

```bash
node dist/src/cli/evidence-bin.js --root /path/to/repository
```

This starts a standalone stdio MCP server exposing only the five prototype tools. Existing Madar MCP profiles remain untouched.

## Qualification state

The #736 holdouts were frozen and hashed before these source changes; see the `HOLDOUT-FREEZE-736` issue comment.

Synthetic focused controls locally exercised the three anchor classes corresponding to the old failures:

- static Nest route (`GET /users/me` shape)
- exact queue literal (`section-research-queue` shape)
- exact TypeScript symbol (`refundCredit` shape)

**This is not the early product gate.** The real GoValidate 3/3 anchor gate remains mandatory and must run against the pinned repository revision before graph work or full six-task evaluation. If any of the three real anchors remains unresolved, #736 requires a kill verdict rather than task-specific tuning.

## Explicit non-scope

No graph redesign, embeddings, reranking, Context Pack redesign, answerability v2, generic LSP framework, SCIP, tree-sitter fallback, release work, monorepo work, or language expansion.

Draft until CI and the early real-repository gate are complete.

Refs #735
Refs #736