### PR TITLE
fix(retrieve): expand authenticated owners within available budgets

### DIFF
--- a/scripts/lib/semantic-independence-selftest.mjs
+++ b/scripts/lib/semantic-independence-selftest.mjs
@@ -99,13 +99,16 @@ const MEMBERSHIP_ANCHOR = `  const matchedNodes = packedNodes.map((node) => {
     if (!state) {
       return node
     }
+    if (state.allocationOnly) {
+      return attachCompleteOwnerState(node, state)
+    }
     return attachCompleteOwnerState({
       ...node,
       snippet: state.fullSnippet,
       snippet_line_number: state.fullLineNumber,
       snippet_scope: 'symbol' as const,
       representation_type: 'detail' as const,
-      representation_reason: COMPLETE_OWNER_REPRESENTATION_REASON,
+      representation_reason: state.representationReason,
     }, state)
   })
 `

--- a/src/runtime/query-evidence-dependencies.ts
+++ b/src/runtime/query-evidence-dependencies.ts
@@ -449,11 +449,12 @@ function numberPhysicalSourceRows(sourceText: string, startLine: number): {
 }
 
 /**
- * Authenticates and serializes a complete, exact, small JS/TS function or
- * method owner from the source snapshot already retained by retrieval.
+ * Authenticates and serializes a complete, exact JS/TS function or method
+ * owner from the source snapshot already retained by retrieval.
  */
