### PR TITLE
fix(deps): update fast-uri to 3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -728,9 +728,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

The inherited `fast-uri 3.1.5` development dependency makes the Ubuntu/Node 22 security audit fail on `next`, blocking PRs #742 and #747. Update its locked version to `3.1.6`, the patched 3.x release for all four recorded advisories.

Only the `version`, `resolved`, and `integrity` values in the single `node_modules/fast-uri` lock entry change. Byte comparison confirms every other byte is preserved, including Ajv ranges, `dev: true`, license and funding.

## Testing

- Clean install completed on Node 22.22.3; both Ajv dependency paths resolve `fast-uri 3.1.6`.
- `npm audit --audit-level=high`: zero vulnerabilities.
- Qualification validator: all 21 frozen files intact.
- Focused existing qualification-contract and MCP registry tests: 55 passed across both files.
- `git diff --check` and clean candidate verification passed on `0c7c100630e962c25e687badd49197c3322d897b`.
- Fresh independent FINAL review: `GO-748` on the exact candidate; packet-only review with no tool calls. PREQUAL used a separate fresh reviewer.
- Local launch timeouts and process samples are retained with the execution evidence; no product changes or audit suppression were used to address them.

[CI run 34081270107](https://github.com/mohanagy/madar/actions/runs/34081270107) passed all six OS/Node lanes on attempt 1 at `0c7c100630e962c25e687badd49197c3322d897b`. Ubuntu/Node 22 passed the security audit, demo generation and enforced eval thresholds. GitHub test-merge tree equals the reviewed candidate tree. CodeRabbit reviewed this head and reported no actionable findings.

The demo report-only grounded-match value is 116.7%; it is outside the enforced thresholds and is not used as evidence of answer quality. This dependency repair makes no real-repository quality claim.

- [x] `npm run test:run` — full CI matrix
- [x] `npm run typecheck` — CI
- [x] `npm run build` — CI
- [x] `npm pack --dry-run` — Ubuntu/Node 20 CI

## Checklist

- [x] Docs assessed: no user-visible interface change
- [x] Tests assessed: existing Ajv consumer validation is used; no literal dependency-version test added
- [x] This PR does not include private corpora, secrets, credentials, proprietary prompts, sensitive raw logs, or accidental generated artifacts
- [x] I kept this PR focused on a single change or tightly related set of changes

## Related issues

Refs #748. Integration of PRs #742 and #747 remains blocked until this repair is merged and verified afterward. #740 remains open.