-export function completeSmallOwnerSourceEvidence(
+function authenticatedCompleteOwnerSourceEvidence(
   input: CompleteSmallOwnerSourceInput,
+  limits?: { maxLines: number; maxCharacters: number },
 ): CompleteSmallOwnerSourceEvidence | null {
   try {
     if (
@@ -462,7 +463,7 @@ export function completeSmallOwnerSourceEvidence(
       || !Number.isInteger(input.ownerRange.end)
       || input.ownerRange.start < 1
       || input.ownerRange.end < input.ownerRange.start
-      || input.ownerRange.end - input.ownerRange.start + 1 > COMPLETE_SMALL_OWNER_MAX_LINES
+      || (limits && input.ownerRange.end - input.ownerRange.start + 1 > limits.maxLines)
     ) {
       return null
     }
@@ -505,7 +506,7 @@ export function completeSmallOwnerSourceEvidence(
       !source
       || source.startLine !== input.ownerRange.start
       || source.endLine !== input.ownerRange.end
-      || source.text.length > COMPLETE_SMALL_OWNER_MAX_CHARACTERS
+      || (limits && source.text.length > limits.maxCharacters)
     ) {
       return null
     }
@@ -520,6 +521,23 @@ export function completeSmallOwnerSourceEvidence(
   } catch {
     return null
   }
+}
+
+/** Authenticates and serializes an exact owner for budget-aware allocation. */
+export function completeOwnerSourceEvidence(
+  input: CompleteSmallOwnerSourceInput,
+): CompleteSmallOwnerSourceEvidence | null {
+  return authenticatedCompleteOwnerSourceEvidence(input)
+}
+
+/** Preserves the established bounded small-owner representation contract. */
+export function completeSmallOwnerSourceEvidence(
+  input: CompleteSmallOwnerSourceInput,
+): CompleteSmallOwnerSourceEvidence | null {
+  return authenticatedCompleteOwnerSourceEvidence(input, {
+    maxLines: COMPLETE_SMALL_OWNER_MAX_LINES,
+    maxCharacters: COMPLETE_SMALL_OWNER_MAX_CHARACTERS,
+  })
 }
 
 function normalizedSource(value: string): string {

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -87,6 +87,7 @@ import {
 } from './retrieve/pipeline.js'
 import { communitiesFromGraph, estimateQueryTokens } from './serve.js'
 import {
+  completeOwnerSourceEvidence,
   completeSmallOwnerSourceEvidence,
   completeQueryEvidenceLiteralStatement,
   ownerLocalDeclarationEvidence,
@@ -540,10 +541,16 @@ function truncateSnippetToTokenBudget(
   }
 }
 
-function applyRetrieveSnippetBudgetToNodes<TNode extends { snippet?: string | null }>(
+function applyRetrieveSnippetBudgetToNodes<TNode extends {
+  label: string
+  source_file: string
+  line_number: number
+  snippet?: string | null
+}>(
   nodes: readonly TNode[],
   options: RetrieveSnippetOptions = {},
   eligibleNodeIndexes?: ReadonlySet<number>,
+  maximumMatchedNodeTokens = Number.POSITIVE_INFINITY,
 ): {
   nodes: Array<TNode & { snippet: string | null; snippet_truncated: boolean }>
   usedTokens: number
@@ -580,7 +587,7 @@ function applyRetrieveSnippetBudgetToNodes<TNode extends { snippet?: string | nu
     }
 
     const remainingSnippetBudget = Math.max(0, snippetBudget - usedTokens)
-    if (completeOwner) {
+    if (completeOwner && !completeOwner.allocationOnly) {
       const fullTokens = snippetTokenCount(completeOwner.fullSnippet)
       if (fullTokens <= remainingSnippetBudget) {
         usedTokens += fullTokens
@@ -590,7 +597,8 @@ function applyRetrieveSnippetBudgetToNodes<TNode extends { snippet?: string | nu
           snippet_line_number: completeOwner.fullLineNumber,
           snippet_scope: 'symbol' as const,
           snippet_truncated: priorTruncation,
-          representation_reason: COMPLETE_OWNER_REPRESENTATION_REASON,
+          representation_type: 'detail' as const,
+          representation_reason: completeOwner.representationReason,
         }, completeOwner)
       }
 
@@ -623,17 +631,70 @@ function applyRetrieveSnippetBudgetToNodes<TNode extends { snippet?: string | nu
         ? withoutCompleteOwnerRepresentationClaim(node)
         : node),
       snippet: boundedSnippet.snippet,
-      snippet_truncated: priorTruncation || shapedSnippet.truncated || boundedSnippet.truncated,
+      snippet_truncated: priorTruncation
+        || shapedSnippet.truncated
+        || boundedSnippet.truncated
+        || completeOwner?.allocationOnly === true,
     }, completeOwner)
   })
 
-  const serializedSnippetTokensUsed = shapedNodes.reduce(
+  let serializedSnippetTokensUsed = shapedNodes.reduce(
     (total, node) => total + snippetTokenCount(node.snippet),
     0,
   )
+  let serializedMatchedNodeTokensUsed = tokenCountForMatchedNodes(shapedNodes)
+  const promotedNodes = shapedNodes.map((node, index) => {
+    const completeOwner = completeOwnerMatchedNodes.get(node)
+    if (!completeOwner?.allocationOnly) {
+      return node
+    }
+    const snippetEligible = eligibleNodeIndexes === undefined
+      ? index < topNWithSnippet
+      : eligibleNodeIndexes.has(index)
+    if (!snippetEligible) {
+      return node
+    }
+
+    const currentSnippetTokens = snippetTokenCount(node.snippet)
+    const fullSnippetTokens = snippetTokenCount(completeOwner.fullSnippet)
+    const nextSnippetTokens = serializedSnippetTokensUsed - currentSnippetTokens + fullSnippetTokens
+    const currentEntryTokens = estimateRetrieveEntryTokens(
+      node.label,
+      node.source_file,
+      node.line_number,
+      node.snippet ?? null,
+    )
+    const fullEntryTokens = estimateRetrieveEntryTokens(
+      node.label,
+      node.source_file,
+      node.line_number,
+      completeOwner.fullSnippet,
+    )
+    const nextMatchedNodeTokens = serializedMatchedNodeTokensUsed - currentEntryTokens + fullEntryTokens
+    if (
+      nextSnippetTokens > snippetBudget
+      || nextMatchedNodeTokens > maximumMatchedNodeTokens
+    ) {
+      return node
+    }
+
+    serializedSnippetTokensUsed = nextSnippetTokens
+    serializedMatchedNodeTokensUsed = nextMatchedNodeTokens
+    const priorTruncation = 'snippet_truncated' in nodes[index]!
+      && (nodes[index] as { snippet_truncated?: boolean }).snippet_truncated === true
+    return attachCompleteOwnerState({
+      ...node,
+      snippet: completeOwner.fullSnippet,
+      snippet_line_number: completeOwner.fullLineNumber,
+      snippet_scope: 'symbol' as const,
+      snippet_truncated: priorTruncation,
+      representation_type: 'detail' as const,
+      representation_reason: completeOwner.representationReason,
+    }, completeOwner)
+  })
 
   return {
-    nodes: shapedNodes,
+    nodes: promotedNodes,
     usedTokens: serializedSnippetTokensUsed,
     remainingTokens: Math.max(0, snippetBudget - serializedSnippetTokensUsed),
   }
@@ -715,8 +776,16 @@ export function withRetrieveSnippetBudget(
   result: RetrieveResult,
   options: RetrieveSnippetOptions = {},
 ): RetrieveResult {
-  const shapedNodes = applyRetrieveSnippetBudgetToNodes(result.matched_nodes, options)
   const baseNodeTokenCount = tokenCountForMatchedNodes(result.matched_nodes)
+  const maximumMatchedNodeTokens = result.task_contract
+    ? baseNodeTokenCount + Math.max(0, result.task_contract.budget - result.token_count)
+    : Number.POSITIVE_INFINITY
+  const shapedNodes = applyRetrieveSnippetBudgetToNodes(
+    result.matched_nodes,
+    options,
+    undefined,
+    maximumMatchedNodeTokens,
+  )
   const shapedNodeTokenCount = tokenCountForMatchedNodes(shapedNodes.nodes)
   const retrievalPlan = reconcileRetrievalPlanQueryEvidence(
     result.retrieval_plan,
@@ -792,6 +861,7 @@ interface QueryEvidenceSnippetOptions {
   nodeKind?: string
   externalCall?: boolean
   authenticatedOwner?: boolean
+  maximumCompleteOwnerTokens?: number
   sourceLocation?: string | null
   fileNodeLike?: boolean
   derived?: boolean
@@ -804,11 +874,14 @@ interface CompleteOwnerSnippetState {
   fallbackSnippet: string
   fallbackLineNumber: number
   fallbackScope: QueryEvidenceSnippet['scope']
+  representationReason: string
+  allocationOnly: boolean
 }
 
 const completeOwnerQuerySnippets = new WeakMap<QueryEvidenceSnippet, CompleteOwnerSnippetState>()
 const completeOwnerMatchedNodes = new WeakMap<object, CompleteOwnerSnippetState>()
 const COMPLETE_OWNER_REPRESENTATION_REASON = 'complete small owner source'
+const ALLOCATED_COMPLETE_OWNER_REPRESENTATION_REASON = 'complete owner source within snippet allocation'
 
 function attachCompleteOwnerState<T extends object>(
   target: T,
@@ -826,7 +899,10 @@ function copyCompleteOwnerState<T extends object>(source: object, target: T): T 
 
 function withoutCompleteOwnerRepresentationClaim<T extends object>(source: T): T {
   const output = { ...source } as T & { representation_reason?: string }
-  if (output.representation_reason === COMPLETE_OWNER_REPRESENTATION_REASON) {
+  if (
+    output.representation_reason === COMPLETE_OWNER_REPRESENTATION_REASON
+    || output.representation_reason === ALLOCATED_COMPLETE_OWNER_REPRESENTATION_REASON
+  ) {
     delete output.representation_reason
   }
   return output
@@ -1894,7 +1970,7 @@ export function readQueryEvidenceSnippet(
       lineNumber: completed?.lineNumber ?? baseline[0]!.source.index,
       scope,
     }
-    const completeOwner = ownerRange && options.authenticatedOwner === true
+    const completeSmallOwner = ownerRange && options.authenticatedOwner === true
       ? completeSmallOwnerSourceEvidence({
           sourceFilePath: sourceFile,
           sourceLines: lines,
@@ -1904,11 +1980,29 @@ export function readQueryEvidenceSnippet(
           ...(options.externalCall !== undefined ? { externalCall: options.externalCall } : {}),
         })
       : null
+    const completeOwner = completeSmallOwner ?? (ownerRange && options.authenticatedOwner === true
+      ? completeOwnerSourceEvidence({
+          sourceFilePath: sourceFile,
+          sourceLines: lines,
+          ownerRange,
+          label: options.label,
+          ...(options.nodeKind ? { nodeKind: options.nodeKind } : {}),
+          ...(options.externalCall !== undefined ? { externalCall: options.externalCall } : {}),
+        })
+      : null)
     if (!completeOwner) {
       return fallback
     }
 
-    const result: QueryEvidenceSnippet = {
+    const allocationOnly = completeSmallOwner === null
+    if (
+      allocationOnly
+      && options.maximumCompleteOwnerTokens !== undefined
+      && snippetTokenCount(completeOwner.snippet) > options.maximumCompleteOwnerTokens
+    ) {
+      return fallback
+    }
+    const result: QueryEvidenceSnippet = allocationOnly ? fallback : {
       snippet: completeOwner.snippet,
       lineNumber: completeOwner.lineNumber,
       scope: 'symbol',
@@ -1919,6 +2013,10 @@ export function readQueryEvidenceSnippet(
       fallbackSnippet: fallback.snippet,
       fallbackLineNumber: fallback.lineNumber,
       fallbackScope: fallback.scope,
+      representationReason: allocationOnly
+        ? ALLOCATED_COMPLETE_OWNER_REPRESENTATION_REASON
+        : COMPLETE_OWNER_REPRESENTATION_REASON,
+      allocationOnly,
     })
     return result
   } catch {
@@ -5379,6 +5477,7 @@ function buildRetrieveResultFromOrderedCandidates(
         nodeKind: node.nodeKind,
         externalCall: node.externalCall,
         authenticatedOwner: true,
+        maximumCompleteOwnerTokens: taskContract.budget,
         sourceLocation: node.sourceLocation,
         fileNodeLike: node.fileNodeLike,
         derived: node.lineNumberDerived && lineRangeFromSourceLocation(node.sourceLocation) === null,
@@ -5489,13 +5588,16 @@ function buildRetrieveResultFromOrderedCandidates(
     if (!state) {
       return node
     }
+    if (state.allocationOnly) {
+      return attachCompleteOwnerState(node, state)
+    }
     return attachCompleteOwnerState({
       ...node,
       snippet: state.fullSnippet,
       snippet_line_number: state.fullLineNumber,
       snippet_scope: 'symbol' as const,
       representation_type: 'detail' as const,
-      representation_reason: COMPLETE_OWNER_REPRESENTATION_REASON,
+      representation_reason: state.representationReason,
     }, state)
   })
   const packedNodeTokens = tokenCountForMatchedNodes(packedNodes)
@@ -6716,14 +6818,17 @@ export function compactRetrieveResult(result: RetrieveResult, options: RetrieveS
         compactPack.relationships,
       )
     : undefined
+  const compactPackNodeTokenCount = compactPack.nodes.reduce(
+    (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet ?? null),
+    0,
+  )
+  const maximumMatchedNodeTokens = compactPackNodeTokenCount
+    + Math.max(0, compactPack.task_contract.budget - compactPack.token_count)
   const shapedNodes = applyRetrieveSnippetBudgetToNodes(
     compactPack.nodes,
     options,
     preferredSnippetNodeIndexes,
-  )
-  const compactPackNodeTokenCount = compactPack.nodes.reduce(
-    (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet ?? null),
-    0,
+    maximumMatchedNodeTokens,
   )
   const shapedNodeTokenCount = shapedNodes.nodes.reduce(
     (total, node) => total + estimateRetrieveEntryTokens(node.label, node.source_file, node.line_number, node.snippet ?? null),

--- a/src/runtime/retrieve.ts
+++ b/src/runtime/retrieve.ts
@@ -567,7 +567,7 @@ function applyRetrieveSnippetBudgetToNodes<TNode extends {
       ? node.snippet
       : null
 
-    if (originalSnippet === null && !completeOwner) {
+    if (originalSnippet === null && (!completeOwner || completeOwner.allocationOnly)) {
       return attachCompleteOwnerState({
         ...withoutCompleteOwnerRepresentationClaim(node),
         snippet: null,
@@ -6798,14 +6798,20 @@ export function compactRetrieveResult(result: RetrieveResult, options: RetrieveS
         ...(Number.isFinite(compactFrameworkLimit) ? { max_nodes: compactFrameworkLimit } : {}),
       })
   for (const compactNode of compactPack.nodes) {
-    if (typeof compactNode.snippet !== 'string' || compactNode.snippet.length === 0) {
-      continue
-    }
     const sourceNode = fullPack.nodes.find((node) => (
       typeof compactNode.node_id === 'string'
       && compactNode.node_id === node.node_id
     ))
-    if (sourceNode) {
+    const sourceState = sourceNode
+      ? completeOwnerMatchedNodes.get(sourceNode)
+      : undefined
+    if (
+      sourceNode
+      && (
+        (typeof compactNode.snippet === 'string' && compactNode.snippet.length > 0)
+        || sourceState?.allocationOnly === true
+      )
+    ) {
       copyCompleteOwnerState(sourceNode, compactNode)
     }
   }

--- a/tests/unit/retrieve-small-owner-representation.test.ts
+++ b/tests/unit/retrieve-small-owner-representation.test.ts
@@ -465,6 +465,9 @@ describe('complete small-owner source representation', () => {
     ].join('\n')
     const source = `${ownerSource}\nexport function adaptiveOwnerLexicalDecoy() { return 'adaptive-owner-start adaptive-owner-finish'; }\n`
     const fixture = generatedFixture(source)
+    const ownerSourceLocation = fixture.graph.nodeEntries()
+      .find(([, attributes]) => attributes.label === 'adaptiveOwner()')?.[1].source_location
+    expect(ownerSourceLocation).toBe('L1-L26')
     const retrieved = retrieveContext(fixture.graph, {
       question: 'Show adaptiveOwner start and finish checkpoints with the intervening persistence control flow',
       budget: 4_000,
@@ -519,35 +522,92 @@ describe('complete small-owner source representation', () => {
     expect(insufficientOwner.representation_reason).not.toBe('complete owner source within snippet allocation')
     expect(insufficient.snippet_budget_tokens_used).toBeLessThanOrEqual(allocationBudget - 1)
 
-    retrieved.task_contract = {
+    const totalConstrained = {
+      ...retrieved,
+      task_contract: {
       ...retrieved.task_contract!,
       budget: retrieved.token_count,
+      },
     }
-    const noTotalHeadroom = withRetrieveSnippetBudget(retrieved, {
+    const noTotalHeadroom = withRetrieveSnippetBudget(totalConstrained, {
       snippetBudget: allocationBudget,
       topNWithSnippet: retrieved.matched_nodes.length,
     })
     expect(matchedByLabel(noTotalHeadroom, 'adaptiveOwner()').snippet).not.toBe(expected)
-    expect(noTotalHeadroom.token_count).toBeLessThanOrEqual(retrieved.task_contract.budget)
+    expect(noTotalHeadroom.token_count).toBeLessThanOrEqual(totalConstrained.task_contract.budget)
 
-    const externalFallback = readQueryEvidenceSnippet(fixture.sourceFile, 1, {
+    const directOwnerSource = ownerSource.replace('    attempt += 1;\n', '')
+    const directFixture = generatedFixture(`${directOwnerSource}\n`)
+    const directExpected = numberedLines(directOwnerSource)
+    const directOwnerSourceLocation = directFixture.graph.nodeEntries()
+      .find(([, attributes]) => attributes.label === 'adaptiveOwner()')?.[1].source_location
+    expect(directOwnerSourceLocation).toBe('L1-L25')
+
+    const authenticatedComplete = readQueryEvidenceSnippet(directFixture.sourceFile, 1, {
+      question: 'Show adaptiveOwner start and finish checkpoints',
+      label: 'adaptiveOwner()',
+      nodeKind: 'function',
+      authenticatedOwner: true,
+      sourceLocation: String(directOwnerSourceLocation),
+    })
+    expect(authenticatedComplete?.snippet).toBe(directExpected)
+
+    const externalFallback = readQueryEvidenceSnippet(directFixture.sourceFile, 1, {
       question: 'Show adaptiveOwner start and finish checkpoints',
       label: 'adaptiveOwner()',
       nodeKind: 'function',
       externalCall: true,
       authenticatedOwner: true,
-      sourceLocation: '1-26',
+      sourceLocation: String(directOwnerSourceLocation),
     })
-    expect(externalFallback?.snippet).not.toBe(expected)
+    expect(externalFallback?.snippet).not.toBe(directExpected)
+    expect(externalFallback?.snippet).toContain('adaptive-owner-start')
+    expect(externalFallback?.snippet).toContain('adaptive-owner-finish')
 
-    const unauthenticatedFallback = readQueryEvidenceSnippet(fixture.sourceFile, 1, {
+    const unauthenticatedFallback = readQueryEvidenceSnippet(directFixture.sourceFile, 1, {
       question: 'Show adaptiveOwner start and finish checkpoints',
       label: 'adaptiveOwner()',
       nodeKind: 'function',
       authenticatedOwner: false,
-      sourceLocation: '1-26',
+      sourceLocation: String(directOwnerSourceLocation),
     })
-    expect(unauthenticatedFallback?.snippet).not.toBe(expected)
+    expect(unauthenticatedFallback?.snippet).not.toBe(directExpected)
+    expect(unauthenticatedFallback?.snippet).toContain('adaptive-owner-start')
+    expect(unauthenticatedFallback?.snippet).toContain('adaptive-owner-finish')
+
+    const omitted = withRetrieveSnippetBudget(retrieved, {
+      snippetBudget: allocationBudget,
+      topNWithSnippet: 0,
+    })
+    const omittedOwner = matchedByLabel(omitted, 'adaptiveOwner()')
+    expect(omittedOwner.snippet).toBeNull()
+    expect(omittedOwner.snippet_truncated).toBe(true)
+    expect(omittedOwner.representation_reason).not.toBe('complete owner source within snippet allocation')
+    expect(omitted.matched_nodes.map((node) => node.node_id)).toEqual(
+      retrieved.matched_nodes.map((node) => node.node_id),
+    )
+
+    const projectedOmitted = contextPackFromRetrieveResult(omitted)
+    expect(projectedOmitted.nodes.find((node) => node.label === 'adaptiveOwner()')?.snippet).toBeNull()
+
+    const restored = withRetrieveSnippetBudget(omitted, {
+      snippetBudget: allocationBudget,
+      topNWithSnippet: omitted.matched_nodes.length,
+    })
+    expect(matchedByLabel(restored, 'adaptiveOwner()').snippet).toBe(expected)
+    expect(restored.snippet_budget_tokens_used).toBeLessThanOrEqual(allocationBudget)
+    expect(restored.token_count).toBeLessThanOrEqual(restored.task_contract!.budget)
+    expect(restored.matched_nodes.map((node) => node.node_id)).toEqual(
+      omitted.matched_nodes.map((node) => node.node_id),
+    )
+
+    const compactRestored = compactRetrieveResultForStdio(omitted, {
+      snippetBudget: allocationBudget,
+      topNWithSnippet: omitted.matched_nodes.length,
+    })
+    expect(matchedByLabel(compactRestored, 'adaptiveOwner()').snippet).toBe(expected)
+    expect(compactRestored.snippet_budget_tokens_used).toBeLessThanOrEqual(allocationBudget)
+    expect(compactRestored.token_count).toBeLessThanOrEqual(omitted.task_contract!.budget)
   }, 120_000)
 
   it('admits exactly 2000 original owner characters and rejects 2001', () => {
@@ -760,6 +820,9 @@ describe('complete small-owner source representation', () => {
       retrievalLevel: 5,
       retrievalStrategy: 'slice-v1',
     })
+    const full = fresh()
+    const fullSnippet = ownerSnippet(full)!
+    const exactCost = estimateQueryTokens(fullSnippet)
     for (const options of [
       { snippetBudget: 0, topNWithSnippet: 12 },
       { snippetBudget: 2_400, topNWithSnippet: 0 },
@@ -768,6 +831,21 @@ describe('complete small-owner source representation', () => {
       expect(ownerSnippet(shaped)).toBeNull()
       expect(matchedByLabel(shaped, 'parseDecimalRatio()').snippet_truncated).toBe(true)
       expect(shaped.snippet_budget_tokens_used).toBe(0)
+
+      const restored = withRetrieveSnippetBudget(shaped, {
+        snippetBudget: exactCost,
+        topNWithSnippet: 12,
+      })
+      expect(ownerSnippet(restored)).toBe(fullSnippet)
+      expect(restored.matched_nodes.map((node) => node.node_id)).toEqual(
+        shaped.matched_nodes.map((node) => node.node_id),
+      )
+
+      const compactNull = compactRetrieveResultForStdio(shaped, {
+        snippetBudget: exactCost,
+        topNWithSnippet: 12,
+      })
+      expect(ownerSnippet(compactNull)).toBeNull()
     }
   }, 120_000)
 

--- a/tests/unit/retrieve-small-owner-representation.test.ts
+++ b/tests/unit/retrieve-small-owner-representation.test.ts
@@ -8,6 +8,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { generateGraph } from '../../src/infrastructure/generate.js'
 import {
   compactRetrieveResultForStdio,
+  contextPackFromRetrieveResult,
+  readQueryEvidenceSnippet,
   retrieveContext,
   withRetrieveSnippetBudget,
   type RetrieveOptions,
@@ -431,6 +433,122 @@ describe('complete small-owner source representation', () => {
       nodeKind: 'function',
     })).toBeNull()
   })
+
+  it('promotes an authenticated 26-line owner only when its exact representation fits allocation', () => {
+    const ownerSource = [
+      'export function adaptiveOwner(input: string) {',
+      '  const normalized = input.trim();',
+      "  recordCheckpoint('adaptive-owner-start');",
+      "  if (normalized === '') {",
+      "    return { status: 'empty' };",
+      '  }',
+      '  let attempt = 0;',
+      '  while (attempt < 3) {',
+      '    attempt += 1;',
+      '    try {',
+      '      const loaded = loadCandidate(normalized);',
+      '      if (!loaded.allowed) {',
+      "        continue;",
+      '      }',
+      '      const transformed = transformCandidate(loaded);',
+      '      if (transformed.requiresReview) {',
+      '        queueReview(transformed);',
+      "        return { status: 'queued' };",
+      '      }',
+      '      persistCandidate(transformed);',
+      "      return { status: 'stored' };",
+      '    } catch (error) {',
+      "      recordCheckpoint('adaptive-owner-finish');",
+      '    }',
+      '  }',
+      '}',
+    ].join('\n')
+    const source = `${ownerSource}\nexport function adaptiveOwnerLexicalDecoy() { return 'adaptive-owner-start adaptive-owner-finish'; }\n`
+    const fixture = generatedFixture(source)
+    const retrieved = retrieveContext(fixture.graph, {
+      question: 'Show adaptiveOwner start and finish checkpoints with the intervening persistence control flow',
+      budget: 4_000,
+      retrievalLevel: 5,
+    })
+    const expected = numberedLines(ownerSource)
+    const owner = matchedByLabel(retrieved, 'adaptiveOwner()')
+    const exactCost = estimateQueryTokens(expected)
+    const baselineSnippetCost = retrieved.matched_nodes.reduce(
+      (total, node) => total + estimateQueryTokens(node.snippet ?? ''),
+      0,
+    )
+    const allocationBudget = baselineSnippetCost - estimateQueryTokens(owner.snippet!) + exactCost
+
+    expect(owner.snippet).not.toBe(expected)
+    expect(owner.snippet).toContain('adaptive-owner-start')
+    expect(owner.snippet).toContain('adaptive-owner-finish')
+    expect(owner.snippet).not.toContain('persistCandidate(transformed)')
+
+    const allocated = withRetrieveSnippetBudget(retrieved, {
+      snippetBudget: allocationBudget,
+      topNWithSnippet: retrieved.matched_nodes.length,
+    })
+    const allocatedOwner = matchedByLabel(allocated, 'adaptiveOwner()')
+    expect(allocatedOwner.snippet).toBe(expected)
+    expect(allocatedOwner.snippet_truncated).toBe(false)
+    expect(allocatedOwner.representation_reason).toBe('complete owner source within snippet allocation')
+    expect(allocated.snippet_budget_tokens_used).toBe(allocationBudget)
+    expect(allocated.matched_nodes.map((node) => node.node_id)).toEqual(
+      retrieved.matched_nodes.map((node) => node.node_id),
+    )
+
+    const projected = contextPackFromRetrieveResult(allocated)
+    const projectedOwner = projected.nodes.find((node) => node.label === 'adaptiveOwner()')
+    expect(projectedOwner?.snippet).toBe(expected)
+    expect(projected.token_count).toBeLessThanOrEqual(projected.task_contract.budget)
+
+    const compact = compactRetrieveResultForStdio(retrieved, {
+      snippetBudget: allocationBudget,
+      topNWithSnippet: retrieved.matched_nodes.length,
+    })
+    expect(matchedByLabel(compact, 'adaptiveOwner()').snippet).toBe(expected)
+
+    const insufficient = withRetrieveSnippetBudget(retrieved, {
+      snippetBudget: allocationBudget - 1,
+      topNWithSnippet: retrieved.matched_nodes.length,
+    })
+    const insufficientOwner = matchedByLabel(insufficient, 'adaptiveOwner()')
+    expect(insufficientOwner.snippet).not.toBe(expected)
+    expect(insufficientOwner.snippet).not.toBeNull()
+    expect(insufficientOwner.snippet_truncated).toBe(true)
+    expect(insufficientOwner.representation_reason).not.toBe('complete owner source within snippet allocation')
+    expect(insufficient.snippet_budget_tokens_used).toBeLessThanOrEqual(allocationBudget - 1)
+
+    retrieved.task_contract = {
+      ...retrieved.task_contract!,
+      budget: retrieved.token_count,
+    }
+    const noTotalHeadroom = withRetrieveSnippetBudget(retrieved, {
+      snippetBudget: allocationBudget,
+      topNWithSnippet: retrieved.matched_nodes.length,
+    })
+    expect(matchedByLabel(noTotalHeadroom, 'adaptiveOwner()').snippet).not.toBe(expected)
+    expect(noTotalHeadroom.token_count).toBeLessThanOrEqual(retrieved.task_contract.budget)
+
+    const externalFallback = readQueryEvidenceSnippet(fixture.sourceFile, 1, {
+      question: 'Show adaptiveOwner start and finish checkpoints',
+      label: 'adaptiveOwner()',
+      nodeKind: 'function',
+      externalCall: true,
+      authenticatedOwner: true,
+      sourceLocation: '1-26',
+    })
+    expect(externalFallback?.snippet).not.toBe(expected)
+
+    const unauthenticatedFallback = readQueryEvidenceSnippet(fixture.sourceFile, 1, {
+      question: 'Show adaptiveOwner start and finish checkpoints',
+      label: 'adaptiveOwner()',
+      nodeKind: 'function',
+      authenticatedOwner: false,
+      sourceLocation: '1-26',
+    })
+    expect(unauthenticatedFallback?.snippet).not.toBe(expected)
+  }, 120_000)
 
   it('admits exactly 2000 original owner characters and rejects 2001', () => {
     const owner = (characterCount: number) => {


### PR DESCRIPTION
Retrieval could return separated query-matching lines from a function larger than the small-owner limit even when enough snippet and total retrieval budget remained. Allocate complete authenticated owner source after the existing selected snippets fit, so a larger function includes intervening control flow without displacing selected evidence.

Keep the established small-owner limits and source authentication. If complete source does not fit, preserve a bounded partial excerpt without a completeness claim. Preserve allocation-only owner state through compact output and null snippets, while retaining existing small-owner restoration behavior. Align the existing mutation-test anchor with the changed block; mutation payloads and assertions remain unchanged.

Validation:

- 44 owning tests, typecheck, build, production-independence positive/negative controls, and diff hygiene pass on final bytes.
- Independent exact-final review returned GO on `5f91c188f36c21f74b90f8e103651b26a3ef792e`. The earlier CRLF/source/budget probes are supplemented by null-state restoration regressions and a valid authentication positive/negative control.
- Failing-first evidence is retained for the original large-owner null TypeError and the small-owner restoration regression caught during correction. The earlier CI anchor failure is also retained.
- A replay on the final runtime expands one selected owner from 2 separated rows to 90 source-exact rows. All 10 selected nodes, order, relationships and other snippets remain unchanged; reported usage is 1,381/9,000 total tokens and 1,244/6,500 snippet tokens.

Related to #740. This establishes a retrieval improvement; broader answer quality, complete workflow speed and usage remain unproven. #740 remains open.
